### PR TITLE
fix: Epic Issueテンプレートのステータス表記「□」を「☐ 未着手」に統一

### DIFF
--- a/.opencode/commands/issue/templates/issue_desc_epic.md
+++ b/.opencode/commands/issue/templates/issue_desc_epic.md
@@ -29,15 +29,15 @@ REQ-{req_number}
 <!-- 【必須】 -->
 | # | Issue | ステータス | 内容 |
 |---|-------|-----------|------|
-| {seq} | #{child_issue} | ☐ | {child_1_title} |
-| {seq} | #{child_issue} | ☐ | {child_2_title} |
+| {seq} | #{child_issue} | ☐ 未着手 | {child_1_title} |
+| {seq} | #{child_issue} | ☐ 未着手 | {child_2_title} |
 
 ## ステータス追跡
 
 <!-- 【必須】 -->
 | 状態 | 件数 |
 |------|------|
-| ☐ | {total} |
+| ☐ 未着手 | {total} |
 | 🔄 進行中 | 0 |
 | ✅ 完了 | 0 |
 | ❌ 対処不要 | 0 |


### PR DESCRIPTION
## 概要

<!-- 【必須】 -->
Epic Issue本文テンプレート（`issue_desc_epic.md`）のステータス表記「☐」を他ファイルと統一して「☐ 未着手」に修正。

## 実装内容

<!-- 【必須】 -->
- `.opencode/commands/issue/templates/issue_desc_epic.md` の3箇所を修正:
  - 分解テーブル（Decomposition）のステータス列: `☐` → `☐ 未着手`（2箇所）
  - ステータス追跡テーブルの状態列: `☐` → `☐ 未着手`（1箇所）
- 修正により、`epic-status-tracker` SKILL.md の正規表現パターンとの整合性が確保される

## テスト結果

<!-- 【必須】 -->
- テンプレートファイルの目視確認: 3箇所すべて「☐ 未着手」に更新済み ✅
- 他テンプレート（`issue_desc_backlog_epic.md`）との一貫性確認: 合致 ✅

## 品質メトリクス

<!-- 【必須】 -->
| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 要件カバレッジ | 3/3箇所 | 100% | ✅ |
| テンプレート整合性 | 4ファイル一貫 | 一貫性あり | ✅ |

Closes #179
