### PR TITLE
旧REQ全件分類・マーキング（40件の3分類）

### DIFF
--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -1,55 +1,78 @@
 # Requirements Index
 
-## 有効な要件
+REQ-0041（REQ体系再基準化）により、既存REQ群（REQ-0001〜REQ-0040）を以下の3分類に分類しています。詳細は [REQ-0041](REQ-0041.md) を参照。
+
+## Retained（現行基準）
+
+以下のREQは現行仕様の基準としてそのまま維持します。
 
 | REQ ID   | Title                                | 領域              |
 | -------- | ------------------------------------ | ----------------- |
 | REQ-0001 | AgentDevFlow ワークフローアーキテクチャ          | workflow          |
-| REQ-0002 | AgentDevFlow コマンドプロトコル               | commands          |
 | REQ-0003 | Case 並列実行             | parallel          |
-| REQ-0004 | 要件・ADRドキュメントシステム   | requirements/adr  |
 | REQ-0005 | Epic Issue 管理                | epic              |
 | REQ-0006 | Sisyphus プラン基盤         | sisyphus          |
-| REQ-0007 | ナレッジパイプライン高度化                   | knowledge/learning         |
 | REQ-0008 | スキル品質フレームワーク              | skill             |
-| REQ-0009 | テンプレートシステム                      | templates         |
-| REQ-0010 | AgentDevFlow Command実装改善：安全性・品質・状態管理 | workflow/safety/quality |
-| REQ-0011 | Issue/PR書き込み後の内容品質自動検証 | quality-assurance/encoding |
 | REQ-0012 | 自然言語ポリシー | language/japanese |
+| REQ-0018 | agentdev-req-analysis 未決分岐解消メソドロジー | req-analysis/wall-discussion/methodology |
+| REQ-0020 | Epic Issue 実行順序 SSoT と case-run Epic Orchestrator 化 | epic/orchestration/ssot/wave |
+| REQ-0021 | AgentDevFlow ガードレールのスクリプト化と skill-local scripts 配置方針 | integrity/scripts/skill-structure/guardrails |
+| REQ-0030 | agentdev コマンド群の体系的テスト実装 | testing/quality/commands/skills/templates/epic |
+| REQ-0031 | GitHub本文内リポジトリ参照リンクの正規化 | github/link-normalization/url/templates/verification/commands |
+| REQ-0032 | case-close 未チェック項目達成判定 | enhancement/case-close/checkbox/completion-gate/achievement-check/autonomous-resolution |
+| REQ-0034 | req-define 関連ドキュメント更新候補抽出と後続工程への伝播 | enhancement/req-define/document-update/impact-detection |
+| REQ-0035 | DOC-MAP導入と requirements/views 廃止による文書探索・維持管理再設計 | doc-map/views-abolition/document-structure |
+| REQ-0038 | case実行信頼性向上（チェックボックス確認・pull前チェック・docs整合性grep） | enhancement/reliability/case-run/case-close |
+
+## Partially Superseded（一部移行）
+
+以下のREQは一部が新基準REQ群に移行しました。本文冒頭に移行範囲が記載されています。現行仕様として読める部分と、そうでない部分があります。
+
+| REQ ID   | Title                                | 領域              |
+| -------- | ------------------------------------ | ----------------- |
+| REQ-0002 | AgentDevFlow コマンドプロトコル               | commands          |
+| REQ-0004 | 要件・ADRドキュメントシステム   | requirements/adr  |
+| REQ-0007 | ナレッジパイプライン高度化                   | knowledge/learning         |
+| REQ-0009 | テンプレートシステム                      | templates         |
+| REQ-0011 | Issue/PR書き込み後の内容品質自動検証 | quality-assurance/encoding |
 | REQ-0014 | case-run 自律修正ループと責務分離の明確化 | workflow/self-healing/ci-cd |
 | REQ-0015 | 関連ドキュメントの要件達成対象化 | workflow/issue-commands/documentation/scope/verification |
 | REQ-0016 | Command/Skill/Template/Script責任分界とtips要件ソース化 | commands/skills/templates/scripts/knowledge |
 | REQ-0017 | AgentDevFlow plugin namespace 統一と learning / intake / integrity の正式化 | agentdev/namespace/plugin/learning/intake/integrity/migration |
-| REQ-0018 | agentdev-req-analysis 未決分岐解消メソドロジー | req-analysis/wall-discussion/methodology |
 | REQ-0019 | intake / learning の責任境界明確化と workflow 組み込み | agentdev/intake/learning/workflow/boundary |
-| REQ-0020 | Epic Issue 実行順序 SSoT と case-run Epic Orchestrator 化 | epic/orchestration/ssot/wave |
-| REQ-0021 | AgentDevFlow ガードレールのスクリプト化と skill-local scripts 配置方針 | integrity/scripts/skill-structure/guardrails |
 | REQ-0022 | .agentdev domain state 更新後の git 永続化 | agentdev/git/persistence/domain-state |
