### PR TITLE
docs(requirements): 旧REQ↔新基準REQ対応表作成（全40件分）

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,14 @@
   - [REQ-0039: req-backlog コマンドと Requirement Unit パイプライン](requirements/REQ-0039.md)
   - [REQ-0040: 子Issue PRに Findings / Intake候補を永続化し、case-closeで回収する](requirements/REQ-0040.md)
   - [REQ-0041: REQ体系再基準化 — 旧REQ分類・新基準REQ群・分類ゲート](requirements/REQ-0041.md)
+  - [REQ-0042: REQ/ADR/SPEC/DOC-MAP 基準構造](requirements/REQ-0042.md)
+  - [REQ-0043: req-define / req-save / REQ分類ゲート](requirements/REQ-0043.md)
+  - [REQ-0044: Command / Skill / Template / Script 責任分界](requirements/REQ-0044.md)
+  - [REQ-0045: AgentDevFlow command protocol](requirements/REQ-0045.md)
+  - [REQ-0046: intake / learning / req-backlog / RU lifecycle](requirements/REQ-0046.md)
+  - [REQ-0047: case-run / case-close / post-run capture](requirements/REQ-0047.md)
+  - [REQ-0048: reporting / GitHub body / link / writing quality](requirements/REQ-0048.md)
+  - [REQ-0049: integrity / validation / tests](requirements/REQ-0049.md)
 
 ## Specifications
 

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -43,6 +43,14 @@
 | REQ-0039 | req-backlog コマンドと Requirement Unit パイプライン | workflow/req-backlog/ru-lifecycle/promoted |
 | REQ-0040 | 子Issue PRに Findings / Intake候補を永続化し、case-closeで回収する | intake/pr-template/case-run/case-close/epic-orchestrator |
 | REQ-0041 | REQ体系再基準化 — 旧REQ分類・新基準REQ群・分類ゲート | req-rebaselining/classification/correspondence-table/quality-gate |
+| REQ-0042 | REQ/ADR/SPEC/DOC-MAP 基準構造 | req-structure/adr-structure/spec-structure/doc-map/canonical-boundary |
+| REQ-0043 | req-define / req-save / REQ分類ゲート | req-define/req-save/classification-gate/create-append-update |
+| REQ-0044 | Command / Skill / Template / Script 責任分界 | commands/skills/templates/scripts/responsibility-boundary |
+| REQ-0045 | AgentDevFlow command protocol | commands/protocol/workflow-patterns/ssot |
+| REQ-0046 | intake / learning / req-backlog / RU lifecycle | intake/learning/req-backlog/ru-lifecycle/domain-state |
+| REQ-0047 | case-run / case-close / post-run capture | case-run/case-close/findings/epic-orchestrator/reliability |
+| REQ-0048 | reporting / GitHub body / link / writing quality | reporting/github-body/link-normalization/writing-quality/gh-cli |
+| REQ-0049 | integrity / validation / tests | integrity/validation/tests/guardrails/consistency |
 
 ## Superseded
 

--- a/docs/requirements/REQ-0042.md
+++ b/docs/requirements/REQ-0042.md
@@ -1,0 +1,71 @@
+---
+id: REQ-0042
+title: "REQ/ADR/SPEC/DOC-MAP 基準構造"
+created: "2026-05-30"
+updated: "2026-05-30"
+tags: [req-structure, adr-structure, spec-structure, doc-map, canonical-boundary, per-file]
+---
+
+## 目的
+
+AgentDevFlow における要件（REQ）、アーキテクチャ決定記録（ADR）、現在仕様（SPEC）、文書探索入口（DOC-MAP）の基準構造を定義する。各文書種別の責務・基準境界・参照関係を明確にし、読み手がどの文書を基準として読むべきかを一意に判定できるようにする。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0042-001 | `docs/requirements/REQ-{NNNN}.md` を要件本文の永続基準とすること（SHALL） |
+| REQ-0042-002 | `REQ-{NNNN}` は4桁ゼロ埋めの安定IDとし、欠番は再利用しないこと（SHALL） |
+| REQ-0042-003 | REQ-IDに area名・topic名・英字suffixを含めないこと（SHALL） |
+| REQ-0042-004 | REQの要件行はRFC 2119言語（SHALL/SHOULD/MAY）で記述すること（SHALL） |
+| REQ-0042-005 | REQの操作モデルは CREATE（新規作成）・APPEND（セクション追記）・UPDATE（内容変更）の3種とすること（SHALL） |
+| REQ-0042-006 | 要件行IDは `REQ-{NNNN}-{MMM}`（3桁ゼロ埋め）で一意に識別すること（SHALL） |
+| REQ-0042-007 | REQ frontmatter は `id`、`title`、`created`、`updated`、`tags` を必須フィールドとすること（SHALL） |
+| REQ-0042-008 | `docs/adr/ADR-{NNNN}.md` をアーキテクチャ判断の基準とすること（SHALL） |
+| REQ-0042-009 | ADRは取り返しのつかない技術判断のみを記録対象とすること（SHALL） |
+| REQ-0042-010 | ADR frontmatter の status は `proposed` / `accepted` / `deprecated` / `superseded-by:[ADR-MMMM]` を使用すること（SHALL） |
+| REQ-0042-011 | Accepted済みADRのDecision本文を意味変更してはならないこと。判断を変更する場合は新ADRを作成し、既存ADRを `superseded-by` または `deprecated` にすること（SHALL） |
+| REQ-0042-012 | ADR本文を area / topic / view 別ファイルへ移動しないこと（SHALL） |
+| REQ-0042-013 | `docs/specs/*.md` を現在仕様の基準とすること（SHALL） |
+| REQ-0042-014 | SPECは実装者が参照する現在仕様であり、REQ/ADRの判断内容を代替しないこと（SHALL） |
+| REQ-0042-015 | `docs/DOC-MAP.md` を文書探索・参照経路の入口とし、基準文書の内容を代替しないこと（SHALL） |
+| REQ-0042-016 | DOC-MAPは基準ではなく、REQ/ADR/SPECの内容を代替しないこと（SHALL） |
+| REQ-0042-017 | 文書間に矛盾がある場合は、REQを優先すること（SHALL） |
+| REQ-0042-018 | `docs/requirements/README.md` は手書きインデックスとして維持し、REQ一覧と分類を提供すること（SHALL） |
+| REQ-0042-019 | `docs/adr/README.md` はADR分類ビューとして維持し、ADR一覧・Status View・Topic View・Decision Map・Related REQを提供すること（SHALL） |
+| REQ-0042-020 | `docs/requirements/views/` は使用しないこと（SHALL） |
+| REQ-0042-021 | `docs/requirements/areas/` は作成しないこと（SHALL） |
+| REQ-0042-022 | `INDEX.md` は新規作成しないこと（SHALL） |
+| REQ-0042-023 | ADR → Issue の逆参照は原則禁止すること（SHALL） |
+| REQ-0042-024 | Accepted済みADRのDecision本文の意味変更はUPDATE対象外とし、判断変更は新ADRで扱うこと（SHALL） |
+| REQ-0042-025 | REQ → ADR、ADR → ADR、Issue → ADR の参照は許可すること（MAY） |
+| REQ-0042-026 | ADR本文からREQへの逆参照は必須にしないこと（SHALL） |
+| REQ-0042-027 | ADRファイル操作は CREATE / APPEND / UPDATE に限定し、APPENDは補足・関連情報の追加に、UPDATEはステータス変更・frontmatter更新・誤字修正に使用すること（SHALL） |
+| REQ-0042-028 | SPLIT検出時は保存可能範囲（CREATE/APPEND/UPDATE）を実行し、保存全体を中止しないこと（SHALL） |
+| REQ-0042-029 | requirements review finding は `.sisyphus/drafts/` に保存し、`docs/requirements/` には保存しないこと（SHALL） |
+| REQ-0042-030 | finding 種別は SPLIT / MOVE / RETIRE / DUPLICATE / OBSOLETE / DRIFT とすること（SHALL） |
+
+## 適用範囲
+
+- **対象**:
+  - REQ/ADR/SPEC/DOC-MAP の基準構造定義
+  - 各文書種別の責務・基準境界・参照関係
+  - REQファイルの操作モデル（CREATE/APPEND/UPDATE）
+  - ADRファイルの操作モデル（CREATE/APPEND/UPDATE）
+  - REQ-ID / ADR-ID の採番規約
+  - frontmatter 必須フィールド
+  - DOC-MAP の位置づけ（参照用文書・非基準）
+  - README.md の役割（手書きインデックス・分類ビュー）
+  - finding protocol（形式・保存先・種別定義）
+- **対象外**:
+  - 各コマンドの内部手順
+  - コード実装
+  - テンプレートの内容
+  - 要件分析手法（req-analysisの管轄）
+  - 仕様適合性検出（spec-complianceの管轄）
+
+## 関連情報
+
+- **Related ADRs**: ADR-0007（REQ/ADR基準構造の再定義）, ADR-0008（DOC-MAP導入とviews廃止）, ADR-0009（REQ体系再基準化）
+- **Supersedes**: REQ-0004（要件・ADRドキュメントシステム）のうち views関連以外の基準構造要件
+- **Related**: REQ-0035（DOC-MAP導入とviews廃止）

