### PR TITLE
feat(skills): 全スキル品質改善 - description英語統一とSKILL.md補強（REQ-0024）

### DIFF
--- a/.opencode/skills/epic-status-tracker/SKILL.md
+++ b/.opencode/skills/epic-status-tracker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: epic-status-tracker
-description: 親Epic Issueのステータス追跡テーブルを更新するプロトコル。issue-work Phase A（🔄 進行中）と issue-close Step 8（✅ 完了）から参照される。
+description: Updates parent Epic Issue status tracking tables across issue-work and issue-close workflows. USE FOR: updating Epic status to in-progress or completed, tracking child Issue progress in parent Epics, detecting parent-child relationships via Parent: #N patterns. DO NOT USE FOR: creating Epics, managing non-Epic Issues, or general Issue operations.
 ---
 
 # Epic Status Tracker

--- a/.opencode/skills/gh-cli-best-practices/SKILL.md
+++ b/.opencode/skills/gh-cli-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-cli-best-practices
-description: Windows環境(cmd/PS)で GitHub CLI (gh issue/pr/release) を使用する際、複数行の本文(--body)によるエスケープエラーを回避し、一時ファイル(--body-file)経由の実行を強制する。
+description: Enforces safe GitHub CLI usage on Windows (PowerShell/cmd) by routing all multi-line body content through temporary files to prevent encoding and escaping errors. USE FOR: running gh issue/pr/release commands with --body or --body-file, reading gh command output safely on Windows, or writing Issue/PR content. DO NOT USE FOR: basic gh commands without body content, non-Windows environments, or general git operations.
 ---
 
 # gh-cli-best-practices

--- a/.opencode/skills/issue-guide-phases/SKILL.md
+++ b/.opencode/skills/issue-guide-phases/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-guide-phases
-description: 開発ワークフローのフェーズ定義・SSoT遷移・パターン判定基準・コマンド関連・docs構造を提供。issue-*コマンドのフェーズ判定フェーズで参照される知識ベース。
+description: Provides development workflow phase definitions, SSoT transitions, pattern matching criteria, command mappings, and docs structure for the issue-* command pipeline. USE FOR: determining workflow phases, Pattern A/B classification, scale assessment, resolving command dependencies, or understanding docs/ directory layout. DO NOT USE FOR: specific command execution logic, requirement analysis, or compliance checking.
 ---
 
 # Issue Guide Phases スキル

--- a/.opencode/skills/issue-guide-reports/SKILL.md
+++ b/.opencode/skills/issue-guide-reports/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-guide-reports
-description: 各コマンドの完了報告フォーマット・チェックボックス更新ルール・サブエージェント出力ポリシーを提供。issue-*コマンドの完了報告時とサブエージェント利用時に参照される。
+description: Defines completion report formats, checkbox update rules, and sub-agent verbatim output policies for issue-* commands. USE FOR: generating command completion reports, updating Issue checkboxes, formatting sub-agent output, or applying report templates. DO NOT USE FOR: workflow phase definitions, pattern classification, or architecture decisions.
 ---
 
 # Issue Guide Reports スキル

--- a/.opencode/skills/issue-guide-review/SKILL.md
+++ b/.opencode/skills/issue-guide-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-guide-review
-description: レビューNG時の対応フロー・issue-next推論ルールを提供。レビュー完了フェーズのNG対応と次コマンド推論で参照される。
+description: Provides review rejection handling flows and issue-next inference rules for post-review scenarios. USE FOR: handling review NG results, determining next command after review rejection, classifying rejection types (spec-bug, impl-bug, scope-creep), or resolving Epic-related command inference. DO NOT USE FOR: general command execution, requirement analysis, or implementation planning.
 ---
 
 # Issue Guide Review スキル

--- a/.opencode/skills/obsidian-note-workflow/SKILL.md
+++ b/.opencode/skills/obsidian-note-workflow/SKILL.md
@@ -22,13 +22,27 @@ Obsidian Vaultでノートを作成・管理・整理する場合
 | 定着 | 40_resources/42_notes | type/permanent | リンク付け |
 | アーカイブ | 50_archives | status/archived | 移動 |
 
