### PR TITLE
docs: README/DOC-MAPを新基準REQ群中心に再構成

### DIFF
--- a/docs/DOC-MAP.md
+++ b/docs/DOC-MAP.md
@@ -1,6 +1,6 @@
 # DOC-MAP
 
-> **参照用文書**: DOC-MAP は文書探索・参照経路の入口であり、要件の基準ではない（REQ-0035 / ADR-0008）。
+> **参照用文書**: DOC-MAP は文書探索・参照経路の入口であり、要件の基準ではない（REQ-0042 / REQ-0035 / ADR-0008）。
 > 基準は各 `REQ-{NNNN}.md`、`ADR-{NNNN}.md`、`specs/*.md` ファイルである。
 
 ## 基準境界
@@ -9,77 +9,85 @@
 |----------|------|------|
 | REQ | `requirements/REQ-{NNNN}.md` | 要件定義の永続基準 |
 | ADR | `adr/ADR-{NNNN}.md` | アーキテクチャ決定記録の基準 |
-| SPEC | `specs/*.md` | 現在アーキテクチャの基準（REQ-0035-006） |
+| SPEC | `specs/*.md` | 現在アーキテクチャの基準（REQ-0042 / REQ-0035） |
 | DOC-MAP | このファイル | 文書探索入口（参照用・分類索引） |
 
-## ドキュメント管理・構造
+## 新基準REQ群（現行基準）
+
+REQ体系再基準化（REQ-0041 / ADR-0009）により整理統合された8件。仕様参照の第一参照先。
 
 | REQ | タイトル | 概要 |
 |-----|---------|------|
-| [REQ-0004](requirements/REQ-0004.md) | 要件・ADRドキュメントシステム | REQ/ADR管理規則 |
-| [REQ-0009](requirements/REQ-0009.md) | テンプレートシステム | テンプレート管理 |
-| [REQ-0016](requirements/REQ-0016.md) | Command/Skill/Template/Script責任分界とtips要件ソース化 | 責務分界定義 |
-| [REQ-0028](requirements/REQ-0028.md) | Documentation granularity and responsibility restructuring | ドキュメント粒度・責務再構築 |
-| [REQ-0041](requirements/REQ-0041.md) | REQ体系再基準化 — 旧REQ分類・新基準REQ群・分類ゲート | 旧REQ分類・新基準REQ群・対応表・分類ゲート |
+| [REQ-0042](requirements/REQ-0042.md) | REQ/ADR/SPEC/DOC-MAP 基準構造 | 文書種別の責務・基準境界・参照関係・操作モデル |
+| [REQ-0043](requirements/REQ-0043.md) | req-define / req-save / REQ分類ゲート | 入出力契約・操作分類・反映作業混入防止 |
+| [REQ-0044](requirements/REQ-0044.md) | Command / Skill / Template / Script 責任分界 | 各artifactの責務境界・配置規約・品質基準 |
+| [REQ-0045](requirements/REQ-0045.md) | AgentDevFlow command protocol | 入出力契約・実行順序・Pattern体系・SSoT遷移 |
+| [REQ-0046](requirements/REQ-0046.md) | intake / learning / req-backlog / RU lifecycle | パイプライン責務境界・成果物lifecycle・状態遷移 |
+| [REQ-0047](requirements/REQ-0047.md) | case-run / case-close / post-run capture | 実行プロセス・信頼性・Findings回収・完了ゲート |
+| [REQ-0048](requirements/REQ-0048.md) | reporting / GitHub body / link / writing quality | 完了報告・本文品質検証・リンク正規化・AI-slop抑止 |
+| [REQ-0049](requirements/REQ-0049.md) | integrity / validation / tests | 横断的整合性検証・バリデーション・テスト体系 |
 
-## ワークフロー・実行基盤
+## Retained（現行有効な旧REQ）
+
+後継REQなし。独立有効な要件。
 
 | REQ | タイトル | 概要 |
 |-----|---------|------|
 | [REQ-0001](requirements/REQ-0001.md) | AgentDevFlow ワークフローアーキテクチャ | ワークフロー全体のアーキテクチャ定義 |
 | [REQ-0003](requirements/REQ-0003.md) | Case 並列実行 | 複数Issueの並列実行基盤 |
+| [REQ-0005](requirements/REQ-0005.md) | Epic Issue 管理 | Epic管理基盤 |
 | [REQ-0006](requirements/REQ-0006.md) | Sisyphus プラン基盤 | プラン管理・実行基盤 |
-| [REQ-0014](requirements/REQ-0014.md) | case-run 自律修正ループと責務分離の明確化 | Self-healing loop とCI/CD検証 |
-| [REQ-0015](requirements/REQ-0015.md) | 関連ドキュメントの要件達成対象化 | ドキュメント更新の要件管理 |
-| [REQ-0020](requirements/REQ-0020.md) | Epic Issue 実行順序 SSoT と case-run Epic Orchestrator 化 | Epic Orchestration設計 |
-| [REQ-0034](requirements/REQ-0034.md) | req-define 関連ドキュメント更新候補抽出と後続工程への伝播 | 要件変更に伴う関連ドキュメント更新候補の検出・伝播 |
-| [REQ-0039](requirements/REQ-0039.md) | req-backlog コマンドと Requirement Unit パイプライン | req-backlog 新設、RU lifecycle、promoted artifact 統合・分割基準 |
-
-## コマンドプロトコル・品質
-
-| REQ | タイトル | 概要 |
-|-----|---------|------|
-| [REQ-0002](requirements/REQ-0002.md) | AgentDevFlow コマンドプロトコル | コマンド定義・操作モデル |
-| [REQ-0010](requirements/REQ-0010.md) | AgentDevFlow Command実装改善：安全性・品質・状態管理 | コマンド安全性・品質基盤 |
-| [REQ-0013](requirements/REQ-0013.md) | intake 承認フロー分割と解消済み確認機能 *(superseded by REQ-0039)* | intake承認フロー改善 |
-| [REQ-0024](requirements/REQ-0024.md) | 全 agentdev コマンドの完了報告フォーマット統一 | 完了報告フォーマット標準化 |
-| [REQ-0029](requirements/REQ-0029.md) | intake-open promoted artifact 一括処理 *(superseded by REQ-0039)* | intake一括処理機能 |
-| [REQ-0038](requirements/REQ-0038.md) | case実行信頼性向上（チェックボックス確認・pull前チェック・docs整合性grep） | case実行プロセスの信頼性強化 |
-
-## 品質・整合性
-
-| REQ | タイトル | 概要 |
-|-----|---------|------|
 | [REQ-0008](requirements/REQ-0008.md) | スキル品質フレームワーク | スキル品質基準 |