--- a/docs/requirements/REQ-0043.md
+++ b/docs/requirements/REQ-0043.md
@@ -1,0 +1,60 @@
+---
+id: REQ-0043
+title: "req-define / req-save / REQ分類ゲート"
+created: "2026-05-30"
+updated: "2026-05-30"
+tags: [req-define, req-save, classification-gate, create-append-update, req-file-manager, wall-discussion]
+---
+
+## 目的
+
+`req-define` と `req-save` コマンドが従うべき入出力契約・操作分類・分類ゲートを定義する。要件定義プロセスにおいて、新規REQ作成前に要件行候補が変更後仕様か既存成果物への反映作業かを分類し、反映作業のみを表す候補が新規REQの独立要件行として混入するのを防止する。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0043-001 | `req-define` はセッション会話を入力とし、要件docを出力すること（SHALL） |
+| REQ-0043-002 | `req-define` は壁打ちの意図把握後、要件展開の前に、`docs/requirements/REQ-*.md` をスキャンし、ユーザーの要件説明と既存REQの関連性を推論して該当REQを特定すること（SHALL） |
+| REQ-0043-003 | 照合で関連REQが特定された場合、`req-define` はその内容を壁打ちコンテキストに即時反映すること（SHALL） |
+| REQ-0043-004 | `req-define` は照合結果に基づき req-operation（CREATE/APPEND/UPDATE）および target-req を確定すること（SHALL） |
+| REQ-0043-005 | `req-define` は CREATE を選択する前に APPEND/UPDATE 候補を必ず評価すること（SHALL） |
+| REQ-0043-006 | 同一コンポーネント・同一スコープの既存REQが存在する場合、`req-define` は APPEND をデフォルトの操作として選択すること（SHALL） |
+| REQ-0043-007 | `req-define` は CREATE を選択する場合、APPEND/UPDATE ではない理由を `create-rationale` フィールドに記録すること（SHALL） |
+| REQ-0043-008 | APPEND/UPDATE 候補があるにもかかわらず CREATE と判断する場合、`req-define` はユーザーに判断根拠を提示すること（SHALL） |
+| REQ-0043-009 | 照合の判定要素は、タイトル（高）、tags（中）、目的セクション（高）、要件内容（中）とし、総合的に関連性を判定すること（SHALL） |
+| REQ-0043-010 | 操作分類の判定軸は、対象コンポーネント・対象スコープ・目的の連続性・要件行追加可能性・独立目的の有無（全て重み:高）とすること（SHALL） |
+| REQ-0043-011 | `req-define` は新規REQ作成前に、要件行候補が変更後仕様か既存成果物への反映作業かを分類すること（SHALL） |
+| REQ-0043-012 | `req-define` は、既存成果物への反映作業のみを表す候補を、新規REQの独立要件行として扱ってはならない（SHALL） |
+| REQ-0043-013 | `req-define` は Step 0 で現在のセッションコンテキストを分析し、6項目（要件内容・Pattern判定・Scale判定・ADR判断・要件doc構造化・適用範囲）を依存関係順に推論すること（SHALL） |
+| REQ-0043-014 | `req-define` は関連ドキュメント更新候補を抽出し、対象パス・検出語句・判定・必要対応を出力すること（SHALL） |
+| REQ-0043-015 | 関連ドキュメント更新候補の判定は、少なくとも `直接矛盾`・`更新候補`・`影響なし` に分類すること（SHALL） |
+| REQ-0043-016 | `req-save` は `.sisyphus/drafts/` のドラフトを入力とし、REQファイル・ADRファイル・インデックス更新を出力すること（SHALL） |
+| REQ-0043-017 | `req-save` は CREATE対象REQの保存前に、既存成果物への反映作業だけを表す要件行が残っていないか検査すること（SHALL） |
+| REQ-0043-018 | `req-save` は、反映作業のみの要件行を検出した場合、保存を停止し、該当行・判定理由・移送先を報告すること（SHALL） |
+| REQ-0043-019 | `req-save` は draft status を `saved` に更新してから commit / push すること（SHALL） |
+| REQ-0043-020 | `req-save` は保存後に `docs/requirements/README.md` と `docs/README.md` の整合性を検証すること（SHALL） |
+| REQ-0043-021 | `req-save` は `adr-required: true` の場合に `docs/adr/ADR-{NNNN}.md` を作成すること（SHALL） |
+| REQ-0043-022 | `req-define` は明示入力ファイルを source 種別に依存せず `Requirement Source` として記録すること（SHALL） |
+| REQ-0043-023 | `req-define` の探索順序は、明示入力ファイル → `DOC-MAP.md` → 各 README / SPEC入口 → 基準REQ/ADR/SPEC → Step 4b限定探索とすること（SHOULD） |
+
+## 適用範囲
+
+- **対象**:
+  - `req-define` の入出力契約・既存REQ照合・操作分類・Step 0 セッションコンテキスト検知
+  - `req-define` の関連ドキュメント更新候補抽出
+  - `req-define` の分類ゲート（反映作業混入防止）
+  - `req-save` の入出力契約・保存前検査・整合性検証
+  - `req-save` の分類ゲート（反映作業要件行検出）
+  - 操作分類の判定要素・判定軸
+- **対象外**:
+  - 各コマンドの内部手順の詳細
+  - テンプレートの内容
+  - case-open / case-run / case-close の動作
+  - ADRファイル管理操作（agentdev-adr-file-managerの管轄）
+
+## 関連情報
+
+- **Related**: REQ-0042（REQ/ADR/SPEC/DOC-MAP基準構造）
+- **Related**: REQ-0041（REQ体系再基準化 — 分類ゲート要件: 013〜016）
+- **Related**: REQ-0034（req-define関連ドキュメント更新候補抽出）

