### PR TITLE
Phase 4: README.md インデックスの新REQ一覧とdeprecated分離

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,15 @@
   - [REQ-0025: スキル品質改善: skill-authoring-best-practices準拠のトリガー・一貫性修正](requirements/REQ-0025.md)
   - [REQ-0026: epic-status-tracker 未着手ステータスの表記統一（アイコン＋テキスト）](requirements/REQ-0026.md)
   - [REQ-0027: 要件管理体制の再構築：領域別総体管理と仕様体系の確立](requirements/REQ-0027.md)
+  - [REQ-0028: Issue Workflow Architecture](requirements/REQ-0028.md)
+  - [REQ-0029: Issue Command Protocol](requirements/REQ-0029.md)
+  - [REQ-0030: Issue Parallel Execution](requirements/REQ-0030.md)
+  - [REQ-0031: Requirements & ADR Document System](requirements/REQ-0031.md)
+  - [REQ-0032: Epic Issue Management](requirements/REQ-0032.md)
+  - [REQ-0033: Sisyphus Plan Infrastructure](requirements/REQ-0033.md)
+  - [REQ-0034: Knowledge Pipeline](requirements/REQ-0034.md)
+  - [REQ-0035: Skill Quality Framework](requirements/REQ-0035.md)
+  - [REQ-0036: Template System](requirements/REQ-0036.md)
 
 ## Specifications
 

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -1,31 +1,47 @@
 # Requirements Index
 
