### PR TITLE
feat: 構造検証テスト実装（REQ-0030-001〜008, Phase B）

### DIFF
--- a/.opencode/skills/agentdev-integrity/scripts/commands_structure.test.ts
+++ b/.opencode/skills/agentdev-integrity/scripts/commands_structure.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Structure validation tests for command definition files.
+ * REQ-0030-001: Command frontmatter required fields existence
+ * REQ-0030-002: Steps section structure and load_skills reference existence
+ *
+ * Tests the ACTUAL command files in .opencode/commands/agentdev/*.md (not fixtures).
+ * Gap analysis: existing check_integrity.test.ts tests the script via subprocess
+ * with temp fixtures, but does NOT directly assert on real repo files.
+ */
+
+import { describe, it, expect } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+
+const SCRIPT_DIR = import.meta.dir;
+// Walk up to repo root (contains .opencode/)
+function findRepoRoot(start: string): string {
+  let dir = path.resolve(start);
+  for (let i = 0; i < 20; i++) {
+    if (fs.existsSync(path.join(dir, ".opencode"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(start);
+}
+
+const REPO_ROOT = findRepoRoot(SCRIPT_DIR);
+const CMD_DIR = path.join(REPO_ROOT, ".opencode", "commands", "agentdev");
+const SKILLS_DIR = path.join(REPO_ROOT, ".opencode", "skills");
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function parseFrontmatter(content: string): Record<string, string | string[]> | null {
+  const parts = content.split("---");
+  if (parts.length < 3) return null;
+  const yaml = parts[1].trim();
+  const result: Record<string, string | string[]> = {};
+  const lines = yaml.split("\n");
+  let currentKey: string | null = null;
+  const currentArray: string[] = [];
+
+  function flushArray() {
+    if (currentKey !== null && currentArray.length > 0) {
+      result[currentKey] = [...currentArray];
+    }
+    currentKey = null;
+    currentArray.length = 0;
+  }
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    if (trimmed.startsWith("- ") && currentKey !== null) {
+      currentArray.push(trimmed.slice(2).trim());
+      continue;
+    }
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx === -1) continue;
+    flushArray();
+    const key = trimmed.slice(0, colonIdx).trim();
+    const value = trimmed.slice(colonIdx + 1).trim();
+    if (value === "") {
+      currentKey = key;
+      currentArray.length = 0;
+    } else if (value.startsWith("[") && value.endsWith("]")) {
+      result[key] = value
+        .slice(1, -1)
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+    } else {
+      result[key] = value.replace(/^["']|["']$/g, "");
+    }
+  }
+  flushArray();
+  return result;
+}
+
+function getCommandFiles(): string[] {
+  if (!fs.existsSync(CMD_DIR)) return [];
+  return fs.readdirSync(CMD_DIR)
+    .filter((f) => f.endsWith(".md") && f !== "README.md")
+    .sort();
+}
+
+function getSkillDirs(): Set<string> {
+  if (!fs.existsSync(SKILLS_DIR)) return new Set();
+  return new Set(
+    fs.readdirSync(SKILLS_DIR, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+  );
+}
+
+// ─── REQ-0030-001: Command frontmatter required fields ──────────────────────
+
+describe("REQ-0030-001: Command frontmatter required fields", () => {
+  const cmdFiles = getCommandFiles();
+  const REQUIRED_FIELDS = ["description", "agent", "load_skills"];
+
+  it("command files exist under .opencode/commands/agentdev/", () => {
+    expect(cmdFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const file of cmdFiles) {
+    describe(`command file: ${file}`, () => {
+      const content = fs.readFileSync(path.join(CMD_DIR, file), "utf-8");
+      const fm = parseFrontmatter(content);
+
+      it("has valid frontmatter", () => {
+        expect(fm).not.toBeNull();
+      });
+
+      if (fm) {
+        for (const field of REQUIRED_FIELDS) {
+          it(`has required field "${field}"`, () => {
+            expect(fm[field]).toBeDefined();
+            if (Array.isArray(fm[field])) {
+              expect((fm[field] as string[]).length).toBeGreaterThan(0);
+            } else {
+              expect(fm[field]).not.toBe("");
+            }
+          });
+        }
+      }
+    });
+  }
+});
+
+// ─── REQ-0030-002: Steps section structure and load_skills references ───────
+
+describe("REQ-0030-002: Steps section structure and load_skills references", () => {
+  const cmdFiles = getCommandFiles();
+  const skillDirs = getSkillDirs();
+
+  for (const file of cmdFiles) {
+    describe(`command file: ${file}`, () => {
+      const content = fs.readFileSync(path.join(CMD_DIR, file), "utf-8");
+
+      it("has Step or Phase sections (## Step, ## Phase, or ## Input)", () => {
+        const hasStructure = /(^##\s+(Step|Phase|Input|準備|実装|提出))/m.test(content);
+        expect(hasStructure).toBe(true);
+      });
+
+      // load_skills references must point to existing skill directories
+      const fm = parseFrontmatter(content);
+      const loadSkills = fm
+        ? (Array.isArray(fm["load_skills"]) ? fm["load_skills"] as string[] : [])
+        : [];
+
+      for (const skill of loadSkills) {
+        it(`load_skills "${skill}" references an existing skill directory`, () => {
+          expect(skillDirs.has(skill)).toBe(true);
+        });
+      }
+    });
+  }
+});

--- a/.opencode/skills/agentdev-integrity/scripts/skills_structure.test.ts
+++ b/.opencode/skills/agentdev-integrity/scripts/skills_structure.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+
+const SCRIPT_DIR = import.meta.dir;
+
+function findRepoRoot(start: string): string {
+  let dir = path.resolve(start);
+  for (let i = 0; i < 20; i++) {
+    if (fs.existsSync(path.join(dir, ".opencode"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(start);
+}
+
+const REPO_ROOT = findRepoRoot(SCRIPT_DIR);
+const SKILLS_DIR = path.join(REPO_ROOT, ".opencode", "skills");
+
+function getSkillDirs(): string[] {
+  if (!fs.existsSync(SKILLS_DIR)) return [];
+  return fs.readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+}
+
+function parseSkillFrontmatter(content: string): Record<string, string> | null {
+  const parts = content.split("---");
+  if (parts.length < 3) return null;
+  const body = parts[1].trim();
+  const fields: Record<string, string> = {};
+  for (const line of body.split("\n")) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+    const key = line.slice(0, colonIndex).trim();
+    const value = line.slice(colonIndex + 1).trim();
+    fields[key] = value;
+  }
+  return Object.keys(fields).length > 0 ? fields : null;
+}
+
+function extractSeeAlsoRefs(content: string): string[] {
+  const refs: string[] = [];
+  const seeAlsoMatch = content.match(/## See Also([\s\S]*?)$/);
+  if (!seeAlsoMatch) return refs;
+  const section = seeAlsoMatch[1];
+  const boldPattern = /\*\*(agentdev-[a-z0-9-]+)\*\*/g;
+  let match: RegExpExecArray | null;
+  while ((match = boldPattern.exec(section)) !== null) {
+    refs.push(match[1]);
+  }
+  const linkPattern = /\[(agentdev-[a-z0-9-]+)\]\([^)]*\)/g;
+  while ((match = linkPattern.exec(section)) !== null) {
+    refs.push(match[1]);
+  }
+  return [...new Set(refs)];
+}
+
+function hasSection(content: string, heading: string): boolean {
+  const pattern = new RegExp(`^## .*${escapeRegex(heading)}`, "m");
+  return pattern.test(content);
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getSectionContent(content: string, heading: string): string {
+  const escaped = escapeRegex(heading);
+  const pattern = new RegExp(`^## .*${escaped}\\s*\\n([\\s\\S]*?)(?=^## |$)`, "m");
+  const match = content.match(pattern);
+  return match ? match[1].trim() : "";
+}
+
+const skillDirs = getSkillDirs();
+const skillDirSet = new Set(skillDirs);
+
+describe("REQ-0030-003: Skill frontmatter required fields", () => {
+  it("skill directories exist under .opencode/skills/", () => {
+    expect(skillDirs.length).toBeGreaterThan(0);
+  });
+
+  for (const dirName of skillDirs) {
+    describe(`skill: ${dirName}`, () => {
+      const skillMdPath = path.join(SKILLS_DIR, dirName, "SKILL.md");
+
+      it("has SKILL.md", () => {
+        expect(fs.existsSync(skillMdPath)).toBe(true);
+      });
+
+      if (fs.existsSync(skillMdPath)) {
+        const content = fs.readFileSync(skillMdPath, "utf-8");
+        const fm = parseSkillFrontmatter(content);
+
+        it("has valid frontmatter", () => {
+          expect(fm).not.toBeNull();
+        });
+
+        if (fm) {
+          it("has 'name' field", () => {
+            expect(fm["name"]).toBeDefined();
+            expect(fm["name"]).not.toBe("");
+          });
+
+          it("has 'description' field", () => {
+            expect(fm["description"]).toBeDefined();
+            expect(fm["description"]).not.toBe("");
+          });
+        }
+      }
+    });
+  }
+});
+
+describe("REQ-0030-004: Skill USE FOR / DO NOT USE FOR sections and See Also references", () => {
+  for (const dirName of skillDirs) {
+    describe(`skill: ${dirName}`, () => {
+      const skillMdPath = path.join(SKILLS_DIR, dirName, "SKILL.md");
+
+      if (!fs.existsSync(skillMdPath)) return;
+
+      const content = fs.readFileSync(skillMdPath, "utf-8");
+
+      it("has 'USE FOR' content (section heading or in description)", () => {
+        const hasHeading = hasSection(content, "USE FOR");
+        const fm = parseSkillFrontmatter(content);
+        const inDescription = fm?.["description"]?.includes("USE FOR") ?? false;
+        expect(hasHeading || inDescription).toBe(true);
+      });
+
+      it("'USE FOR' content is non-empty", () => {
+        const headingBody = getSectionContent(content, "USE FOR");
+        if (headingBody.length > 0) {
+          expect(headingBody.length).toBeGreaterThan(0);
+        } else {
+          const fm = parseSkillFrontmatter(content);
+          const desc = fm?.["description"] ?? "";
+          const useForMatch = desc.match(/USE FOR:\s*(.+?)(?:\. DO NOT|\.?$)/);
+          expect(useForMatch).not.toBeNull();
+          expect(useForMatch![1].trim().length).toBeGreaterThan(0);
+        }
+      });
+
+      it("has 'DO NOT USE FOR' content (section heading or in description)", () => {
+        const hasHeading = hasSection(content, "DO NOT USE FOR");
+        const fm = parseSkillFrontmatter(content);
+        const inDescription = fm?.["description"]?.includes("DO NOT USE FOR") ?? false;
+        expect(hasHeading || inDescription).toBe(true);
+      });
+
+      it("'DO NOT USE FOR' content is non-empty", () => {
+        const headingBody = getSectionContent(content, "DO NOT USE FOR");
+        if (headingBody.length > 0) {
+          expect(headingBody.length).toBeGreaterThan(0);
+        } else {
+          const fm = parseSkillFrontmatter(content);
+          const desc = fm?.["description"] ?? "";
+          const dontMatch = desc.match(/DO NOT USE FOR:\s*(.+?)$/);
+          expect(dontMatch).not.toBeNull();
+          expect(dontMatch![1].trim().length).toBeGreaterThan(0);
+        }
+      });
+
+      const seeAlsoRefs = extractSeeAlsoRefs(content);
+      for (const ref of seeAlsoRefs) {
+        it(`See Also reference "${ref}" points to existing skill directory`, () => {
+          expect(skillDirSet.has(ref)).toBe(true);
+        });
+      }
+    });
+  }
+});

--- a/.opencode/skills/agentdev-integrity/scripts/templates_structure.test.ts
+++ b/.opencode/skills/agentdev-integrity/scripts/templates_structure.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+
+const SCRIPT_DIR = import.meta.dir;
+
+function findRepoRoot(start: string): string {
+  let dir = path.resolve(start);
+  for (let i = 0; i < 20; i++) {
+    if (fs.existsSync(path.join(dir, ".opencode"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(start);
+}
+
+const REPO_ROOT = findRepoRoot(SCRIPT_DIR);
+const TEMPLATES_DIR = path.join(
+  REPO_ROOT,
+  ".opencode",
+  "skills",
+  "agentdev-workflow-templates",
+  "templates",
+);
+
+const TEMPLATES_WITH_FRONTMATTER = [
+  "issue_desc_feature.md",
+  "issue_desc_bug.md",
+  "issue_desc_epic.md",
+  "issue_desc_child.md",
+  "issue_desc_backlog_child.md",
+  "issue_desc_backlog_epic.md",
+];
+
+const TEMPLATES_WITHOUT_FRONTMATTER = [
+  "issue_comment_bug_analysis.md",
+  "issue_comment_bug_record.md",
+  "issue_comment_feature_implementation.md",
+  "issue_comment_feature_technical.md",
+  "issue_comment_review_ng.md",
+  "issue_comment_update.md",
+  "pr_desc.md",
+];
+
+function getTemplateFiles(): string[] {
+  if (!fs.existsSync(TEMPLATES_DIR)) return [];
+  return fs.readdirSync(TEMPLATES_DIR)
+    .filter((f) => f.endsWith(".md"))
+    .sort();
+}
+
+function extractFrontmatterKeys(content: string): Set<string> | null {
+  const match = content.match(/^---\s*\r?\n([\s\S]*?)\r?\n---\s*\r?\n/);
+  if (!match) return null;
+  const body = match[1];
+  const keys = new Set<string>();
+  for (const line of body.split(/\r?\n/)) {
+    const kv = line.match(/^([\w-]+)\s*:/);
+    if (kv) keys.add(kv[1]);
+  }
+  return keys;
+}
+
+function countRequiredMarkers(content: string): number {
+  const markerRe = /<!--\s*【必須】\s*-->/g;
+  return (content.match(markerRe) || []).length;
+}
+
+const templateFiles = getTemplateFiles();
+
+describe("REQ-0030-005: Template frontmatter required fields and required sections", () => {
+  it("template files exist in agentdev-workflow-templates/templates/", () => {
+    expect(templateFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const file of templateFiles) {
+    describe(`template: ${file}`, () => {
+      const content = fs.readFileSync(path.join(TEMPLATES_DIR, file), "utf-8");
+
+      if (TEMPLATES_WITH_FRONTMATTER.includes(file)) {
+        const keys = extractFrontmatterKeys(content);
+
+        it("has frontmatter", () => {
+          expect(keys).not.toBeNull();
+        });
+
+        if (keys) {
+          it("has 'name' field in frontmatter", () => {
+            expect(keys.has("name")).toBe(true);
+          });
+
+          it("has 'about' field in frontmatter", () => {
+            expect(keys.has("about")).toBe(true);
+          });
+        }
+      } else {
+        it("has content (non-frontmatter template)", () => {
+          expect(content.trim().length).toBeGreaterThan(0);
+        });
+      }
+
+      it("has at least one <!-- 【必須】 --> marker", () => {
+        const count = countRequiredMarkers(content);
+        expect(count).toBeGreaterThan(0);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## 概要

Issue #373 (Phase B: 構造検証テスト実装) の対応PR。REQ-0030-001〜005, 006, 007, 008に対応する構造検証テストを追加。

## 実装内容

### Gap分析結果
既存のintegrity validatorスクリプト（`check_integrity.ts`, `lint_skills.ts`, `check_templates.ts`）はsubprocess+fixture方式でスクリプトの動作を検証しているが、リポジトリ内の実際の定義ファイルを直接検証するテストは未実装だった。

### 新規追加テスト

| テストファイル | 対象REQ | 検証内容 |
|---|---|---|
| `commands_structure.test.ts` | REQ-0030-001, 002 | コマンドfrontmatter必須フィールド(`description`, `agent`, `load_skills`)、Steps/Phaseセクション構造、load_skills参照先存在確認 |
| `skills_structure.test.ts` | REQ-0030-003, 004 | スキルfrontmatter必須フィールド(`name`, `description`)、USE FOR / DO NOT USE FOR内容存在確認（headingまたはdescription内）、See Also参照先存在確認 |
| `templates_structure.test.ts` | REQ-0030-005 | テンプレートfrontmatter必須項目(`name`, `about`)、必須セクションマーカー(`<!-- 【必須】 -->`)存在確認 |

### テスト数
- 382テスト、494 assertion、全PASS
- 14コマンド定義ファイル、20スキル定義ファイル、13テンプレートファイルを検証

## 完了条件

- [x] REQ-0030-001: 全コマンド定義ファイルの frontmatter 必須フィールド存在確認テストが実装されている
- [x] REQ-0030-002: 全コマンド定義ファイルの Steps セクション構造と load_skills 参照先存在確認テストが実装されている
- [x] REQ-0030-003: 全スキル定義ファイルの frontmatter 必須フィールド存在確認テストが実装されている
- [x] REQ-0030-004: 全スキル定義ファイルの USE FOR / DO NOT USE FOR セクションと See Also 参照先存在確認テストが実装されている
- [x] REQ-0030-005: 全テンプレートファイルの frontmatter 必須項目と必須セクション存在確認テストが実装されている
- [x] REQ-0030-006: 既存 integrity validator とのギャップ分析が実施され、重複しない新規テストが追加されている
- [x] REQ-0030-007: 全テストが `bun test` で PASS する
- [x] REQ-0030-008: テストスクリプトが対応する scripts/ ディレクトリに `*.test.ts` として配置されている

## テスト結果

```
bun test v1.3.10
382 pass
0 fail
494 expect() calls
Ran 382 tests across 3 files. [54.00ms]
```

Refs: #373