-| [REQ-0011](requirements/REQ-0011.md) | Issue/PR書き込み後の内容品質自動検証 | 書き込み検証自動化 |
+| [REQ-0012](requirements/REQ-0012.md) | 自然言語ポリシー | 日本語表記規約 |
+| [REQ-0018](requirements/REQ-0018.md) | agentdev-req-analysis 未決分岐解消メソドロジー | 未決分岐解消手法 |
+| [REQ-0020](requirements/REQ-0020.md) | Epic Issue 実行順序 SSoT と case-run Epic Orchestrator 化 | Epic Orchestration設計 |
 | [REQ-0021](requirements/REQ-0021.md) | AgentDevFlow ガードレールのスクリプト化と skill-local scripts 配置方針 | ガードレールスクリプト化 |
 | [REQ-0030](requirements/REQ-0030.md) | agentdev コマンド群の体系的テスト実装 | テスト体系実装 |
 | [REQ-0031](requirements/REQ-0031.md) | GitHub本文内リポジトリ参照リンクの正規化 | リンク正規化 |
-| [REQ-0036](requirements/REQ-0036.md) | agentdev-no-ai-slop-writing Skill 追加 | 自然言語成果物の文章品質ゲート |
+| [REQ-0032](requirements/REQ-0032.md) | case-close 未チェック項目達成判定 | 完了ゲート判定 |
+| [REQ-0034](requirements/REQ-0034.md) | req-define 関連ドキュメント更新候補抽出と後続工程への伝播 | 要件変更伝播 |
+| [REQ-0035](requirements/REQ-0035.md) | DOC-MAP導入と requirements/views 廃止による文書探索・維持管理再設計 | DOC-MAP設計 |
+| [REQ-0038](requirements/REQ-0038.md) | case実行信頼性向上（チェックボックス確認・pull前チェック・docs整合性grep） | case実行信頼性 |
 
-## ナレッジパイプライン
+## Partially Superseded（一部後継REQに移行済み）
+
+旧REQの一部だけを後継REQへ移行し、残りは限定的基準として残す。
+
+| REQ | タイトル | 後継REQ |
+|-----|---------|---------|
+| [REQ-0002](requirements/REQ-0002.md) | AgentDevFlow コマンドプロトコル | REQ-0045 |
+| [REQ-0004](requirements/REQ-0004.md) | 要件・ADRドキュメントシステム | REQ-0042 |
+| [REQ-0007](requirements/REQ-0007.md) | ナレッジパイプライン高度化 | REQ-0046 |
+| [REQ-0009](requirements/REQ-0009.md) | テンプレートシステム | REQ-0044 |
+| [REQ-0010](requirements/REQ-0010.md) | AgentDevFlow Command実装改善：安全性・品質・状態管理 | REQ-0045 |
+| [REQ-0011](requirements/REQ-0011.md) | Issue/PR書き込み後の内容品質自動検証 | REQ-0048 |
+| [REQ-0014](requirements/REQ-0014.md) | case-run 自律修正ループと責務分離の明確化 | REQ-0047 |
+| [REQ-0015](requirements/REQ-0015.md) | 関連ドキュメントの要件達成対象化 | REQ-0047 |
+| [REQ-0016](requirements/REQ-0016.md) | Command/Skill/Template/Script責任分界とtips要件ソース化 | REQ-0044 |
+| [REQ-0017](requirements/REQ-0017.md) | AgentDevFlow plugin namespace 統一と learning / intake / integrity の正式化 | REQ-0044 |
+| [REQ-0019](requirements/REQ-0019.md) | intake / learning の責任境界明確化と workflow 組み込み | REQ-0046 |
+| [REQ-0022](requirements/REQ-0022.md) | .agentdev domain state 更新後の git 永続化 | REQ-0049 |
+| [REQ-0024](requirements/REQ-0024.md) | 全 agentdev コマンドの完了報告フォーマット統一 | REQ-0048 |
+| [REQ-0025](requirements/REQ-0025.md) | intake 系コマンドの .agentdev/intake 更新後の git 永続化 | REQ-0049 |
+| [REQ-0026](requirements/REQ-0026.md) | intake lifecycle の queue/archive 再定義 | REQ-0046 |
+| [REQ-0027](requirements/REQ-0027.md) | learning artifact lifecycle の責任範囲明確化 | REQ-0046 |
+| [REQ-0036](requirements/REQ-0036.md) | agentdev-no-ai-slop-writing Skill 追加 | REQ-0048 |
+| [REQ-0037](requirements/REQ-0037.md) | worktree 削除時の残存ファイル対策強化 | REQ-0047 |
+| [REQ-0039](requirements/REQ-0039.md) | req-backlog コマンドと Requirement Unit パイプライン | REQ-0046 |
+| [REQ-0040](requirements/REQ-0040.md) | 子Issue PRに Findings / Intake候補を永続化し、case-closeで回収する | REQ-0047 |
+
+## Superseded（全面置き換え済み）
+
+| REQ | タイトル | 後継REQ |
+|-----|---------|---------|
+| [REQ-0013](requirements/REQ-0013.md) | intake 承認フロー分割と解消済み確認機能 | REQ-0046 |
+| [REQ-0023](requirements/REQ-0023.md) | learning staging stub の取り込み追跡と取り込み後アーカイブ | REQ-0046 |
+| [REQ-0028](requirements/REQ-0028.md) | Documentation granularity and responsibility restructuring | REQ-0042 |
+| [REQ-0029](requirements/REQ-0029.md) | intake-open promoted artifact 一括処理 | REQ-0046 |
+| [REQ-0033](requirements/REQ-0033.md) | AgentDevFlow command / skill 定義の二次整合性是正 | REQ-0049 |
+
+## 管理REQ
 
 | REQ | タイトル | 概要 |
 |-----|---------|------|
