### PR TITLE
feat(commands): issue-req明示入力ファイル対応

### DIFF
--- a/.opencode/commands/issue/issue-req.md
+++ b/.opencode/commands/issue/issue-req.md
@@ -18,6 +18,11 @@ load_skills:
 - ユーザーの自然言語による機能追加/バグ修正の説明
 - GitHub Issue URL（既存Issueの場合）
 - エラーログ（バグ修正の場合）
+- **ユーザーが明示した入力ファイル**（要件ソース — Requirement Source）:
+  - 要件化前の設計メモ、調査メモ、反映指示書
+  - tips-elevate が生成した staging stub（Requirement Source 形式）
+  - その他変更内容・背景・制約・完了条件を含む source file
+  - source file の種類に依存しない汎用的な入力扱いとする（elevation-staging 専用分岐は追加しない）
 
 ## Output
 
@@ -61,39 +66,45 @@ load_skills:
          ADR: {必要/不要} [信頼度: 高/低]
          要件構造化: {完了/未完了} [信頼度: 高/低]
          適用範囲: {確定/未確定} [信頼度: 高/低]
-         {draft存在時} ドラフト: {ファイル名}（Step 7 完了と判定）
+          {draft存在時} ドラフト: {ファイル名}（Step 9 完了と判定）
        ```
        **ユーザー訂正**: ユーザーが「違う」「やり直し」と応じた場合 → Step 1 から通常壁打ちを開始
        **ユーザー承認・黙示的同意**: ユーザーが内容に同意または先への指示をした場合 → 推論結果を採用
     
-    d) **ルーティング判定**（推論サマリー表示後、ユーザーの同意を確認した後に実行）:
-       - **全項目 高信頼度で推論済み（+ draft 存在）**:
-         - Pattern B → Step 9（要件doc確認）へスキップ（要件doc + draft は既に存在）
-         - Pattern A → Step 9（要件doc確認）へスキップ（要件doc はセッション内に存在）
-       - **全項目 高信頼度で推論済み（draft なし）**:
-         - Pattern B → Step 7（ドラフト保存）へスキップ
-         - Pattern A → Step 9（要件doc確認）へスキップ
+     d) **ルーティング判定**（推論サマリー表示後、ユーザーの同意を確認した後に実行）:
+        - **全項目 高信頼度で推論済み（+ draft 存在）**:
+          - Pattern B → Step 10（要件doc確認）へスキップ（要件doc + draft は既に存在）
+          - Pattern A → Step 10（要件doc確認）へスキップ（要件doc はセッション内に存在）
+        - **全項目 高信頼度で推論済み（draft なし）**:
+          - Pattern B → Step 9（ドラフト保存）へスキップ
+          - Pattern A → Step 10（要件doc確認）へスキップ
        - **一部項目が低信頼度または未推論**:
          - 推論済み項目（高信頼度）を継承し、不足項目のみを対象に Step 1（壁打ち）を開始
          - 壁打ちでは不足項目のみを深掘り（既に推論済みの項目は再確認しない）
        - **推論結果なし（セッションに要件情報が存在しない）**:
          - 通常の Step 1 から開始（既存動作と同じ）
 
-1. ユーザーとの壁打ち対話を開始 → `req-analysis` の壁打ちメソッドロジーに従って深掘り
-2. 既存REQ照合 → `req-file-manager` の照合方法論に従って実行（REQ-0002-009〜011）:
+ 1. 明示入力ファイルの読み込み（指定された場合）:
+    - ユーザーがファイルパスを指定した場合、Read tool で該当ファイルを読み込む
+    - Requirement Source 形式（背景・問題・望ましい変更・対象範囲・反映先候補・既存対策確認・制約・受け入れ条件を含む構造）を想定するが、任意のテキスト形式も受け入れる
+    - 読み込んだ内容を壁打ちの初期コンテキストとして扱う（source file の種類による分岐は行わない）
+    - 複数ファイルが指定された場合は全て読み込む
+ 2. ユーザーとの壁打ち対話を開始 → `req-analysis` の壁打ちメソッドロジーに従って深掘り
+    - 明示入力ファイルが読み込まれている場合、その内容を壁打ちの開始点として活用（ファイル内容から要件の構造化を先行して進める）
+ 3. 既存REQ照合 → `req-file-manager` の照合方法論に従って実行（REQ-0002-009〜011）:
    - `docs/requirements/REQ-*.md` をスキャンし、ユーザーの要件と既存REQの関連性を推論（タイトル・タグ・目的・要件内容の重み付けによる総合判定）
    - 関連REQがある場合: 該当REQの内容（目的・要件・適用範囲）を壁打ちコンテキストに即時反映し、ユーザーとともに変更点を深掘り
    - 操作分類を確定: `CREATE`（該当REQなし）、`APPEND`（既存REQへの要件行追加）、`UPDATE`（既存REQの内容修正）
    - 複数REQが該当する場合、それぞれに対する操作を個別に指定
    - 分類結果は `draft-meta` の `req-operation` と `target-req` に記録
-3. 要件を展開 → `req-analysis` の分析観点に従って網羅（照合で取得した関連REQの内容を反映）
-4. ADR閾値以上の技術判断が発生した場合 → `adr-guidelines` に従ってADR判断を記録（ADRファイルの作成は issue-save-req で実行）
-5. 要件doc形式で生成 → テンプレート: `.opencode/skills/req-file-manager/templates/doc_requirement.md` を Read tool で読み込み、目的/要件/適用範囲の構造に従って内容を構造化
+ 4. 要件を展開 → `req-analysis` の分析観点に従って網羅（照合で取得した関連REQの内容を反映）
+ 5. ADR閾値以上の技術判断が発生した場合 → `adr-guidelines` に従ってADR判断を記録（ADRファイルの作成は issue-save-req で実行）
+ 6. 要件doc形式で生成 → テンプレート: `.opencode/skills/req-file-manager/templates/doc_requirement.md` を Read tool で読み込み、目的/要件/適用範囲の構造に従って内容を構造化
    **テンプレート準拠要件**: テンプレートの【必須】セクション（目的、要件、適用範囲）が全て要件docに含まれること。必須セクションが欠落している場合、生成をやり直すこと。
-6. パターン判定:
+ 7. パターン判定:
     - ラベルに基づいて Pattern 判定: `bug`, `critical` → Pattern A, `enhancement`, `feature` → Pattern B, `refactor`, `maintenance` → Pattern C, `docs`, `chore` → Pattern D
     - **Pattern A + ADR必要時の Pattern B 昇格**: Pattern A で ADR閾値以上の技術判断が発生した場合、Pattern B に昇格する（REQファイル・ADRファイルの作成が必要となるため）
-7. スケール判断（Pattern B のみ実行）:
+ 8. スケール判断（Pattern B のみ実行）:
     - Pattern B であっても、`issue-lifecycle` の並列実行パターンにおけるスケール判断条件を用いて `standard` または `large` を判定:
       - **large**: 以下のいずれか1つ以上の条件を満たす場合
         - 複数モジュールにまたがる (e.g., UI + API + DB)
@@ -105,7 +116,7 @@ load_skills:
       - 分解計画を次の形式で整理: `decomposition: [{scope, modules, description}]`
       - スケール判断結果と分解計画をユーザーに提示し、分解方針の確認を求める
     - **standard と判定された場合**: 分解不要、そのまま単一Issueで進む方針を提示する（確認停止しない）
-8. ドラフト保存:
+ 9. ドラフト保存:
     - **パターンB（機能追加）**: `.sisyphus/drafts/req-draft-{topic-slug}.md` にドラフトを保存。ドラフトは doc_requirement.md テンプレート構造（目的/要件/適用範囲）に以下のメタデータセクションを追加:
       ```markdown
       ## draft-meta（issue-save-req 用）