-| REQ-0023 | learning staging stub の取り込み追跡と取り込み後アーカイブ | learning/staging-stub/archive/import-tracking |
 | REQ-0024 | 全 agentdev コマンドの完了報告フォーマット統一 | enhancement/workflow-reporting/command-system/completion-reports |
 | REQ-0025 | intake 系コマンドの .agentdev/intake 更新後の git 永続化 | agentdev/git/persistence/intake |
 | REQ-0026 | intake lifecycle の queue/archive 再定義 | agentdev/intake/lifecycle/queue/archive/refactor |
 | REQ-0027 | learning artifact lifecycle の責任範囲明確化 | learning/lifecycle/artifact/documentation/command/skill |
-| REQ-0028 | Documentation granularity and responsibility restructuring | documentation/granularity/responsibility |
-| REQ-0030 | agentdev コマンド群の体系的テスト実装 | testing/quality/commands/skills/templates/epic |
-| REQ-0031 | GitHub本文内リポジトリ参照リンクの正規化 | github/link-normalization/url/templates/verification/commands |
-| REQ-0032 | case-close 未チェック項目達成判定 | enhancement/case-close/checkbox/completion-gate/achievement-check/autonomous-resolution |
-| REQ-0033 | AgentDevFlow command / skill 定義の二次整合性是正 | agentdev/consistency/guardrails/command-definitions/skill-definitions |
-| REQ-0034 | req-define 関連ドキュメント更新候補抽出と後続工程への伝播 | enhancement/req-define/document-update/impact-detection |
-| REQ-0035 | DOC-MAP導入と requirements/views 廃止による文書探索・維持管理再設計 | doc-map/views-abolition/document-structure |
 | REQ-0036 | agentdev-no-ai-slop-writing Skill 追加 | skill/writing-quality/ai-slop/natural-language |
 | REQ-0037 | worktree 削除時の残存ファイル対策強化 | case-close/case-run/worktree/error-handling |
-| REQ-0038 | case実行信頼性向上（チェックボックス確認・pull前チェック・docs整合性grep） | enhancement/reliability/case-run/case-close |
 | REQ-0039 | req-backlog コマンドと Requirement Unit パイプライン | workflow/req-backlog/ru-lifecycle/promoted |
 | REQ-0040 | 子Issue PRに Findings / Intake候補を永続化し、case-closeで回収する | intake/pr-template/case-run/case-close/epic-orchestrator |
-| REQ-0041 | REQ体系再基準化 — 旧REQ分類・新基準REQ群・分類ゲート | req-rebaselining/classification/correspondence-table/quality-gate |
 
-## Superseded
+## Superseded（全面置き換え）
+
+以下のREQは全面置き換えられました。現行仕様として読むことは推奨されません。履歴・参照用として保持されています。
 
 | REQ ID | Title | Superseded by |
 | ------ | ----- | ------------- |
 | REQ-0013 | intake 承認フロー分割と解消済み確認機能 | REQ-0039 |
+| REQ-0023 | learning staging stub の取り込み追跡と取り込み後アーカイブ | REQ-0039 |
+| REQ-0028 | Documentation granularity and responsibility restructuring | REQ-0041 |
 | REQ-0029 | intake-open promoted artifact 一括処理 | REQ-0039 |
+| REQ-0033 | AgentDevFlow command / skill 定義の二次整合性是正 | REQ-0041 |
+
+## 未分類
+
+| REQ ID | Title | 領域 |
+| ------ | ----- | ---- |
+| REQ-0010 | AgentDevFlow Command実装改善：安全性・品質・状態管理 | workflow/safety/quality |
+
+## 再基準化要件
+
+| REQ ID | Title | 領域 |
+| ------ | ----- | ---- |
+| REQ-0041 | REQ体系再基準化 — 旧REQ分類・新基準REQ群・分類ゲート | req-rebaselining/classification/correspondence-table/quality-gate |
 
 ## ディレクトリ構造の方針
 
@@ -70,3 +93,4 @@
 - ADR-0004: 要件管理構造の area-based 移行方針（superseded by ADR-0007）
 - ADR-0007: REQ/ADR基準構造と分類ビュー運用の再定義（superseded by ADR-0008）
 - ADR-0008: DOC-MAP導入と requirements/views 廃止
+- ADR-0009: REQ体系再基準化 — 旧REQ分類モデル・対応表・分類ゲート導入

--- a/docs/requirements/REQ-0002.md
+++ b/docs/requirements/REQ-0002.md
@@ -2,9 +2,18 @@
 id: REQ-0002
 title: "AgentDevFlow コマンドプロトコル"
 created: "2026-05-11"
-updated: "2026-05-24"
+updated: "2026-05-30"
 tags: [commands, protocol, interface, session-context, req-comparison]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: コマンド間の入出力契約の基本定義（REQ-0002-001〜006, 008）、req-define の既存REQ照合プロセス（REQ-0002-009〜011, 024〜028）、Step 0 のセッションコンテキスト検知（REQ-0002-012〜022）
