### PR TITLE
feat: スキル品質改善 - DO NOT USE FOR追加・USE FOR表記統一・日英混在解消

### DIFF
--- a/.opencode/skills/adr-file-manager/SKILL.md
+++ b/.opencode/skills/adr-file-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr-file-manager
-description: Manages ADR numbering and architecture decision record file operations (CREATE/APPEND/UPDATE). Use when creating ADR files, appending sections, or updating existing ADRs.
+description: Manages ADR numbering and architecture decision record file operations (CREATE/APPEND/UPDATE). USE FOR: creating ADR files, appending sections, or updating existing ADRs. DO NOT USE FOR: evaluating whether an ADR is needed, analyzing requirement quality, or general document management.
 ---
 
 # ADRファイル管理

--- a/.opencode/skills/adr-guidelines/SKILL.md
+++ b/.opencode/skills/adr-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr-guidelines
-description: Evaluates whether architectural decisions require an ADR. Use when proposing architecture changes, selecting tech stacks, or making hard-to-reverse technical decisions.
+description: Evaluates whether architectural decisions require an ADR. USE FOR: proposing architecture changes, selecting tech stacks, or making hard-to-reverse technical decisions. DO NOT USE FOR: creating or managing ADR files, requirement analysis, or implementation planning.
 ---
 
 # ADR評価ガイドライン

--- a/.opencode/skills/archive-completed-plan/SKILL.md
+++ b/.opencode/skills/archive-completed-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: archive-completed-plan
-description: Use when a development plan is completed and you want to clean up the workspace by moving related files to the archive.
+description: Cleans up workspace by moving completed plan files to archive. USE FOR: archiving completed plans and cleaning up workspace. DO NOT USE FOR: creating new plans, starting work on plans, or general file management unrelated to plan archival.
 ---
 
 # Archive Completed Plan

--- a/.opencode/skills/commands-creator/SKILL.md
+++ b/.opencode/skills/commands-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commands-creator
-description: Creates and configures OpenCode custom commands for automating recurring tasks. Use when creating commands, setting up command templates, or configuring agent/model bindings.
+description: Creates and configures OpenCode custom commands for automating recurring tasks. USE FOR: creating commands, setting up command templates, or configuring agent/model bindings. DO NOT USE FOR: executing existing commands, modifying skill files, or general development tasks.
 ---
 
 # commands-creator

--- a/.opencode/skills/conventional-commits/SKILL.md
+++ b/.opencode/skills/conventional-commits/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conventional-commits
-description: Generates commit messages following Conventional Commits v1.0.0 spec. Use when creating commits, writing commit messages, or formatting commit history.
+description: Generates commit messages following Conventional Commits v1.0.0 spec. USE FOR: creating commits, writing commit messages, or formatting commit history. DO NOT USE FOR: git operations beyond commit messages, branch naming conventions, or changelog generation.
 ---
 
 # conventional-commits

--- a/.opencode/skills/git-worktree/SKILL.md
+++ b/.opencode/skills/git-worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-worktree
-description: Manages git worktree creation, switching, and cleanup based on Issue numbers. Use when creating worktrees, switching between branches, or cleaning up completed worktrees.
+description: Manages git worktree creation, switching, and cleanup based on Issue numbers. USE FOR: creating worktrees, switching between branches, or cleaning up completed worktrees. DO NOT USE FOR: basic git operations like commit/push/pull, branch management without worktrees, or merge conflict resolution.
 ---
 
 # git-worktree

--- a/.opencode/skills/obsidian-note-workflow/SKILL.md
+++ b/.opencode/skills/obsidian-note-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian-note-workflow
-description: Manages Obsidian Vault note lifecycle (capture, organize, solidify, archive) with tagging and Zettelkasten principles. Use when creating notes, organizing inbox, adding tags, or archiving notes.
+description: Manages Obsidian Vault note lifecycle (capture, organize, solidify, archive) with tagging and Zettelkasten principles. USE FOR: creating notes, organizing inbox, adding tags, or archiving notes. DO NOT USE FOR: vault configuration, plugin setup, periodic review processes, or general file management outside the note lifecycle.
 ---
 
 # Obsidian Note Workflow
