### PR TITLE
feat(agentdev): .agentdev domain state 更新後の git 永続化

### DIFF
--- a/.opencode/commands/agentdev/case-close.md
+++ b/.opencode/commands/agentdev/case-close.md
@@ -91,6 +91,19 @@ PRをマージし、Caseに記録を追記し、クローズ後にworktreeとブ
             - `gh issue close {epic_number} --reason completed` でEpicをクローズ
             - 完了報告に「Epic #{N} を自動クローズ」と表示
         - 1件以上 "OPEN" の子Issueがある場合 → スキップ（完了報告に「Epic #{N}: N件未完了のためスキップ」と表示）
+8b. 実行前同期（git pull）:
+    - カレントディレクトリで `git pull --ff-only` を実行する
+    - **失敗時**: 以下の構造化エラーメッセージを表示して停止する（自動解消しない）:
+      ```
+      ## Git 同期エラー
+
+      **エラー種別**: pull --ff-only 失敗
+      **停止理由**: リモートに未取り込みの変更があり、fast-forward マージできない
+      **対象ブランチ**: {current_branch}
+      **ユーザーアクション**: 手動で `git pull --rebase` または `git stash && git pull --ff-only && git stash pop` を実行してください
+      **raw git output**:
+      {git_error_output}
+      ```
 9. 学びの検知・抽出: `agentdev-learning-capture` スキルに従い、エージェントが自ら学びの有無を判断する
     - **禁止**: ユーザーに学びの有無を問うこと（「学びはありますか？」等）は禁止。エージェントが判断する
     - エージェントが学びありと判断 → 13フィールド形式でエントリを生成し、ユーザー承認を求めず `.agentdev/learning/inbox.md` に直接追記する。追記後、追記内容をユーザーに通知する（承認や却下は求めない）
@@ -104,10 +117,35 @@ PRをマージし、Caseに記録を追記し、クローズ後にworktreeとブ
     - **別々の成果物**: intake item と learning item を別々に件数・保存先・次ステップを表示する（SHALL）。混合した単一成果物にしない
     - **既存 learning capture 原則の維持**: Step 9 の learning capture の原則（ユーザーに学びを問わない、承認なしで蓄積し通知する）は維持する（SHALL）
     - **Split Rule の適用**: 観測が intake と learning の両方に該当する場合、`capture-boundaries.md` の Split Rule（具体的修正対象 → intake item、再発防止知見 → learning item、両方 → 分割）に従い、別々の成果物として作成
+9c. .agentdev 変更の commit と push（learning + intake 同一 commit）:
+    - `git diff --name-only` で `.agentdev/` 配下の変更ファイルを確認する
+    - **変更なし時**: commit/push せず、Step 11 の完了報告で「変更なし」と報告
+    - **変更あり時**:
+        1. `git add` は `.agentdev/` 配下の変更ファイルのみを対象とする（SHALL）。他のパスを巻き込まない
+        2. commit message: `chore(agentdev): close case #N and capture domain state`（Conventional Commits 形式）（SHALL）
+           - `#N` は対象Issue番号に置換
+        3. learning capture (Step 9) と intake capture (Step 9b) の成果物を**同一 commit** に含める（SHALL）
+        4. `git push` を実行する
+        5. **push 失敗時**: 以下の構造化エラーメッセージを表示し、完了扱いにしない（SHALL）:
+           ```
+           ## Git Push エラー
+
+           **エラー種別**: push 失敗
+           **停止理由**: リモートへのプッシュに失敗
+           **対象ブランチ**: {current_branch}
+           **変更ファイル**: {changed_files}
+           **ユーザーアクション**: 手動で `git push` を実行してください
+           **raw git output**:
+           {git_error_output}
+           ```
 10. Plan アーカイブ: `.sisyphus/plans/` から該当Issue番号に関連するplanファイルを検索
     - planファイルが見つかった場合 → `agentdev-archive-plan` スキルに従ってアーカイブ実行
     - planファイルが見つからない場合 → スキップ（注記付き）
 11. 完了報告 → `agentdev-workflow-reporting` の完了報告フォーマット
+    - **git 永続化結果**（完了報告に追加）:
+        - 変更の有無（あり/なし）
+        - 変更ありの場合: commit されたファイル一覧、commit hash、push 成否
+        - 変更なしの場合: 「変更なし（commit/push スキップ）」
 
 ## Guardrails
 
