### PR TITLE
feat(intake-open): promoted artifact 一括処理モードを追加 (#360)

### DIFF
--- a/.opencode/commands/agentdev/intake-open.md
+++ b/.opencode/commands/agentdev/intake-open.md
@@ -26,36 +26,73 @@ load_skills:
 
 ## Steps
 
-1. **Artifact 検出**: 引数の有無に応じて promoted artifact を特定する:
-   - 引数なし + promoted artifact が1件 → 自動検出して次 Step へ進む
-   - 引数なし + promoted artifact が0件 → エラー停止: `promoted artifact が存在しません。/agentdev/intake-promote で整形してください。`
-   - 引数なし + promoted artifact が2件以上 → 候補一覧を表示して停止: `promoted artifact が複数あります。対象を指定してください: {候補一覧}`
-   - 引数あり → 指定されたファイル名に対応する `.agentdev/intake/promoted/intake-open/{filename}` を読み込む
+引数なし実行時、promoted artifact を全件自動処理する（一括処理モード）。引数あり実行時は指定された artifact のみ処理する。各 artifact は独立して処理され、1件の失敗が後続の処理を妨げない（continue-on-error）。全 artifact の処理完了後に git 永続化を1回だけ実行する（REQ-0029）。
 
-   artifact の検索方法: `.agentdev/intake/promoted/intake-open/*.md` のファイル一覧を取得する。
+### Step 0: 実行前同期（git pull --ff-only）
 
-2. **Artifact 読み込み**: promoted artifact の内容をパースする:
-   - frontmatter は持たない（ディレクトリ配置が一次状態）
-   - 整形済み item 群: タイトル、概要、対象範囲、完了条件等
-   - 後続ルート情報: 単一 Issue または Epic + 子Issue 構成
+全 artifact 処理の前に `git pull --ff-only` を1回だけ実行する（REQ-0029-007, 008）。
 
-3. **構成判定**: artifact の内容から Issue 構成を判定する:
-   - 単一 item → **Single Issue flow**（Step 4〜6）
-   - 複数 item または Epic 構成指定あり → **Epic flow**（Step 7〜12）
+- `git pull --ff-only` を実行する
+- **失敗時**: 以下の構造化エラーメッセージを表示して停止する（artifact 処理を開始せず全体停止）。自動解消しない:
+  ```
+  ## Git 同期エラー
 
-4. **[Single Issue] テンプレート選択**: item の内容に応じてテンプレートを選択する:
+  **エラー種別**: pull --ff-only 失敗
+  **停止理由**: リモートに未取り込みの変更があり、fast-forward マージできない
+  **対象ブランチ**: {current_branch}
+  **ユーザーアクション**: 手動で `git pull --rebase` または `git stash && git pull --ff-only && git stash pop` を実行してください
+  **raw git output**:
+  {git_error_output}
+  ```
+
+### Step 1: Artifact 検出
+
+引数の有無に応じて promoted artifact を特定する（REQ-0029-001, 002, 003, 013）:
+
+- 引数なし + promoted artifact が0件 → エラー停止: `promoted artifact が存在しません。/agentdev/intake-promote で整形してください。`
+- 引数なし + promoted artifact が1件以上 → ファイル名昇順で全件取得し、一括処理モードで Step 2 へ進む
+- 引数あり → 指定されたファイル名に対応する `.agentdev/intake/promoted/intake-open/{filename}` のみを取得し、Step 2 へ進む
+
+artifact の検索方法: `.agentdev/intake/promoted/intake-open/*.md` のファイル一覧を取得する。
+
+### Step 2: Artifact 反復ループ
+
+Step 1 で検出された artifact をファイル名昇順で順次処理する（REQ-0029-002, 004, 005, 006）。
+
+各 artifact について以下の 2a〜2e を実行する:
+
+#### 2a: Artifact 読み込み
+
+promoted artifact の内容をパースする:
+- frontmatter は持たない（ディレクトリ配置が一次状態）
+- 整形済み item 群: タイトル、概要、対象範囲、完了条件等
+- 後続ルート情報: 単一 Issue または Epic + 子Issue 構成
+
+#### 2b: 構成判定
+
+artifact の内容から Issue 構成を判定する（REQ-0029-004）:
+- 単一 item → **Single Issue flow**（2c-i）
+- 複数 item または Epic 構成指定あり → **Epic flow**（2c-ii）
+
+#### 2c: Issue 作成
+
+構成判定結果に応じて、以下のいずれかの flow を実行する:
+
+##### 2c-i: [Single Issue flow]
+
+1. **テンプレート選択**: item の内容に応じてテンプレートを選択する:
    - テンプレート: `.opencode/skills/agentdev-workflow-templates/templates/issue_desc_feature.md` または `issue_desc_bug.md`
    - **テンプレート準拠要件**: テンプレートの `【必須】` セクションが全て Issue 本文に含まれること。必須セクションが欠落している場合、生成をやり直すこと。
 
-5. **[Single Issue] Issue 作成**:
+2. **Issue 作成**:
    - artifact の内容から Issue 本文を生成
    - ラベル: item 内容に応じて選定（`enhancement` または `bug` 等）
    - `agentdev-gh-cli` に従って `--body-file` で作成
    - `agentdev-gh-cli` の VERIFY操作（書き込み内容検証）を実行すること
 
-6. **[Single Issue] 完了報告** → Step 13 へ
+##### 2c-ii: [Epic flow]
 
-7. **[Epic flow] Epic Issue 作成**:
+1. **Epic Issue 作成**:
    - テンプレート: `.opencode/skills/agentdev-workflow-templates/templates/issue_desc_epic.md`
    - artifact のサマリー情報から Epic Issue 本文を生成
    - **テンプレート準拠要件**: テンプレートの `【必須】` セクションが全て Epic Issue 本文に含まれること。必須セクションが欠落している場合、生成をやり直すこと。
@@ -65,7 +102,7 @@ load_skills:
    - `agentdev-gh-cli` の VERIFY操作（書き込み内容検証）を実行すること
    - 作成された Issue 番号を `{epic_number}` として記録
 
-8. **[Epic flow] 子Issue 作成**: 各 item を Epic 配下の子Issue として作成する:
+2. **子Issue 作成**: 各 item を Epic 配下の子Issue として作成する:
    - テンプレート: `.opencode/skills/agentdev-workflow-templates/templates/issue_desc_child.md`
    - **テンプレート準拠要件**: テンプレートの `【必須】` セクションが全て子Issue 本文に含まれること。
    - `Parent: #{epic_number}` を先頭行に配置
@@ -73,62 +110,70 @@ load_skills:
    - `agentdev-gh-cli` に従って `--body-file` で作成
    - `agentdev-gh-cli` の VERIFY操作（書き込み内容検証）を実行すること
 
-9. **[Epic flow] Epic 更新**: 全子Issue 作成後、Epic Issue 本文の子Issue リンクを実際の Issue 番号で更新する:
+3. **Epic 更新**: 全子Issue 作成後、Epic Issue 本文の子Issue リンクを実際の Issue 番号で更新する:
    - `agentdev-gh-cli` に従って `--body-file` で更新
    - テンプレートの `【必須】` セクションが維持されていることを確認
 
-10. **[Epic flow] ステータス追跡更新**: `agentdev-epic-tracker` に従って Epic のステータスを初期化する。
+4. **ステータス追跡更新**: `agentdev-epic-tracker` に従って Epic のステータスを初期化する。
 
-11. **[Epic flow] 完了報告** → Step 13 へ
+#### 2d: Artifact 削除
 
-12. *(reserved for future expansion)*
+Issue 作成および VERIFY が成功した場合のみ、当該 promoted artifact を `.agentdev/intake/promoted/intake-open/` から削除する（REQ-0029-005）。
+- **削除条件**: Issue 作成 + VERIFY が正常完了した場合のみ
+- **削除しない場合**: Issue 作成失敗・VERIFY 失敗・エラー発生時は artifact を残す（リトライ可能にするため）
 
-12b. **実行前同期（git pull）**:
-     - `git pull --ff-only` を実行する
-     - **失敗時**: 以下の構造化エラーメッセージを表示して停止する（自動解消しない）:
-       ```
-       ## Git 同期エラー
+#### 2e: 失敗時の継続
 
-       **エラー種別**: pull --ff-only 失敗
-       **停止理由**: リモートに未取り込みの変更があり、fast-forward マージできない
-       **対象ブランチ**: {current_branch}
-       **ユーザーアクション**: 手動で `git pull --rebase` または `git stash && git pull --ff-only && git stash pop` を実行してください
-       **raw git output**:
-       {git_error_output}
-       ```
+artifact 単位の処理失敗時は、当該 artifact を残したうえで後続 artifact の処理を継続する（REQ-0029-006）。
+- 失敗した artifact のファイル名とエラー内容を記録する
+- 後続 artifact の処理を妨げない（前の artifact の失敗が後続に影響しない）
+- ループ終了後、Step 4 の完了報告で成功・失敗の全件を報告する
 
-13. **Artifact 削除**: Issue 作成が成功した（VERIFY で検証済みの）promoted artifact を `.agentdev/intake/promoted/intake-open/` から削除する。
-    - **削除条件**: Issue 作成 + VERIFY が正常完了した場合のみ
-    - **削除しない場合**: Issue 作成失敗・VERIFY 失敗・エラー発生時は artifact を残す（リトライ可能にするため）
+### Step 3: Git 永続化
 
-13b. **.agentdev/intake 変更の commit と push**:
-     - `git diff --name-only` で `.agentdev/intake/` 配下の変更ファイルを確認する
-     - **変更なし時**: commit/push せず、Step 14 の完了報告で「変更なし」と報告
-     - **変更あり時**:
-       1. `git add` は `.agentdev/intake/` 配下の変更ファイルのみを対象とする（SHALL）。他のパスを巻き込まない
-       2. commit message: `chore(agentdev): issue intake items`（Conventional Commits 形式）（SHALL）
-       3. `git push` を実行する
-       4. **push 失敗時**: 以下の構造化エラーメッセージを表示し、完了扱いにしない（SHALL）:
-          ```
-          ## Git Push エラー
+全 artifact の処理完了後、`.agentdev/intake/` 配下の変更を1 commit / 1 push する（REQ-0029-009, 010）。
 
-          **エラー種別**: push 失敗
-          **停止理由**: リモートへのプッシュに失敗
-          **対象ブランチ**: {current_branch}
-          **変更ファイル**: {changed_files}
-          **ユーザーアクション**: 手動で `git push` を実行してください
-          **raw git output**:
-          {git_error_output}
-          ```
+- `git diff --name-only` で `.agentdev/intake/` 配下の変更ファイルを確認する
+- **変更なし時**: commit/push せず、Step 4 の完了報告で「変更なし」と報告
+- **変更あり時**:
+  1. `git add` は `.agentdev/intake/` 配下の変更ファイルのみを対象とする（SHALL）。他のパスを巻き込まない
+  2. commit message: `chore(agentdev): issue intake items`（Conventional Commits 形式）（SHALL）
+  3. `git push` を実行する
+  4. **push 失敗時**: 以下の構造化エラーメッセージを表示し、完了扱いにしない（SHALL）:
+     ```
+     ## Git Push エラー
 
-14. **完了報告** → `agentdev-workflow-reporting` の完了報告フォーマット（`completion-reports.md` → intake-open 完了時）に従って出力。git 永続化結果（変更有無・ファイル一覧・commit hash・push 成否）を含める
+     **エラー種別**: push 失敗
+     **停止理由**: リモートへのプッシュに失敗
+     **対象ブランチ**: {current_branch}
+     **変更ファイル**: {changed_files}
+     **ユーザーアクション**: 手動で `git push` を実行してください
+     **raw git output**:
+     {git_error_output}
+     ```
+
+### Step 4: 完了報告
+
+`agentdev-workflow-reporting` の完了報告フォーマット（`completion-reports.md` → intake-open 一括処理完了時）に従って出力する（REQ-0029-011, 012）。
+
+以下を含める:
+- 成功件数、失敗件数
+- 削除済み artifact 一覧
+- 残存 artifact 一覧（失敗・リトライ対象）
+- 作成 Issue 番号一覧（単一 Issue および Epic + 子Issue）
+- git 永続化結果（変更有無・ファイル一覧・commit hash・push 成否）
+- 検証結果（`agentdev-gh-cli` VERIFY 操作の結果）
 
 ## Error Handling
 
 | エラー | 対処 |
 |--------|------|
-| git pull --ff-only 失敗 | 構造化エラーメッセージを表示して停止。自動解消しない |
-| git push 失敗 | 構造化エラーメッセージを表示。完了扱いにしない |
+| git pull --ff-only 失敗 | 構造化エラーメッセージを表示して全体停止。artifact 処理を開始しない（REQ-0029-008） |
+| git push 失敗 | 構造化エラーメッセージを表示。完了扱いにしない（REQ-0029-010） |
+| artifact 読み込み失敗 | 当該 artifact をスキップし、後続 artifact の処理を継続。失敗を記録して Step 4 で報告 |
+| Issue 作成失敗 | 当該 artifact を残し、後続 artifact の処理を継続。失敗を記録して Step 4 で報告 |
+| VERIFY 失敗 | 当該 artifact を残し、後続 artifact の処理を継続。失敗を記録して Step 4 で報告 |
+| 引数なし + artifact 0件 | エラーメッセージを表示して停止（一括処理対象なし） |
 
 ## Guardrails
 
@@ -152,3 +197,7 @@ load_skills:
 
 ### 出力制約
 - G13: サブエージェントの最終出力は verbatim で出力する（再フォーマット禁止）
+
+### 一括処理制約（REQ-0029）
+- G14: 引数なし + 1件以上の全件処理時、artifact 単位の失敗で全体停止しないこと
+- G15: ループ内の各 artifact 処理は独立しており、前の artifact の失敗が後続に影響しないこと

--- a/.opencode/skills/agentdev-workflow-reporting/reference/completion-reports.md
+++ b/.opencode/skills/agentdev-workflow-reporting/reference/completion-reports.md
@@ -268,6 +268,76 @@ Epic + 子Issue を作成した場合は以下の報告を出力する。
   - 次のステップ: /agentdev/case-run {epic_N}
 ```
 
+## intake-open 一括処理完了時
+
+引数なし実行で複数 promoted artifact を一括処理した場合の報告フォーマット。
+
+### 全件成功時
+
+```
+✅ intake-open 完了（一括処理）
+  - 処理結果:
+      - 成功: {success_count}件
+      - 失敗: 0件
+  - 作成 Issue: #{N1}, #{N2}, ...（{count}件）
+  - 削除済み artifact: {deleted_artifact_list}
+  - 残存 artifact: なし
+  - 検証結果: ✅ OK（{N}件の書き込み操作を検証済み）
+  - git 永続化:
+      - 変更: {あり/なし}
+      - {変更ありの場合: commit: {hash}, files: {file_list}, push: {成功/失敗}}
+      - {変更なしの場合: commit/push スキップ}
+  - 次のステップ: /agentdev/case-run {N1}（最初の成功Issue）
+```
+
+### 部分失敗あり
+
+```
+⚠️ intake-open 完了（一括処理 — 部分失敗）
+  - 処理結果:
+      - 成功: {success_count}件
+      - 失敗: {failure_count}件
+  - 作成 Issue: #{N1}, #{N2}, ...（{count}件）
+  - 削除済み artifact: {deleted_artifact_list}
+  - 残存 artifact: {remaining_artifact_list}
+  - 検証結果: ✅ OK（{N}件の書き込み操作を検証済み）
+  - 失敗詳細:
+      - {artifact_name}: {error_summary}
+  - git 永続化:
+      - 変更: {あり/なし}
+      - {変更ありの場合: commit: {hash}, files: {file_list}, push: {成功/失敗}}
+      - {変更なしの場合: commit/push スキップ}
+  - 次のステップ:
+    - 成功したIssue: /agentdev/case-run {N1}
+    - 残存artifactの再実行: /agentdev/intake-open {remaining_artifact}
+```
+
+### 全件失敗時
+
+```
+❌ intake-open 完了（一括処理 — 全件失敗）
+  - 処理結果:
+      - 成功: 0件
+      - 失敗: {failure_count}件
+  - 作成 Issue: なし
+  - 削除済み artifact: なし
+  - 残存 artifact: {remaining_artifact_list}
+  - 失敗詳細:
+      - {artifact_name}: {error_summary}
+      - ...
+  - git 永続化:
+      - 変更: なし
+      - commit/push スキップ
+```
+
+### フォーマット共通ルール
+
+- 処理結果の 成功/失敗 カウントは必須
+- Issue 番号は作成順（ファイル名昇順と同一）で列挙
+- artifact 名はファイル名（パス含まない）で列挙
+- 失敗詳細は artifact ごとのエラー概要（1行）
+- git 永続化セクションのルールは他の intake 系コマンドと同一
+
 ## case-run Epic Orchestrator 集約完了報告
 
 Epic Orchestrator モード（`/agentdev/case-run {epic_N}`）で全 Wave 完了後に出力する集約報告フォーマット。各子 Issue の subagent が個別の case-run 完了報告を出力した後に、親エージェントが本フォーマットで集約結果を報告する。


### PR DESCRIPTION
## 概要

intake-open コマンドに promoted artifact の一括処理モードを追加する（REQ-0029）。

引数なし実行時に、promoted artifact を全件自動処理する。artifact 単位の失敗で後続を継続し（continue-on-error）、全処理完了後に git commit/push を1回だけ実行する。

## 変更内容

### `.opencode/commands/agentdev/intake-open.md`

- **Step 0（新設）**: 実行前同期（git pull --ff-only）— 全処理前に1回
- **Step 1（変更）**: Artifact 検出 — 引数なし+1件以上で全件取得（旧「2件以上で候補一覧→停止」を廃止）
- **Step 2（新設）**: Artifact 反復ループ（continue-on-error）— 2a: 読み込み → 2b: 構成判定 → 2c: Issue作成 → 2d: 成功時のみ削除 → 2e: 失敗時継続
- **Step 3（新設）**: Git 永続化 — 全処理後に1 commit / 1 push
- **Step 4（新設）**: 完了報告 — 一括処理結果を構造化出力
- 既存 Single Issue flow / Epic flow は Step 2c のサブステップとして維持
- ガードレール G14, G15 を追加

### `.opencode/skills/agentdev-workflow-reporting/reference/completion-reports.md`

- 「## intake-open 一括処理完了時」セクション追加（全件成功時・部分失敗あり・全件失敗時の3パターン）

## テスト戦略

- ユニットテスト: 各要件の期待動作を検証
- E2Eテスト: 複数 promoted artifact 配置状態での一括処理フロー検証

Closes: #360