@@ -24,17 +24,17 @@ Obsidian Vaultでノートを作成・管理・整理する場合
 
 ## Stages
 
-### Capture (収集)
-Capture ideas, bookmarks, and fleeting notes into `00_inbox` with `type/inbox` tag. No formatting required — raw capture is the priority. Process later during organizing stage.
+### Capture（収集）
+アイデア、ブックマーク、一時ノートを `00_inbox` に `type/inbox` タグ付きでキャプチャする。フォーマット不要 — 生のキャプチャが最優先。後で整理ステージで処理する。
 
-### Organize (整理)
-Move notes from `00_inbox` to `40_resources/41_inbox`, apply appropriate tags (`type/note`, domain tags), and assign a descriptive title. Each note should have one clear purpose.
+### Organize（整理）
+`00_inbox` から `40_resources/41_inbox` にノートを移動し、適切なタグ（`type/note`、ドメインタグ）を適用して説明的なタイトルを割り当てる。各ノートは1つの明確な目的を持つこと。
 
-### Solidify (定着)
-Transform organized notes into permanent notes in `40_resources/42_notes` with `type/permanent` tag. Add bidirectional links to related notes, refine content for long-term value, and ensure atomicity (one idea per note).
+### Solidify（定着）
+整理済みノートを `40_resources/42_notes` の `type/permanent` タグ付き恒久ノートに変換する。関連ノートへの双方向リンクを追加し、長期的価値のために内容を洗練させ、原子性（1ノート1アイデア）を確保する。
 
-### Archive (アーカイブ)
-Move completed or inactive notes to `50_archives` with `status/archived` tag. Notes remain searchable but out of active workspace. Review periodically for reactivation.
+### Archive（アーカイブ）
+完了または非アクティブなノートを `status/archived` タグ付きで `50_archives` に移動する。ノートは検索可能だがアクティブなワークスペースから外れる。定期的にレビューして再活性化を検討する。
 
 ## Implementation
 各ステージの詳細手順と具体例は、references/ ディレクトリの各ファイルを参照:

--- a/.opencode/skills/obsidian-vault-review/SKILL.md
+++ b/.opencode/skills/obsidian-vault-review/SKILL.md
@@ -1,17 +1,13 @@
 ---
 name: obsidian-vault-review
-description: Supports periodic Obsidian Vault reviews (daily, weekly, monthly, quarterly, yearly) with Dataview queries. Use when performing vault reviews, analyzing note statistics, or organizing periodic reflections.
+description: Supports periodic Obsidian Vault reviews (daily, weekly, monthly, quarterly, yearly) with Dataview queries. USE FOR: performing vault reviews, analyzing note statistics, or organizing periodic reflections. DO NOT USE FOR: creating individual notes, modifying note content, general vault configuration, or one-time setup tasks.
 ---
 
 # Obsidian Vault定期レビュー
 
 ## Overview
 
-このスキルはObsidian Vaultの定期レビュープロセスを支援します。日次・週次・月次・四半期・年次の各レビューにおいて、目的、範囲、手順を明確にし、Dataviewクエリを使用した効率的な分析と整理を可能にします。
-
-## When to Use
-
-Obsidian Vaultの定期レビューを行う際に使用：
+このスキルはObsidian Vaultの定期レビュープロセスを支援します。日次・週次・月次・四半期・年次の各レビューにおいて、目的、範囲、手順を明確にし、Dataviewクエリを使用した効率的な分析と整理を可能にします。定期レビューの対象:
 - 日次レビュー（Inboxの整理、今日の成果確認）
 - 週次レビュー（週間の振り返り、来週の計画）
 - 月次レビュー（月間の成果、プロジェクト進捗）