-| [REQ-0007](requirements/REQ-0007.md) | ナレッジパイプライン高度化 | 学びの3層パイプライン |
-| [REQ-0023](requirements/REQ-0023.md) | learning staging stub の取り込み追跡と取り込み後アーカイブ | staging stub管理 |
-| [REQ-0027](requirements/REQ-0027.md) | learning artifact lifecycle の責任範囲明確化 | artifact lifecycle定義 |
-
-## Intake系
-
-| REQ | タイトル | 概要 |
-|-----|---------|------|
-| [REQ-0019](requirements/REQ-0019.md) | intake / learning の責任境界明確化と workflow 組み込み | intake/learning境界定義 |
-| [REQ-0025](requirements/REQ-0025.md) | intake 系コマンドの .agentdev/intake 更新後の git 永続化 | intake git永続化 |
-| [REQ-0026](requirements/REQ-0026.md) | intake lifecycle の queue/archive 再定義 | intake lifecycle再設計 |
-| [REQ-0040](requirements/REQ-0040.md) | 子Issue PRに Findings / Intake候補を永続化し、case-closeで回収する | PR本文永続チャネル・case-run/case-close回収 |
-
-## 設定・名前空間・基盤
-
-| REQ | タイトル | 概要 |
-|-----|---------|------|
-| [REQ-0005](requirements/REQ-0005.md) | Epic Issue 管理 | Epic管理基盤 |
-| [REQ-0012](requirements/REQ-0012.md) | 自然言語ポリシー | 日本語表記規約 |
-| [REQ-0017](requirements/REQ-0017.md) | AgentDevFlow plugin namespace 統一と learning / intake / integrity の正式化 | namespace統一 |
-| [REQ-0018](requirements/REQ-0018.md) | agentdev-req-analysis 未決分岐解消メソドロジー | 未決分岐解消手法 |
-| [REQ-0022](requirements/REQ-0022.md) | .agentdev domain state 更新後の git 永続化 | domain state永続化 |
+| [REQ-0041](requirements/REQ-0041.md) | REQ体系再基準化 — 旧REQ分類・新基準REQ群・分類ゲート | 分類ゲート・対応表（mapping-table.md） |

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,56 +4,76 @@
 
 要件定義書の一覧とインデックス。
 