@@ -140,3 +178,8 @@ PRをマージし、Caseに記録を追記し、クローズ後にworktreeとブ
 
 ### 出力制約
 - G20: サブエージェントの最終出力はverbatimで出力する（再フォーマット禁止）
+- G21: Step 8b の `git pull --ff-only` 失敗時は自動解消せず、構造化エラーメッセージを表示して停止すること
+- G22: Step 9c の commit は `.agentdev/` 配下のみを対象とすること。他のパスを巻き込まないこと
+- G23: Step 9c で learning capture と intake capture の成果物を同一 commit に含めること
+- G24: Step 9c の push 失敗時は完了扱いにせず、構造化エラーメッセージを表示して停止すること
+- G25: `.agentdev/` 配下に変更がない場合は commit/push をスキップすること

--- a/.opencode/commands/agentdev/learning-promote.md
+++ b/.opencode/commands/agentdev/learning-promote.md
@@ -65,6 +65,20 @@ load_skills:
    - 承認したクラスタのみ処理
    - 承認しない → 「昇華をキャンセルしました」と報告して終了
 
+   **6b. 実行前同期（git pull）**:
+   - `git pull --ff-only` を実行する
+   - **失敗時**: 以下の構造化エラーメッセージを表示して停止する（自動解消しない）:
+     ```
+     ## Git 同期エラー
+     
+     **エラー種別**: pull --ff-only 失敗
+     **停止理由**: リモートに未取り込みの変更があり、fast-forward マージできない
+     **対象ブランチ**: {current_branch}
+     **ユーザーアクション**: 手動で `git pull --rebase` または `git stash && git pull --ff-only && git stash pop` を実行してください
+     **raw git output**:
+     {git_error_output}
+     ```
+
 7. **Requirement Source stub 生成**（staging領域のみ）:
    - 出力先: `.agentdev/learning/elevation-staging/`
    - ファイル名: `{disposal-category}-{name}.md`
@@ -84,6 +98,26 @@ load_skills:
       3. ユーザーが prune を承認した場合のみ実行
       4. archive.md から該当エントリを除去（deferred・未処理は保持）
 
+   **8b. .agentdev 変更の commit と push**:
+   - `git diff --name-only` で `.agentdev/` 配下の変更ファイルを確認する
+   - **変更なし時**: commit/push せず、Step 9 の完了報告で「変更なし」と報告
+   - **変更あり時**:
+      1. `git add` は `.agentdev/` 配下の変更ファイルのみを対象とする（SHALL）。他のパスを巻き込まない
+      2. commit message: `chore(agentdev): promote learning findings`（Conventional Commits 形式）（SHALL）
+      3. `git push` を実行する
+      4. **push 失敗時**: 以下の構造化エラーメッセージを表示し、完了扱いにしない（SHALL）:
+         ```
+         ## Git Push エラー
+         
+         **エラー種別**: push 失敗
+         **停止理由**: リモートへのプッシュに失敗
+         **対象ブランチ**: {current_branch}
+         **変更ファイル**: {changed_files}
+         **ユーザーアクション**: 手動で `git push` を実行してください
+         **raw git output**:
+         {git_error_output}
+         ```
+
 9. **完了報告**:
    - 生成した stub ファイル一覧（パス・カテゴリ・内容要約）
    - prune 結果（除去したエントリ数・残存エントリ数）
@@ -94,6 +128,10 @@ load_skills:
    - **注意事項**:
       - `.opencode/` への直接配置・直接反映は行わないこと
       - stub は必ず `req-define` を経由すること（`case-run` に直接渡さないこと）
+   - **git 永続化結果**:
+      - 変更の有無（あり/なし）
+      - 変更ありの場合: commit されたファイル一覧、commit hash、push 成否
+      - 変更なしの場合: 「変更なし（commit/push スキップ）」
 
 ## Guardrails
 
@@ -128,6 +166,8 @@ load_skills:
 | ユーザーが承認しない | 「昇華をキャンセルしました」と報告して終了 |
 | staging領域の書込失敗 | エラー内容を報告 |
 | archive.mdの prune 失敗 | stub 生成は保持。prune エラー内容を報告し、手動での prune を案内 |
+| git pull --ff-only 失敗 | 構造化エラーメッセージを表示して停止。自動解消しない |
+| git push 失敗 | 構造化エラーメッセージを表示。完了扱いにしない |
 
 ## 注意事項
 