+## Stages
+
+### Capture (収集)
+Capture ideas, bookmarks, and fleeting notes into `00_inbox` with `type/inbox` tag. No formatting required — raw capture is the priority. Process later during organizing stage.
+
+### Organize (整理)
+Move notes from `00_inbox` to `40_resources/41_inbox`, apply appropriate tags (`type/note`, domain tags), and assign a descriptive title. Each note should have one clear purpose.
+
+### Solidify (定着)
+Transform organized notes into permanent notes in `40_resources/42_notes` with `type/permanent` tag. Add bidirectional links to related notes, refine content for long-term value, and ensure atomicity (one idea per note).
+
+### Archive (アーカイブ)
+Move completed or inactive notes to `50_archives` with `status/archived` tag. Notes remain searchable but out of active workspace. Review periodically for reactivation.
+
 ## Implementation
-詳細は references/ ディレクトリの各ファイルを参照
-- note-lifecycle.md: ライフサイクル詳細
-- tag-guidelines.md: タグ設計ガイドライン
-- link-patterns.md: リンク付けパターン
+各ステージの詳細手順と具体例は、references/ ディレクトリの各ファイルを参照:
+- [note-lifecycle.md](references/note-lifecycle.md): ライフサイクル詳細
+- [tag-guidelines.md](references/tag-guidelines.md): タグ設計ガイドライン
+- [link-patterns.md](references/link-patterns.md): リンク付けパターン
 
 ## Common Mistakes
-- タグを付けすぎる
-- リンクなしの孤立ノート
-- ファイル整理の未完了
+- **Too many tags**: Adding 5+ tags to a single note creates noise. Limit to 2-3 meaningful tags per note. Example: ❌ `#idea #project #work #important #urgent` → ✅ `#project/alpha type/note`
+- **Orphan notes without links**: Notes without any `[[wiki-links]]` become undiscoverable. Always link new notes to at least one existing note. Example: ❌ A standalone meeting note → ✅ Meeting note linked to project note and person note
+- **Incomplete organization**: Leaving notes in `00_inbox` after processing. Once reviewed and tagged, move to the appropriate stage folder immediately

--- a/.opencode/skills/obsidian-skill-maintainer/SKILL.md
+++ b/.opencode/skills/obsidian-skill-maintainer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian-skill-maintainer
-description: Obsidian Vaultの運用ルールに基づくagent-skillの作成・更新・整理を管理。運用ルールが変更された場合、このスキルを起動して他のスキルのreferenceを更新します。
+description: Manages creation, update, and organization of Obsidian Vault agent-skills based on vault operational rules. USE FOR: creating new Obsidian skills, updating skills after vault rule changes, reviewing skill inventory, or maintaining skill cross-references. DO NOT USE FOR: general coding tasks, Obsidian note management, or skill quality evaluation.
 ---
 
 # Obsidian Skill Maintainer

--- a/.opencode/skills/obsidian-vault-review/SKILL.md
+++ b/.opencode/skills/obsidian-vault-review/SKILL.md
@@ -28,6 +28,31 @@ Obsidian Vaultの定期レビューを行う際に使用：
 | 四半期レビュー | 3ヶ月毎 | 四半期目標達成状況 | `references/quarterly-review.md` |
 | 年次レビュー | 1年毎 | 年間振り返り、次年計画 | `references/yearly-review.md` |
 
+## Review Types
+
+### Daily Review
+Quick inbox triage and daily accomplishments. Move notes from `00_inbox` to appropriate folders, tag unprocessed items, and record key achievements. Target: 5-10 minutes.
+
+### Weekly Review
+Reflect on the past week's progress and plan the next. Review project status, process remaining inbox items, and update weekly objectives. Target: 20-30 minutes.
+
+### Monthly Review
+Assess monthly achievements and project milestones. Review goal progress, identify stalled projects, and re-prioritize tasks. Target: 30-60 minutes.
+
+### Quarterly Review
+Evaluate quarterly objective completion and adjust long-term goals. Analyze trends across months, identify systemic patterns, and set next quarter's OKRs. Target: 1-2 hours.
+
+### Yearly Review
+Comprehensive annual reflection and next-year planning. Review all quarters, archive completed projects, and define annual themes and objectives. Target: 2-4 hours.
+
 ## Implementation
 