+> **新基準REQに移行した範囲**: コマンド入出力の現行仕様の完全再定義（REQ-D候補）、intake-from-github/intake-open の定義（REQ-0002-007, 023）は REQ-0039 により移行済み
+> **後継REQ**: REQ-D（AgentDevFlow command protocol）候補
+> **履歴として残す理由**: Step 0 ルーティング設計の経緯、APPEND-first ルール導入の判断記録
 
 ## 目的
 

--- a/docs/requirements/REQ-0004.md
+++ b/docs/requirements/REQ-0004.md
@@ -2,9 +2,18 @@
 id: REQ-0004
 title: "要件・ADRドキュメントシステム"
 created: "2026-05-11"
-updated: "2026-05-28"
+updated: "2026-05-30"
 tags: [requirements, adr, documents, lifecycle, views, canonical-structure, finding-protocol, doc-map, views-abolition]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: REQ基準構造の基本規約（REQ-0004-008〜011）、ADR記録基準（REQ-0004-012〜013）、ADR基準構造とREADME分類ビュー（REQ-0004-047〜067）、ADR作成基準と参照ルール（REQ-0004-057〜067）、コマンド責務分界（REQ-0004-068〜074）、ADRファイル操作モデル（REQ-0004-075〜080）、SPLIT・Finding Protocol（REQ-0004-019〜027）、操作分類の判定軸（REQ-0004-028〜029）
+> **新基準REQに移行した範囲**: views 関連要件（REQ-0004-032〜034, 037〜041, 042〜045, 083〜085, 087）は REQ-0035 に移行済み。REQ基準構造と文書体系の再基準化部分は REQ-A候補に移行
+> **後継REQ**: REQ-A（REQ/ADR/SPEC/DOC-MAP基準構造）候補
+> **履歴として残す理由**: area-based移行方針撤回の判断経緯、views 廃止から DOC-MAP への移行履歴
 
 ## 目的
 

--- a/docs/requirements/REQ-0007.md
+++ b/docs/requirements/REQ-0007.md
@@ -2,9 +2,18 @@
 id: REQ-0007
 title: "ナレッジパイプライン高度化"
 created: "2026-05-11"
-updated: "2026-05-29"
+updated: "2026-05-30"
 tags: [knowledge, learning, pipeline, capture, refine, promote, prevention, autonomous]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: learning pipeline の基本設計（REQ-0007-001〜006）、learning-capture の自律蓄積化（REQ-0007-003〜005, 008, 036〜041）、learning-refine の問題クラス分類・8軸評価（REQ-0007-011, 033, 034）、learning-promote の処分区分・既存対策照合（REQ-0007-016〜018, 035）、staging stub の Requirement Source 形式（REQ-0007-021, 043）、project-local knowledge 反映先（REQ-0007-031, 045）、learning/intake 独立原則（REQ-0007-047〜049）
+> **新基準REQに移行した範囲**: staging stub 出力先・RU lifecycle（REQ-0007-032）は REQ-0039 に移行。promoted → req-backlog → RU → req-define の流れは REQ-E候補に移行
+> **後継REQ**: REQ-E（intake / learning / req-backlog / RU lifecycle）候補
+> **履歴として残す理由**: learning pipeline の基本設計思想（実観測ベース・出口を厳しく）、capture/refine/promote の3段階設計の経緯
 
 ## 目的
 

--- a/docs/requirements/REQ-0009.md
+++ b/docs/requirements/REQ-0009.md
@@ -2,9 +2,18 @@
 id: REQ-0009
 title: "テンプレートシステム"
 created: "2026-05-11"
-updated: "2026-05-19"
+updated: "2026-05-30"
 tags: [templates, naming, variables]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: テンプレートの配置・命名規則（REQ-0009-001）、ドキュメントテンプレートの frontmatter・プレースホルダー規約（REQ-0009-003）、セクション見出しの日本語規約（REQ-0009-007）
+> **新基準REQに移行した範囲**: テンプレートのセクション構成・必須セクション定義（REQ-0009-002, 004〜006, 008〜010）は REQ-C候補（Command/Skill/Template/Script責任分界）に移行。PR/Issue テンプレートの詳細構成は REQ-G候補（reporting / GitHub body）に移行
+> **後継REQ**: REQ-C候補、REQ-G候補
+> **履歴として残す理由**: テンプレート配置・命名規則の初期設計経緯
 
 ## 目的
 

--- a/docs/requirements/REQ-0011.md
+++ b/docs/requirements/REQ-0011.md
@@ -2,9 +2,18 @@
 id: REQ-0011
 title: "Issue/PR書き込み後の内容品質自動検証"
 created: "2026-05-12"
-updated: "2026-05-23"
+updated: "2026-05-30"
 tags: [enhancement, feature, quality-assurance, encoding, formatting]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: 検証の3観点（エンコーディング・Markdown構造・テンプレート必須セクション）（REQ-0011-002〜005）、検証結果の完了報告への反映（REQ-0011-008）