--- a/.opencode/commands/agentdev/learning-refine.md
+++ b/.opencode/commands/agentdev/learning-refine.md
@@ -70,6 +70,21 @@ archive.md 内の古い単発レアケースを削除候補として特定する
 - アーカイブ移動の承認を求める
 - ユーザーが承認しない → 「アーカイブをキャンセルしました。evaluation-report.mdは保存済みです」と報告して終了
 
+### 8b. 実行前同期（git pull）
+
+- `git pull --ff-only` を実行する
+- **失敗時**: 以下の構造化エラーメッセージを表示して停止する（自動解消しない）:
+  ```
+  ## Git 同期エラー
+  
+  **エラー種別**: pull --ff-only 失敗
+  **停止理由**: リモートに未取り込みの変更があり、fast-forward マージできない
+  **対象ブランチ**: {current_branch}
+  **ユーザーアクション**: 手動で `git pull --rebase` または `git stash && git pull --ff-only && git stash pop` を実行してください
+  **raw git output**:
+  {git_error_output}
+  ```
+
 ### 9. アーカイブ移動（原子的操作 — 最重要）
 
 - **Step A**: inbox.md の全エントリを archive.md に追記。各エントリに `**移動日**: YYYY-MM-DD` フィールドを追加
@@ -85,12 +100,37 @@ archive.md 内の古い単発レアケースを削除候補として特定する
   ```
 - Step B が失敗 → inbox.md は変更しない。エラー内容を報告
 
+### 9b. .agentdev 変更の commit と push
+
+- `git diff --name-only` で `.agentdev/` 配下の変更ファイルを確認する
+- **変更なし時**: commit/push せず、Step 10 の完了報告で「変更なし」と報告
+- **変更あり時**:
+  1. `git add` は `.agentdev/` 配下の変更ファイルのみを対象とする（SHALL）。他のパスを巻き込まない
+  2. commit message: `chore(agentdev): refine learning entries`（Conventional Commits 形式）（SHALL）
+  3. `git push` を実行する
+  4. **push 失敗時**: 以下の構造化エラーメッセージを表示し、完了扱いにしない（SHALL）:
+     ```
+     ## Git Push エラー
+     
+     **エラー種別**: push 失敗
+     **停止理由**: リモートへのプッシュに失敗
+     **対象ブランチ**: {current_branch}
+     **変更ファイル**: {changed_files}
+     **ユーザーアクション**: 手動で `git push` を実行してください
+     **raw git output**:
+     {git_error_output}
+     ```
+
 ### 10. 完了報告
 
 - 問題クラス数（未分類含む）
 - 処理したエントリ数（inbox → archive）
 - prune したエントリ数（実施した場合）
 - evaluation-report.md のパス
+- **git 永続化結果**:
+  - 変更の有無（あり/なし）
+  - 変更ありの場合: commit されたファイル一覧、commit hash、push 成否
+  - 変更なしの場合: 「変更なし（commit/push スキップ）」
 
 ### 11. learning-promote 提案
 
@@ -113,6 +153,8 @@ archive.md 内の古い単発レアケースを削除候補として特定する
 | archive.md 書込失敗 | inbox.md は変更しない。エラー内容を報告 |
 | 旧フォーマットパース失敗 | 当該エントリをスキップし、警告を出力。処理は継続 |
 | prune候補抽出エラー | prune をスキップし、分類・評価・アーカイブ移動は継続 |
+| git pull --ff-only 失敗 | 構造化エラーメッセージを表示して停止。自動解消しない |
+| git push 失敗 | 構造化エラーメッセージを表示。完了扱いにしない |
 
 ## 注意事項
 

--- a/.opencode/skills/agentdev-workflow-reporting/reference/completion-reports.md
+++ b/.opencode/skills/agentdev-workflow-reporting/reference/completion-reports.md
@@ -78,6 +78,33 @@ Epic Issueを作成した場合は以下の報告を出力する。
   次のステップ: /agentdev/case-run {epic_N}
 ```
 
