### PR TITLE
ADR-0009ステータス更新（proposed → accepted）

### DIFF
--- a/docs/adr/ADR-0009.md
+++ b/docs/adr/ADR-0009.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0009
 title: "REQ体系再基準化 — 旧REQ分類モデル・対応表・分類ゲート導入"
-status: proposed
+status: accepted
 created: "2026-05-30"
 updated: "2026-05-30"
 ---

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,11 +27,11 @@
 - [ADR-0003](ADR-0003.md) — req-define入力の抽象化
 - [ADR-0006](ADR-0006.md) — Epic Issue 本文を実行順序 SSoT とする設計
 - [ADR-0008](ADR-0008.md) — DOC-MAP導入と requirements/views 廃止
-- [ADR-0009](ADR-0009.md) — REQ体系再基準化 — 旧REQ分類モデル・対応表・分類ゲート導入
 
 ### accepted
 
 - [ADR-0005](ADR-0005.md) — AgentDevFlow plugin namespace 統一
+- [ADR-0009](ADR-0009.md) — REQ体系再基準化 — 旧REQ分類モデル・対応表・分類ゲート導入
 
 ### superseded
 


### PR DESCRIPTION
## 概要

ADR-0009（REQ体系再基準化 — 旧REQ分類モデル・対応表・分類ゲート導入）のステータスを `proposed` から `accepted` に更新し、REQ体系再基準化の判断を正式に合意済みとする。

## 実装内容

1. `docs/adr/ADR-0009.md` の frontmatter を更新:
   - `status: proposed` → `status: accepted`
   - `updated: "2026-05-30"` （同日更新）

2. `docs/adr/README.md` の Status View を更新:
   - ADR-0009 を `proposed` セクションから `accepted` セクションに移動
   - `accepted` セクションに `[ADR-0009](ADR-0009.md) — REQ体系再基準化 — 旧REQ分類モデル・対応表・分類ゲート導入` を追加
   - `proposed` セクションから ADR-0009 エントリを削除

## 完了条件

- [x] ADR-0009.md の frontmatter status が `accepted` に更新されている
- [x] `docs/adr/README.md` の Status View に ADR-0009 が accepted セクションに表示されている

## テスト結果

該当なし

## 品質メトリクス

| 項目 | 結果 |
|------|------|
| LSP診断 | 該当なし（Markdownファイルのみ） |
| Commit規約 | ✅ conventional-commits準拠 |
| 変更範囲 | ✅ 対象ファイルのみ（ADR-0009.md, README.md） |

## Findings / Intake候補

該当なし