### PR TITLE
feat(skills): git-worktree操作を独立スキルに切り出し

### DIFF
--- a/.opencode/commands/issue/issue-close.md
+++ b/.opencode/commands/issue/issue-close.md
@@ -4,6 +4,7 @@ load_skills:
   - decision-log
   - issue-guide
   - gh-cli-best-practices
+  - git-worktree
 ---
 
 # 完了処理

--- a/.opencode/commands/issue/issue-work.md
+++ b/.opencode/commands/issue/issue-work.md
@@ -5,6 +5,7 @@ load_skills:
   - decision-log
   - deviation-check
   - issue-guide
+  - git-worktree
 ---
 
 # 実装パイプライン
@@ -26,7 +27,7 @@ Issueに対して計画立案から実装・コミットまでを一気通貫で
 ## Steps
 
 1. Issue本文から要件docと受け入れ基準を抽出 → `req-analysis` のチェックボックス品質基準で検証
-2. Worktree作成・ブランチ準備（`feature/issue-N` or `fix/issue-N`）
+2. Worktree作成・ブランチ準備 → `git-worktree` スキルに従って実行
 3. work planを生成（@plan）→ 実行（/start-work）→ TDD実装
 4. パターンB（機能追加）の場合、HLD/LLD ドキュメントを生成 → テンプレート: `templates/doc_hld.md`, `templates/doc_lld.md`
 5. 実行中に技術判断が発生 → `decision-log` に従って決定エントリ作成

--- a/.opencode/skills/git-worktree/SKILL.md
+++ b/.opencode/skills/git-worktree/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: git-worktree
+description: Windows環境でのgit worktree操作を安全に実行するための手順。issue-work/issue-closeコマンドから参照される。
+---
+
+# git-worktree
+
+## 動作指針
+
+Windows環境でのgit worktree操作を安全に実行するための手順。issue-work/issue-closeコマンドから参照される。
+
+## 命名規則
+
+- worktreeディレクトリ: `.worktrees/{N}-{type}` （例: `.worktrees/516-fix`, `.worktrees/1-feature`）
+- ブランチ名: `{type}/issue-{N}` （例: `fix/issue-516`, `feature/issue-1`）
+- `{type}` の取り得る値: `feature`（機能追加・enhancement） / `fix`（バグ修正・bug）
+- `{N}` は GitHub Issue 番号（数値）
+- この命名規則は `issue-guide` の完了報告フォーマットと一貫性を持つ
+
+## 標準手順
+
+### worktree作成
+
+1. ベースブランチの特定: `main` または `master` を自動検出
+2. 作成コマンド: `git worktree add ".worktrees/{N}-{type}" -b "{type}/issue-{N}"`
+3. Windows環境: パスにスペースが含まれる可能性があるためダブルクォート必須
+4. 作成後の確認: `git worktree list` で正しく追加されたことを検証
+5. **絶対パス指定の義務付け**: `workdir` パラメータには絶対パスを使用（相対パスはメインリポジトリの誤編集リスクあり。`docs/tips/inbox.md` の既知バグを反映）
+
+### 既存worktree衝突時の対応
+
+- 同名worktreeが既に存在する場合: `git worktree list` で確認 → 既存worktreeを再利用
+- ブランチのみ既存でworktreeがない場合: `git worktree add ".worktrees/{N}-{type}" "{type}/issue-{N}"`（既存ブランチをcheckout）
+- ダーティなworktreeの削除は禁止（未コミット変更がある場合はエラー停止、ユーザーに判断を委ねる）
+
+### worktree削除
+
+1. 削除コマンド: `git worktree remove ".worktrees/{N}-{type}"`
+2. 削除後のクリーンアップ: `git worktree prune`（手動削除されたディレクトリの残存参照を消去）
+3. ブランチ削除: `git branch -d "{type}/issue-{N}"`（マージ済みの場合のみ。未マージなら `-D` は使わずエラー停止）
+
+## 禁止事項
+
+- 相対パスでのworktreeファイル操作禁止（絶対パス必須）
+- `--force` によるダーティworktreeの強制削除禁止
+- メインリポジトリ（非worktree）内でのファイル編集禁止（issue-work中）


### PR DESCRIPTION
## Summary

- `git-worktree` スキルを新規作成（命名規則・作成/削除手順・衝突対応・禁止事項）
- `issue-work.md` の `load_skills` に `git-worktree` を追加、Step 2 の命名表記を修正
- `issue-close.md` の `load_skills` に `git-worktree` を追加

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `.opencode/skills/git-worktree/SKILL.md` | 新規作成（236行）|
| `.opencode/commands/issue/issue-work.md` | load_skills 追加 + Step 2 修正 |
| `.opencode/commands/issue/issue-close.md` | load_skills 追加 |

## テスト計画

- [x] 乖離検査: Issue #589 の受け入れ基準と実装の乖離なし（重大=0, 軽微=0）
- [x] issue-guide の命名規則（155行）→ SKILL.md の命名規則が一貫
- [x] OUT スコープのファイルに変更なし（issue-guide, 他コマンド、.gitignore）

## 関連Issue