+## learning-refine 完了時
+
+```
+✅ learning-refine 完了
+  - 問題クラス数: {N}（未分類含む）
+  - 処理したエントリ数: {N}（inbox → archive）
+  - prune したエントリ数: {N}
+  - evaluation-report.md: {path}
+  - git 永続化:
+      - 変更: {あり/なし}
+      - {変更ありの場合: commit: {hash}, files: {file_list}, push: {成功/失敗}}
+      - {変更なしの場合: commit/push スキップ}
+```
+
+## learning-promote 完了時
+
+```
+✅ learning-promote 完了
+  - 生成 stub: {N}件（{file_list}）
+  - prune 結果: 除去 {N}件 / 残存 {N}件
+  - git 永続化:
+      - 変更: {あり/なし}
+      - {変更ありの場合: commit: {hash}, files: {file_list}, push: {成功/失敗}}
+      - {変更なしの場合: commit/push スキップ}
+  - 次のステップ: /agentdev/req-define {stub_path}
+```
+
 ## case-run 完了時
 
 ```
@@ -131,6 +158,10 @@ Epic Issueを作成した場合は以下の報告を出力する。
   {機能追加の場合: - ドキュメント（REQ・specs）を更新済み}
   {Epic自動クローズの場合: - Epic #{epic_N} を自動クローズ（全子Issue完了）}
   {Epicスキップの場合: - Epic #{epic_N}: N件未完了のためスキップ}
+  - git 永続化:
+      - 変更: {あり/なし}
+      - {変更ありの場合: commit: {hash}, files: {file_list}, push: {成功/失敗}}
+      - {変更なしの場合: commit/push スキップ}
 ```
 
 ## intake-from-github 完了時
@@ -215,3 +246,9 @@ Epic Orchestrator モード（`/agentdev/case-run {epic_N}`）で全 Wave 完了
 - 備考列: 成功時は `—`、失敗時はエラー概要、スキップ時は依存先Wave番号
 - Wave列: Wave番号（Epic本文の実行順序テーブルに対応）
 - 集約行: 成功・失敗・スキップ件数のサマリー
+
+### git 永続化セクションのルール
+
+- learning-refine, learning-promote, case-close の完了報告にのみ git 永続化セクションを含める
+- 変更なしの場合は「commit/push スキップ」とだけ表示する
+- push 失敗時は「push: 失敗」と表示し、完了報告全体を ⚠️ に変更する


### PR DESCRIPTION
## 概要

REQ-0022 に基づき、`.agentdev/` domain state 更新後の git 永続化機能を3コマンドに追加。

## 変更内容

### learning-refine.md
- **Step 8b**: アーカイブ移動前に `git pull --ff-only` を追加（REQ-0022-001）
- **Step 9b**: アーカイブ移動後に scoped commit + push を追加（REQ-0022-004〜009）
  - commit message: `chore(agentdev): refine learning entries`
- **Step 10**: 完了報告に git 永続化結果を追加（REQ-0022-011）
- **Error Handling**: pull/push 失敗時の構造化エラーメッセージを追加

### learning-promote.md
- **Step 6b**: stub 生成前に `git pull --ff-only` を追加（REQ-0022-003）
- **Step 8b**: prune 後に scoped commit + push を追加（REQ-0022-004〜009）
  - commit message: `chore(agentdev): promote learning findings`
- **Step 9**: 完了報告に git 永続化結果を追加（REQ-0022-011）
- **Error Handling**: pull/push 失敗時の構造化エラーメッセージを追加

### case-close.md
- **Step 8b**: learning capture 前に `git pull --ff-only` を追加（REQ-0022-001）
- **Step 9c**: learning + intake capture 後に同一 commit で scoped commit + push を追加（REQ-0022-007）
  - commit message: `chore(agentdev): close case #N and capture domain state`
- **Step 11**: 完了報告に git 永続化結果を追加（REQ-0022-011）
- **Guardrails G21-G25**: git 永続化関連の制約を追加

### completion-reports.md
- **learning-refine 完了時**: 新規フォーマットセクション追加
- **learning-promote 完了時**: 新規フォーマットセクション追加
- **case-close 完了時**: git 永続化セクション追加
- **git 永続化セクションのルール**: 新規サブセクション追加

## 要件カバレッジ

| REQ ID | 内容 | ステータス |
|--------|------|-----------|
| REQ-0022-001〜003 | 実行前同期（pull --ff-only, 失敗時停止, 構造化エラー） | ✅ |
| REQ-0022-004〜007 | scoped commit（changed files only, 巻き込み禁止, CC形式, 同一commit） | ✅ |
| REQ-0022-008〜009 | push（必須, 失敗時完了扱いにしない） | ✅ |
| REQ-0022-010 | 変更なし時は commit/push しない | ✅ |
| REQ-0022-011 | 完了報告に変更有無/ファイル/hash/push成否 | ✅ |
| REQ-0022-012〜014 | 各コマンド定義への変更ポイント | ✅ |

Refs: #334