--- a/.opencode/skills/req-analysis/SKILL.md
+++ b/.opencode/skills/req-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: req-analysis
-description: Provides requirement analysis methods with quality criteria and ADR threshold judgment. Use when analyzing requirements, defining acceptance criteria, or evaluating requirement completeness.
+description: Provides requirement analysis methods with quality criteria and ADR threshold judgment. USE FOR: analyzing requirements, defining acceptance criteria, or evaluating requirement completeness. DO NOT USE FOR: creating requirement files, managing file operations, architecture decision evaluation, or implementation planning.
 ---
 
 # 要件分析スキル

--- a/.opencode/skills/req-file-manager/SKILL.md
+++ b/.opencode/skills/req-file-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: req-file-manager
-description: Manages REQ numbering and requirement file operations (CREATE/APPEND/UPDATE). Use when creating requirement files, appending sections, or updating existing requirements.
+description: Manages REQ numbering and requirement file operations (CREATE/APPEND/UPDATE). USE FOR: creating requirement files, appending sections, or updating existing requirements. DO NOT USE FOR: analyzing requirement quality, creating ADR files, general document management, or requirement gathering.
 ---
 
 # REQファイル管理

--- a/.opencode/skills/spec-compliance/SKILL.md
+++ b/.opencode/skills/spec-compliance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-compliance
-description: Detects deviations between implementation and requirements (REQ), work plan, and architecture decisions (ADR) as a quality gate. Use when completing implementation, before creating PRs, or during post-implementation review.
+description: Detects deviations between implementation and requirements (REQ), work plan, and architecture decisions (ADR) as a quality gate. USE FOR: completing implementation, before creating PRs, or during post-implementation review. DO NOT USE FOR: requirement analysis, test execution, code quality reviews without requirement comparison, or general code review.
 ---
 
 # Deviation Check スキル

--- a/.opencode/skills/tips-capture/SKILL.md
+++ b/.opencode/skills/tips-capture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tips-capture
-description: Extracts and captures learnings when problems are solved. Use when fixing bugs, completing investigations, finishing implementations, or discovering technical insights.
+description: Extracts and captures learnings when problems are solved. USE FOR: fixing bugs, completing investigations, finishing implementations, or discovering technical insights. DO NOT USE FOR: general note-taking, documentation generation, or knowledge base management beyond the tips workflow.
 ---
 
 # tips-capture


### PR DESCRIPTION
# スキル品質改善: skill-authoring-best-practices準拠のトリガー・一貫性修正

## 概要

全19スキルの description トリガー品質を `skill-authoring-best-practices` の Frontmatter Check 基準に引き上げる。12スキルへの `DO NOT USE FOR` 追加、表記統一、obsidian系2スキルの日英混在解消。

## 実装内容

### REQ-0025-01: DO NOT USE FOR 追加（12スキル）
- obsidian-vault-review, obsidian-note-workflow, spec-compliance, req-file-manager, req-analysis, git-worktree, adr-file-manager, adr-guidelines, tips-capture, conventional-commits, commands-creator, archive-completed-plan の12スキルに除外条件を追加

### REQ-0025-02: USE FOR 表記統一（12スキル）
- 12スキルの `Use when` 表記を `USE FOR:` 形式に統一

### REQ-0025-03: obsidian-note-workflow 日英混在解消
- Capture/Organize/Solidify/Archive の Stage 説明を日本語に統一

### REQ-0025-04: obsidian-vault-review セクション重複排除
- `## Overview` と `## When to Use` の重複を統合し、Overview に集約

## テスト結果

- Frontmatter Check: 12/12 スキル合格（USE FOR + DO NOT USE FOR 両方あり）
- Budget Check: 全スキル行数上限内（obsidian-vault-review は58→54行で減少）
- Advisory Check: 日英混在解消済み、用語一貫性担保

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| Frontmatter Check 合格率 | 19/19 (100%) | 100% | ✅ |
| Budget Check | 全スキル ≤500行 | ≤500行 | ✅ |
| Advisory Check | 用語一貫性 | 日英混在なし | ✅ |

Closes #126
