### PR TITLE
feat(#285): AgentDevFlow plugin identity と canonical namespace を定義

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,11 @@
+## AgentDevFlow Canonical Namespace
+
+- Plugin 表示名: `AgentDevFlow`
+- Canonical namespace: `agentdev`
+- Public command prefix: `/agentdev/*`
+- Domain state directory: `.agentdev/`
+- 詳細: ADR-0005, REQ-0017
+
 ## 開発環境
 
 - OS: Windows

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # opencode-config
 
-OpenCodeの設定を管理するリポジトリです。Issue駆動開発ワークフローを支えるコマンド・スキル・ドキュメントを一元管理しています。
+AgentDevFlow plugin の設定を管理するリポジトリです。AI agent-assisted development workflow を支えるコマンド・スキル・ドキュメントを一元管理しています。
+
+## AgentDevFlow Plugin
+
+| 項目 | 値 |
+|------|------|
+| Plugin 表示名 | `AgentDevFlow` |
+| Canonical namespace | `agentdev` |
+| Public command prefix | `/agentdev/*` |
+| Domain state directory | `.agentdev/` |
+| Skill prefix | `agentdev-*` |
+| Domains | req, case, learning, intake, integrity |
+
+詳細は [ADR-0005](docs/adr/ADR-0005.md) および [REQ-0017](docs/requirements/REQ-0017.md) を参照。
 
 ## クイックスタート
 

--- a/docs/adr/ADR-0005.md
+++ b/docs/adr/ADR-0005.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0005
 title: "AgentDevFlow を配布 plugin 名として採用し、公開 command namespace を /agentdev/*、domain state を .agentdev/、skill prefix を agentdev-* に統一する"
-status: proposed
+status: accepted
 created: "2026-05-21"
 updated: "2026-05-21"
 ---

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,4 +10,4 @@
 | ADR-0002 | Orchestration skill作成基準の導入 | proposed | 2026-05-18 |
 | ADR-0003 | issue-req入力の抽象化 | proposed | 2026-05-18 |
 | ADR-0004 | 要件管理構造の area-based 移行方針 | proposed | 2026-05-19 |
-| ADR-0005 | AgentDevFlow plugin namespace 統一 | proposed | 2026-05-21 |
+| ADR-0005 | AgentDevFlow plugin namespace 統一 | accepted | 2026-05-21 |


### PR DESCRIPTION
## 概要

Issue #285 の実装。AgentDevFlow plugin の表示名と canonical namespace を定義し、README / ADR に反映する。

## 変更内容

- [x] Plugin表示名 `AgentDevFlow` の定義（README.md に identity セクション追加）
- [x] Canonical namespace `agentdev` の定義（README.md / AGENTS.md に宣言追加）
- [x] ADR-0005 status → accepted に変更
- [x] ADR README の ADR-0005 status 列を accepted に更新
- [x] REQ-0001, REQ-0002 は既に AgentDevFlow terminology 参照済み（変更不要）

## テスト

- docs 内 grep で `AgentFlow`（AgentDevFlow 以外）や `AgenticFlow` の非 canonical 使用が存在しないことを確認
- README / AGENTS.md に `AgentDevFlow` と `agentdev` の対応が明記されていることを確認

Refs: #285