--- a/docs/requirements/REQ-0044.md
+++ b/docs/requirements/REQ-0044.md
@@ -1,0 +1,55 @@
+---
+id: REQ-0044
+title: "Command / Skill / Template / Script 責任分界"
+created: "2026-05-30"
+updated: "2026-05-30"
+tags: [commands, skills, templates, scripts, responsibility-boundary, agentdev-namespace]
+---
+
+## 目的
+
+AgentDevFlow の command / skill / template / script の各artifactが所有すべき内容・所有すべきでない内容の責任分界を定義する。各artifactの責務境界を明確にし、重複記述・責務混線・参照不整合を防止する。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0044-001 | command は実行手順の一次参照（Step番号・ファイルパス・エラーメッセージ・入出力契約）を定義すること（SHALL） |
+| REQ-0044-002 | skill は判定基準・共通知識・宣言的ルールの一次参照を定義すること（SHALL） |
+| REQ-0044-003 | command / skill の責務記述は、command を実行手順の一次参照、skill を判定基準・共通知識の一次参照として分離すること（SHALL） |
+| REQ-0044-004 | command は判定ロジックを直接記述せず、該当する skill を `load_skills` で参照すること（SHALL） |
+| REQ-0044-005 | skill はコマンドの Step 番号・ファイルパス・エラーメッセージを記述しないこと（SHALL） |
+| REQ-0044-006 | template は Issue/PR description やコメントの本文構造を定義し、必須セクションと任意セクションを明確に分けること（SHALL） |
+| REQ-0044-007 | 必須セクションは `該当なし` を許容し、任意セクションは省略可能とすること（SHALL） |
+| REQ-0044-008 | template の選択ルールは `agentdev-workflow-templates` skill に定義すること（SHALL） |
+| REQ-0044-009 | script はガードレール・検査・補助処理の実行可能ロジックを提供し、`agentdev-*` skill 内の `scripts/` に配置すること（SHALL） |
+| REQ-0044-010 | skill の frontmatter は `name` と `description` のみを含め、拡張フィールドを追加しないこと（SHALL） |
+| REQ-0044-011 | skill の description にはトリガー条件を `USE FOR:` と `DO NOT USE FOR:` の形式で埋め込むこと（SHALL） |
+| REQ-0044-012 | SKILL.md の行数は500行以下とし、推定トークン数は複雑度に応じた予算内に収めること（SHOULD） |
+| REQ-0044-013 | Progressive Disclosureパターンを適用し、SKILL.mdを目次として機能させ、詳細は参照ファイル（1階層まで）に配置すること（SHALL） |
+| REQ-0044-014 | skill naming は小文字・数字・ハイフンのみで kebab-case とすること（SHALL） |
+| REQ-0044-015 | command 定義ファイルは `.opencode/commands/agentdev/` に配置すること（SHALL） |
+| REQ-0044-016 | skill 定義ファイルは `.opencode/skills/` に配置すること（SHALL） |
+| REQ-0044-017 | AgentDevFlow の canonical namespace は `agentdev` とし、public command prefix は `/agentdev/*` とすること（SHALL） |
+| REQ-0044-018 | domain state directory は `.agentdev/` とすること（SHALL） |
+| REQ-0044-019 | skill prefix は `agentdev-*` とすること（SHALL） |
+
+## 適用範囲
+
+- **対象**:
+  - command / skill / template / script の責務境界定義
+  - 各artifactの配置規約（ディレクトリ・命名）
+  - skill 品質基準（frontmatter・description・トークン予算・Progressive Disclosure）
+  - namespace規約（agentdev canonical namespace）
+  - template 必須/任意セクションの区別
+- **対象外**:
+  - 各command / skillの内部手順の詳細
+  - コード実装
+  - テンプレートの具体内容
+  - テスト実装
+
+## 関連情報
+
+- **Related ADRs**: ADR-0001（Command/Skill/Template/Script責任分界の正式定義）, ADR-0005（AgentDevFlow plugin namespace統一）
+- **Related**: REQ-0008（スキル品質フレームワーク）
+- **Related**: REQ-0016（Command/Skill/Template/Script責任分界とtips要件ソース化）

--- a/docs/requirements/REQ-0045.md
+++ b/docs/requirements/REQ-0045.md
@@ -1,0 +1,60 @@
+---
+id: REQ-0045
+title: "AgentDevFlow command protocol"
+created: "2026-05-30"
+updated: "2026-05-30"
+tags: [commands, protocol, interface, data-flow, workflow-patterns, ssoT]
+---
+
+## 目的
+
+AgentDevFlow コマンド群が従うべき入出力契約・実行順序・データフローを定義する。コマンド間の結合度を明示し、ワークフロー全体の整合性と拡張性を担保するための通信規約である。ワークフローのマクロフェーズ構成・Pattern体系・SSoT遷移・エラー回復方針を含む。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0045-001 | ワークフローは3つのマクロフェーズ（壁打ち・構造的実行・レビュー完了）で構成すること（SHALL） |
+| REQ-0045-002 | 各マクロフェーズにおけるSSoTを定義し、フェーズ境界を跨ぐ情報の唯一性を保証すること（SHALL） |
+| REQ-0045-003 | 壁打ちフェーズから構造的実行フェーズへの境界において、docs変更をコミット・プッシュすること（SHALL） |
+| REQ-0045-004 | バグ修正（Pattern A）・機能追加（Pattern B）・refactor/maintenance（Pattern C）・docs/chore（Pattern D）の4つのワークフローパターンを定義すること（SHALL） |
+| REQ-0045-005 | Pattern Bにおいて規模判定基準（複数モジュール跨ぎ・PR肥大化リスク・段階的リリース）のいずれかを満たす場合、Epic規模として扱うこと（SHALL） |
+| REQ-0045-006 | 各コマンドはフェーズ境界ルールに従い、自身の入力SSoTと出力SSoTを明示的に定義すること（SHALL） |
+| REQ-0045-007 | ワークフロー実行中のエラー発生時、ユーザーに判断を委ねるか、安全なフォールバック動作に切り替えること。データ損失を伴う自動回復を実行してはならない（SHALL） |
+| REQ-0045-008 | label と metadata/template-type が矛盾する場合、コマンドは停止してユーザー確認を求めること（SHALL） |
+| REQ-0045-009 | 壁打ちフェーズのSSoTはIssue作成状態に応じて遷移すること（SHALL） |
+| REQ-0045-010 | `case-open` は要件docおよびspecs・ADRを読み取り、GitHub Issueを出力すること（SHALL） |
+| REQ-0045-011 | `case-open` は Epic規模の場合、Epic + 子Issueを一括作成すること（SHALL） |
+| REQ-0045-012 | `case-open` は Epic flow / Standard flow の Step 番号を分離すること（SHALL） |
+| REQ-0045-013 | `case-open` は Epic 子Issue最大件数を Issue 作成前に検査すること（SHALL） |
+| REQ-0045-014 | `case-run` は GitHub Issueおよびspecsを読み取り、実装済みブランチ・PRを出力すること（SHALL） |
+| REQ-0045-015 | `case-run` は3フェーズ構成（準備・実装・提出）でべき等な再開ポイントを提供すること（SHALL） |
+| REQ-0045-016 | `case-close` は PRとIssueを入力とし、マージ完了・記録追記・ブランチ削除を実行すること（SHALL） |
+| REQ-0045-017 | `case-update` は Issue本文の更新・コメント追加に加え、REQファイルのAPPEND/UPDATE操作をサポートすること（SHALL） |
+| REQ-0045-018 | `case-update --req` は REQ 更新後の commit / push 方針を明記すること（SHALL） |
+| REQ-0045-019 | `case-run` の git-worktree 使用手順は `agentdev-git-worktree` skill 定義と整合すること（SHALL） |
+| REQ-0045-020 | `case-run` は「多重Issue入力上限（最大5件）」と「Epic Wave内同時実行上限」を別ルールとして定義すること（SHALL） |
+| REQ-0045-021 | Pattern A〜Dの対応表（Type labels, Branch type, REQ要否, ADR要否, specs更新要否, Review focus）を定義すること（SHALL） |
+| REQ-0045-022 | label→Pattern mapping を `bug`→A, `enhancement`/`feature`→B, `refactor`/`maintenance`→C, `docs`/`chore`→D と定義すること（SHALL） |
+| REQ-0045-023 | バグ修正・軽微変更（Pattern A）ではREQファイルを作成せず、Issue本文のみで要件を管理すること（SHALL） |
+
+## 適用範囲
+
+- **対象**:
+  - AgentDevFlow コマンド群の入出力契約・実行順序・データフロー
+  - ワークフロー3フェーズ構成・SSoT遷移ルール
+  - Pattern A/B/C/D判定基準・label→Pattern mapping
+  - case-open / case-run / case-close / case-update の基本契約
+  - エラー回復方針
+- **対象外**:
+  - コマンド内の詳細手順
+  - 並列実行の依存分析の詳細
+  - テンプレートの内容
+  - intake / learning / integrity のパイプライン詳細
+
+## 関連情報
+
+- **Related**: REQ-0042（REQ/ADR/SPEC/DOC-MAP基準構造）
+- **Related**: REQ-0043（req-define / req-save / REQ分類ゲート）
+- **Related**: REQ-0044（Command/Skill/Template/Script責任分界）
+- **Related**: REQ-0020（Epic Issue 実行順序SSoTとcase-run Epic Orchestrator化）