-- [Requirements Index](requirements/README.md)
-  - [REQ-0001: AgentDevFlow ワークフローアーキテクチャ](requirements/REQ-0001.md)
-  - [REQ-0002: AgentDevFlow コマンドプロトコル](requirements/REQ-0002.md)
-  - [REQ-0003: Case 並列実行](requirements/REQ-0003.md)
-  - [REQ-0004: 要件・ADRドキュメントシステム](requirements/REQ-0004.md)
-  - [REQ-0005: Epic Issue 管理](requirements/REQ-0005.md)
-  - [REQ-0006: Sisyphus プラン基盤](requirements/REQ-0006.md)
-  - [REQ-0007: ナレッジパイプライン高度化](requirements/REQ-0007.md)
-  - [REQ-0008: スキル品質フレームワーク](requirements/REQ-0008.md)
-  - [REQ-0009: テンプレートシステム](requirements/REQ-0009.md)
-  - [REQ-0010: AgentDevFlow Command実装改善：安全性・品質・状態管理](requirements/REQ-0010.md)
-  - [REQ-0011: Issue/PR書き込み後の内容品質自動検証](requirements/REQ-0011.md)
-  - [REQ-0012: 自然言語ポリシー](requirements/REQ-0012.md)
-  - [REQ-0013: intake 承認フロー分割と解消済み確認機能](requirements/REQ-0013.md) *(superseded by REQ-0039)*
-  - [REQ-0014: case-run 自律修正ループと責務分離の明確化](requirements/REQ-0014.md)
-  - [REQ-0015: 関連ドキュメントの要件達成対象化](requirements/REQ-0015.md)
-  - [REQ-0016: Command/Skill/Template/Script責任分界とtips要件ソース化](requirements/REQ-0016.md)
-  - [REQ-0017: AgentDevFlow plugin namespace 統一と learning / intake / integrity の正式化](requirements/REQ-0017.md)
-  - [REQ-0018: agentdev-req-analysis 未決分岐解消メソドロジー](requirements/REQ-0018.md)
-  - [REQ-0019: intake / learning の責任境界明確化と workflow 組み込み](requirements/REQ-0019.md)
-  - [REQ-0020: Epic Issue 実行順序 SSoT と case-run Epic Orchestrator 化](requirements/REQ-0020.md)
-  - [REQ-0021: AgentDevFlow ガードレールのスクリプト化と skill-local scripts 配置方針](requirements/REQ-0021.md)
-  - [REQ-0022: .agentdev domain state 更新後の git 永続化](requirements/REQ-0022.md)
-  - [REQ-0023: learning staging stub の取り込み追跡と取り込み後アーカイブ](requirements/REQ-0023.md)
-  - [REQ-0024: 全 agentdev コマンドの完了報告フォーマット統一](requirements/REQ-0024.md)
-  - [REQ-0025: intake 系コマンドの .agentdev/intake 更新後の git 永続化](requirements/REQ-0025.md)
-  - [REQ-0026: intake lifecycle の queue/archive 再定義](requirements/REQ-0026.md)
-  - [REQ-0027: learning artifact lifecycle の責任範囲明確化](requirements/REQ-0027.md)
-  - [REQ-0028: Documentation granularity and responsibility restructuring](requirements/REQ-0028.md)
-  - [REQ-0029: intake-open promoted artifact 一括処理](requirements/REQ-0029.md) *(superseded by REQ-0039)*
-  - [REQ-0030: agentdev コマンド群の体系的テスト実装](requirements/REQ-0030.md)
-  - [REQ-0031: GitHub本文内リポジトリ参照リンクの正規化](requirements/REQ-0031.md)
-  - [REQ-0032: case-close 未チェック項目達成判定](requirements/REQ-0032.md)
-  - [REQ-0033: AgentDevFlow command / skill 定義の二次整合性是正](requirements/REQ-0033.md)
-  - [REQ-0034: req-define 関連ドキュメント更新候補抽出と後続工程への伝播](requirements/REQ-0034.md)
-  - [REQ-0035: DOC-MAP導入と requirements/views 廃止による文書探索・維持管理再設計](requirements/REQ-0035.md)
-  - [REQ-0036: agentdev-no-ai-slop-writing Skill 追加](requirements/REQ-0036.md)
-  - [REQ-0037: worktree 削除時の残存ファイル対策強化](requirements/REQ-0037.md)
-  - [REQ-0038: case実行信頼性向上（チェックボックス確認・pull前チェック・docs整合性grep）](requirements/REQ-0038.md)
-  - [REQ-0039: req-backlog コマンドと Requirement Unit パイプライン](requirements/REQ-0039.md)
-  - [REQ-0040: 子Issue PRに Findings / Intake候補を永続化し、case-closeで回収する](requirements/REQ-0040.md)
-  - [REQ-0041: REQ体系再基準化 — 旧REQ分類・新基準REQ群・分類ゲート](requirements/REQ-0041.md)
-  - [REQ-0042: REQ/ADR/SPEC/DOC-MAP 基準構造](requirements/REQ-0042.md)
-  - [REQ-0043: req-define / req-save / REQ分類ゲート](requirements/REQ-0043.md)
-  - [REQ-0044: Command / Skill / Template / Script 責任分界](requirements/REQ-0044.md)
-  - [REQ-0045: AgentDevFlow command protocol](requirements/REQ-0045.md)
-  - [REQ-0046: intake / learning / req-backlog / RU lifecycle](requirements/REQ-0046.md)
-  - [REQ-0047: case-run / case-close / post-run capture](requirements/REQ-0047.md)
-  - [REQ-0048: reporting / GitHub body / link / writing quality](requirements/REQ-0048.md)
-  - [REQ-0049: integrity / validation / tests](requirements/REQ-0049.md)
+### 新基準REQ群（現行基準）
+
+REQ体系再基準化（REQ-0041 / ADR-0009）により整理統合された8件。現在の仕様参照は以下を第一参照先とすること。
+
+- [REQ-0042: REQ/ADR/SPEC/DOC-MAP 基準構造](requirements/REQ-0042.md)
+- [REQ-0043: req-define / req-save / REQ分類ゲート](requirements/REQ-0043.md)
+- [REQ-0044: Command / Skill / Template / Script 責任分界](requirements/REQ-0044.md)
+- [REQ-0045: AgentDevFlow command protocol](requirements/REQ-0045.md)
+- [REQ-0046: intake / learning / req-backlog / RU lifecycle](requirements/REQ-0046.md)
+- [REQ-0047: case-run / case-close / post-run capture](requirements/REQ-0047.md)
+- [REQ-0048: reporting / GitHub body / link / writing quality](requirements/REQ-0048.md)
+- [REQ-0049: integrity / validation / tests](requirements/REQ-0049.md)
+
+### Retained（現行有効な旧REQ）
+
+- [REQ-0001: AgentDevFlow ワークフローアーキテクチャ](requirements/REQ-0001.md)
+- [REQ-0003: Case 並列実行](requirements/REQ-0003.md)
+- [REQ-0005: Epic Issue 管理](requirements/REQ-0005.md)
+- [REQ-0006: Sisyphus プラン基盤](requirements/REQ-0006.md)
+- [REQ-0008: スキル品質フレームワーク](requirements/REQ-0008.md)
+- [REQ-0012: 自然言語ポリシー](requirements/REQ-0012.md)
+- [REQ-0018: agentdev-req-analysis 未決分岐解消メソドロジー](requirements/REQ-0018.md)
+- [REQ-0020: Epic Issue 実行順序 SSoT と case-run Epic Orchestrator 化](requirements/REQ-0020.md)
+- [REQ-0021: AgentDevFlow ガードレールのスクリプト化と skill-local scripts 配置方針](requirements/REQ-0021.md)
+- [REQ-0030: agentdev コマンド群の体系的テスト実装](requirements/REQ-0030.md)
+- [REQ-0031: GitHub本文内リポジトリ参照リンクの正規化](requirements/REQ-0031.md)
+- [REQ-0032: case-close 未チェック項目達成判定](requirements/REQ-0032.md)
+- [REQ-0034: req-define 関連ドキュメント更新候補抽出と後続工程への伝播](requirements/REQ-0034.md)
+- [REQ-0035: DOC-MAP導入と requirements/views 廃止による文書探索・維持管理再設計](requirements/REQ-0035.md)
+- [REQ-0038: case実行信頼性向上（チェックボックス確認・pull前チェック・docs整合性grep）](requirements/REQ-0038.md)
+
+### Partially Superseded（一部後継REQに移行済み）
+
+- [REQ-0002: AgentDevFlow コマンドプロトコル](requirements/REQ-0002.md) → REQ-0045
+- [REQ-0004: 要件・ADRドキュメントシステム](requirements/REQ-0004.md) → REQ-0042
+- [REQ-0007: ナレッジパイプライン高度化](requirements/REQ-0007.md) → REQ-0046
+- [REQ-0009: テンプレートシステム](requirements/REQ-0009.md) → REQ-0044
+- [REQ-0010: AgentDevFlow Command実装改善：安全性・品質・状態管理](requirements/REQ-0010.md) → REQ-0045
+- [REQ-0011: Issue/PR書き込み後の内容品質自動検証](requirements/REQ-0011.md) → REQ-0048
+- [REQ-0014: case-run 自律修正ループと責務分離の明確化](requirements/REQ-0014.md) → REQ-0047
+- [REQ-0015: 関連ドキュメントの要件達成対象化](requirements/REQ-0015.md) → REQ-0047
+- [REQ-0016: Command/Skill/Template/Script責任分界とtips要件ソース化](requirements/REQ-0016.md) → REQ-0044
+- [REQ-0017: AgentDevFlow plugin namespace 統一と learning / intake / integrity の正式化](requirements/REQ-0017.md) → REQ-0044
+- [REQ-0019: intake / learning の責任境界明確化と workflow 組み込み](requirements/REQ-0019.md) → REQ-0046
+- [REQ-0022: .agentdev domain state 更新後の git 永続化](requirements/REQ-0022.md) → REQ-0049
+- [REQ-0024: 全 agentdev コマンドの完了報告フォーマット統一](requirements/REQ-0024.md) → REQ-0048
+- [REQ-0025: intake 系コマンドの .agentdev/intake 更新後の git 永続化](requirements/REQ-0025.md) → REQ-0049
+- [REQ-0026: intake lifecycle の queue/archive 再定義](requirements/REQ-0026.md) → REQ-0046
+- [REQ-0027: learning artifact lifecycle の責任範囲明確化](requirements/REQ-0027.md) → REQ-0046
+- [REQ-0036: agentdev-no-ai-slop-writing Skill 追加](requirements/REQ-0036.md) → REQ-0048
+- [REQ-0037: worktree 削除時の残存ファイル対策強化](requirements/REQ-0037.md) → REQ-0047
+- [REQ-0039: req-backlog コマンドと Requirement Unit パイプライン](requirements/REQ-0039.md) → REQ-0046
+- [REQ-0040: 子Issue PRに Findings / Intake候補を永続化し、case-closeで回収する](requirements/REQ-0040.md) → REQ-0047
+
+### Superseded（全面置き換え済み）
+
+- ~~[REQ-0013: intake 承認フロー分割と解消済み確認機能](requirements/REQ-0013.md)~~ → REQ-0046
+- ~~[REQ-0023: learning staging stub の取り込み追跡と取り込み後アーカイブ](requirements/REQ-0023.md)~~ → REQ-0046
+- ~~[REQ-0028: Documentation granularity and responsibility restructuring](requirements/REQ-0028.md)~~ → REQ-0042
+- ~~[REQ-0029: intake-open promoted artifact 一括処理](requirements/REQ-0029.md)~~ → REQ-0046
+- ~~[REQ-0033: AgentDevFlow command / skill 定義の二次整合性是正](requirements/REQ-0033.md)~~ → REQ-0049
+
+### 管理REQ
+
+- [REQ-0041: REQ体系再基準化 — 旧REQ分類・新基準REQ群・分類ゲート](requirements/REQ-0041.md)
+- [対応表（mapping-table.md）](requirements/mapping-table.md)
+
+### インデックス
+
+- [Requirements Index（README.md）](requirements/README.md)
 
 ## Specifications
 
