### PR TITLE
feat: req-backlog コマンド定義と RU フォーマットを追加

### DIFF
--- a/.opencode/commands/agentdev/req-backlog.md
+++ b/.opencode/commands/agentdev/req-backlog.md
@@ -1,0 +1,213 @@
+---
+description: promoted artifact を分析・統合し、Requirement Unit（RU）を生成する
+agent: sisyphus
+load_skills:
+  - agentdev-workflow-lifecycle
+  - agentdev-workflow-reporting
+  - agentdev-gh-cli
+---
+
+# Req Backlog
+
+`.agentdev/intake/promoted/*.md` 及び `.agentdev/learning/promoted/*.md` の promoted artifact を読み込み、分析・統合して Requirement Unit（RU）を `.agentdev/backlog/req-units/RU-*.md` として生成する。
+
+**このコマンドは RU 生成のみを行う。** REQ ファイルの保存・Issue の作成は行わない（REQ-0039-001）。
+
+## Input
+
+- `.agentdev/intake/promoted/*.md`（intake パイプラインからの promoted artifact、フラット構造）
+- `.agentdev/learning/promoted/*.md`（learning パイプラインからの promoted artifact、フラット構造）
+
+## Output
+
+- `.agentdev/backlog/req-units/RU-*.md`（Requirement Unit）
+- 成功した promoted artifact の削除（REQ-0039-006）
+
+## RU フォーマット
+
+RU-*.md は以下の構造に従う（REQ-0039-002, 003）:
+
+```markdown
+---
+source_type: {intake | learning | mixed}
+generated_by: req-backlog
+generated_at: {ISO 8601 timestamp}
+status: draft
+sources:
+  - path: {.agentdev/intake/promoted/xxx.md | .agentdev/learning/promoted/xxx.md}
+    type: {intake | learning}
+---
+
+## Sources
+
+{各 source artifact の要点抽出。パススルー禁止（REQ-0039-003）}
+
+## Source Summary
+
+{全 source の共通テーマ・論点の統合サマリ}
+
+## 統合理由
+
+{N:1 統合または 1:N 分割の理由。どの artifact を統合/分割したか、その根拠}
+
+## 要件化の方向
+
+{req-define に渡すべき要件化の方向性・アプローチ・推奨スコープ}
+```
+
+### 粒度ルール（REQ-0039-004）
+
+- **N:1**: 複数 artifact の趣旨が同一の場合、1 RU に統合する
+- **1:N**: 1 artifact 内に複数の独立した論点がある場合、複数 RU に分割する
+- 粒度判定は artifact 間の論理的関連性に基づく
+
+## Steps
+
+### Step 0: 実行前同期（git pull --ff-only）
+
+`git pull --ff-only` を実行する。
+
+- **失敗時**: 以下の構造化エラーメッセージを表示して停止する（自動解消しない）:
+  ```
+  ## Git 同期エラー
+
+  **エラー種別**: pull --ff-only 失敗
+  **停止理由**: リモートに未取り込みの変更があり、fast-forward マージできない
+  **対象ブランチ**: {current_branch}
+  **ユーザーアクション**: 手動で `git pull --rebase` または `git stash && git pull --ff-only && git stash pop` を実行してください
+  **raw git output**:
+  {git_error_output}
+  ```
+
+### Step 1: Artifact 検出
+
+両ディレクトリから promoted artifact を検出する:
+
+- `.agentdev/intake/promoted/*.md`
+- `.agentdev/learning/promoted/*.md`
+
+検出結果の判定:
+- **0件**: 正常終了する（エラー扱いとしない）（REQ-0039-007）。完了報告で「対象なし」と報告
+- **1件以上**: 検出された全 artifact をファイルパス昇順で並べ、Step 2 へ進む
+
+### Step 2: Artifact 読み込み・分析
+
+各 promoted artifact を読み込み、内容を分析する:
+
+- **intake 系**: タイトル・概要・対象範囲・完了条件等の構造化内容を抽出
+- **learning 系**: 背景・問題・望ましい変更・対象範囲・完了条件等の Requirement Source 形式内容を抽出
+- frontmatter は持たない（ディレクトリ配置が一次状態）
+
+分析結果を各 artifact ごとにまとめる:
+
+| 項目 | 内容 |
+|------|------|
+| artifact パス | 元ファイルパス |
+| source type | intake / learning |
+| 主要テーマ | 抽出された主論点 |
+| 関連 artifact 群 | 同一趣旨の可能性がある他 artifact |
+
+### Step 3: 統合・分割判定
+
+分析結果に基づき、RU への統合・分割を判定する（REQ-0039-004）:
+
+- **N:1 統合条件**: 複数 artifact が同一の要件・課題に関する内容を含む
+- **1:N 分割条件**: 1 artifact に独立した複数の論点が含まれる
+- **1:1**: 特別な統合・分割が不要な場合
+
+判定結果をユーザーに提示し、確認を得る:
+
+- 統合・分割の grouping の妥当性
+- 調整指示があれば反映
+
+### Step 4: 矛盾検出
+
+統合対象の artifact 間に矛盾がないか確認する（REQ-0039-005）:
+
+- **矛盾の定義**: 同一事項に対して互いに両立不可能な要求が含まれる状態
+- **矛盾検出時**: 矛盾する artifact を RU 化せず、ユーザーに確認を求める
+  - 矛盾内容と対象 artifact を提示
+  - ユーザーの指示を待つ（どちらを採用するか、両立可能か等）
+- **矛盾しない artifact**: 通常通り RU 化を継続する（partial success）
+- 矛盾の結果、RU 化を見送った artifact は `promoted/` に残置する
+
+### Step 5: RU 生成
+
+統合・分割判定に基づいて RU ファイルを生成する:
+
+1. `.agentdev/backlog/req-units/` ディレクトリが存在しない場合は作成する
+2. 各 RU について:
+   - frontmatter を生成（source_type, generated_by, generated_at, status, sources）
+   - Sources セクション: 各 source の要点（パススルー禁止）（REQ-0039-003）
+   - Source Summary セクション: 統合サマリ
+   - 統合理由セクション: N:1/1:N の理由
+   - 要件化の方向セクション: req-define への推奨方向
+3. ファイル名: `RU-{NNNN}.md`（NNNN は連番、既存ファイルの最大番号 +1 から採番）
+4. 各 RU の内容をユーザーに提示し、確認を得る
+
+### Step 6: 成功 artifact の削除
+
+RU 生成が成功した promoted artifact を削除する（REQ-0039-006, 010）:
+
+- **削除条件**: 当該 artifact が RU に取り込まれ、RU ファイルの生成が確認できた場合のみ
+- **削除対象**: RU 化に成功した `.agentdev/intake/promoted/*.md` 及び `.agentdev/learning/promoted/*.md`
+- **残置対象**: RU 化に失敗した artifact、矛盾検出により保留された artifact
+- 削除結果を記録する（Step 8 の完了報告で集計）
+
+### Step 7: Git 永続化
+
+`.agentdev/` 配下の変更を commit / push する:
+
+- `git diff --name-only` で `.agentdev/` 配下の変更ファイルを確認する
+- **変更なし時**: commit/push せず、Step 8 の完了報告で「変更なし」と報告
+- **変更あり時**:
+  1. `git add` は `.agentdev/` 配下の変更ファイルのみを対象とする（SHALL）
+  2. commit message: `chore(agentdev): generate requirement units via req-backlog`（Conventional Commits 形式）（SHALL）
+  3. `git push` を実行する
+  4. **push 失敗時**: 以下の構造化エラーメッセージを表示し、完了扱いにしない（SHALL）:
+     ```
+     ## Git Push エラー
+
+     **エラー種別**: push 失敗
+     **停止理由**: リモートへのプッシュに失敗
+     **対象ブランチ**: {current_branch}
+     **変更ファイル**: {changed_files}
+     **ユーザーアクション**: 手動で `git push` を実行してください
+     **raw git output**:
+     {git_error_output}
+     ```
+
+### Step 8: 完了報告
+
+完了報告 → `agentdev-workflow-reporting` の完了報告フォーマット（completion-reports.md → req-backlog 完了時）に従って出力。git 永続化結果（変更有無・ファイル一覧・commit hash・push 成否）を含める
+
+## Error Handling
+
+| エラー | 対処 |
+|--------|------|
+| git pull --ff-only 失敗 | 構造化エラーメッセージを表示して停止。自動解消しない |
+| git push 失敗 | 構造化エラーメッセージを表示。完了扱いにしない |
+| artifact 読み込み失敗 | 当該 artifact をスキップし、後続 artifact の処理を継続。失敗を記録して Step 8 で報告 |
+| 矛盾検出 | 矛盾する artifact を RU 化せずユーザーに確認。矛盾しない artifact は通常通り RU 化を継続 |
+| 全件失敗 | 構造化された実行報告を出力して終了（REQ-0039-008） |
+
+## Guardrails
+
+### 責務境界（REQ-0039-001, 009）
+- G01: REQ ファイルの保存を行わない（`req-save` が担当）
+- G02: GitHub Issue の作成を行わない（`case-open` が担当）
+- G03: `req-define` を自動起動しない（次ステップの提示のみ）
+- G04: promoted artifact の単純コピー（パススルー）を生成しない（MUST NOT）（REQ-0039-003）。全 RU は分析・統合された構造化内容でなければならない
+
+### raw item 保護（REQ-0039-009）
+- G05: `.agentdev/intake/inbox/` の intake raw item を更新しない（MUST NOT）
+- G06: `.agentdev/intake/archive/` の intake raw item を更新しない（MUST NOT）
+- G07: `.agentdev/learning/inbox.md` を更新しない（MUST NOT）
+- G08: `.agentdev/learning/archive.md` を更新しない（MUST NOT）
+- G09: raw item の更新は各パイプラインのコマンド（intake-promote, learning-promote）の責務である
+
+### 実行制約
+- G10: promoted artifact は `.agentdev/intake/promoted/*.md` 及び `.agentdev/learning/promoted/*.md` のフラット構造からのみ読み込む（サブディレクトリは探索しない）
+- G11: RU の配置先は `.agentdev/backlog/req-units/` のみ
+- G12: 矛盾検出時はユーザーの指示を待ち、自動的に解決しない
+- G13: partial success をサポートする（成功分は RU 化 + 元 artifact 削除、失敗分は残置）（REQ-0039-010）