--- a/docs/requirements/REQ-0046.md
+++ b/docs/requirements/REQ-0046.md
@@ -1,0 +1,64 @@
+---
+id: REQ-0046
+title: "intake / learning / req-backlog / RU lifecycle"
+created: "2026-05-30"
+updated: "2026-05-30"
+tags: [intake, learning, req-backlog, ru-lifecycle, promoted-artifact, domain-state]
+---
+
+## 目的
+
+AgentDevFlow の intake・learning・req-backlog パイプラインの責務境界と成果物lifecycleを定義する。各パイプラインの入出力・状態遷移・削除条件を明確にし、promoted artifact から Requirement Unit（RU）を経由して req-define へ橋渡しする一連の流れを規定する。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0046-001 | `intake-capture` はユーザー入力から明示できる内容のみを整理し、推測不能なセクションは省略すること（SHALL） |
+| REQ-0046-002 | `intake-review` は intake item を採用・却下・保留に判定し、判定結果をディレクトリ配置で表現すること（SHALL） |
+| REQ-0046-003 | `intake-promote` は採用済み intake item を promoted artifact として `.agentdev/intake/promoted/` に配置すること（SHALL） |
+| REQ-0046-004 | `intake-promote` は req-backlog 用 promoted artifact に Issue化に必要な最小情報（タイトル・概要・対象範囲・完了条件・Issue構成）を含めること（SHALL） |
+| REQ-0046-005 | `intake-from-github` はクローズ済み Issue/PR から残課題を抽出し、intake item として inbox に保存すること（SHALL） |
+| REQ-0046-006 | intake pipeline の domain state は `.agentdev/intake/`（inbox/・accepted/・promoted/・archive/）に配置すること（SHALL） |
+| REQ-0046-007 | `learning-capture` skill は観測から学びを抽出し、`.agentdev/learning/inbox.md` に記録すること（SHALL） |
+| REQ-0046-008 | `learning-capture` は同一観測から learning と intake の両方が発生する場合、成果物を分離すること（SHALL） |
+| REQ-0046-009 | `learning-refine` は inbox.md と archive.md をセマンティック分析し、evaluation-report.md を出力すること（SHALL） |
+| REQ-0046-010 | `learning-promote` は evaluation-report.md と archive.md から昇華判定を行い、Requirement Source stub を `.agentdev/learning/promoted/` に生成すること（SHALL） |
+| REQ-0046-011 | learning pipeline の domain state は `.agentdev/learning/`（inbox.md・archive.md・evaluation-report.md・promoted/）に配置すること（SHALL） |
+| REQ-0046-012 | `req-backlog` は `.agentdev/intake/promoted/*.md` 及び `.agentdev/learning/promoted/*.md` を読み込み、RU（Requirement Unit）を `.agentdev/backlog/req-units/RU-*.md` として生成すること（SHALL） |
+| REQ-0046-013 | `req-backlog` は promoted artifact の単純コピーを生成せず、全RUを分析・統合された構造化内容とすること（SHALL） |
+| REQ-0046-014 | RU の粒度は N:1（複数artifact→1RU統合）及び 1:N（1artifact→複数RU分割）を許可すること（SHALL） |
+| REQ-0046-015 | promoted artifact 間に矛盾が検出された場合、`req-backlog` は矛盾するartifactをRU化せず、ユーザーに確認を求めること（SHALL） |
+| REQ-0046-016 | `req-backlog` は RU 生成に成功した promoted artifact を削除すること（SHALL） |
+| REQ-0046-017 | promoted artifact が0件の場合、`req-backlog` は正常終了すること（SHALL） |
+| REQ-0046-018 | `req-backlog` は intake/learning の raw item（inbox.md・archive.md・entries/）を更新しないこと（SHALL） |
+| REQ-0046-019 | `req-define` は `.agentdev/backlog/req-units/RU-*.md` を Requirement Source として受け入れること（SHALL） |
+| REQ-0046-020 | `req-define` は `.agentdev/intake/promoted/*.md` 及び `.agentdev/learning/promoted/*.md` を直接読み込まないこと（SHALL） |
+| REQ-0046-021 | `req-save` は RU の内容が REQ ファイルに永続化された後、該当RUファイルを削除すること（SHALL） |
+| REQ-0046-022 | `case-open` は RU の内容が GitHub Issue に永続化された後、該当RUファイルを削除すること（SHALL） |
+| REQ-0046-023 | RU 削除のトリガーは永続化完了（REQ保存成功 または Issue作成成功）に限定すること（SHALL） |
+| REQ-0046-024 | promoted artifact の imported 処理は後続ルート（`req-save` または `case-open`）の成功後に実行すること（SHALL） |
+| REQ-0046-025 | `req-define` はユーザーの直接入力及び一般 source file を引き続き Requirement Source として受け入れること（SHALL） |
+| REQ-0046-026 | `intake-promote` が生成する promoted artifact は frontmatter を持たず、route / status はディレクトリ配置で表現すること（SHALL） |
+
+## 適用範囲
+
+- **対象**:
+  - intake pipeline（intake-capture / intake-review / intake-promote / intake-from-github）
+  - learning pipeline（learning-capture / learning-refine / learning-promote）
+  - req-backlog コマンドと RU lifecycle
+  - promoted artifact の lifecycle・imported処理
+  - 各パイプラインの domain state 配置規約
+  - req-define の RU 入力対応
+  - req-save / case-open の RU 削除トリガー
+- **対象外**:
+  - 各コマンドの内部手順の詳細
+  - case-run / case-close の動作
+  - コード実装
+  - integrity pipeline
+
+## 関連情報
+
+- **Related**: REQ-0043（req-define / req-save / REQ分類ゲート）
+- **Related**: REQ-0045（AgentDevFlow command protocol）
+- **Related ADRs**: ADR-0003（req-define入力の抽象化）