@@ -71,12 +91,12 @@
   - [ADR-0001: Command/Skill/Template/Script責任分界の正式定義](adr/ADR-0001.md)
   - [ADR-0002: Orchestration skill作成基準の導入](adr/ADR-0002.md)
   - [ADR-0003: req-define入力の抽象化](adr/ADR-0003.md)
-   - [ADR-0004: 要件管理構造のarea-based移行方針](adr/ADR-0004.md)
-   - [ADR-0005: AgentDevFlow plugin namespace 統一](adr/ADR-0005.md)
-   - [ADR-0006: Epic Issue 本文を実行順序 SSoT とする設計](adr/ADR-0006.md)
-   - [ADR-0007: REQ/ADR基準構造と分類ビュー運用の再定義](adr/ADR-0007.md)
-   - [ADR-0008: DOC-MAP導入と requirements/views 廃止](adr/ADR-0008.md)
-   - [ADR-0009: REQ体系再基準化 — 旧REQ分類モデル・対応表・分類ゲート導入](adr/ADR-0009.md)
+  - [ADR-0004: 要件管理構造のarea-based移行方針](adr/ADR-0004.md)
+  - [ADR-0005: AgentDevFlow plugin namespace 統一](adr/ADR-0005.md)
+  - [ADR-0006: Epic Issue 本文を実行順序 SSoT とする設計](adr/ADR-0006.md)
+  - [ADR-0007: REQ/ADR基準構造と分類ビュー運用の再定義](adr/ADR-0007.md)
+  - [ADR-0008: DOC-MAP導入と requirements/views 廃止](adr/ADR-0008.md)
+  - [ADR-0009: REQ体系再基準化 — 旧REQ分類モデル・対応表・分類ゲート導入](adr/ADR-0009.md)
 
 ## Learning
 

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -1,105 +1,105 @@
 # Requirements Index
 
-REQ-0041（REQ体系再基準化）により、既存REQ群（REQ-0001〜REQ-0040）を以下の3分類に分類しています。詳細は [REQ-0041](REQ-0041.md) を参照。
+## 現行基準（REQ-0042〜REQ-0049）
 
-## Retained（現行基準）
+REQ体系再基準化（REQ-0041 / ADR-0009）により、旧REQ群（REQ-0001〜REQ-0040）を整理統合した新基準REQ群。現在の仕様参照は以下のREQを第一参照先とすること。
 
-以下のREQは現行仕様の基準としてそのまま維持します。
+| REQ ID | タイトル | 対象領域 |
+| ------ | -------- | -------- |
+| REQ-0042 | REQ/ADR/SPEC/DOC-MAP 基準構造 | 文書種別の責務・基準境界・参照関係・操作モデル |
+| REQ-0043 | req-define / req-save / REQ分類ゲート | 入出力契約・操作分類・反映作業混入防止 |
+| REQ-0044 | Command / Skill / Template / Script 責任分界 | 各artifactの責務境界・配置規約・品質基準 |
+| REQ-0045 | AgentDevFlow command protocol | 入出力契約・実行順序・Pattern体系・SSoT遷移 |
+| REQ-0046 | intake / learning / req-backlog / RU lifecycle | パイプライン責務境界・成果物lifecycle・状態遷移 |
+| REQ-0047 | case-run / case-close / post-run capture | 実行プロセス・信頼性・Findings回収・完了ゲート |
+| REQ-0048 | reporting / GitHub body / link / writing quality | 完了報告・本文品質検証・リンク正規化・AI-slop抑止 |
+| REQ-0049 | integrity / validation / tests | 横断的整合性検証・バリデーション・テスト体系 |
 
