### PR TITLE
fix(commands): case-close Step 7のREQ参照をREQ-0037-008〜010に修正

### DIFF
--- a/.opencode/commands/agentdev/case-close.md
+++ b/.opencode/commands/agentdev/case-close.md
@@ -123,7 +123,7 @@ PRをマージし、Caseに記録を追記し、クローズ後にworktreeとブ
     - worktree prune
     - ローカルブランチ削除:
         - `git branch -d "{type}/issue-{N}"` を実行する
-        - **`git branch -d` 失敗時（"not fully merged"）**（SHALL, REQ-0038-002）: squash merge 済みの場合は条件付きで `-D` を許可する:
+        - **`git branch -d` 失敗時（"not fully merged"）**（SHALL, REQ-0037-008〜010）: squash merge 済みの場合は条件付きで `-D` を許可する:
             1. `gh pr view {PR番号} --json state,mergedAt -q '.state + " " + .mergedAt'` で PR がマージ済みであることを確認する
             2. PR がマージ済み（`state: MERGED`）と確認できた場合 → `git branch -D "{type}/issue-{N}"` を実行して強制削除する
             3. PR がマージ済みと確認できない場合 → 警告を表示して停止する（REQ-0001-007）


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

case-close Step 7 の squash merge 後ブランチ強制削除セクションにおける誤ったREQ参照（REQ-0038-002）を正しい参照（REQ-0037-008〜010）に修正する。既存実装の正規REQ接続（新規実装なし）。

## 実装内容
<!-- 【必須】 -->

- `.opencode/commands/agentdev/case-close.md` Step 7: `git branch -d` 失敗時セクションのREQ参照を `REQ-0038-002` → `REQ-0037-008〜010` に修正

## 完了条件
<!-- 【必須】 -->

- [x] case-close Step 7: `git branch -d` が `not fully merged` で失敗した場合、PR が squash merge 済みであることを GitHub 上で確認すること（REQ-0037-008）
- [x] case-close Step 7: PR が merge 済みであることを確認できた場合に限り、`git branch -D` による強制削除を許可すること（REQ-0037-009）
- [x] case-close Step 7: PR が merge 済みであることを確認できない場合、強制削除せず警告を表示して停止すること（REQ-0037-010）
- [x] case-close.md 内の誤った REQ-0038-002 参照を REQ-0037-008〜010 に修正すること（REQ-0037-011）

## テスト結果
<!-- 【必須】 -->

該当なし（command定義ファイルの1行変更のため）

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 変更範囲 | 1ファイル1行 | 最小変更 | ✅ |
| 乖離検出 | 0件 | 0件 | ✅ |

<!-- 【必須】 -->
Closes #413