--- a/docs/requirements/REQ-0047.md
+++ b/docs/requirements/REQ-0047.md
@@ -1,0 +1,65 @@
+---
+id: REQ-0047
+title: "case-run / case-close / post-run capture"
+created: "2026-05-30"
+updated: "2026-05-30"
+tags: [case-run, case-close, post-run, findings, epic-orchestrator, worktree, reliability]
+---
+
+## 目的
+
+AgentDevFlow の case-run / case-close コマンドの実行プロセス・信頼性要件・完了ゲートを定義する。実行中のチェックボックス更新信頼性、git操作の安全性、Findings/Intake候補のPR本文永続化と回収、Epic Orchestratorの並列実行制御を規定する。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0047-001 | `case-run` は3フェーズ構成（準備・実装・提出）でべき等な再開ポイントを提供すること（SHALL） |
+| REQ-0047-002 | `case-run` は worktree で作業し、PRを作成すること（SHALL） |
+| REQ-0047-003 | `case-run` Step 7 は、チェックボックス更新時に `gh issue edit --body-file` の実行結果を確認してから todo を completed にマークすること（SHALL） |
+| REQ-0047-004 | `case-run` Step 7 は、`gh issue edit` の実行が失敗した場合、該当チェックボックスを `[x]` に更新せず、エラーを表示して停止すること（SHALL） |
+| REQ-0047-005 | `case-run` Step 6 は、実装完了後、ローカル実装diffからキーワードを自動抽出し、`docs/specs/` でgrepして矛盾する記述がないか自動確認すること（SHALL） |
+| REQ-0047-006 | `case-run` は Pattern B の specs更新必須条件と、全パターン共通の関連ドキュメント整合性条件を分離すること（SHALL） |
+| REQ-0047-007 | `case-run` は Issue本文に関連ドキュメント更新候補が存在する場合、実装計画に組み込むこと（SHALL） |
+| REQ-0047-008 | `case-run` Step 10.5 は本筋外FindingをPR本文の「Findings / Intake候補」セクションに記録すること（SHALL） |
+| REQ-0047-009 | `case-run` は `.agentdev/intake/inbox/` を直接変更しないこと（SHALL） |
+| REQ-0047-010 | `case-run` は「多重Issue入力上限（最大5件）」と「Epic Wave内同時実行上限」を別ルールとして定義すること（SHALL） |
+| REQ-0047-011 | `case-close` は PR merge / Issue close / `.agentdev` 永続化の結果状態を分離して報告すること（SHALL） |
+| REQ-0047-012 | `case-close` の branch / worktree 削除失敗時は「警告して停止」に統一すること（SHALL） |
+| REQ-0047-013 | `case-close` Step 8b は `git pull --ff-only` 実行前に `git status --porcelain` でローカル変更の有無を確認すること（SHALL） |
+| REQ-0047-014 | `case-close` Step 8b のローカル変更リセットは、PRで削除されたファイルに限定して実行すること（SHALL） |
+| REQ-0047-015 | `case-close` Step 9b はマージ済みPR本文から Findings/Intake候補セクションを取得し、intake item 形式で保存すること（SHALL） |
+| REQ-0047-016 | `case-close` Step 9b は Epicモード時に子Issue PR群を横断走査して回収すること（SHALL） |
+| REQ-0047-017 | `case-close` Step 9b はPR本文の情報を推測で補完しないこと（SHALL） |
+| REQ-0047-018 | `case-close` は未チェック項目の達成判定を実行し、達成済み項目は自動で `[x]` に更新すること（SHALL） |
+| REQ-0047-019 | `case-close` は要件・成果物・SPEC・DOC-MAPの整合確認時に `DOC-MAP.md` を参照すること（SHALL） |
+| REQ-0047-020 | `case-close` は ADR が必要な判断に対してADR作成済みかを検証すること（SHALL） |
+| REQ-0047-021 | `case-close` は ADR本文をAPPEND/UPDATEしないこと（SHALL） |
+| REQ-0047-022 | `case-close` は `promoted/*.md` にartifactが残存する場合、imported処理を実行してから完了報告を出力すること（SHALL） |
+| REQ-0047-023 | `case-close` の手順は REQ を正として扱うこと（SHALL） |
+| REQ-0047-024 | `case-run` は PR diff で新規キーワードまたは未計画のスキーマ変更が見つかった場合、提出処理を進めず work plan / 関連ドキュメント確認へ戻すこと（SHALL） |
+
+## 適用範囲
+
+- **対象**:
+  - case-run の3フェーズ構成・再開ポイント
+  - case-run Step 7 チェックボックス更新信頼性
+  - case-run Step 6 docs/specs/ grep自動確認
+  - case-run Findings/Intake候補PR本文永続化
+  - case-run 多重Issue・Epic Wave制御
+  - case-close の完了ゲート・整合確認
+  - case-close Step 8b git pull前チェック
+  - case-close Step 9b Findings回収
+  - case-close ADR検証・imported処理
+- **対象外**:
+  - req-define / req-save / case-open の動作
+  - intake / learning pipeline の動作
+  - コード実装
+  - テンプレートの内容
+
+## 関連情報
+
+- **Related**: REQ-0045（AgentDevFlow command protocol）
+- **Related**: REQ-0048（reporting / GitHub body / link / writing quality）
+- **Related**: REQ-0049（integrity / validation / tests）
+- **Related**: REQ-0020（Epic Issue 実行順序SSoTとcase-run Epic Orchestrator化）