-| REQ ID   | Title                                | 領域              |
-| -------- | ------------------------------------ | ----------------- |
-| REQ-0001 | AgentDevFlow ワークフローアーキテクチャ          | workflow          |
-| REQ-0003 | Case 並列実行             | parallel          |
-| REQ-0005 | Epic Issue 管理                | epic              |
-| REQ-0006 | Sisyphus プラン基盤         | sisyphus          |
-| REQ-0008 | スキル品質フレームワーク              | skill             |
+> 旧REQ群との対応関係は [mapping-table.md](mapping-table.md) を参照。
+
+## Retained（現行有効な旧REQ）
+
+後継REQなし。旧REQ自体が現行仕様として独立有効。
+
+| REQ ID | タイトル | 領域 |
+| ------ | -------- | ---- |
+| REQ-0001 | AgentDevFlow ワークフローアーキテクチャ | workflow |
+| REQ-0003 | Case 並列実行 | parallel |
+| REQ-0005 | Epic Issue 管理 | epic |
+| REQ-0006 | Sisyphus プラン基盤 | sisyphus |
+| REQ-0008 | スキル品質フレームワーク | skill |
 | REQ-0012 | 自然言語ポリシー | language/japanese |
-| REQ-0018 | agentdev-req-analysis 未決分岐解消メソドロジー | req-analysis/wall-discussion/methodology |
-| REQ-0020 | Epic Issue 実行順序 SSoT と case-run Epic Orchestrator 化 | epic/orchestration/ssot/wave |
-| REQ-0021 | AgentDevFlow ガードレールのスクリプト化と skill-local scripts 配置方針 | integrity/scripts/skill-structure/guardrails |
-| REQ-0030 | agentdev コマンド群の体系的テスト実装 | testing/quality/commands/skills/templates/epic |
-| REQ-0031 | GitHub本文内リポジトリ参照リンクの正規化 | github/link-normalization/url/templates/verification/commands |
-| REQ-0032 | case-close 未チェック項目達成判定 | enhancement/case-close/checkbox/completion-gate/achievement-check/autonomous-resolution |
-| REQ-0034 | req-define 関連ドキュメント更新候補抽出と後続工程への伝播 | enhancement/req-define/document-update/impact-detection |
-| REQ-0035 | DOC-MAP導入と requirements/views 廃止による文書探索・維持管理再設計 | doc-map/views-abolition/document-structure |
-| REQ-0038 | case実行信頼性向上（チェックボックス確認・pull前チェック・docs整合性grep） | enhancement/reliability/case-run/case-close |
+| REQ-0018 | agentdev-req-analysis 未決分岐解消メソドロジー | req-analysis/wall-discussion |
+| REQ-0020 | Epic Issue 実行順序 SSoT と case-run Epic Orchestrator 化 | epic/orchestration/ssot |
+| REQ-0021 | AgentDevFlow ガードレールのスクリプト化と skill-local scripts 配置方針 | integrity/scripts |
+| REQ-0030 | agentdev コマンド群の体系的テスト実装 | testing/quality |
+| REQ-0031 | GitHub本文内リポジトリ参照リンクの正規化 | github/link-normalization |
+| REQ-0032 | case-close 未チェック項目達成判定 | enhancement/case-close |
+| REQ-0034 | req-define 関連ドキュメント更新候補抽出と後続工程への伝播 | enhancement/req-define |
+| REQ-0035 | DOC-MAP導入と requirements/views 廃止による文書探索・維持管理再設計 | doc-map |
+| REQ-0038 | case実行信頼性向上（チェックボックス確認・pull前チェック・docs整合性grep） | enhancement/reliability |
 
-## Partially Superseded（一部移行）
+## Partially Superseded（一部が後継REQに移行済みの旧REQ）
 
-以下のREQは一部が新基準REQ群に移行しました。本文冒頭に移行範囲が記載されています。現行仕様として読める部分と、そうでない部分があります。
+旧REQの一部だけを後継REQへ移行し、残りは履歴または限定的基準として残す。
 