+> **新基準REQに移行した範囲**: agentdev-gh-cli への VERIFY 操作定義（REQ-0011-009, 010）は新基準REQ群の gh-cli 定義に移行。リトライロジックの3段階分類（REQ-0011-007）は REQ-D候補に移行
+> **後継REQ**: REQ-D候補（AgentDevFlow command protocol）、REQ-G候補（reporting / GitHub body）
+> **履歴として残す理由**: 書き込み後自動検証の設計経緯と3段階リトライロジックの判断記録
 
 ## 目的
 

--- a/docs/requirements/REQ-0013.md
+++ b/docs/requirements/REQ-0013.md
@@ -2,9 +2,18 @@
 id: REQ-0013
 title: "intake 承認フロー分割と解消済み確認機能"
 created: "2026-05-17"
-updated: "2026-05-29"
+updated: "2026-05-30"
 tags: [commands, intake, workflow, enhancement]
 ---
+
+> **⚠️ Superseded**
+> 
+> この要件は全面置き換えられました。現行仕様として読むことは推奨されません。
+> 履歴・参照用として保持されています。
+> 
+> **置き換え理由**: intake-open コマンドは REQ-0039 により廃止され、promoted artifact の一括処理・バッチモードは req-backlog コマンドの RU lifecycle に統合された。解消済み確認機能も req-backlog の処理フロー内に再定義されている。
+> **現行仕様として読む範囲**: 該当なし（全面置き換え）
+> **履歴として残す理由**: intake-open の設計経緯と解消済み確認の判定基準（REQ-0013-019〜024）の履歴記録。Issue/PR追跡時の参照用。
 
 ## 目的
 

--- a/docs/requirements/REQ-0014.md
+++ b/docs/requirements/REQ-0014.md
@@ -2,9 +2,18 @@
 id: REQ-0014
 title: "case-run 自律修正ループと責務分離の明確化"
 created: "2026-05-17"
-updated: "2026-05-17"
+updated: "2026-05-30"
 tags: [workflow, issue-commands, self-healing, verification, ci-cd]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: 自律修正ループの停止条件（REQ-0014-007）、テスト期待値の取り扱い（REQ-0014-009）、case-close/case-update の責務境界（REQ-0014-011〜012）
+> **新基準REQに移行した範囲**: Step 11a/11c の自律修正ループ定義（REQ-0014-001〜006, 008）は REQ-F候補（case-run / case-close / post-run capture）に移行。共通ルールの改定（REQ-0014-010）は REQ-D候補に移行
+> **後継REQ**: REQ-F候補、REQ-D候補
+> **履歴として残す理由**: 自律修正の最大試行回数（3回）・カウント規則・停止条件の設計経緯
 
 ## 目的
 

--- a/docs/requirements/REQ-0015.md
+++ b/docs/requirements/REQ-0015.md
@@ -2,9 +2,18 @@
 id: REQ-0015
 title: "関連ドキュメントの要件達成対象化"
 created: "2026-05-18"
-updated: "2026-05-18"
+updated: "2026-05-30"
 tags: [workflow, issue-commands, documentation, scope, verification]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: 関連ドキュメントを要件達成対象とする基本方針（REQ-0015-002〜006）—変更後仕様と矛盾するドキュメントは同一Issue内で更新する原則は現行仕様として有効
+> **新基準REQに移行した範囲**: case-run/case-close の実装コード・設定・関連ドキュメントの更新・確認手順は REQ-F候補に移行。req-define の責務定義（REQ-0015-001）は REQ-B候補に移行
+> **後継REQ**: REQ-F候補、REQ-B候補
+> **履歴として残す理由**: 関連ドキュメントを別Issueに送ることを禁止した判断の経緯
 
 ## 目的
 

--- a/docs/requirements/REQ-0016.md
+++ b/docs/requirements/REQ-0016.md
@@ -2,9 +2,18 @@
 id: REQ-0016
 title: "Command/Skill/Template/Script責任分界とlearning要件ソース化"
 created: "2026-05-18"
-updated: "2026-05-21"
+updated: "2026-05-30"
 tags: [commands, skills, templates, scripts, responsibility-boundary, learning, pipeline, req-define, knowledge]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: Command/Skill/Template/Script の責任分界の基本原則（REQ-0016-001〜004）、load_skills 整合性ルール（REQ-0016-005）、artifact-boundaries の責務項目リスト（REQ-0016-032）、既存の良い分離の維持（REQ-0016-029）
+> **新基準REQに移行した範囲**: orchestration skill 設計（REQ-0016-008, 037〜044）は REQ-D候補に移行。learning pipeline の要件ソース化（REQ-0016-010, 015〜021）は REQ-E候補に移行。case-run の thin 化（REQ-0016-009, 035〜044）は REQ-F候補に移行
+> **後継REQ**: REQ-C候補、REQ-D候補、REQ-E候補、REQ-F候補
+> **履歴として残す理由**: Command薄化・Skill切り出しの判断基準の設計経緯、1 command = 1 orchestration skill を原則としない判断の記録
 
 ## 目的
 