--- a/docs/requirements/REQ-0048.md
+++ b/docs/requirements/REQ-0048.md
@@ -1,0 +1,56 @@
+---
+id: REQ-0048
+title: "reporting / GitHub body / link / writing quality"
+created: "2026-05-30"
+updated: "2026-05-30"
+tags: [reporting, github-body, link-normalization, writing-quality, ai-slop, completion-reports, gh-cli]
+---
+
+## 目的
+
+AgentDevFlow の完了報告フォーマット、GitHub Issue/PR本文の品質検証、リポジトリ参照リンクの正規化、自然言語成果物の文章品質基準を定義する。Issue/PRに書き込まれた内容の文字化け・フォーマット崩れ・リンク不正を自動検出し、AI生成特有の文章品質問題を抑止する。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0048-001 | 全 agentdev コマンドの完了報告は統一フォーマットに従うこと（SHALL） |
+| REQ-0048-002 | 完了報告フォーマットは `agentdev-workflow-reporting` skill に定義すること（SHALL） |
+| REQ-0048-003 | git操作を行わない command の完了報告の `git 永続化` 欄は `該当なし` とすること（SHALL） |
+| REQ-0048-004 | case-run完了報告には「Findings / Intake候補: N件」を含めること（SHALL） |
+| REQ-0048-005 | case-close完了報告には「回収済み: N件 / 保存済み: N件」を含めること（SHALL） |
+| REQ-0048-006 | Issue/PRへの書き込み操作（Issue作成・PR作成・コメント追加・Issue本文更新）の直後に、書き込んだ本文を読み戻し、元テキストと比較する検証ステップを実行すること（SHALL） |
+| REQ-0048-007 | 検証では以下の3点を確認すること（SHALL）: (a) エンコーディング検証（日本語文字列一致・制御文字混入検出） (b) Markdown構造検証（テーブル列数・チェックボックス記法・コードブロック開閉・リスト構造） (c) テンプレート必須セクション検証（`【必須】`マーカー付き見出しの存在確認） |
+| REQ-0048-008 | 各書き込み操作ごとに個別に検証すること（SHALL） |
+| REQ-0048-009 | 検証失敗時は差分の種類に応じて3段階で対応すること（SHALL）: (a) 同一内容リトライ（最大2回＝計3回） (b) 内容再生成（再生成後は(a)に戻さない） (c) ユーザー報告して停止 |
+| REQ-0048-010 | 検証結果（成功/失敗/リトライ回数/検出問題の詳細）を完了報告に含めること（SHOULD） |
+| REQ-0048-011 | GitHub本文内のMarkdownリンクのうち、リポジトリ内パス（`docs/`・`.opencode/`等で始まる相対パス）を使用しないこと（SHALL） |
+| REQ-0048-012 | リポジトリ参照リンクはGitHub URL形式（`https://github.com/{owner}/{repo}/blob/{branch}/{path}`）を使用すること（SHALL） |
+| REQ-0048-013 | コードブロック内・テンプレート変数プレースホルダーはリンク検証対象外とすること（SHALL） |
+| REQ-0048-014 | 自然言語成果物（REQ本文・ADR本文・Issue/PR本文・完了報告）は `agentdev-no-ai-slop-writing` skill の品質基準に従うこと（SHALL） |
+| REQ-0048-015 | `agentdev-gh-cli` skill は Windows 固有の文字化け対策と全環境共通の `--body-file` / VERIFY 制約を分離して記述すること（SHALL） |
+| REQ-0048-016 | `--body` 直接指定は禁止し、`--body-file` / `-F` によるファイル指定を全環境で使用すること（SHALL） |
+| REQ-0048-017 | 保存形式は UTF-8（BOMなし）、改行コードは LF とすること（SHALL） |
+| REQ-0048-018 | `gh` コマンドの読み戻しには Node.js `child_process.execSync` を使用し、PowerShell パイプラインのエンコーディング変換を回避すること（SHALL） |
+| REQ-0048-019 | コミットメッセージは日本語で記述し、Conventional Commits 形式に従うこと（SHALL） |
+
+## 適用範囲
+
+- **対象**:
+  - 完了報告フォーマット統一
+  - Issue/PR書き込み後の内容品質自動検証（エンコーディング・Markdown構造・テンプレート必須セクション）
+  - リポジトリ参照リンクの正規化
+  - 自然言語成果物の文章品質基準
+  - gh CLI使用ルール（Windows環境対応・--body-file必須・読み戻し安全性）
+  - コミットメッセージ規約
+- **対象外**:
+  - 各コマンドの内部手順
+  - コード実装
+  - テンプレートの具体内容
+  - テスト実装
+
+## 関連情報
+
+- **Related**: REQ-0045（AgentDevFlow command protocol）
+- **Related**: REQ-0047（case-run / case-close / post-run capture）
+- **Related**: REQ-0049（integrity / validation / tests）

--- a/docs/requirements/REQ-0049.md
+++ b/docs/requirements/REQ-0049.md
@@ -1,0 +1,65 @@
+---
+id: REQ-0049
+title: "integrity / validation / tests"
+created: "2026-05-30"
+updated: "2026-05-30"
+tags: [integrity, validation, tests, guardrails, consistency, scripts]
+---
+
+## 目的
+
+AgentDevFlow の横断的整合性検証・バリデーション・テスト体系を定義する。ドキュメント・スキル・コマンド間の整合性を静的に検査し、ガードレールをスクリプト化して実行時の不整合を防止し、体系的テストでコマンド群の品質を担保する。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0049-001 | `integrity-check` コマンドは REQ/ADR/SPEC/DOC-MAPの横断的整合性を検査すること（SHALL） |
+| REQ-0049-002 | `integrity-check` の read-only 制約は「検査対象artifactを変更しない」の意味とし、report / intake item の生成は例外とすること（SHALL） |
+| REQ-0049-003 | `integrity-check` は git操作を行わず、完了報告に「git永続化なし。必要なら別途 commit」を明示すること（SHALL） |
+| REQ-0049-004 | `integrity-check` の検査範囲は以下を含むこと（SHALL）: REQ frontmatter検証、ADR↔REQ相互参照整合性、Skill↔load_skills参照整合性、Command-map整合性、旧namespace残存検出、完了報告フォーマット検証、Template必須セクション検証、Skill構造lint |
+| REQ-0049-005 | `integrity-check` は検査カテゴリの追加・変更を `agentdev-integrity` skill 定義の更新で行うこと（SHALL） |
+| REQ-0049-006 | `integrity-check` は `DOC-MAP.md` の存在・参照先ファイルの存在・REQ/ADR/SPEC基準境界違反を検出すること（SHALL） |
+| REQ-0049-007 | `integrity-check` は `docs/requirements/views/` が残存している場合に検出すること（SHALL） |
+| REQ-0049-008 | `integrity-check` は `requirements/README.md` のREQ一覧と `REQ-*.md` 実体の不一致を検出すること（SHALL） |
+| REQ-0049-009 | `integrity-check` は `adr/README.md` のADR一覧と `ADR-*.md` 実体の不一致を検出すること（SHALL） |
+| REQ-0049-010 | `integrity-check` は検出結果を finding ごとに分類し、推奨routeを提示すること（SHALL） |
+| REQ-0049-011 | `integrity-check` は REQ/ADR/SPEC/DOC-MAPを直接自動更新しないこと（SHALL） |
+| REQ-0049-012 | 具体的な未修正事項は intake に送る候補として扱うこと（SHALL） |
+| REQ-0049-013 | 再発原因・予防策・検査観点として残す価値があるfindingは learning に送る候補として扱うこと（SHALL） |
+| REQ-0049-014 | 要件・責務・ワークフロー変更が必要なfindingは req-define 入力候補として扱うこと（SHALL） |
+| REQ-0049-015 | `integrity-check` は intake item を作成する場合、同名ファイル衝突時は `intake-capture` と同じ連番付与ルールを使うこと（SHALL） |
+| REQ-0049-016 | `integrity-check` の report 出力先は `.sisyphus/integrity-report.md` とし、都度上書きとすること（SHALL） |
+| REQ-0049-017 | `agentdev-integrity` と `integrity-check` は report 出力形式を一致させること（SHALL） |
+| REQ-0049-018 | `agentdev-integrity` は検査・レポートschemaまでを責務とし、intake item化の最終判断は `integrity-check` command に限定すること（SHALL） |
+| REQ-0049-019 | AgentDevFlow ガードレールはスクリプト化し、`agentdev-*` skill 内の `scripts/` に配置すること（SHALL） |
+| REQ-0049-020 | ガードレールスクリプトは command 定義から参照され、command 定義には検証ロジックを直接記述しないこと（SHALL） |
+| REQ-0049-021 | agentdev コマンド群は体系的テストで品質を担保すること（SHALL） |
+| REQ-0049-022 | テスト対象は command / skill / template / epic の各層をカバーすること（SHALL） |
+| REQ-0049-023 | 読込・評価・ユーザー承認後に `git pull --ff-only` を実行する設計では、読込時hashとpull後hashの一致検証を必須とすること（SHALL） |
+| REQ-0049-024 | `.agentdev` domain state 更新後は git 永続化を行うこと（SHALL） |
+| REQ-0049-025 | DOC-MAP更新漏れが繰り返し発生する場合は workflow-gap として扱うこと（SHOULD） |
+
+## 適用範囲
+
+- **対象**:
+  - integrity-check コマンドの検査範囲・出力・制約
+  - agentdev-integrity skill の検査定義・検査カテゴリ
+  - DOC-MAP整合性検査
+  - README↔実体不整合検出
+  - findingの分類・route提示
+  - ガードレールのスクリプト化・配置方針
+  - 体系的テスト実装
+  - git hash検証
+  - domain state git永続化
+- **対象外**:
+  - 各コマンドの内部手順
+  - コード実装
+  - intake / learning pipeline の動作
+  - case-run / case-close の動作
+
+## 関連情報
+
+- **Related**: REQ-0042（REQ/ADR/SPEC/DOC-MAP基準構造）
+- **Related**: REQ-0048（reporting / GitHub body / link / writing quality）
+- **Related**: REQ-0035（DOC-MAP導入とviews廃止）

