### PR TITLE
feat(#290): .agentdev/ domain state directory を作成

### DIFF
--- a/.agentdev/README.md
+++ b/.agentdev/README.md
@@ -1,0 +1,47 @@
+# .agentdev/ — AgentDevFlow Domain State Directory
+
+AgentDevFlow plugin の canonical domain state を格納するディレクトリ。
+
+## 目的
+
+AgentDevFlow の永続化すべき domain artifact（intake items、learning data、integrity reports 等）を格納する。各サブディレクトリの構成は、実装を担当する子issueで定義される（REQ-0017-009）。
+
+## .sisyphus/ との責任分離
+
+| ディレクトリ | 役割 | 内容 |
+|---|---|---|
+| `.sisyphus/` | Sisyphus runtime workspace | 実行計画 (plans)、証跡 (evidence)、タスク (tasks)、実行状態 (execution)、下書き (drafts)、レポート (reports)、アーカイブ (archives) |
+| `.agentdev/` | AgentDevFlow domain state | intake items、learning pipeline data、integrity reports 等の canonical domain artifact |
+
+### 原則
+
+- `.sisyphus/` は Sisyphus runtime が管理する一時的な作業領域
+- `.agentdev/` は AgentDevFlow の domain として永続化すべき状態
+- 両者は明確に分離され、互いに依存しない
+
+### 例外: .sisyphus/drafts/req-draft-*.md (REQ-0017-046)
+
+`/agentdev/req-define` が生成する draft は、Prometheus runtime constraint により `.sisyphus/drafts/` に保存される。これらの working draft は **AgentDevFlow の canonical domain state ではない**。
+
+- `.sisyphus/drafts/req-draft-*.md` = Prometheus working draft（canonical domain state ではない）
+- `/agentdev/req-save` の出力（REQ / ADR / requirements index）= AgentDevFlow domain artifact（canonical）
+- 既存の `.sisyphus/drafts/req-draft-*.md` を `.agentdev/` 配下へ移行する要件はない
+
+## サブディレクトリ構成
+
+初期状態では `.agentdev/` 直下にファイルを配置しない。各サブディレクトリは対応する子issueで作成される:
+
+| サブディレクトリ | 対象 Issue | 内容 |
+|---|---|---|
+| `intake/` | #286 | intake items |
+| `learning/` | #288 | learning pipeline data |
+| `integrity/` | #291 | integrity reports |
+
+## 参照
+
+- REQ-0017: AgentDevFlow plugin namespace 統一と learning / intake / integrity の正式化
+- REQ-0017-007: `.agentdev/` SHALL be the domain state directory
+- REQ-0017-008: `.sisyphus/` = runtime workspace, `.agentdev/` = domain state
+- REQ-0017-009: Sub-directory structure defined by child issues
+- REQ-0017-046: `.sisyphus/drafts/req-draft-*.md` exception
+- ADR-0005: AgentDevFlow plugin namespace 採用

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,23 @@
 - Domain state directory: `.agentdev/`
 - 詳細: ADR-0005, REQ-0017
 
+## ディレクトリ責任分離（REQ-0017-008）
+
+### .sisyphus/ — Sisyphus Runtime Workspace
+
+Sisyphus が管理する実行時の一時作業領域。plan、evidence、tasks、execution state、drafts、reports、archives を格納する。
+
+- plans, drafts, evidence, execution, notepads, tasks, reports, archives
+- **例外**: `.sisyphus/drafts/req-draft-*.md` は Prometheus runtime working draft であり、AgentDevFlow の canonical domain state ではない（REQ-0017-046）
+
+### .agentdev/ — AgentDevFlow Domain State
+
+AgentDevFlow の canonical domain artifact を格納する永続領域。intake items、learning pipeline data、integrity reports 等の domain state を保持する。
+
+- intake items, learning data, integrity reports
+- サブディレクトリ構成は各子issueで定義（REQ-0017-009）
+- `.sisyphus/drafts/req-draft-*.md` を `.agentdev/` に移行する要件はない（REQ-0017-046）
+
 ## 開発環境
 
 - OS: Windows


### PR DESCRIPTION
## 概要

AgentDevFlow domain state の canonical directory `.agentdev/` を作成し、Sisyphus runtime workspace `.sisyphus/` との責任分離を明確化する。

Refs: #290
Parent: #284

## 変更内容

- **`.agentdev/.gitkeep`**: ディレクトリを git でトラッキングするための空ファイル
- **`.agentdev/README.md`**: `.agentdev/` の目的と `.sisyphus/` との責任分離を説明
- **`AGENTS.md`**: ディレクトリ責任分離セクションを追加（REQ-0017-008）

## 対応要件

| 要件 ID | 内容 | ステータス |
|---------|------|-----------|
| REQ-0017-007 | `.agentdev/` SHALL be the domain state directory | ✅ |
| REQ-0017-008 | `.sisyphus/` = runtime workspace, `.agentdev/` = domain state | ✅ |
| REQ-0017-009 | Sub-directory structure defined by child issues | ✅ |
| REQ-0017-046 | `.sisyphus/drafts/req-draft-*.md` exception | ✅ |

## 範囲外（他 issue で対応）

- サブディレクトリ（`intake/`, `learning/`, `integrity/`）の作成 → #286, #288, #291
- `docs/specs/system.md` / `docs/specs/patterns.md` の更新 → parent #284
- コマンドファイルの変更 → 各コマンド移行 issue

## テスト戦略

- [x] `.agentdev/` directory が作成されている
- [x] `.sisyphus/` と `.agentdev/` の責任分離がドキュメント化されている（AGENTS.md + .agentdev/README.md）
- [x] REQ-0017-046 の例外要件（`.sisyphus/drafts/` の取り扱い）が反映されている
- [x] REQ-0017-007, 0017-008, 0017-009, 0017-046 の要件を満たしている
