### PR TITLE
feat(#286): intake capture/review/promote コマンドを新設

### DIFF
--- a/.opencode/commands/agentdev/intake-capture.md
+++ b/.opencode/commands/agentdev/intake-capture.md
@@ -1,0 +1,92 @@
+---
+description: 未分類の変更候補を手動入力から intake item として保存する
+agent: sisyphus
+load_skills:
+  - issue-lifecycle
+  - issue-completion-reporting
+---
+
+# Intake Capture（手動入力）
+
+ユーザーの手動入力から intake item を作成し、`.agentdev/intake/inbox/` に保存する。
+
+**このコマンドは保存専用である。** GitHub Issue の作成・採用可否の判断は行わない（REQ-0017-024）。
+
+## Input
+
+- ユーザーの自然言語による変更候補の記述
+- 任意で観測元・影響・判断保留事項の指定
+
+## Output
+
+- `.agentdev/intake/inbox/YYYY-MM-DD-{topic-slug}.md` に保存された intake item
+
+## Intake Item 形式
+
+intake item は以下の Markdown artifact とする（REQ-0017-032）。workflow 管理用の frontmatter・状態フィールド・重複排除キーは持たない（REQ-0017-033, REQ-0017-035, REQ-0017-039）。
+
+```markdown
+# {タイトル}
+
+## 観測
+{何が観測されたか}
+
+## 今回扱わない理由
+{なぜ今すぐ対応しないのか}
+
+## 影響
+{影響の評価}
+
+## レビューで決めること
+{レビューで判断すべき点}
+
+## 根拠（任意）
+{補足情報・証拠}
+```
+
+**セクションに関する制約**:
+- 各セクションの見出し名は固定しない。ユーザーの入力に合わせて適切に整理する
+- 必須セクション・省略不可セクションを設けない（REQ-0017-037）
+- frontmatter・状態値・メタデータフィールドを必須にしない（REQ-0017-038, REQ-0017-039）
+
+## Steps
+
+1. **入力の受領**: ユーザーから変更候補の内容を受け取る。自然言語で記述された内容をそのまま取り扱う。
+
+2. **intake item の生成**: ユーザーの入力を上記 intake item 形式に整理する。ユーザーが明示的に指定していないセクションは、入力内容から推測して記載する。推測不能な場合は空セクションとして残す。
+
+3. **ファイル名の生成**:
+   - 日付: 実行時のシステム日付（`YYYY-MM-DD`）
+   - topic-slug: タイトルから生成（小文字英数字・ハイフン区切り、30文字以内）
+   - 形式: `YYYY-MM-DD-{topic-slug}.md`
+
+4. **保存**:
+   - 保存先: `.agentdev/intake/inbox/`
+   - ディレクトリが存在しない場合は作成する
+   - 同名ファイルが存在する場合は `{topic-slug}-2`, `{topic-slug}-3` のように連番を付与する
+
+5. **完了報告** → `issue-completion-reporting` の完了報告フォーマットに従って出力:
+   ```
+   ✅ intake item を保存しました。
+     タイトル: {タイトル}
+     ファイル: .agentdev/intake/inbox/YYYY-MM-DD-{topic-slug}.md
+     次のステップ: /agentdev/intake-review
+   ```
+
+## Guardrails
+
+### 責務境界（REQ-0017-024）
+- G01: GitHub Issue の作成を行わない（`intake-open` が担当）
+- G02: 採用可否の判断を行わない（`intake-review` が担当）
+- G03: intake item の変更・更新を行わない（保存のみ）
+- G04: review・整形・分類を行わない（後続コマンドの責務）
+
+### 形式制約（REQ-0017-032〜039）
+- G05: workflow 管理 artifact として扱わない（REQ-0017-033）
+- G06: frontmatter・状態値・重複排除キー・後続 artifact 参照を必須にしない（REQ-0017-035, REQ-0017-039）
+- G07: 特定セクションを必須セクションとして扱わない（REQ-0017-037）
+- G08: review 結果を item に書き込まない（REQ-0017-038）
+
+### 実行制約
+- G09: ユーザーの入力内容を過度に解釈・変形しない（元の意図を保ったまま整理する）
+- G10: 保存先は `.agentdev/intake/inbox/` のみ（他ディレクトリへの保存は禁止）

--- a/.opencode/commands/agentdev/intake-from-github.md
+++ b/.opencode/commands/agentdev/intake-from-github.md
@@ -1,0 +1,125 @@
+---
+description: クローズ済み GitHub Issue/PR から未回収の変更候補を intake item として保存する
+agent: sisyphus
+load_skills:
+  - issue-lifecycle
+  - issue-completion-reporting
+  - gh-cli-best-practices
+---
+
+# Intake from GitHub
+
+クローズ済みの GitHub Issue / PR の本文・コメントから未回収の変更候補を抽出し、intake item として `.agentdev/intake/inbox/` に保存する。
+
+旧 `issue-backlog` の抽出機能を intake workflow に再定義したコマンド（REQ-0017-018）。
+
+**このコマンドは保存専用である。** GitHub Issue の作成・採用可否の判断は行わない（REQ-0017-024）。
+
+## Input
+
+- ユーザーの自然言語による期間指定（「直近1週間」「今月」「2026-05-02から」等）
+- または特定の Issue/PR 番号の指定
+
+## Output
+
+- `.agentdev/intake/inbox/YYYY-MM-DD-{topic-slug}.md` に保存された intake item（候補ごとに1ファイル）
+- 抽出サマリーレポート（ユーザー確認用）
+
+## Intake Item 形式
+
+`intake-capture` と同一形式（REQ-0017-032）。frontmatter・状態フィールド・重複排除キーは持たない。
+
+```markdown
+# {タイトル}
+
+## 観測
+{何が観測されたか}
+
+## 今回扱わない理由
+{なぜ今すぐ対応しないのか}
+
+## 影響
+{影響の評価}
+
+## レビューで決めること
+{レビューで判断すべき点}
+
+## 根拠（任意）
+{元 Issue/PR 番号、元テキストのコンテキスト等}
+```
+
+## Steps
+
+1. **期間解釈**: ユーザーの自然言語による期間指定を解釈し、GitHub CLI の検索クエリ用日付範囲（`since` / `until`）に変換する。現在日付は実行時のシステム日付を使用する。
+
+2. **データ取得**: `gh` CLI を使用して、指定期間内にクローズされた Issue と PR を取得する:
+   - Issues: `gh issue list --state closed --search "closed:>=YYYY-MM-DD" --limit 100 --json number,title,body,state,closedAt,labels,comments`
+   - PRs: `gh pr list --state closed --search "closed:>=YYYY-MM-DD" --limit 100 --json number,title,body,state,closedAt,labels,comments`
+   - `gh-cli-best-practices` に従ってコマンドを実行する（読み取り操作は READ 操作手順に従う）
+   - コメントも取得: `gh issue view {N} --json comments` / `gh pr view {N} --json comments`
+
+2a. **既抽出スキップ**: 取得した各 Issue/PR のコメントにマーカーキーワード `backlog-extracted` が含まれているか確認する:
+   - 含まれている → 当該 Issue/PR を抽出対象からスキップする
+   - 含まれていない → 抽出対象として次 Step へ進む
+
+3. **構造的検出**: 取得した Issue/PR の本文およびコメントから、未チェックのチェックボックス（`- [ ]` または `* [ ]`）を構造的に抽出する。チェック済み（`- [x]`）は除外。
+
+4. **LLM 全文解析**: 構造的検出で捕捉できなかった残課題を LLM による全文解析で抽出する:
+   - 対象キーワード: 「対象外」「先送り」「別途対応」「後で」「TODO」「FIXME」「今後の課題」「残課題」「要検討」等
+   - 暗黙的な残課題（否定表現等）も検出
+   - 各抽出結果に元テキストのコンテキスト（前後文）を付与
+
+5. **intake item 生成**: 抽出した各候補を intake item 形式に整理する:
+   - 1 候補につき 1 ファイル
+   - ファイル名: `YYYY-MM-DD-{topic-slug}.md`
+   - 観測元（Issue/PR 番号）は「根拠」セクションに記載
+   - 元テキストのコンテキストも「根拠」セクションに含める
+
+6. **保存**:
+   - 保存先: `.agentdev/intake/inbox/`
+   - ディレクトリが存在しない場合は作成する
+   - 同名ファイルが存在する場合は連番を付与する
+
+7. **サマリーレポート提示**: 抽出結果をサマリーとしてユーザーに提示する:
+   ```
+   ## Intake from GitHub 抽出サマリー
+
+   - 対象期間: {since} 〜 {until}
+   - 対象 Issue/PR 数: {N}
+   - 抽出候補数: {M}
+   - 保存先: .agentdev/intake/inbox/
+
+   | # | タイトル | 元 Issue/PR | ファイル |
+   |---|----------|-------------|----------|
+   | 1 | ... | #XX | YYYY-MM-DD-xxx.md |
+   ```
+
+8. **完了報告** → `issue-completion-reporting` の完了報告フォーマットに従って出力:
+   ```
+   ✅ intake item の抽出・保存が完了しました。
+     対象期間: {since} 〜 {until}
+     抽出件数: {N}件
+     保存先: .agentdev/intake/inbox/
+     次のステップ: /agentdev/intake-review
+   ```
+
+## Guardrails
+
+### 責務境界（REQ-0017-024）
+- G01: GitHub Issue の作成を行わない（`intake-open` が担当）
+- G02: 採用可否の判断を行わない（`intake-review` が担当）
+- G03: review・整形・分類の判断を行わない（後続コマンドの責務）
+- G04: Issue/PR へのコメント投稿・マーカー付与は行わない（`intake-open` が担当）
+
+### 形式制約（REQ-0017-032〜039）
+- G05: workflow 管理 artifact として扱わない（REQ-0017-033）
+- G06: frontmatter・状態値・重複排除キー・後続 artifact 参照を必須にしない（REQ-0017-035, REQ-0017-039）
+- G07: 特定セクションを必須セクションとして扱わない（REQ-0017-037）
+- G08: review 結果を item に書き込まない（REQ-0017-038）
+
+### 実行制約
+- G09: データ取得は `gh` CLI のみ使用（GitHub API 直接呼び出し不可）
+- G10: 対象はクローズ済み Issue/PR のみ（オープン中は対象外）
+- G11: `gh-cli-best-practices` に従って読み取り操作を実行する
+- G12: 保存先は `.agentdev/intake/inbox/` のみ
+- G13: サブエージェントの最終出力は verbatim で出力する（再フォーマット禁止）

--- a/.opencode/commands/agentdev/intake-promote.md
+++ b/.opencode/commands/agentdev/intake-promote.md
@@ -1,0 +1,99 @@
+---
+description: レビュー済み intake item を後続コマンド（req-define / intake-open）に渡せる入力 artifact に整形する
+agent: sisyphus
+load_skills:
+  - issue-lifecycle
+  - issue-completion-reporting
+---
+
+# Intake Promote
+
+`.agentdev/intake/accepted/` 内のレビュー済み intake item を、`req-define` または `intake-open` に渡せる入力 artifact に整形する。
+
+**このコマンドは整形のみを行う。** GitHub Issue の作成は行わない（REQ-0017-026）。
+
+## Input
+
+- レビュー済み intake item 群（`.agentdev/intake/accepted/` 内の Markdown ファイル）
+- ユーザーによる整形指示・追加コンテキスト（対話的に）
+
+## Output
+
+- 整形済み入力 artifact（`req-define` 用 または `intake-open` 用）
+- 整形済み item は `.agentdev/intake/promoted/` に保存
+
+## 整形の方向性
+
+レビュー済み item の後続ルートに応じて整形内容が異なる（REQ-0017-027）:
+
+| 後続ルート | 条件 | 整形内容 |
+|------------|------|----------|
+| `req-define` | 要件定義が必要な item | req-define への入力に適した形式に整理 |
+| `intake-open` | Issue 化可能な item | intake-open への入力 artifact 形式に整形 |
+
+## Steps
+
+1. **accepted の確認**: `.agentdev/intake/accepted/` 内の intake item を一覧表示する:
+   - ファイル一覧の取得
+   - item 数のカウント
+   - accepted が空の場合はその旨を報告して終了
+
+2. **item の読み込み**: 各 intake item を読み込み、内容と review 時の判定を把握する。
+
+3. **後続ルートの確認**: 各 item について、ユーザーに後続ルートを確認する:
+   - `req-define` ルート: 要件定義が必要（新規機能・仕様変更等）
+   - `intake-open` ルート: Issue 化可能（バグ修正・小規模改善等）
+   - 複数 item を束ねて1つの artifact にすることも可能（ユーザーの指示による）
+
+4. **整形**: 後続ルートに応じて item を整形する:
+
+   **req-define 用**:
+   - 観測内容・影響・課題を整理
+   - req-define で壁打ちしやすい形式に構造化
+   - 既存要件との関連・差分を明記
+
+   **intake-open 用**:
+   - Issue 本文として使用可能な形式に整形
+   - タイトル・概要・対象範囲・完了条件を整理
+   - 複数 item を束ねる場合は Epic + 子 Issue 構成を提示
+   - intake-open がそのまま入力として使用できる形式（REQ-0017-026a）
+
+5. **ユーザー確認**: 整形結果を提示し、ユーザーの確認を得る:
+   - 内容の修正指示
+   - ルートの変更指示
+   - 束ね方の調整
+
+6. **保存**:
+   - 保存先: `.agentdev/intake/promoted/`
+   - ディレクトリが存在しない場合は作成する
+   - ファイル名: `YYYY-MM-DD-{topic-slug}.md`（元 item 名を維持、または束ねた内容に応じた名前）
+
+7. **完了報告** → `issue-completion-reporting` の完了報告フォーマットに従って出力:
+   ```
+   ✅ intake item の整形が完了しました。
+     整形対象: {N}件
+     req-define 用: {R}件
+     intake-open 用: {P}件
+     保存先: .agentdev/intake/promoted/
+     次のステップ:
+       - /agentdev/req-define（要件定義が必要な場合）
+       - /agentdev/intake-open（Issue 化する場合）
+   ```
+
+## Guardrails
+
+### 責務境界（REQ-0017-026）
+- G01: GitHub Issue の作成を行わない（`intake-open` が担当）
+- G02: intake item の元の内容を改変しない（整理・構造化のみ）
+- G03: `req-define` や `intake-open` を自動起動しない（次ステップの提示のみ）
+
+### 形式制約（REQ-0017-032〜039）
+- G04: workflow 管理 artifact として扱わない（REQ-0017-033）
+- G05: 整形結果に frontmatter・状態値を必須にしない（REQ-0017-035）
+- G06: 整形結果に重複排除キー・後続 artifact 参照を含めない（REQ-0017-039）
+- G07: 元 item の本文に整形結果を書き込まない（REQ-0017-038）
+
+### 実行制約
+- G08: 整形はユーザーとの対話を通じて行う
+- G09: 保存先は `.agentdev/intake/promoted/` のみ
+- G10: 整形後の item を accepted ディレクトリから移動・削除しない（intake-open 側で管理）

--- a/.opencode/commands/agentdev/intake-review.md
+++ b/.opencode/commands/agentdev/intake-review.md
@@ -1,0 +1,104 @@
+---
+description: inbox 内の intake item をレビューし、採用・却下・保留の判定を行う
+agent: sisyphus
+load_skills:
+  - issue-lifecycle
+  - issue-completion-reporting
+---
+
+# Intake Review
+
+`.agentdev/intake/inbox/` 内の intake item をレビューし、各 item について採用可否の判断を行う。
+
+**このコマンドは review・採用可否判断のみを行う。** GitHub Issue の作成・item の変更・後続コマンドの起動は行わない（REQ-0017-025）。
+
+## Input
+
+- レビュー対象の intake item 群（`.agentdev/intake/inbox/` 内の Markdown ファイル）
+- ユーザーによる追加コンテキスト・修正指示（対話的に）
+
+## Output
+
+- レビュー結果レポート（ユーザー確認用）
+- レビュー結果に基づく item の分類（採用 / 却下 / 保留）
+
+## 判定値
+
+intake-review の判定値は以下の 3 値とする（REQ-0017-028）:
+
+| 判定 | 意味 | 後続 |
+|------|------|------|
+| `採用` | 対応すべきと判断。req-define または intake-promote に進む | `/agentdev/req-define` または `/agentdev/intake-promote` |
+| `保留` | 判断を保留。再度 review 対象として inbox に残す | 再度 `/agentdev/intake-review` |
+| `却下` | 対応不要と判断 | アーカイブ |
+
+## Steps
+
+1. **inbox の確認**: `.agentdev/intake/inbox/` 内の intake item を一覧表示する:
+   - ファイル一覧の取得
+   - item 数のカウント
+   - inbox が空の場合はその旨を報告して終了
+
+2. **item の読み込み**: 各 intake item を読み込み、内容を把握する。
+
+3. **レビュー・評価**: 各 item について以下の観点で評価する:
+   - 観測内容の妥当性・重要性
+   - 影響の程度
+   - 対応の緊急度・優先度
+   - 既存要件・仕様との関連
+   - 対応方針の方向性（要件定義が必要か、既に Issue 化可能か）
+
+4. **ユーザーとの対話的レビュー**: 評価結果を提示し、ユーザーと対話しながら判定を確定する:
+   - 各 item の評価を提示
+   - ユーザーの追加コンテキストを受け付ける
+   - 判定の修正指示を受け付ける
+   - 全 item の判定が確定するまで対話を継続
+
+5. **レビュー結果の整理**: 確定した判定を整理し、結果レポートを生成する:
+   ```markdown
+   ## Intake Review 結果
+
+   | # | タイトル | 判定 | 後続 | 備考 |
+   |---|----------|------|------|------|
+   | 1 | ... | 採用 | req-define | ... |
+   | 2 | ... | 採用 | intake-promote | ... |
+   | 3 | ... | 保留 | - | ... |
+   | 4 | ... | 却下 | - | ... |
+   ```
+
+6. **item の振り分け**: 判定に基づいて item を振り分ける:
+   - `採用` → `.agentdev/intake/accepted/` に移動
+   - `保留` → `.agentdev/intake/inbox/` に残す（移動しない）
+   - `却下` → `.agentdev/intake/rejected/` に移動
+
+7. **完了報告** → `issue-completion-reporting` の完了報告フォーマットに従って出力:
+   ```
+   ✅ intake review が完了しました。
+     レビュー対象: {N}件
+     採用: {A}件（req-define: {R}件, intake-promote: {P}件）
+     保留: {H}件
+     却下: {D}件
+     次のステップ:
+       - 採用（要件定義が必要）: /agentdev/req-define
+       - 採用（Issue 化可能）: /agentdev/intake-promote
+   ```
+
+## Guardrails
+
+### 責務境界（REQ-0017-025）
+- G01: GitHub Issue の作成を行わない（`intake-open` が担当）
+- G02: 直接 `case-run` を起動しない（REQ-0017-025）
+- G03: item の内容を変更・更新しない（判定に基づく振り分けのみ）
+- G04: `intake-promote` や `req-define` を自動起動しない（次ステップの提示のみ）
+
+### 形式制約（REQ-0017-032〜039）
+- G05: workflow 管理 artifact として扱わない（REQ-0017-033）
+- G06: review 結果を item の本文に書き込まない（REQ-0017-038）
+- G07: 状態遷移を item 内に記録しない（ディレクトリ移動のみで表現）
+- G08: 後続 artifact への参照を item に追記しない（REQ-0017-039）
+
+### 実行制約
+- G09: レビューはユーザーとの対話を通じて行う（AI のみでの自動判定はしない）
+- G10: 判定は item ごとに個別に行う（一括判定はユーザーが明示的に指示した場合のみ）
+- G11: item の移動先は `.agentdev/intake/` 配下のみ（REQ-0017-035）
+- G12: ディレクトリ移動を必須の状態表現として扱わない（REQ-0017-036）


### PR DESCRIPTION
## 概要

intake workflow の capture / review / promote コマンドを新設し、未分類の変更候補の受け付け→レビュー→整形の流れを定義する。

## 変更内容

### 新設コマンド（4ファイル）

| コマンド | 責務 | MUST NOT 制約 |
|----------|------|---------------|
| `intake-capture.md` | 手動入力から intake item を保存 | Issue 作成・採用判断を行わない（REQ-0017-024） |
| `intake-from-github.md` | クローズ済み Issue/PR から候補抽出・保存 | Issue 作成・採用判断を行わない（REQ-0017-024） |
| `intake-review.md` | inbox item のレビューと採用/却下/保留判定 | Issue 作成・item 変更・case-run 起動を行わない（REQ-0017-025） |
| `intake-promote.md` | レビュー済み item の req-define/intake-open 用整形 | GitHub Issue 作成を行わない（REQ-0017-026） |

### intake workflow 流れ

```
intake-capture / intake-from-github
  ↓ .agentdev/intake/inbox/
intake-review
  ↓ accepted/ | rejected/ | inbox/(保留)
intake-promote
  ↓ .agentdev/intake/promoted/
intake-open (Issue #293)
```

### intake item 形式

- REQ-0017-032〜039 に準拠
- frontmatter・状態値・重複排除キーなし（簡潔な Markdown artifact）
- セクション必須なし（REQ-0017-037）
- review 結果は item 本体に書き込まない（REQ-0017-038）

## REQ 参照

- REQ-0017-023: 5コマンド定義（intake-open は Issue #293）
- REQ-0017-024: capture/from-github は保存専用
- REQ-0017-025: review は review・採用判断のみ
- REQ-0017-026: promote は整形のみ
- REQ-0017-028: review 判定値（採用/却下/保留）
- REQ-0017-032〜039: intake item 形式制約

Refs: #286