--- a/docs/requirements/mapping-table.md
+++ b/docs/requirements/mapping-table.md
@@ -1,0 +1,108 @@
+---
+id: mapping-table
+title: "旧REQ↔新基準REQ対応表"
+created: "2026-05-30"
+updated: "2026-05-30"
+---
+
+## 目的
+
+REQ体系再基準化（REQ-0041 / ADR-0009）に伴い、旧REQ全40件（REQ-0001〜REQ-0040）と新基準REQ群（REQ-0042〜REQ-0049）の対応関係を明記する。各旧REQについて、現行分類・後継REQ・継承内容・非継承内容・反映作業の移送先を一覧化し、後続工程での参照可能性を確保する。
+
+## 対応表
+
+| 旧REQ ID | 現行分類 | 後継REQ | 継承する内容 | 継承しない内容 | 反映作業の移送先 | 備考 |
+|---|---|---|---|---|---|---|
+| REQ-0001 | retained | —（現行有効） | 全文現行仕様 | — | — | ワークフローアーキテクチャ。3フェーズ構成・SSoT遷移・エラー回復はREQ-0045と重複するが、REQ-0001自体がアーキテクチャ基盤として独立有効 |
+| REQ-0002 | partially superseded | REQ-0045 | 入出力契約・フェーズ境界の基本概念 | 既存REQ照合ロジック（→REQ-0043）・Pattern拡張（→REQ-0045）・SSoT遷移詳細（→REQ-0045） | 関連ドキュメント更新候補 | コマンドプロトコルの基礎はREQ-0045に再定義済み |
+| REQ-0003 | retained | —（現行有効） | 全文現行仕様 | — | — | Case並列実行・Wave実行モデル |
+| REQ-0004 | partially superseded | REQ-0042 | REQ/ADRのper-file基準構造・frontmatter規約 | views関連（→REQ-0035で廃止済み）・finding protocol（→REQ-0042）・SPLIT検出時の操作（→REQ-0042） | 関連ドキュメント更新候補 | ドキュメントシステムの基準構造はREQ-0042に再定義済み |
+| REQ-0005 | retained | —（現行有効） | 全文現行仕様 | — | — | Epic Issue管理・親子関係・自動クローズ |
+| REQ-0006 | retained | —（現行有効） | 全文現行仕様 | — | — | Sisyphusプラン基盤 |
+| REQ-0007 | partially superseded | REQ-0046 | learning pipeline の3目的（再発防止・抽象化・反映） | staging stub管理（→REQ-0046）・旧tips-*コマンド参照・具体的なコマンド手順（→REQ-0046） | follow-up | ナレッジパイプラインの目的はREQ-0046に再定義済み |
+| REQ-0008 | retained | —（現行有効） | 全文現行仕様 | — | — | スキル品質フレームワーク。frontmatter・description・トークン予算 |
+| REQ-0009 | partially superseded | REQ-0044 | テンプレートの命名・配置・変数規約の基本概念 | テンプレート選択ルール（→REQ-0044）・テンプレート構造詳細（→REQ-0044） | 関連ドキュメント更新候補 | テンプレートシステムはREQ-0044に再定義済み |
+| REQ-0010 | partially superseded | REQ-0045 | Pattern拡張・SSoT明確化・エラー回復の基本方針 | draft状態遷移・Guardrails整理・旧issue-*コマンド参照 | 関連ドキュメント更新候補 | Command実装改善の基本方針はREQ-0045に統合済み |
+| REQ-0011 | partially superseded | REQ-0048 | Issue/PR書き込み後の品質検証（3観点・リトライ） | 個別コマンド手順・テンプレート参照 | 関連ドキュメント更新候補 | 内容品質自動検証はREQ-0048に再定義済み |
+| REQ-0012 | retained | —（現行有効） | 全文現行仕様 | — | — | 自然言語ポリシー（日本語統一） |
+| REQ-0013 | superseded | REQ-0046 | —（全面置き換え） | 全面置き換え | — | intake承認フロー分割はREQ-0039→REQ-0046に統合。旧intake-from-github手順は全面置き換え |
+| REQ-0014 | partially superseded | REQ-0047 | case-run自律修正ループの基本方針 | Step番号依存の詳細手順・旧issue-work参照・CI/CD具体手順 | follow-up | 自律修正ループはREQ-0047に再定義済み |
+| REQ-0015 | partially superseded | REQ-0047 | 関連ドキュメントの要件達成対象化の基本方針 | 個別ドキュメント更新指示 | 関連ドキュメント更新候補 | 要件達成対象化はREQ-0047に再定義済み |
+| REQ-0016 | partially superseded | REQ-0044 | Command/Skill/Template/Script責任分界の基本概念 | learning要件ソース化の旧手順（→REQ-0043）・旧staging stub参照 | 関連ドキュメント更新候補 | 責任分界はREQ-0044に再定義済み |
+| REQ-0017 | partially superseded | REQ-0044 | plugin namespace統一（agentdev）・domain state定義 | 旧issue-*→agentdev移行手順・旧tips-*参照 | follow-up | namespace統一はREQ-0044に再定義済み |
+| REQ-0018 | retained | —（現行有効） | 全文現行仕様 | — | — | 未決分岐解消メソドロジー |
+| REQ-0019 | partially superseded | REQ-0046 | intake / learning 責任境界の基本方針 | 個別コマンド手順・旧intake-open参照 | follow-up | 責任境界明確化はREQ-0046に再定義済み |
+| REQ-0020 | retained | —（現行有効） | 全文現行仕様 | — | — | Epic Issue実行順序SSoT・Epic Orchestrator |
+| REQ-0021 | retained | —（現行有効） | 全文現行仕様 | — | — | ガードレールのスクリプト化・skill-local scripts配置 |
+| REQ-0022 | partially superseded | REQ-0049 | .agentdev git永続化の基本パターン | 個別コマンド手順・旧コマンド名参照 | follow-up | git永続化はREQ-0049に再定義済み |
+| REQ-0023 | superseded | REQ-0046 | —（全面置き換え） | 全面置き換え | — | staging stubの取り込み追跡はREQ-0046のRU lifecycleに全面置き換え |
+| REQ-0024 | partially superseded | REQ-0048 | 完了報告フォーマット統一の基本方針 | 個別コマンド手順・旧完了報告形式 | 関連ドキュメント更新候補 | 完了報告フォーマットはREQ-0048に再定義済み |
+| REQ-0025 | partially superseded | REQ-0049 | intake系コマンドのgit永続化パターン | 個別コマンド手順・旧コマンド名参照 | follow-up | git永続化はREQ-0049に再定義済み |
+| REQ-0026 | partially superseded | REQ-0046 | intake lifecycleのqueue/archive再定義の基本方針 | 個別ディレクトリ構造詳細・旧コマンド名参照 | 関連ドキュメント更新候補 | intake lifecycleはREQ-0046に再定義済み |
+| REQ-0027 | partially superseded | REQ-0046 | learning artifact lifecycleの責任範囲の基本方針 | 個別artifactの詳細手順・旧コマンド名参照 | 関連ドキュメント更新候補 | learning lifecycleはREQ-0046に再定義済み |
+| REQ-0028 | superseded | REQ-0042 | —（全面置き換え） | 全面置き換え | — | ドキュメント粒度・責務再構築はREQ-0042の基準構造定義に全面置き換え |
+| REQ-0029 | superseded | REQ-0046 | —（全面置き換え） | 全面置き換え | — | intake-open一括処理はREQ-0039→REQ-0046に全面置き換え |
+| REQ-0030 | retained | —（現行有効） | 全文現行仕様 | — | — | コマンド群の体系的テスト実装 |
+| REQ-0031 | retained | —（現行有効） | 全文現行仕様 | — | — | GitHub本文内リポジトリ参照リンクの正規化 |
+| REQ-0032 | retained | —（現行有効） | 全文現行仕様 | — | — | case-close未チェック項目達成判定 |
+| REQ-0033 | superseded | REQ-0049 | —（全面置き換え） | 全面置き換え | — | 二次整合性是正はREQ-0049のintegrity/validationに全面置き換え |
+| REQ-0034 | retained | —（現行有効） | 全文現行仕様 | — | — | req-define関連ドキュメント更新候補抽出 |
+| REQ-0035 | retained | —（現行有効） | 全文現行仕様 | — | — | DOC-MAP導入とviews廃止 |
+| REQ-0036 | partially superseded | REQ-0048 | AI-slop検出・文章品質ゲートの基本方針 | Skill定義の詳細手順 | follow-up | 文章品質ゲートはREQ-0048に再定義済み |
+| REQ-0037 | partially superseded | REQ-0047 | worktree削除時の残存ファイル対策の基本方針 | 個別Step手順 | follow-up | worktree残存ファイル対策はREQ-0047に再定義済み |
+| REQ-0038 | retained | —（現行有効） | 全文現行仕様 | — | — | case実行信頼性向上 |
+| REQ-0039 | partially superseded | REQ-0046 | req-backlog/RUパイプラインの基本概念 | promoted artifact詳細手順・旧コマンド名参照 | 関連ドキュメント更新候補 | RU lifecycleはREQ-0046に再定義済み |
+| REQ-0040 | partially superseded | REQ-0047 | Findings/Intake候補のPR本文永続化・回収の基本方針 | 個別Step手順・Epic横断回収詳細 | follow-up | Findings回収はREQ-0047に再定義済み |
+
+## 凡例
+
+### 分類の意味
+
+| 分類 | 意味 |
+|---|---|
+| retained | 旧REQのID・本文をそのまま現行基準として維持する。後継REQなし |
+| partially superseded | 旧REQの一部だけを後継REQへ移行し、残りは履歴または限定的基準として残す |
+| superseded | 旧REQを現行基準として読まず、後継REQまたは履歴参照に置き換える |
+
+### 記号の説明
+
+| 記号 | 意味 |
+|---|---|
+| —（現行有効） | 後継REQなし。旧REQ自体が現行仕様として有効 |
+| —（全面置き換え） | 旧REQの内容は全て後継REQに置き換わっている |
+| — | 該当項目なし |
+
+### 反映作業の移送先
+
+| 移送先 | 意味 |
+|---|---|
+| 関連ドキュメント更新候補 | req-define / case-run で関連ドキュメント更新候補として扱う |
+| follow-up | 後続Caseまたは別Issueで対応する |
+| — | 移送対象なし（retainedまたはsupersededで移送不要） |
+
+### 新基準REQ群の概要
+
+| REQ ID | タイトル | 対象領域 |
+|---|---|---|
+| REQ-0042 | REQ/ADR/SPEC/DOC-MAP 基準構造 | 文書種別の責務・基準境界・参照関係・操作モデル |
+| REQ-0043 | req-define / req-save / REQ分類ゲート | 入出力契約・操作分類・反映作業混入防止 |
+| REQ-0044 | Command / Skill / Template / Script 責任分界 | 各artifactの責務境界・配置規約・品質基準 |
+| REQ-0045 | AgentDevFlow command protocol | 入出力契約・実行順序・Pattern体系・SSoT遷移 |
+| REQ-0046 | intake / learning / req-backlog / RU lifecycle | パイプライン責務境界・成果物lifecycle・状態遷移 |
+| REQ-0047 | case-run / case-close / post-run capture | 実行プロセス・信頼性・Findings回収・完了ゲート |
+| REQ-0048 | reporting / GitHub body / link / writing quality | 完了報告・本文品質検証・リンク正規化・AI-slop抑止 |
+| REQ-0049 | integrity / validation / tests | 横断的整合性検証・バリデーション・テスト体系 |
+
+## 分類統計
+
+| 分類 | 件数 | REQ |
+|---|---|---|
+| retained | 15 | REQ-0001, 0003, 0005, 0006, 0008, 0012, 0018, 0020, 0021, 0030, 0031, 0032, 0034, 0035, 0038 |
+| partially superseded | 20 | REQ-0002, 0004, 0007, 0009, 0010, 0011, 0014, 0015, 0016, 0017, 0019, 0022, 0024, 0025, 0026, 0027, 0036, 0037, 0039, 0040 |
+| superseded | 5 | REQ-0013, 0023, 0028, 0029, 0033 |
+
+## 関連情報
+
+- **Related**: REQ-0041（REQ体系再基準化）
+- **Related ADRs**: ADR-0009（REQ体系再基準化）
+- **Related**: REQ-0042〜REQ-0049（新基準REQ群）