--- a/.opencode/skills/agentdev-workflow-lifecycle/reference/artifact-lifecycle.md
+++ b/.opencode/skills/agentdev-workflow-lifecycle/reference/artifact-lifecycle.md
@@ -1,0 +1,74 @@
+# 成果物ライフサイクル
+
+RU・promoted artifact・REQ ファイル等の成果物ライフサイクルの宣言的ルールを定義する（REQ-0039-021）。
+
+## 成果物一覧
+
+| 成果物 | 格納先 | 生成コマンド | 消費コマンド | 削除トリガー |
+|--------|--------|-------------|-------------|-------------|
+| intake promoted artifact | `.agentdev/intake/promoted/*.md` | `intake-promote` | `req-backlog` | RU 化成功時（REQ-0039-006） |
+| learning promoted artifact | `.agentdev/learning/promoted/*.md` | `learning-promote` | `req-backlog` | RU 化成功時（REQ-0039-006） |
+| Requirement Unit（RU） | `.agentdev/backlog/req-units/RU-*.md` | `req-backlog` | `req-define`, `req-save`, `case-open` | REQ ファイル永続化完了時（REQ-0039-015）または Issue 作成完了時（REQ-0039-016） |
+| REQ ファイル | `docs/requirements/REQ-{NNNN}.md` | `req-save` | `case-open`, `case-run`, `case-close` | なし（永続） |
+| ADR ファイル | `docs/adr/ADR-*.md` | `req-save` | 参照のみ | なし（永続、superseded で管理） |
+
+## RU ライフサイクル
+
+### 生成
+
+- **生成コマンド**: `req-backlog`
+- **入力**: intake promoted artifact + learning promoted artifact
+- **出力**: `.agentdev/backlog/req-units/RU-*.md`
+- **フォーマット**: frontmatter（source_type, generated_by, generated_at, status, sources）+ Sources + Source Summary + 統合理由 + 要件化の方向（REQ-0039-002）
+
+### 消費
+
+RU は以下の2つのルートで消費される:
+
+1. **req-define ルート**: `req-backlog` → `req-define`（RU を明示入力ファイルとして読み込み）→ `req-save` → `case-open` → `case-run`
+2. **直接 Issue 化ルート**: `req-backlog` → `req-define` → `case-open`（バグ修正・軽微変更の場合）
+
+### 削除
+
+RU の削除トリガーは以下のいずれか（REQ-0039-015, 016, 017）:
+
+| トリガー | コマンド | 条件 |
+|----------|---------|------|
+| REQ ファイル永続化完了 | `req-save` | RU の内容が REQ ファイルに正常保存された後 |
+| Issue 作成完了 | `case-open` | RU の内容が GitHub Issue に正常作成された後 |
+
+- **削除条件**: Requirement Source の永続化完了（REQ ファイル保存成功 または Issue 作成成功）に限定
+- **残置条件**: 永続化が未完了の場合は RU を残置する
+
+## Promoted Artifact ライフサイクル
+
+### Intake Promoted
+
+- **生成**: `intake-promote` が `.agentdev/intake/promoted/*.md`（フラット）に出力
+- **消費**: `req-backlog` が読み込み
+- **削除**: RU 化成功時に `req-backlog` が削除（REQ-0039-006）
+- **残置**: RU 化失敗・矛盾検出時は `promoted/` に残置
+
+### Learning Promoted
+
+- **生成**: `learning-promote` が `.agentdev/learning/promoted/*.md`（フラット）に出力
+- **消費**: `req-backlog` が読み込み
+- **削除**: RU 化成功時に `req-backlog` が削除（REQ-0039-006）
+- **残置**: RU 化失敗・矛盾検出時は `promoted/` に残置
+
+## データフロー
+
+```
+intake-promote → .agentdev/intake/promoted/*.md ──┐
+                                                    ├→ req-backlog → .agentdev/backlog/req-units/RU-*.md
+learning-promote → .agentdev/learning/promoted/*.md ┘                     │
+                                                                          ├→ req-define → req-save → REQ ファイル（RU 削除）
+                                                                          └→ req-define → case-open → Issue（RU 削除）
+```
+
+## 制約
+
+- promoted artifact はフラット構造（サブディレクトリなし）からのみ読み込む（REQ-0039-011, 012）
+- `req-define` は promoted artifact を直接読み込まない（REQ-0039-019）。RU 経由が必須
+- `req-define` はユーザーの直接入力及び一般 source file を引き続き受け入れる（REQ-0039-020）
+- raw item（inbox.md, archive.md, entries/）は req-backlog の更新対象外（REQ-0039-009）

