### PR TITLE
refactor: remove finding open→consumed lifecycle (Issue #270)

### DIFF
--- a/.opencode/commands/issue/issue-req.md
+++ b/.opencode/commands/issue/issue-req.md
@@ -22,8 +22,9 @@ load_skills:
   - 要件化前の設計メモ、調査メモ、反映指示書
   - tips-elevate が生成した staging stub（Requirement Source 形式）
   - その他変更内容・背景・制約・完了条件を含む source file
-  - issue-save-req が SPLIT 検出時に作成した requirements review finding（`.sisyphus/drafts/requirements-review-finding-{topic-slug}.md`）
-  - source file の種類に依存しない汎用的な入力扱いとする（elevation-staging 専用分岐は追加しない）
+- issue-save-req が SPLIT 検出時に作成した requirements review finding（`.sisyphus/drafts/requirements-review-finding-{topic-slug}.md`）
+- finding ファイルを含め全てのユーザー明示入力ファイルは read-only の Requirement Source である（G04）。status や frontmatter の更新・上書きは行わない
+- source file の種類に依存しない汎用的な入力扱いとする（elevation-staging 専用分岐は追加しない）
 
 ## Output
 

--- a/.opencode/skills/issue-lifecycle/reference/requirements-review-finding-protocol.md
+++ b/.opencode/skills/issue-lifecycle/reference/requirements-review-finding-protocol.md
@@ -1,12 +1,14 @@
 # Requirements Review Finding プロトコル
 
-`issue-save-req` と `issue-req` 間の requirements review finding のライフサイクルとスキーマを定義する。finding は要件レビューで検出された問題（SPLIT・重複・廃止・乖離等）を構造的に記録し、`issue-req` の明示入力ファイルとして次工程に渡すための中間アーティファクトである。
+`issue-save-req` と `issue-req` 間の requirements review finding のスキーマと扱いを定義する。finding は要件レビューで検出された問題（SPLIT・重複・廃止・乖離等）を構造的に記録し、`issue-req` の明示入力ファイルとして次工程に渡すための中間アーティファクトである。
+
+finding は state管理対象ではなく、issue-req の入力として read-only で参照される Requirement Source である。作成以降の status 更新や state遷移は行わない。
 
 ## Finding の保存先
 
 - `.sisyphus/drafts/requirements-review-finding-{topic-slug}.md`
 - `docs/requirements/` には保存しない
-- backlog-draft-protocol とは独立したライフサイクル（別の来源・別の経路・別のステータス値）
+- backlog-draft-protocol とは独立した中間アーティファクト（state管理なし・read-only参照）
 
 ## Finding の frontmatter
 
@@ -17,7 +19,6 @@ source_req: REQ-{NNNN} | null
 source_command: issue-save-req
 topic_slug: {topic-slug}
 created: "{YYYY-MM-DD}"
-status: open | consumed
 ---
 ```
 
@@ -30,7 +31,6 @@ status: open | consumed
 | `source_command` | string | finding を作成したコマンド名 |
 | `topic_slug` | string | finding の主題を示すスラグ（ファイル名と一致） |
 | `created` | date | 作成日（YYYY-MM-DD） |
-| `status` | enum | `open`（未処理）/ `consumed`（処理済み） |
 
 ## Finding の本文構造
 
@@ -62,24 +62,12 @@ status: open | consumed
 | `OBSOLETE` | 要件が既に古く現在のシステムに適合しない | requirements review 時 |
 | `DRIFT` | 要件と実装の間に乖離が生じている | requirements review 時 |
 
-## Finding ライフサイクル
-
-```
-open → consumed
-```
-
-| 状態 | 遷移トリガー | 説明 |
-|------|-------------|------|
-| `open` | `issue-save-req` SPLIT検出時の作成 | 初期状態。処理待ち |
-| `consumed` | `issue-req` が finding を入力として処理完了時 | finding が正式な要件変更に変換された状態 |
-
 ## 次工程
 
 Finding は `issue-req` の明示入力ファイルとして渡される（ADR-0003 パターン）。
 
 1. `issue-req` が finding ファイルを読み込む（明示入力ファイルとしての読み込み）
 2. `issue-req` が finding の内容を解析し、正式な要件変更（CREATE / APPEND / UPDATE）に変換する
-3. 変換後、finding の `status` を `consumed` に更新する
 
 ## コマンド間の責務分離
 
@@ -88,18 +76,17 @@ Finding は `issue-req` の明示入力ファイルとして渡される（ADR-0
 | Finding 作成 | `issue-save-req` | SPLIT検出時に finding ファイルを作成 |
 | Finding 消費 | `issue-req` | 明示入力ファイルとして読み込み、要件変更に変換 |
 | Finding 保存 | `issue-save-req` | `.sisyphus/drafts/` に保存 |
-| Finding status 更新 | `issue-req` | 処理完了時に `consumed` に更新 |
 
 ## backlog-draft-protocol との分離
 
-Finding は backlog-draft-protocol とは独立したライフサイクルで管理する。
+Finding は backlog-draft-protocol とは独立した中間アーティファクトである。state管理（ライフサイクル）は行わない。
 
 | 項目 | backlog-draft | finding |
 |------|---------------|---------|
 | 経路 | `issue-backlog` → `issue-backlog-create` | `issue-save-req` → `issue-req` |
-| ステータス値 | `draft` / `approved` / `issued` | `open` / `consumed` |
+| ステータス値 | `draft` / `approved` / `issued` | なし（state管理外） |
 | frontmatter 構造 | period / sources 等を含む | finding_type / source_req 等を含む |
-| ライフサイクルトリガー | クローズ済みissue/PRからの残課題抽出 | SPLIT検出・要件レビュー時の問題検出 |
+| 作成トリガー | クローズ済みissue/PRからの残課題抽出 | SPLIT検出・要件レビュー時の問題検出 |
 | 保存先 | `.sisyphus/drafts/` | `.sisyphus/drafts/`（同一場所・別管理） |
 
 ## 参照

--- a/docs/requirements/REQ-0004.md
+++ b/docs/requirements/REQ-0004.md
@@ -38,11 +38,11 @@ tags: [requirements, adr, documents, lifecycle, area-based, finding-protocol]
 | REQ-0004-022 | REQ-0004 操作モデルと req-file-manager 操作モードを整合させるものとする（SHALL） |
 | REQ-0004-023 | requirements review finding protocol は issue-lifecycle reference として定義する（SHALL） |
 | REQ-0004-024 | finding の保存先は .sisyphus/drafts/ とし、docs/requirements/ には保存しない（SHALL） |
-| REQ-0004-025 | finding は backlog-draft-protocol に統合せず、独立したライフサイクルで管理する（SHALL） |
+| REQ-0004-025 | finding は backlog-draft-protocol に統合せず、独立した中間アーティファクトとして扱う（state管理・ライフサイクルは行わない）（SHALL） |
 | REQ-0004-026 | finding は issue-req の明示入力ファイルとして渡し、正式な要件変更へ変換する（SHALL） |
 | REQ-0004-027 | finding 種別は SPLIT / MOVE / RETIRE / DUPLICATE / OBSOLETE / DRIFT とする（SHALL） |
 
 ## 適用範囲
 
-- **対象**: REQファイルの構造・操作モデル・採番規則、area-based current document構造、area file frontmatter規約、INDEX.md生成方針、ADRの作成基準、REQ/ADRの整合性管理、README インデックス管理、requirements review finding protocol（形式・保存先・ライフサイクル・種別定義・次工程）
+- **対象**: REQファイルの構造・操作モデル・採番規則、area-based current document構造、area file frontmatter規約、INDEX.md生成方針、ADRの作成基準、REQ/ADRの整合性管理、README インデックス管理、requirements review finding protocol（形式・保存先・種別定義・次工程）
 - **対象外**: 要件分析手法（req-analysisスキルの管轄）、仕様適合性検出（spec-complianceスキルの管轄）、docs/specs/ の内容管理、既存REQ-{NNNN}.mdファイルの一括移行


### PR DESCRIPTION
## 概要

`requirements-review-finding-protocol.md` の `open → consumed` ライフサイクル定義が `issue-req` の Guardrails G04（read-only 入力ファイル）と矛盾していた問題を解消。

Closes #270

## 変更内容

### `requirements-review-finding-protocol.md`（主要変更）

- **FR-001**: frontmatter から `status: open | consumed` フィールドを削除
- **FR-002**: `open → consumed` ライフサイクルセクション全体を削除
- **FR-003**: 次工程セクションから status 更新 step（step 3）を削除
- **FR-004**: 責務テーブルから「Finding status 更新 | issue-req」行を削除
- **FR-005**: backlog-draft 比較テーブルの status 列を「なし（state管理外）」に更新、ライフサイクル関連記述を修正
- **FR-006**: finding が state管理対象ではなく read-only の Requirement Source である旨を明記

### `issue-req.md`（minor）

- **FR-007**: Input セクションに finding の read-only 注記を追加

### `REQ-0004.md`（wording）

- **FR-008**: REQ-0004-025 を「独立した中間アーティファクト（state管理・ライフサイクルは行わない）」に更新

### 変更不要（確認済み）

- `issue-save-req.md`: status 更新の参照なし、コンプライアント済み
- `command-map.md`: 既に READ-only 表示

## テスト結果

grep 検証により以下を確認:
- finding protocol に `open → consumed` / `status: open` / `consumed に更新` パターンなし
- `issue-req.md` に read-only 注記存在
- REQ-0004-025 に「中間アーティファクト」含む

## 関連

- ADR-0003（issue-req入力の抽象化）
- REQ-0004-023〜027（finding protocol 要件）