### PR DESCRIPTION
## 概要

<!-- 【必須】 -->
旧REQ（REQ-0001〜REQ-0040）と新基準REQ群（REQ-0042〜REQ-0049）の対応表を `docs/requirements/mapping-table.md` に作成した。REQ-0041の「対応表必須項目」に従い、全40件の旧REQについて7項目（旧REQ ID、現行分類、後継REQ、継承する内容、継承しない内容、反映作業の移送先、備考）を記録した。

## 実装内容

<!-- 【必須】 -->
- `docs/requirements/mapping-table.md` を新規作成
  - frontmatter: id / title / created / updated
  - 目的セクション
  - 対応表本体（40行・7列のMarkdownテーブル）
  - 凡例セクション（分類の意味、記号の説明、反映作業の移送先、新基準REQ群の概要）
  - 分類統計（retained: 15件、partially superseded: 20件、superseded: 5件）
- 分類別内容基準に従い各旧REQの対応関係を整理:
  - retained: 後継REQ「—（現行有効）」、継承内容「全文現行仕様」
  - partially superseded: 後継REQに該当新基準REQ番号、継承・非継承範囲を明記
  - superseded: 後継REQに該当新基準REQ番号、継承内容「—（全面置き換え）」

## 完了条件

<!-- 【必須】 -->
- [x] 全40件の旧REQについて対応表が存在する
- [x] 各旧REQに継承・置換・廃止・未継承の範囲が明記されている
- [x] `partially superseded` の旧REQに後継REQ・対象範囲が明記されている
- [x] 対応表が docs/requirements/ 配下に配置されている

## テスト結果

<!-- 【必須】 -->
- 対応表ファイル存在確認: ✅ `docs/requirements/mapping-table.md`
- 全40件記載確認: ✅ 40行の対応表エントリ
- 分類統計整合性: ✅ retained(15) + partially superseded(20) + superseded(5) = 40

## 品質メトリクス

<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 旧REQ全件カバレッジ | 40/40 | 40/40 | ✅ |
| 対応表必須項目（7項目） | 全行完備 | 全行完備 | ✅ |
| 新基準REQへの参照正確性 | 8 REQ参照 | REQ-0042〜0049 | ✅ |

## Findings / Intake候補

<!-- 【必須】 -->
該当なし

## 決定事項

<!-- 【任意】 -->
- REQ-0010はタスクの分類リストに記載がなかったが、内容がREQ-0045と重複するため partially superseded に分類した

<!-- 【必須】 -->
Closes #443
