### PR TITLE
feat: issue-*コマンドのfrontmatterにエージェント型指定を追加

### DIFF
--- a/.opencode/commands/issue/issue-close.md
+++ b/.opencode/commands/issue/issue-close.md
@@ -1,5 +1,6 @@
 ---
 description: PRをマージし、対応記録を追記し、Issueをクローズしてブランチを削除する
+agent: build
 load_skills:
   - issue-guide
   - gh-cli-best-practices

--- a/.opencode/commands/issue/issue-create.md
+++ b/.opencode/commands/issue/issue-create.md
@@ -1,5 +1,6 @@
 ---
 description: 要件定義をもとにGitHub Issueを作成する
+agent: build
 load_skills:
   - issue-guide
   - gh-cli-best-practices

--- a/.opencode/commands/issue/issue-next.md
+++ b/.opencode/commands/issue/issue-next.md
@@ -1,5 +1,6 @@
 ---
 description: 次のコマンドを推論・実行する。セッションコンテキストのみ使用（gh/gitコマンド禁止）。
+agent: build
 load_skills:
   - issue-guide
   - deviation-check

--- a/.opencode/commands/issue/issue-req.md
+++ b/.opencode/commands/issue/issue-req.md
@@ -1,5 +1,6 @@
 ---
 description: 要件を整理・定義する（機能追加・バグ修正共通）
+agent: build
 load_skills:
   - req-analysis
   - adr-guidelines

--- a/.opencode/commands/issue/issue-update.md
+++ b/.opencode/commands/issue/issue-update.md
@@ -1,5 +1,6 @@
 ---
 description: 既存Issueの本文更新、コメント追加、またはREQファイル更新を行う
+agent: build
 load_skills:
   - issue-guide
   - gh-cli-best-practices

--- a/.opencode/commands/issue/issue-work.md
+++ b/.opencode/commands/issue/issue-work.md
@@ -1,5 +1,6 @@
 ---
 description: 計画立案からコミットまでを一気通貫で実行する（@plan + /start-work + commit統合）
+agent: build
 load_skills:
   - req-analysis
   - deviation-check

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -1,0 +1,5 @@
+# Requirements Index
+
+| REQ ID | Title | Status | Issue |
+|--------|-------|--------|-------|
+| REQ-0030 | issue-*コマンドのfrontmatterにエージェント型指定を追加 | implemented | #30 |

--- a/docs/requirements/REQ-0030.md
+++ b/docs/requirements/REQ-0030.md
@@ -1,0 +1,75 @@
+---
+id: REQ-0030
+title: "issue-*コマンドのfrontmatterにエージェント型指定を追加"
+classification: FR
+category: maintainability
+status: implemented
+issue: 30
+adr: null
+created: "2026-05-06"
+updated: "2026-05-06"
+tags: [commands, agent, frontmatter]
+related_to: []
+depends_on: []
+---
+
+> このドキュメントは①バイブス壁打ちフェーズで作成されます。
+
+# issue-*コマンドのfrontmatterにエージェント型指定を追加
+
+## 背景・課題
+
+6つのissue-*コマンドのfrontmatterにエージェント指定がないため、ハーネスのデフォルトエージェントが使用される。OpenCodeではPlan（Prometheus）がデフォルトとなり、Planエージェント特有の「計画作成指向」システムプロンプトが干渉する問題があった。
+
+## 目標
+
+全6コマンドのfrontmatterに `agent: build` を明記し、デフォルトエージェントの誤用を防止する。
+
+## 方向性
+
+frontmatterに `agent: build` を1行追加する最小変更で対応。
+
+## 機能要件
+
+- [x] 6コマンドのfrontmatterに `agent: build` が追加されている
+  - **Given**: 6つのissue-*コマンドファイルが存在する
+  - **When**: 各コマンドのfrontmatterを確認する
+  - **Then**: 全てに `agent: build` が含まれている
+
+- [x] issue-req 実行時にPlan（Prometheus）ではなくBuild（Sisyphus）が起動することを確認
+  - **Given**: issue-reqコマンドに `agent: build` が設定されている
+  - **When**: issue-reqを実行する
+  - **Then**: Buildエージェントが起動し、ファイル書込操作が成功する
+
+- [x] issue-req 完了時の「次のステップ」が `/issue/issue-create` を推奨することを確認
+  - **Given**: issue-reqがBuildエージェントで正常完了する
+  - **When**: 完了報告を確認する
+  - **Then**: 次のステップとして `/issue/issue-create` が推奨される
+
+**品質基準**: 各要件は 測定可能・一意・実装可能 であること。
+
+## 非機能要件（オプション）
+
+- 8つの主要ハーネス間での移植性を確保するため、汎用的な `build` エージェント型を使用
+
+## スコープ
+
+### 対象
+
+- `.opencode/commands/issue/issue-req.md`
+- `.opencode/commands/issue/issue-create.md`
+- `.opencode/commands/issue/issue-work.md`
+- `.opencode/commands/issue/issue-update.md`
+- `.opencode/commands/issue/issue-close.md`
+- `.opencode/commands/issue/issue-next.md`
+
+### 対象外
+
+- エージェント定義の新規作成
+- load_skillsの変更
+- コマンド本文の変更
+
+## 関連情報（オプション）
+
+- **Issue**: #30
+- **PR**: #31

--- a/docs/specs/patterns.md
+++ b/docs/specs/patterns.md
@@ -1,0 +1,18 @@
+# Implementation Patterns
+
+## コマンドfrontmatter規約
+
+### エージェント指定
+
+全てのissue-*コマンドはfrontmatterに `agent: build` を明記する。
+
+```yaml
+---
+description: ...
+agent: build
+load_skills:
+  - ...
+---
+```
+
+**理由**: デフォルトエージェント（Plan/Prometheus）の誤用を防止するため。PlanエージェントはRead-only権限であり、ファイル書込やコマンド実行ができない。

--- a/docs/specs/system.md
+++ b/docs/specs/system.md
@@ -1,0 +1,18 @@
+# System Specification
+
+## コマンドシステム
+
+### issue-*コマンド群
+
+issue-*コマンドは6つのコマンドで構成され、3マクロフェーズの開発ワークフローを提供する。
+
+| コマンド | 役割 | エージェント |
+|---|---|---|
+| `/issue/issue-req` | 要件定義（壁打ち） | build |
+| `/issue/issue-create` | Issue登録 | build |
+| `/issue/issue-work` | 実装パイプライン | build |
+| `/issue/issue-update` | Issue更新 | build |
+| `/issue/issue-close` | 完了処理 | build |
+| `/issue/issue-next` | 次コマンド推論 | build |
+
+全コマンドは `agent: build` をfrontmatterに指定し、Buildエージェント（Read+Write+Execute権限）で実行される。これはREQ-0030で導入された。


### PR DESCRIPTION
## 概要

issue-*コマンドのfrontmatterにエージェント型（`agent: build`）を明記し、デフォルトエージェントの誤用を防止する。

## 実装内容

- 6コマンド（issue-req, issue-create, issue-work, issue-update, issue-close, issue-next）のfrontmatterに `agent: build` を追加
- Plan（Prometheus）がデフォルト起動される問題を解決
- REQファイル作成等の書込操作に失敗する問題を解決

## テスト結果

- 6ファイルのfrontmatter変更を確認（`git diff` で `agent: build` の追加のみ）
- 乖離検出: 重大乖離・軽微乖離ともになし

## 決定事項

- 全コマンドをBuildで統一（新規エージェント定義は不要）
- 振る舞いの差異は既存の `load_skills` で制御

Closes #30