-| REQ ID   | Title                                                   | Status      |
-| -------- | ------------------------------------------------------- | ----------- |
-| REQ-0001 | issue-\*コマンドのfrontmatterにエージェント型指定を追加 | implemented |
-| REQ-0002 | 全14スキルのSkill Authoring Best Practices準拠改善      | implemented |
-| REQ-0003 | issue-\*コマンドのagent変更と壁打ち結論ハイライト追加    | implemented |
-| REQ-0004 | issue-reqワークフローの再設計（承認ゲート・パターン分離・命名統一） | implemented |
-| REQ-0005 | issue-*コマンドのサブエージェント最終出力のverbatim出力            | implemented |
-| REQ-0006 | issue-*コマンド完了報告フォーマットのシンプル化                   | implemented |
-| REQ-0007 | issue-*コマンドのテンプレート参照解決修正                         | planned     |
-| REQ-0008 | issue-update要件更新機能の包括的ブラッシュアップ                 | planned     |
-| REQ-0009 | REQフォーマットの簡素化（分類・カテゴリ・関連情報フィールドの除去） | planned     |
-| REQ-0010 | Issue/ADR/REQスキル群連携性改善（load_skills補完・See Also追加・テンプレート拡張） | planned     |
-| REQ-0011 | issue-guide スキルの3-way分割と依存関係リファクタリング                               | planned     |
-| REQ-0012 | Tips-Capture運用パイプライン再設計                                                   | planned     |
-| REQ-0013 | archive-completed-plan の命名規則統一                                                 | planned     |
-| REQ-0014 | issue-close コマンドの学び抽出ステップ修正（tips-capture 整合性）                     | planned     |
-| REQ-0015 | 定期的残課題バックログ抽出ワークフローの策定（issue-backlog コマンド）                         | planned     |
-| REQ-0016 | gh CLI読み取り安全性の追加（文字化け対策）                                               | planned     |
-| REQ-0017 | issue-work 複数Issue並列実行機能                                                          | planned     |
-| REQ-0018 | issue-close Epic自動クローズ機能                                                          | implemented     |
-| REQ-0019 | issue-backlog: バックログ抽出済みマーキングによる再抽出防止                              | implemented |
-| REQ-0020 | Epic Issueステータス追跡の自動化                                                        | implemented     |
-| REQ-0021 | skill-authoring-best-practices 再構成 — Waza品質概念マージ                              | implemented     |
-| REQ-0022 | Epic Issueテンプレートのepic-status-tracker互換化とバックログ専用テンプレート新設         | implemented     |
-| REQ-0023 | epic-status-tracker ステータス追跡テーブルフォーマット改善                              | planned         |
-| REQ-0024 | 全スキル品質改善: skill-authoring-best-practices 準拠                                 | implemented     |
-| REQ-0025 | スキル品質改善: skill-authoring-best-practices準拠のトリガー・一貫性修正 | implemented |
-| REQ-0026 | epic-status-tracker 未着手ステータスの表記統一（アイコン＋テキスト） | implemented |
-| REQ-0027 | 要件管理体制の再構築：領域別総体管理と仕様体系の確立 | planned |
+## 有効な要件
+
+| REQ ID   | Title                                | 領域              |
+| -------- | ------------------------------------ | ----------------- |
+| REQ-0028 | Issue Workflow Architecture          | workflow          |
+| REQ-0029 | Issue Command Protocol               | commands          |
+| REQ-0030 | Issue Parallel Execution             | parallel          |
+| REQ-0031 | Requirements & ADR Document System   | requirements/adr  |
+| REQ-0032 | Epic Issue Management                | epic              |
+| REQ-0033 | Sisyphus Plan Infrastructure         | sisyphus          |
+| REQ-0034 | Knowledge Pipeline                   | knowledge         |
+| REQ-0035 | Skill Quality Framework              | skill             |
+| REQ-0036 | Template System                      | templates         |
+
+## 廃止済み要件
+
+| REQ ID   | Title                                                   | Status     |
+| -------- | ------------------------------------------------------- | ---------- |
+| REQ-0001 | issue-\*コマンドのfrontmatterにエージェント型指定を追加 | deprecated |
+| REQ-0002 | 全14スキルのSkill Authoring Best Practices準拠改善      | deprecated |
+| REQ-0003 | issue-\*コマンドのagent変更と壁打ち結論ハイライト追加    | deprecated |
+| REQ-0004 | issue-reqワークフローの再設計（承認ゲート・パターン分離・命名統一） | deprecated |
+| REQ-0005 | issue-*コマンドのサブエージェント最終出力のverbatim出力            | deprecated |
+| REQ-0006 | issue-*コマンド完了報告フォーマットのシンプル化                   | deprecated |
+| REQ-0007 | issue-*コマンドのテンプレート参照解決修正                         | deprecated |
+| REQ-0008 | issue-update要件更新機能の包括的ブラッシュアップ                 | deprecated |
+| REQ-0009 | REQフォーマットの簡素化（分類・カテゴリ・関連情報フィールドの除去） | deprecated |
+| REQ-0010 | Issue/ADR/REQスキル群連携性改善（load_skills補完・See Also追加・テンプレート拡張） | deprecated |
+| REQ-0011 | issue-guide スキルの3-way分割と依存関係リファクタリング                               | deprecated |
+| REQ-0012 | Tips-Capture運用パイプライン再設計                                                   | deprecated |
+| REQ-0013 | archive-completed-plan の命名規則統一                                                 | deprecated |
+| REQ-0014 | issue-close コマンドの学び抽出ステップ修正（tips-capture 整合性）                     | deprecated |
+| REQ-0015 | 定期的残課題バックログ抽出ワークフローの策定（issue-backlog コマンド）                         | deprecated |
+| REQ-0016 | gh CLI読み取り安全性の追加（文字化け対策）                                               | deprecated |
+| REQ-0017 | issue-work 複数Issue並列実行機能                                                          | deprecated |
+| REQ-0018 | issue-close Epic自動クローズ機能                                                          | deprecated |
+| REQ-0019 | issue-backlog: バックログ抽出済みマーキングによる再抽出防止                              | deprecated |
+| REQ-0020 | Epic Issueステータス追跡の自動化                                                        | deprecated |
+| REQ-0021 | skill-authoring-best-practices 再構成 — Waza品質概念マージ                              | deprecated |
+| REQ-0022 | Epic Issueテンプレートのepic-status-tracker互換化とバックログ専用テンプレート新設         | deprecated |
+| REQ-0023 | epic-status-tracker ステータス追跡テーブルフォーマット改善                              | deprecated |
+| REQ-0024 | 全スキル品質改善: skill-authoring-best-practices 準拠                                 | deprecated |
+| REQ-0025 | スキル品質改善: skill-authoring-best-practices準拠のトリガー・一貫性修正 | deprecated |
+| REQ-0026 | epic-status-tracker 未着手ステータスの表記統一（アイコン＋テキスト） | deprecated |
+| REQ-0027 | 要件管理体制の再構築：領域別総体管理と仕様体系の確立 | deprecated |


### PR DESCRIPTION
## 概要

docs/requirements/README.md と docs/README.md を新REQ構成に更新

## 実装内容

### docs/requirements/README.md
- 有効な要件セクション: REQ-0028〜REQ-0036（9件）を領域別に表示
- 廃止済み要件セクション: REQ-0001〜REQ-0027（27件）をdeprecatedとして分離表示

### docs/README.md
- REQ-0028〜REQ-0036 のリンクを追加

## テスト結果

- 有効な要件: 9件（REQ-0028〜REQ-0036） ✅
- 廃止済み要件: 27件（REQ-0001〜REQ-0027） ✅
- docs/README.md: 新REQリンク9件追加 ✅

Closes #136