--- a/.opencode/skills/agentdev-workflow-reporting/reference/completion-reports.md
+++ b/.opencode/skills/agentdev-workflow-reporting/reference/completion-reports.md
@@ -24,7 +24,7 @@
 2. **完了報告テキスト（後）**: 本スキルの完了報告フォーマットに従ったテキストを出力する
 3. **中間出力の禁止**: TodoWrite更新と完了報告テキストの間に、他の中間出力（ログ・進捗報告・確認メッセージ等）を挟まない
 
-**適用対象**: req-define, req-save, case-open, case-run, case-run (Epic Orchestrator), case-close, case-update, intake-capture, intake-from-github, intake-review, intake-promote, intake-open, learning-refine, learning-promote, integrity-check の全完了報告ステップ
+**適用対象**: req-define, req-save, case-open, case-run, case-run (Epic Orchestrator), case-close, case-update, intake-capture, intake-from-github, intake-review, intake-promote, intake-open, req-backlog, learning-refine, learning-promote, integrity-check の全完了報告ステップ
 
 **理由**: 完了報告テキストがユーザーに最後に表示されることで、最終結果の視認性が向上する
 
@@ -463,6 +463,83 @@ git 永続化: 変更なし（commit/push スキップ）
 - 失敗詳細は artifact ごとのエラー概要（1行）
 - git 永続化セクションのルールは他の intake 系コマンドと同一
 
