### PR TITLE
feat(issue-workflow): 品質メトリクス基盤構築

### DIFF
--- a/.opencode/commands/issue/templates/report_deviation.md
+++ b/.opencode/commands/issue/templates/report_deviation.md
@@ -5,15 +5,21 @@
 ### 乖離1
 
 - **影響度**: 重大 / 軽微
+- **乖離タイプ**: `spec-bug` | `impl-bug` | `scope-creep`
 - **対象**: {要件docの該当セクション / 変更ファイル}
 - **内容**: {乖離の具体的な説明}
+- **影響REQ番号**: {REQ番号の配列（例: `[REQ-3.2, REQ-3.3]`）}
+- **修正方針**: `req-update(APPEND)` | `req-update(UPDATE)` | `code-fix` | `scope-reduction`
 - **推奨アクション**: 修正 / 承認 / 差し戻し
 - **理由**: {推奨アクションの根拠}
 
 ### 乖離2
 
 - **影響度**: 重大 / 軽微
+- **乖離タイプ**: `spec-bug` | `impl-bug` | `scope-creep`
 - **対象**: {要件docの該当セクション / 変更ファイル}
 - **内容**: {乖離の具体的な説明}
+- **影響REQ番号**: {REQ番号の配列（例: `[REQ-3.2, REQ-3.3]`）}
+- **修正方針**: `req-update(APPEND)` | `req-update(UPDATE)` | `code-fix` | `scope-reduction`
 - **推奨アクション**: 修正 / 承認 / 差し戻し
 - **理由**: {推奨アクションの根拠}

--- a/.sisyphus/quality/FORMAT.md
+++ b/.sisyphus/quality/FORMAT.md
@@ -1,0 +1,27 @@
+# Quality Log Format
+
+品質ログは各フェーズの品質データを集約する。
+
+## ログエントリ形式
+
+ファイル名: `quality-{YYYY-MM-DD}-{issue-number}.json`
+
+```json
+{
+  "timestamp": "ISO-8601",
+  "issue_number": "N",
+  "phase": "vibe-wall-hit | structured-execution | review-complete",
+  "deviations": {
+    "major": 0,
+    "minor": 0,
+    "types": []
+  },
+  "affected_reqs": [],
+  "action_taken": "proceed | partial-rollback | full-rollback",
+  "notes": "free text"
+}
+```
+
+## 記録タイミング
+- deviation-check 実行時（②構造的実行フェーズ完了時）
+- レビューNG検出時（③レビュー完了フェーズ）


### PR DESCRIPTION
## Summary

- .sisyphus/quality/ ディレクトリと FORMAT.md を新設し、品質ログ形式（JSON）を定義
- eport_deviation.md テンプレートを5→8フィールドに拡張（乖離タイプ, 影響REQ番号, 修正方針を追加）
- deviation-check SKILL.md の出力形式は変更せず（ガードレール遵守）

## Changes

| File | Change |
|------|--------|
| .sisyphus/quality/.gitkeep | 新規（空ディレクトリのGit管理） |
| .sisyphus/quality/FORMAT.md | 新規（品質ログ形式定義） |
| .opencode/commands/issue/templates/report_deviation.md | 5→8フィールド拡張 |

## Verification

- [x] quality/ ディレクトリ存在
- [x] FORMAT.md に deviations, issue_number フィールド定義
- [x] eport_deviation.md に3新フィールド（乖離タイプ, 影響REQ番号, 修正方針）
- [x] 既存5フィールド維持
- [x] deviation-check SKILL.md 未変更

Closes #64