--- a/docs/requirements/REQ-0017.md
+++ b/docs/requirements/REQ-0017.md
@@ -2,9 +2,18 @@
 id: REQ-0017
 title: "AgentDevFlow plugin namespace 統一と learning / intake / integrity の正式化"
 created: "2026-05-21"
-updated: "2026-05-23"
+updated: "2026-05-30"
 tags: [agentdev, namespace, plugin, learning, intake, integrity, migration]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: Plugin/Product Identity（REQ-0017-001〜003）、Public Command Namespace（REQ-0017-004〜006）、Domain State Directory（REQ-0017-007〜009, 046）、Skill Prefix（REQ-0017-010〜014）、Command Migration（REQ-0017-015〜019）、Command Deletion（REQ-0017-040〜041）、Terminology（REQ-0017-042〜043）
+> **新基準REQに移行した範囲**: Learning Pipeline・Intake Workflow・Integrity Check・Intake Item Format の詳細定義（REQ-0017-020〜039）は各ドメインの新基準REQ（REQ-D, REQ-E）に移行。Child Issue Split（REQ-0017-044〜045）は実行済み
+> **後継REQ**: REQ-D候補、REQ-E候補
+> **履歴として残す理由**: issue-* → agentdev/* 移行の判断経緯、.agentdev/ と .sisyphus/ の責任分離の設計記録
 
 ## 目的
 

--- a/docs/requirements/REQ-0019.md
+++ b/docs/requirements/REQ-0019.md
@@ -2,9 +2,18 @@
 id: REQ-0019
 title: "intake / learning の責任境界明確化と workflow 組み込み"
 created: "2026-05-22"
-updated: "2026-05-29"
+updated: "2026-05-30"
 tags: [agentdev, intake, learning, workflow, boundary, capture, post-run]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: intake / learning の定義と境界（REQ-0019-001〜002）、split rule（REQ-0019-005〜006）、intake が learning の前段ではない独立原則（REQ-0019-003）、capture-boundaries.md の SSoT 配置（REQ-0019-007〜008）、各 command の責務境界（REQ-0019-023〜028）、説明整合性（REQ-0019-029〜031）
+> **新基準REQに移行した範囲**: case-run/case-close への post-run capture 組み込み（REQ-0019-009〜020）は REQ-F候補に移行。intake-promote の promoted artifact 配置（REQ-0019-004）は REQ-0039/REQ-E候補に移行
+> **後継REQ**: REQ-E候補（intake / learning / req-backlog / RU lifecycle）、REQ-F候補
+> **履歴として残す理由**: intake/learning の split rule の設計経緯、post-run capture の判断記録
 
 ## 目的
 

--- a/docs/requirements/REQ-0022.md
+++ b/docs/requirements/REQ-0022.md
@@ -2,9 +2,18 @@
 id: REQ-0022
 title: ".agentdev domain state 更新後の git 永続化"
 created: "2026-05-23"
-updated: "2026-05-23"
+updated: "2026-05-30"
 tags: [agentdev, git, persistence, domain-state, learning, intake, case-close]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: git 永続化の基本パターン（実行前同期・scoped commit・push）（REQ-0022-001〜010）、完了報告への反映（REQ-0022-011）
+> **新基準REQに移行した範囲**: 各コマンドへの具体的な Step 挿入位置（REQ-0022-012〜014）は REQ-D候補に移行。agentdev-workflow-reporting の完了報告フォーマット連携は REQ-G候補に移行
+> **後継REQ**: REQ-D候補、REQ-G候補
+> **履歴として残す理由**: scoped commit（.agentdev/ のみ）と全体 commit の分離判断の設計経緯
 
 ## 目的
 

--- a/docs/requirements/REQ-0023.md
+++ b/docs/requirements/REQ-0023.md
@@ -2,9 +2,18 @@
 id: REQ-0023
 title: "learning staging stub の取り込み追跡と取り込み後アーカイブ"
 created: "2026-05-23"
-updated: "2026-05-29"
+updated: "2026-05-30"
 tags: [learning, staging-stub, case-close, case-open, req-define, archive, import-tracking]
 ---
+
+> **⚠️ Superseded**
+> 
+> この要件は全面置き換えられました。現行仕様として読むことは推奨されません。
+> 履歴・参照用として保持されています。
+> 
+> **置き換え理由**: promoted artifact の取り込み追跡は REQ-0039 の RU lifecycle（promoted → req-backlog → RU → req-define → req-save/case-open）に統合された。staging stub の archive 処理は RU の削除管理（REQ-0039-015〜017）に移行し、Requirement Source セクションの転記は req-backlog の RU 生成に置き換えられた。
+> **現行仕様として読む範囲**: 該当なし（全面置き換え）
+> **履歴として残す理由**: staging stub の archive・imported 判定・取り込み記録形式の設計経緯の記録。
 
 ## 目的
 

--- a/docs/requirements/REQ-0024.md
+++ b/docs/requirements/REQ-0024.md
@@ -2,9 +2,18 @@
 id: REQ-0024
 title: "全 agentdev コマンドの完了報告フォーマット統一"
 created: "2026-05-23"
-updated: "2026-05-25"
+updated: "2026-05-30"
 tags: [enhancement, workflow-reporting, command-system, completion-reports]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: 完了報告の共通必須フィールド（REQ-0024-006〜014）、完了報告フォーマットの基本形・条件分岐形・case-close 例（REQ-0024-001〜005, 015〜016）
+> **新基準REQに移行した範囲**: integrity-check の完了報告フォーマット検証（REQ-0024-017〜018）は REQ-H候補に移行。Epic Orchestrator 集約完了報告（REQ-0024-020）は REQ-F候補に移行。agentdev-workflow-reporting のレビュー観点（REQ-0024-019）は REQ-G候補に移行。intake-open 関連（REQ-0024-021）は REQ-0039 により廃止済み
+> **後継REQ**: REQ-G候補（reporting / GitHub body / link / writing quality）、REQ-F候補、REQ-H候補
+> **履歴として残す理由**: 完了報告フォーマットの統一化の設計経緯、Todo最終出力禁止・汎用締め文禁止の判断記録
 
 ## 目的
 

--- a/docs/requirements/REQ-0025.md
+++ b/docs/requirements/REQ-0025.md
@@ -2,9 +2,18 @@
 id: REQ-0025
 title: "intake 系コマンドの .agentdev/intake 更新後の git 永続化"
 created: "2026-05-23"
-updated: "2026-05-23"
+updated: "2026-05-30"
 tags: [agentdev, git, persistence, intake, domain-state]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: intake 系コマンドの git 永続化の基本パターン（実行前同期・scoped commit・push）（REQ-0025-001〜010）
+> **新基準REQに移行した範囲**: 各 intake コマンドへの具体的な Step 挿入位置（REQ-0025-011〜015）は REQ-D候補に移行。intake-open（REQ-0025-015）は REQ-0039 により廃止済み
+> **後継REQ**: REQ-D候補、REQ-E候補
+> **履歴として残す理由**: REQ-0022 の intake 横展開の設計経緯
 
 ## 目的
 

--- a/docs/requirements/REQ-0026.md
+++ b/docs/requirements/REQ-0026.md
@@ -2,9 +2,18 @@
 id: REQ-0026
 title: "intake lifecycle の queue/archive 再定義"
 created: "2026-05-23"
-updated: "2026-05-29"
+updated: "2026-05-30"
 tags: [agentdev, intake, lifecycle, queue, archive, refactor]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: ディレクトリ構造の基本方針（REQ-0026-001〜003）、intake-review の振り分け（REQ-0026-004）、intake-promote の処理（REQ-0026-005）、状態管理方針（REQ-0026-008〜010）
+> **新基準REQに移行した範囲**: promoted artifact の RU 化・削除（REQ-0026-006〜007）は REQ-0039 に移行。各コマンドへの具体的手順は REQ-D候補・REQ-E候補に移行
+> **後継REQ**: REQ-E候補（intake / learning / req-backlog / RU lifecycle）
+> **履歴として残す理由**: frontmatter 状態管理からディレクトリ配置への一本化判断の記録
 
 ## 目的
 

--- a/docs/requirements/REQ-0027.md
+++ b/docs/requirements/REQ-0027.md
@@ -2,9 +2,18 @@
 id: REQ-0027
 title: "learning artifact lifecycle の責任範囲明確化"
 created: "2026-05-23"
-updated: "2026-05-23"
+updated: "2026-05-30"
 tags: [learning, lifecycle, artifact, documentation, command, skill]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: learning artifact の責務分類（inbox.md / archive.md / evaluation-report.md / promoted/）（REQ-0027-001〜013）、command 責任境界（REQ-0027-014〜015）、archive.md の living pool 定義（REQ-0027-016）
+> **新基準REQに移行した範囲**: promoted/ stub の req-backlog → RU → req-define の流れ（REQ-0027-010〜011）は REQ-0039/REQ-E候補に移行。処理ロジック不変の制約（REQ-0027-017）は新基準REQ群の要件行として再定義
+> **後継REQ**: REQ-E候補
+> **履歴として残す理由**: archive.md が「終端履歴」ではなく「living pool」である定義の設計経緯
 
 ## 目的
 

--- a/docs/requirements/REQ-0028.md
+++ b/docs/requirements/REQ-0028.md
@@ -2,9 +2,18 @@
 id: REQ-0028
 title: "Documentation granularity and responsibility restructuring"
 created: "2026-05-23"
-updated: "2026-05-23"
+updated: "2026-05-30"
 tags: [documentation, granularity, responsibility, redundancy, docs]
 ---
+
+> **⚠️ Superseded**
+> 
+> この要件は全面置き換えられました。現行仕様として読むことは推奨されません。
+> 履歴・参照用として保持されています。
+> 
+> **置き換え理由**: 文書責務の判断基準・Post-Run Capture 帰属マッピングは、REQ-0041 の新基準REQ群（REQ-A〜H候補構成）で現行仕様として再定義される。個別の記述問題修正（REQ-0028-001〜011）は、新基準REQの要件行として再構成される。
+> **現行仕様として読む範囲**: 該当なし（全面置き換え）
+> **履歴として残す理由**: 文書責務判断基準の設計経緯と Post-Run Capture 帰属マッピングの記録。
 
 ## 目的
 

--- a/docs/requirements/REQ-0029.md
+++ b/docs/requirements/REQ-0029.md
@@ -2,9 +2,18 @@
 id: REQ-0029
 title: "intake-open promoted artifact 一括処理"
 created: "2026-05-23"
-updated: "2026-05-29"
+updated: "2026-05-30"
 tags: [agentdev, intake, batch-processing, enhancement]
 ---
+
+> **⚠️ Superseded**
+> 
+> この要件は全面置き換えられました。現行仕様として読むことは推奨されません。
+> 履歴・参照用として保持されています。
+> 
+> **置き換え理由**: intake-open コマンドは REQ-0039 により廃止され、promoted artifact の一括処理は req-backlog コマンドに統合された。continue-on-error（partial success）・一括 git 永続化・batch 向け完了報告フォーマットも req-backlog に引き継がれている。
+> **現行仕様として読む範囲**: 該当なし（全面置き換え）
+> **履歴として残す理由**: intake-open のバッチ処理設計・continue-on-error・一括 git 永続化の設計経緯の記録。
 
 ## 目的
 

--- a/docs/requirements/REQ-0033.md
+++ b/docs/requirements/REQ-0033.md
@@ -2,9 +2,18 @@
 id: REQ-0033
 title: "AgentDevFlow command / skill 定義の二次整合性是正"
 created: "2026-05-24"
-updated: "2026-05-25"
+updated: "2026-05-30"
 tags: [agentdev, consistency, guardrails, command-definitions, skill-definitions]
 ---
+
+> **⚠️ Superseded**
+> 
+> この要件は全面置き換えられました。現行仕様として読むことは推奨されません。
+> 履歴・参照用として保持されています。
+> 
+> **置き換え理由**: command / skill 定義の整合性是正は、REQ-0041 の新基準REQ群（REQ-C: Command/Skill/Template/Script責任分界、REQ-D: AgentDevFlow command protocol）で現行仕様として再定義される。59件の個別是正項目は新基準REQの要件行として再構成される。
+> **現行仕様として読む範囲**: 該当なし（全面置き換え）
+> **履歴として残す理由**: R1-R36一次是正後の残存不整合59件の記録。Issue #340 / PR #341 の後続対応の設計経緯。
 
 ## 目的
 

--- a/docs/requirements/REQ-0036.md
+++ b/docs/requirements/REQ-0036.md
@@ -2,9 +2,18 @@
 id: REQ-0036
 title: "agentdev-no-ai-slop-writing Skill 追加"
 created: "2026-05-29"
-updated: "2026-05-29"
+updated: "2026-05-30"
 tags: [skill, writing-quality, ai-slop, natural-language]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: AI-slop の11ルール（REQ-0036-005）、出力原則（REQ-0036-015）、forbidden-phrases.md の9カテゴリ構造（REQ-0036-006〜008）、例外条件（REQ-0036-009）
+> **新基準REQに移行した範囲**: Skill の新規作成手順・load_skills 追加（REQ-0036-001〜004, 011〜014）は REQ-C候補に移行。文章品質ゲートの完了報告への反映は REQ-G候補に移行
+> **後継REQ**: REQ-C候補、REQ-G候補
+> **履歴として残す理由**: AI-slop 検出ルールの設計経緯、forbidden-phrases の9カテゴリ分類の判断記録
 
 ## 目的
 

--- a/docs/requirements/REQ-0037.md
+++ b/docs/requirements/REQ-0037.md
@@ -2,9 +2,18 @@
 id: REQ-0037
 title: worktree 削除時の残存ファイル対策強化
 created: 2026-05-29
-updated: 2026-05-29
+updated: 2026-05-30
 tags: [case-close, case-run, worktree, error-handling, bug, enhancement]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: case-close の未コミット変更検出・squash merge 済み確認（REQ-0037-001〜003）、プロセスロック時の対応（REQ-0037-004）、squash merge 後の条件付き -D 許可（REQ-0037-008〜010）
+> **新基準REQに移行した範囲**: case-run の未コミット変更検出（REQ-0037-005〜006）は REQ-F候補に移行。agentdev-git-worktree スキルの更新（REQ-0037-007）は REQ-D候補に移行
+> **後継REQ**: REQ-F候補、REQ-D候補
+> **履歴として残す理由**: Issue #344, #381, #389 で発生した worktree remove 失敗の対応経緯、squash merge 後 -D 許可の判断記録
 
 ## 目的
 

--- a/docs/requirements/REQ-0039.md
+++ b/docs/requirements/REQ-0039.md
@@ -6,6 +6,15 @@ updated: 2026-05-30
 tags: [workflow, req-backlog, ru-lifecycle, promoted, structural-simplification]
 ---
 
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: req-backlog コマンドの基本設計（REQ-0039-001〜010）、RU の粒度・矛盾検出（REQ-0039-032〜035）、RU lifecycle の削除管理（REQ-0039-015〜017）、reference ファイル責務分離（REQ-0039-037）
+> **新基準REQに移行した範囲**: req-define の入力制約（REQ-0039-018〜020）は REQ-B候補に移行。req-save/case-open の RU 削除トリガーは各ドメインの新基準REQに移行
+> **後継REQ**: REQ-E候補（intake / learning / req-backlog / RU lifecycle）、REQ-B候補
+> **履歴として残す理由**: promoted artifact → RU → req-define パイプラインの設計経緯、intake-open 廃止に伴う構造簡素化の判断記録
+
 ## 目的
 
 AgentDevFlow において `/agentdev/req-backlog` コマンドと Requirement Unit（RU）を導入し、intake・learning パイプラインで生成された promoted artifact を要件化前の中間成果物として一元管理する。RU は req-define への構造化入力として機能し、promoted artifact から要件定義への橋渡しを担う。

--- a/docs/requirements/REQ-0040.md
+++ b/docs/requirements/REQ-0040.md
@@ -2,9 +2,18 @@
 id: REQ-0040
 title: 子Issue PRに Findings / Intake候補を永続化し、case-closeで回収する
 created: 2026-05-29
-updated: 2026-05-29
+updated: 2026-05-30
 tags: [intake, pr-template, case-run, case-close, epic-orchestrator]
 ---
+
+> **⚠️ Partially Superseded**
+> 
+> この要件は一部が新基準REQ群に移行しました。現行仕様として読める部分と、そうでない部分があります。
+> 
+> **現行仕様として読める範囲**: PR 本文を永続チャネルとする基本設計（REQ-0040-001, 005）、case-close での PR 回収・Epic 横断回収（REQ-0040-007〜009）
+> **新基準REQに移行した範囲**: case-run への Step 追加・検証制約（REQ-0040-002〜004, 006）は REQ-F候補に移行。workflow-orchestration のサブエージェント指示（REQ-0040-006, 012）は REQ-D候補に移行。テンプレート定義の更新（REQ-0040-001）は REQ-G候補に移行
+> **後継REQ**: REQ-F候補、REQ-G候補、REQ-D候補
+> **履歴として残す理由**: PR 本文を intake/learning の永続チャネルとする設計経緯
 
 ## 目的
 


### PR DESCRIPTION
## 概要

REQ-0041（REQ体系再基準化）に基づき、旧REQ群（REQ-0001〜REQ-0040）の全40件を `retained` / `partially superseded` / `superseded` の3分類に分類し、superseded / partially superseded のREQに本文冒頭のSuperseded表記を追加する。

## 実装内容

### superseded（5件）— 全面置き換え表記を追加

| REQ | 置き換え理由 |
|-----|-------------|
| REQ-0013 | intake-open 廃止、解消済み確認は req-backlog に統合 |
| REQ-0023 | staging stub の archive 処理は RU lifecycle に移行 |
| REQ-0028 | 文書責務判断基準は新基準REQ群で再定義 |
| REQ-0029 | intake-open 廃止、バッチ処理は req-backlog に統合 |
| REQ-0033 | 59件の整合性是正は新基準REQ群で再定義 |

### partially superseded（19件）— 移行範囲・後継REQ・履歴理由を記載

REQ-0002, 0004, 0007, 0009, 0011, 0014, 0015, 0016, 0017, 0019, 0022, 0024, 0025, 0026, 0027, 0036, 0037, 0039, 0040

各REQの本文冒頭に、現行仕様として読める範囲・新基準REQに移行した範囲・後継REQ候補・履歴として残す理由を記載した blockquote を挿入。

### retained（15件）— 変更なし

REQ-0001, 0003, 0005, 0006, 0008, 0012, 0018, 0020, 0021, 0030, 0031, 0032, 0034, 0035, 0038

### README.md の再構成

`docs/requirements/README.md` を単一テーブルから3カテゴリ（Retained / Partially Superseded / Superseded）に再構成。

## 完了条件

- [x] 全40件の旧REQが3分類のいずれかに分類されている
- [x] `superseded` / `partially superseded` のREQ本文冒頭にSuperseded表記が追加されている
- [x] `retained` のREQは変更されていない
- [x] REQ-0013 / REQ-0029 のような既存Superseded REQが冒頭表記と整合している

## テスト結果

該当なし（ドキュメント変更のみ）

## 品質メトリクス

- 変更ファイル数: 25（24 REQ + 1 README）
- retained 変更数: 0（15件は無変更を確認）
- superseded 表記: 5件追加
- partially superseded 表記: 19件追加

## Findings / Intake候補

該当なし

Refs: #441