+## req-backlog 完了時
+
+### 全件成功時
+
+```
+✅ req-backlog 完了
+
+完了コマンド: /agentdev/req-backlog
+対象: promoted artifact {count}件（intake: {I}件 / learning: {L}件）
+結果:
+  - 生成 RU: {N}件（{ru_file_list}）
+  - 削除済み artifact: {deleted_artifact_list}
+  - 残存 artifact: なし
+検証結果: ✅ OK
+git 永続化: commit: {hash}, push: {成功/失敗}
+次のコマンド: /agentdev/req-define {ru_path}
+```
+
+### 対象なし（0件）
+
+```
+✅ req-backlog 完了
+
+完了コマンド: /agentdev/req-backlog
+対象: promoted artifact 0件
+結果:
+  - 対象なし（promoted artifact が存在しない）
+  - 生成 RU: 0件
+検証結果: ✅ OK
+git 永続化: 該当なし
+次のコマンド: なし
+```
+
+### 部分失敗あり（矛盾・エラー）
+
+```
+⚠️ req-backlog 完了
+
+完了コマンド: /agentdev/req-backlog
+対象: promoted artifact {count}件（intake: {I}件 / learning: {L}件）
+結果:
+  - 生成 RU: {success_count}件（{ru_file_list}）
+  - 削除済み artifact: {deleted_artifact_list}
+  - 残存 artifact: {remaining_artifact_list}
+  - 失敗詳細: {artifact_name}: {reason}（矛盾/エラー）
+検証結果: ⚠️ 部分成功
+git 永続化: commit: {hash}, push: {成功/失敗}
+次のコマンド:
+  - 成功したRU: /agentdev/req-define {ru_path}
+  - 残存artifactの確認後、再実行: /agentdev/req-backlog
+```
+
+### 全件失敗時
+
+```
+❌ req-backlog 完了
+
+完了コマンド: /agentdev/req-backlog
+対象: promoted artifact {count}件
+結果:
+  - 生成 RU: 0件
+  - 削除済み artifact: なし
+  - 残存 artifact: {remaining_artifact_list}
+  - 失敗詳細: {artifact_name}: {reason}
+検証結果: ❌ NG
+git 永続化: 変更なし（commit/push スキップ）
+次のコマンド: 失敗原因を確認後、再実行: /agentdev/req-backlog
+```
+
+### フォーマット共通ルール
+
+- 処理結果の 成功/失敗 カウントは必須
+- RU ファイル名は生成順で列挙
+- artifact 名はファイル名（パス含まない）で列挙
+- 失敗詳細は artifact ごとの理由概要（1行）
+- 0件時はエラー扱いとしない（REQ-0039-007）
+
 ## learning-refine 完了時
 
 ```
@@ -516,6 +593,6 @@ git 永続化: 該当なし
 
 ### git 永続化セクションのルール
 
-- learning-refine, learning-promote, case-close, intake-capture, intake-from-github, intake-review, intake-promote, intake-open の完了報告に git 永続化セクションを含める
+- learning-refine, learning-promote, case-close, intake-capture, intake-from-github, intake-review, intake-promote, intake-open, req-backlog の完了報告に git 永続化セクションを含める
 - 変更なしの場合は「変更なし（commit/push スキップ）」と表示する
 - push 失敗時は「push: 失敗」と表示し、完了報告全体を ⚠️ に変更する


### PR DESCRIPTION
## 概要

`req-backlog` コマンドの定義ファイルと Requirement Unit（RU）フォーマットを新規作成し、REQ-0039 Section A（REQ-0039-001 ~ 010）に対応する。

Refs: #422

## 変更内容

### 新規作成

- **`.opencode/commands/agentdev/req-backlog.md`** — req-backlog コマンド定義
  - Input: `.agentdev/intake/promoted/*.md` + `.agentdev/learning/promoted/*.md`（フラット構造）
  - Output: `.agentdev/backlog/req-units/RU-*.md`
  - Steps: artifact 検出 → 読み込み・分析 → 統合・分割判定 → 矛盾検出 → RU 生成 → 成功 artifact 削除 → Git 永続化 → 完了報告
  - Guardrails: raw item 不更新（G05-G09）、passthrough 禁止（G04）、partial success（G13）
  - frontmatter: `agent: sisyphus`, `load_skills: [agentdev-workflow-lifecycle, agentdev-workflow-reporting, agentdev-gh-cli]`

- **`.opencode/skills/agentdev-workflow-lifecycle/reference/artifact-lifecycle.md`** — 成果物ライフサイクルルール
  - RU・promoted artifact の生成・消費・削除トリガーを定義
  - データフロー図を含む

### 更新

- **`.opencode/skills/agentdev-workflow-reporting/reference/completion-reports.md`**
  - `req-backlog 完了時` セクション追加（全件成功 / 対象なし / 部分失敗 / 全件失敗の4パターン）
  - 適用対象リストに `req-backlog` を追加
  - git 永続化セクションのルールに `req-backlog` を追加

## REQ カバレッジ

| REQ ID | 内容 | 対応 |
|--------|------|------|
| REQ-0039-001 | promoted → RU 生成 | ✅ Step 1-5 |
| REQ-0039-002 | RU フォーマット | ✅ RU フォーマット セクション |
| REQ-0039-003 | passthrough 禁止 | ✅ G04 |
| REQ-0039-004 | N:1/1:N 粒度 | ✅ Step 3 + 粒度ルール |
| REQ-0039-005 | 矛盾検出 | ✅ Step 4 |
| REQ-0039-006 | 成功 artifact 削除 | ✅ Step 6 |
| REQ-0039-007 | 0件正常終了 | ✅ Step 1 |
| REQ-0039-008 | 全件失敗時の報告 | ✅ Error Handling |
| REQ-0039-009 | raw item 不更新 | ✅ G05-G09 |
| REQ-0039-010 | partial success | ✅ G13 + Step 6 |
| REQ-0039-021 | artifact-lifecycle.md | ✅ 新規作成 |

## テスト結果

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| frontmatter 妥当性 | agent, load_skills, description あり | 必須フィールド存在 | ✅ |
| RU フォーマット構造 | frontmatter 5項目 + 4セクション | 必須構造存在 | ✅ |
| 完了条件 | 7/7 チェックボックス達成 | 全達成 | ✅ |