@@ -122,10 +133,10 @@ load_skills:
       ```
     - **パターンA（バグ修正・軽微変更）**: ドラフト保存不要。セッション内で要件docを完結させる
     - **パターンC（リファクタリング・保守作業）/ パターンD（ドキュメント・雑務）**: ドラフト保存不要。セッション内で要件docを完結させる（Pattern Aと同等のlightweight workflow）
-9. 要件doc確認: 生成した要件doc（パターンB: ドラフト内容、パターンA/C/D: セッション内要件doc）をユーザーに提示する。明示的な承認は求めず、提示のみを行う
+10. 要件doc確認: 生成した要件doc（パターンB: ドラフト内容、パターンA/C/D: セッション内要件doc）をユーザーに提示する。明示的な承認は求めず、提示のみを行う
     - **差し戻し**: ユーザーが修正・差し戻しを指示した場合、壁打ちを継続（Step 1に戻る）
     - **要件doc確定**: ユーザーが次のコマンド（`/issue/issue-save-req` または `/issue/issue-create`）を実行したことを要件doc確定の意思表示として扱う
-10. 完了報告 → `issue-reporting` の完了報告フォーマットに従って出力（壁打ち結論ハイライトの表示を必ず含めること）:
+11. 完了報告 → `issue-completion-reporting` の完了報告フォーマットに従って出力（壁打ち結論ハイライトの表示を必ず含めること）:
     - パターンB: `次のステップ: /issue/issue-save-req`
     - パターンA/C/D: `次のステップ: /issue/issue-create`
 
@@ -133,7 +144,9 @@ load_skills:
 
 - バイブスフェーズのみ（実装コード禁止）
 - **ファイル編集スコープ**: `.sisyphus/drafts/**` のみ作成・編集を許可
-- **docs/ 配下のファイルは一切参照・書き込みしない**（例外: `docs/requirements/**` は Read-only 参照を許可。既存REQ照合のため Step 2 で使用）
+- **ユーザーが明示した入力ファイルは read-only で参照可能**（要件ソースとして扱うが、内容を変更・上書きしない）
+- **docs/ 配下の広範な探索は禁止**（例外: 明示入力ファイルと `docs/requirements/**` の read-only 参照は許可。既存REQ照合のため Step 3 で使用）
+- **inbox.md / archive.md を直接ロードしない**（raw tips は要件ソースとして扱わない。ただし昇華済みの staging stub や evaluation-report は明示入力ファイルとして read-only 参照を許可）
 - 関連ドキュメントの個別ファイル列挙をユーザーに求めない。責務は要件の壁打ち・構造化に専念する
 - **git コマンドは実行しない**
 - チェックボックスは測定可能で一意であること → `req-analysis` のチェックボックス品質基準


### PR DESCRIPTION
## 概要

issue-req の Input に「ユーザーが明示した入力ファイル」を追加し、要件ソースとして汎用的に扱えるようにする（ADR-0003 対応）。

## 実装内容

### Input セクション拡張
- ユーザーが明示した入力ファイル（要件ソース — Requirement Source）を入力タイプとして追加
- 対象ファイル: 要件化前の設計メモ、調査メモ、反映指示書、tips-elevate の staging stub、その他 source file
- source file の種類に依存しない汎用的な入力扱い（elevation-staging 専用分岐なし）

### Steps 更新
- Step 1 を新設: 明示入力ファイルの読み込み（指定された場合）
  - Read tool でファイルを読み込み、壁打ちの初期コンテキストとして扱う
  - Requirement Source 形式を想定するが任意のテキスト形式も受け入れる
  - 複数ファイル対応
- Step 2（壁打ち対話）に明示入力ファイルの活用を追記
- 既存 Step 1〜10 を Step 2〜11 に再採番
- Step 0 ルーティングの Step 番号参照を更新

### Guardrails 修正
- ユーザーが明示した入力ファイルは read-only で参照可能
- docs/ 配下の広範な探索は禁止（例外: 明示入力ファイルと docs/requirements/** の read-only 参照）
- inbox.md / archive.md を直接ロードしない（ただし昇華済み staging stub は明示入力として許可）

### 修正（ボーナス）
- `issue-reporting` → `issue-completion-reporting` に修正（REQ-0016-022 対応）

## 完了条件

- [x] issue-req の Input に「ユーザーが明示した入力ファイル」が追加されている
- [x] elevation-staging 専用分岐が存在しない
- [x] Guardrails に read-only 参照制限・docs変換禁止・inbox/archive直接ロード禁止が記載されている

## テスト結果

- issue-req.md の Input セクションに明示入力ファイルの記述があることを確認 ✅
- Guardrails セクションに 3 つの制約が明記されていることを確認 ✅
- elevation-staging 専用ロジック（staging特化の分岐）が存在しないことを確認 ✅
- Step 番号の参照整合性を確認（Step 0 ルーティング → Step 9/10） ✅

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 変更ファイル数 | 1 | - | ✅ |
| LSP diagnostics | N/A (markdown) | エラー0件 | ✅ |
| 対象外ファイル変更 | なし | 対象外変更なし | ✅ |

## REQ照合

| REQ ID | 内容 | 対応 |
|---|---|---|
| REQ-0016-015 | Input にユーザーが明示した入力ファイルを追加 | ✅ |
| REQ-0016-016 | elevation-staging 専用分岐追加禁止 | ✅ |
| REQ-0016-017 | Guardrails 修正 | ✅ |
| REQ-0016-022 | issue-reporting → issue-completion-reporting | ✅ |
| REQ-0007-042 | 明示入力ファイル read-only 要件ソース | ✅ |
| REQ-0007-043 | staging stub は Requirement Source 形式 | ✅ |
| REQ-0007-044 | inbox/archive 直接ロード禁止 | ✅ |
| REQ-0007-046 | load-tips 不作成 | ✅（該当作業なし） |

Closes #247