-| REQ ID   | Title                                | 領域              |
-| -------- | ------------------------------------ | ----------------- |
-| REQ-0002 | AgentDevFlow コマンドプロトコル               | commands          |
-| REQ-0004 | 要件・ADRドキュメントシステム   | requirements/adr  |
-| REQ-0007 | ナレッジパイプライン高度化                   | knowledge/learning         |
-| REQ-0009 | テンプレートシステム                      | templates         |
-| REQ-0011 | Issue/PR書き込み後の内容品質自動検証 | quality-assurance/encoding |
-| REQ-0014 | case-run 自律修正ループと責務分離の明確化 | workflow/self-healing/ci-cd |
-| REQ-0015 | 関連ドキュメントの要件達成対象化 | workflow/issue-commands/documentation/scope/verification |
-| REQ-0016 | Command/Skill/Template/Script責任分界とtips要件ソース化 | commands/skills/templates/scripts/knowledge |
-| REQ-0017 | AgentDevFlow plugin namespace 統一と learning / intake / integrity の正式化 | agentdev/namespace/plugin/learning/intake/integrity/migration |
-| REQ-0019 | intake / learning の責任境界明確化と workflow 組み込み | agentdev/intake/learning/workflow/boundary |
-| REQ-0022 | .agentdev domain state 更新後の git 永続化 | agentdev/git/persistence/domain-state |
-| REQ-0024 | 全 agentdev コマンドの完了報告フォーマット統一 | enhancement/workflow-reporting/command-system/completion-reports |
-| REQ-0025 | intake 系コマンドの .agentdev/intake 更新後の git 永続化 | agentdev/git/persistence/intake |
-| REQ-0026 | intake lifecycle の queue/archive 再定義 | agentdev/intake/lifecycle/queue/archive/refactor |
-| REQ-0027 | learning artifact lifecycle の責任範囲明確化 | learning/lifecycle/artifact/documentation/command/skill |
-| REQ-0036 | agentdev-no-ai-slop-writing Skill 追加 | skill/writing-quality/ai-slop/natural-language |
-| REQ-0037 | worktree 削除時の残存ファイル対策強化 | case-close/case-run/worktree/error-handling |
-| REQ-0039 | req-backlog コマンドと Requirement Unit パイプライン | workflow/req-backlog/ru-lifecycle/promoted |
-| REQ-0040 | 子Issue PRに Findings / Intake候補を永続化し、case-closeで回収する | intake/pr-template/case-run/case-close/epic-orchestrator |
-| REQ-0041 | REQ体系再基準化 — 旧REQ分類・新基準REQ群・分類ゲート | req-rebaselining/classification/correspondence-table/quality-gate |
-| REQ-0042 | REQ/ADR/SPEC/DOC-MAP 基準構造 | req-structure/adr-structure/spec-structure/doc-map/canonical-boundary |
-| REQ-0043 | req-define / req-save / REQ分類ゲート | req-define/req-save/classification-gate/create-append-update |
-| REQ-0044 | Command / Skill / Template / Script 責任分界 | commands/skills/templates/scripts/responsibility-boundary |
-| REQ-0045 | AgentDevFlow command protocol | commands/protocol/workflow-patterns/ssot |
-| REQ-0046 | intake / learning / req-backlog / RU lifecycle | intake/learning/req-backlog/ru-lifecycle/domain-state |
-| REQ-0047 | case-run / case-close / post-run capture | case-run/case-close/findings/epic-orchestrator/reliability |
-| REQ-0048 | reporting / GitHub body / link / writing quality | reporting/github-body/link-normalization/writing-quality/gh-cli |
-| REQ-0049 | integrity / validation / tests | integrity/validation/tests/guardrails/consistency |
+| REQ ID | タイトル | 後継REQ | 領域 |
+| ------ | -------- | ------- | ---- |
+| REQ-0002 | AgentDevFlow コマンドプロトコル | REQ-0045 | commands |
+| REQ-0004 | 要件・ADRドキュメントシステム | REQ-0042 | requirements/adr |
+| REQ-0007 | ナレッジパイプライン高度化 | REQ-0046 | knowledge/learning |
+| REQ-0009 | テンプレートシステム | REQ-0044 | templates |
+| REQ-0010 | AgentDevFlow Command実装改善：安全性・品質・状態管理 | REQ-0045 | workflow/safety |
+| REQ-0011 | Issue/PR書き込み後の内容品質自動検証 | REQ-0048 | quality-assurance |
+| REQ-0014 | case-run 自律修正ループと責務分離の明確化 | REQ-0047 | workflow/self-healing |
+| REQ-0015 | 関連ドキュメントの要件達成対象化 | REQ-0047 | workflow/documentation |
+| REQ-0016 | Command/Skill/Template/Script責任分界とtips要件ソース化 | REQ-0044 | commands/skills |
+| REQ-0017 | AgentDevFlow plugin namespace 統一と learning / intake / integrity の正式化 | REQ-0044 | agentdev/namespace |
+| REQ-0019 | intake / learning の責任境界明確化と workflow 組み込み | REQ-0046 | agentdev/intake/learning |
+| REQ-0022 | .agentdev domain state 更新後の git 永続化 | REQ-0049 | agentdev/git |
+| REQ-0024 | 全 agentdev コマンドの完了報告フォーマット統一 | REQ-0048 | enhancement/workflow-reporting |
+| REQ-0025 | intake 系コマンドの .agentdev/intake 更新後の git 永続化 | REQ-0049 | agentdev/git |
+| REQ-0026 | intake lifecycle の queue/archive 再定義 | REQ-0046 | agentdev/intake |
+| REQ-0027 | learning artifact lifecycle の責任範囲明確化 | REQ-0046 | learning/lifecycle |
+| REQ-0036 | agentdev-no-ai-slop-writing Skill 追加 | REQ-0048 | skill/writing-quality |
+| REQ-0037 | worktree 削除時の残存ファイル対策強化 | REQ-0047 | case-close/worktree |
+| REQ-0039 | req-backlog コマンドと Requirement Unit パイプライン | REQ-0046 | workflow/req-backlog |
+| REQ-0040 | 子Issue PRに Findings / Intake候補を永続化し、case-closeで回収する | REQ-0047 | intake/pr-template |
 
-## Superseded（全面置き換え）
+## Superseded（全面置き換え済み）
 
-以下のREQは全面置き換えられました。現行仕様として読むことは推奨されません。履歴・参照用として保持されています。
+旧REQを現行基準として読まず、後継REQまたは履歴参照に置き換える。
 
-| REQ ID | Title | Superseded by |
-| ------ | ----- | ------------- |
-| REQ-0013 | intake 承認フロー分割と解消済み確認機能 | REQ-0039 |
-| REQ-0023 | learning staging stub の取り込み追跡と取り込み後アーカイブ | REQ-0039 |
-| REQ-0028 | Documentation granularity and responsibility restructuring | REQ-0041 |
-| REQ-0029 | intake-open promoted artifact 一括処理 | REQ-0039 |
-| REQ-0033 | AgentDevFlow command / skill 定義の二次整合性是正 | REQ-0041 |
+| REQ ID | タイトル | 後継REQ |
+| ------ | -------- | ------- |
+| REQ-0013 | intake 承認フロー分割と解消済み確認機能 | REQ-0046 |
+| REQ-0023 | learning staging stub の取り込み追跡と取り込み後アーカイブ | REQ-0046 |
+| REQ-0028 | Documentation granularity and responsibility restructuring | REQ-0042 |
+| REQ-0029 | intake-open promoted artifact 一括処理 | REQ-0046 |
+| REQ-0033 | AgentDevFlow command / skill 定義の二次整合性是正 | REQ-0049 |
 
-## 未分類
+## 分類ゲート
 
