### PR TITLE
fix: BOM検出をraw bytes読み取りに変更

### DIFF
--- a/.opencode/skills/agentdev-gh-cli/scripts/verify_body.test.ts
+++ b/.opencode/skills/agentdev-gh-cli/scripts/verify_body.test.ts
@@ -89,6 +89,10 @@ beforeAll(() => {
     "utf-8",
   );
   writeFileSync(join(TEMP_DIR, "actual_control_chars.md"), VALID_BODY + "\n\x01\x02\x03", "utf-8");
+
+  const bomPrefix = Buffer.from([0xef, 0xbb, 0xbf]);
+  const bomContent = Buffer.concat([bomPrefix, Buffer.from(VALID_BODY, "utf-8")]);
+  writeFileSync(join(TEMP_DIR, "actual_bom.md"), bomContent);
 });
 
 afterAll(() => {
@@ -184,5 +188,33 @@ describe("verify_body.ts", () => {
       (r) => r.category === "Encoding" && r.check === "Control characters" && r.level === "ng",
     );
     expect(hasControlNg).toBe(true);
+  });
+
+  it("BOM detection: exit 1, NG when actual file has BOM", () => {
+    const result = runScript([
+      "--expected", join(TEMP_DIR, "expected.md"),
+      "--actual", join(TEMP_DIR, "actual_bom.md"),
+      "--json",
+    ]);
+    expect(result.exitCode).toBe(1);
+    const parsed: ReportJson = JSON.parse(result.stdout);
+    const hasBomNg = parsed.results.some(
+      (r) => r.category === "Encoding" && r.check === "UTF-8 / LF" && r.level === "ng" && r.message.includes("BOM"),
+    );
+    expect(hasBomNg).toBe(true);
+  });
+
+  it("No BOM: existing actual.md passes BOM check", () => {
+    const result = runScript([
+      "--expected", join(TEMP_DIR, "expected.md"),
+      "--actual", join(TEMP_DIR, "actual.md"),
+      "--json",
+    ]);
+    expect(result.exitCode).toBe(0);
+    const parsed: ReportJson = JSON.parse(result.stdout);
+    const hasBomOk = parsed.results.some(
+      (r) => r.category === "Encoding" && r.check === "UTF-8 / LF" && r.level === "ok" && r.message.includes("No BOM"),
+    );
+    expect(hasBomOk).toBe(true);
   });
 });

--- a/.opencode/skills/agentdev-gh-cli/scripts/verify_body.ts
+++ b/.opencode/skills/agentdev-gh-cli/scripts/verify_body.ts
@@ -67,7 +67,13 @@ function printBodyHelp(): void {
   console.log(lines.join("\n"));
 }
 
-function checkEncoding(actual: string, results: CheckResult[]): void {
+function checkBOMFromBytes(buffer: ArrayBuffer): boolean {
+  if (buffer.byteLength < 3) return false;
+  const bytes = new Uint8Array(buffer);
+  return bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf;
+}
+
+function checkEncoding(actual: string, hasBOM: boolean, results: CheckResult[]): void {
   if (actual.includes("\r\n")) {
     const crlfCount = (actual.match(/\r\n/g) || []).length;
     results.push(ng("Encoding", "UTF-8 / LF", `Actual text contains ${crlfCount} CRLF line ending(s)`));
@@ -75,8 +81,8 @@ function checkEncoding(actual: string, results: CheckResult[]): void {
     results.push(ok("Encoding", "UTF-8 / LF", "No CRLF line endings detected"));
   }
 
-  if (actual.charCodeAt(0) === 0xfeff) {
-    results.push(ng("Encoding", "UTF-8 / LF", "Actual text starts with BOM marker"));
+  if (hasBOM) {
+    results.push(ng("Encoding", "UTF-8 / LF", "Actual file starts with UTF-8 BOM (EF BB BF)"));
   } else {
     results.push(ok("Encoding", "UTF-8 / LF", "No BOM marker detected"));
   }
@@ -348,6 +354,8 @@ async function main(): Promise<void> {
 
   const expected = await expectedFile.text();
   const actual = await actualFile.text();
+  const actualBytes = await actualFile.arrayBuffer();
+  const actualHasBOM = checkBOMFromBytes(actualBytes);
 
   if (opts.dryRun) {
     console.log(`Would verify ${expectedPath} against ${actualPath}`);
@@ -357,7 +365,7 @@ async function main(): Promise<void> {
 
   const results: CheckResult[] = [];
 
-  checkEncoding(actual, results);
+  checkEncoding(actual, actualHasBOM, results);
   checkJapanesePreservation(expected, actual, results);
   checkTableConsistency(actual, results, "actual");
   checkCheckboxSyntax(expected, actual, results);


### PR DESCRIPTION
## 変更内容

`verify_body.ts` の BOM 検出を raw bytes 読み取りに変更する修正。

### 問題

`Bun.file().text()` は UTF-8 BOM を自動ストリップするため、`actual.charCodeAt(0) === 0xfeff` による BOM チェックが機能していなかった。BOM 付きファイルを渡しても常に「BOM なし」と判定される状態だった。

### 修正内容

- `checkBOMFromBytes()` 関数を追加: `ArrayBuffer` の先頭3バイト `0xEF 0xBB 0xBF` を確認
- `checkEncoding()` のシグネチャを変更: テストベースの `hasBOM: boolean` パラメータを受け取る
- `main()` で actual ファイルを `arrayBuffer()` で読み取り、BOM 判定結果を `checkEncoding()` に渡す

### テスト

- BOM ありファイルの検出テスト（exit 1, NG）
- BOM なしファイルの正常判定テスト（exit 0, OK）
- 既存テスト 7件 + 新規テスト 2件 = 全 9件パス

## 関連 Issue

Closes: #366