-レビュー実施時は、適切な参照ファイルを確認し、手順に従って進めてください。各参照ファイルには具体的なDataviewクエリとチェックリストが含まれています。
+各レビュー種別の具体的なDataviewクエリとチェックリストは、対応する参照ファイルに記載されています:
+
+- 日次: [references/daily-review.md](references/daily-review.md)
+- 週次: [references/weekly-review.md](references/weekly-review.md)
+- 月次: [references/monthly-review.md](references/monthly-review.md)
+- 四半期: [references/quarterly-review.md](references/quarterly-review.md)
+- 年次: [references/yearly-review.md](references/yearly-review.md)
+
+レビュー実施時は、上記の対応する参照ファイルを読み込み、手順に従ってください。

--- a/.opencode/skills/skill-authoring-best-practices/SKILL.md
+++ b/.opencode/skills/skill-authoring-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-authoring-best-practices
-description: SKILL.mdの作成・改善時に参照するベストプラクティスガイド。USE FOR: スキル新規作成、既存スキル改善、スキル品質レビュー、スキル構造設計、トリガーdescription執筆、progressive disclosure設計。DO NOT USE FOR: コマンド定義の作成、一般的なコーディング作業、ドキュメントの単純修正。
+description: Provides quality criteria and best practices for authoring OpenCode SKILL.md files across five evaluation axes and four check protocols. USE FOR: creating new skills, improving existing skills, reviewing skill quality, designing skill structure, writing trigger descriptions, or planning progressive disclosure. DO NOT USE FOR: creating command definitions, general coding tasks, or simple documentation fixes.
 ---
 
 # Skill Authoring Best Practices


### PR DESCRIPTION
## 概要

全19スキルの品質評価（skill-authoring-best-practices 準拠）で検出された課題を解消。7スキルのdescriptionを英語3人称 + USE FOR / DO NOT FOR形式に統一し、2スキルのSKILL.md本文を補強。

## 実装内容

### REQ-0024-01 + 02: description更新（7スキル）
- `epic-status-tracker`: 英語3人称 + USE FOR/DO NOT FOR形式に更新
- `issue-guide-phases`: 英語3人称 + USE FOR/DO NOT FOR形式に更新
- `issue-guide-reports`: 英語3人称 + USE FOR/DO NOT FOR形式に更新
- `issue-guide-review`: 英語3人称 + USE FOR/DO NOT FOR形式に更新
- `gh-cli-best-practices`: 英語3人称 + USE FOR/DO NOT FOR形式に更新
- `obsidian-skill-maintainer`: 英語3人称 + USE FOR/DO NOT FOR形式に更新
- `skill-authoring-best-practices`: 日本語→英語化、USE FOR/DO NOT FOR保持

### REQ-0024-03: SKILL.md本文補強（2スキル）
- `obsidian-vault-review`: レビュー種別別（日次/週次/月次/四半期/年次）の概要と所要時間を追加、references/への導線を明確化
- `obsidian-note-workflow`: 各ステージ（収集/整理/定着/アーカイブ）の説明を追加、Common Mistakesに具体例を追加

## テスト結果

対象ファイルはMarkdownのみ。型チェック/Lint/ビルド/テストは該当なし。

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 乖離検出 | 0件 | 0件 | ✅ |
| 変更ファイル数 | 9ファイル | 対象9スキル | ✅ |

## 決定事項

- description言語を英語に統一（REQ-0024合意事項）
- skill-authoring-best-practicesは空description→英語description（REQ-0024-02）

Closes #124