-| REQ ID | Title | 領域 |
-| ------ | ----- | ---- |
-| REQ-0010 | AgentDevFlow Command実装改善：安全性・品質・状態管理 | workflow/safety/quality |
+REQ-0041（REQ体系再基準化）で定義された分類ゲートに基づき、全40件の旧REQ（REQ-0001〜REQ-0040）を以下の3カテゴリに分類している。
 
-## 再基準化要件
+| 分類 | 件数 | 意味 |
+| ---- | ---- | ---- |
+| retained | 15 | 旧REQのID・本文をそのまま現行基準として維持。後継REQなし |
+| partially superseded | 20 | 旧REQの一部だけを後継REQへ移行し、残りは履歴または限定的基準として残す |
+| superseded | 5 | 旧REQを現行基準として読まず、後継REQまたは履歴参照に置き換える |
 
-| REQ ID | Title | 領域 |
-| ------ | ----- | ---- |
-| REQ-0041 | REQ体系再基準化 — 旧REQ分類・新基準REQ群・分類ゲート | req-rebaselining/classification/correspondence-table/quality-gate |
+## 基準構造
 
-## ディレクトリ構造の方針
+### per-file 基準
 
-### 基準構造（per-file）
-
-`REQ-{NNNN}.md` を要件の永続基準とする。各要件が1ファイルに対応する。要件の判断・更新において REQ を基準とし、`docs/DOC-MAP.md` は文書探索の参照入口として使用する。文書間の記述に矛盾がある場合は、REQ を優先する。
+`REQ-{NNNN}.md` を要件の永続基準とする（REQ-0042-001）。各要件が1ファイルに対応する。要件の判断・更新において REQ を基準とし、`docs/DOC-MAP.md` は文書探索の参照入口として使用する。文書間の記述に矛盾がある場合は、REQ を優先する。
 
 ### DOC-MAP（文書探索入口）
 
-`docs/DOC-MAP.md` は文書探索・参照経路の入口として機能する参照用文書である（REQ-0035 / ADR-0008）。基準は各 `REQ-{NNNN}.md` ファイルである。
-
-- `INDEX.md` は作成しない（ADR-0007 で README.md 分類ビューに統一方針）
-- `areas/`、`sources/` は作成しない
-- 現在仕様の基準は `docs/specs/*.md` に、文書探索の入口は `docs/DOC-MAP.md` に集約
+`docs/DOC-MAP.md` は文書探索・参照経路の入口として機能する参照用文書である（REQ-0042 / REQ-0035 / ADR-0008）。基準は各 `REQ-{NNNN}.md` ファイルである。
 
 ### 関連
 
-- ADR-0004: 要件管理構造の area-based 移行方針（superseded by ADR-0007）
-- ADR-0007: REQ/ADR基準構造と分類ビュー運用の再定義（superseded by ADR-0008）
-- ADR-0008: DOC-MAP導入と requirements/views 廃止
+- REQ-0041: REQ体系再基準化
 - ADR-0009: REQ体系再基準化 — 旧REQ分類モデル・対応表・分類ゲート導入
+- [mapping-table.md](mapping-table.md): 旧REQ↔新基準REQ対応表


### PR DESCRIPTION
# PR本文テンプレート

Pull Request作成時の本文テンプレート。

## 概要
<!-- 【必須】 -->

`docs/requirements/README.md`、`docs/DOC-MAP.md`、`docs/README.md` を新基準REQ群（REQ-0042〜REQ-0049）を文書探索の入口とする構造に再設計した。旧REQ群を retained / partially superseded / superseded の3カテゴリに区分し、現行基準と履歴の区別を明確にした。

## 実装内容
<!-- 【必須】 -->

### docs/requirements/README.md
- 新基準REQ群（REQ-0042〜REQ-0049）を「現行基準」セクションとして先頭に配置
- 旧REQ群を3カテゴリ（retained / partially superseded / superseded）に区分
- mapping-table.mdへのリンクを配置
- 分類ゲートの統計（retained: 15件、partially superseded: 20件、superseded: 5件）を記載
- 基準構造セクションをREQ-0042参照に更新

### docs/DOC-MAP.md
- 「新基準REQ群（現行基準）」セクションを新設し、8件の新基準REQを第一参照先として配置
- 旧REQを retained / partially superseded / superseded / 管理REQ セクションに分離
- 旧command名・旧directory名・旧workflow名がactive仕様として残らない構造に変更
- テーマ別セクション（ワークフロー・コマンドプロトコル・品質・ナレッジパイプライン・Intake系・設定）を廃止し、分類ベースのセクションに統一

### docs/README.md
- Requirementsセクションを新基準REQ群強調構成に更新
- 新基準REQ群（8件）、retained（15件）、partially superseded（20件）、superseded（5件）、管理REQのサブセクション構成
- 対応表（mapping-table.md）へのリンクを追加

## 完了条件

<!-- 【必須】 -->
- [x] README.mdが新基準REQ群を「現行基準」として示している
- [x] README.mdで旧REQが「履歴・参照用」として区別されている
- [x] DOC-MAP.mdが新基準REQ群を探索入口として示している
- [x] 旧command名・旧directory名がactive仕様として残っていない

## テスト結果
<!-- 【必須】 -->

- docs/requirements/README.md: 「現行基準」セクションにREQ-0042〜0049が8件記載、retained/partially superseded/superseded の3カテゴリで旧REQを分類確認
- docs/DOC-MAP.md: 「新基準REQ群（現行基準）」セクションが最初の探索セクション、旧REQは分類セクションに分離済み
- docs/README.md: Requirementsセクションに「新基準REQ群（現行基準）」サブセクションが最初に配置

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 新基準REQ群の記載 | 8件 | 8件 | ✅ |
| retained分類 | 15件 | 15件 | ✅ |
| partially superseded分類 | 20件 | 20件 | ✅ |
| superseded分類 | 5件 | 5件 | ✅ |
| mapping-table.mdリンク | あり | あり | ✅ |

## Findings / Intake候補
<!-- 【必須】 -->

該当なし

## 決定事項
<!-- 【任意】 -->

該当なし

<!-- 【必須】 -->
Closes #444
