### PR TITLE
feat: Command Implementation Pattern Taxonomy 導入

### DIFF
--- a/.opencode/commands/agentdev/case-close.md
+++ b/.opencode/commands/agentdev/case-close.md
@@ -1,6 +1,7 @@
 ---
 description: PRをマージし、対応記録を追記し、Caseをクローズしてブランチを削除する
 agent: sisyphus
+implementation_pattern: file-pipeline
 load_skills:
   - agentdev-workflow-lifecycle
   - agentdev-workflow-reporting

--- a/.opencode/commands/agentdev/case-open.md
+++ b/.opencode/commands/agentdev/case-open.md
@@ -1,6 +1,7 @@
 ---
 description: 要件定義をもとにGitHub Issueを作成する
 agent: sisyphus
+implementation_pattern: file-pipeline
 load_skills:
   - agentdev-workflow-lifecycle
   - agentdev-workflow-reporting

--- a/.opencode/commands/agentdev/case-run.md
+++ b/.opencode/commands/agentdev/case-run.md
@@ -1,6 +1,7 @@
 ---
 description: 計画立案からコミットまでを一気通貫で実行する。3フェーズ構成でべき等性・再開ポイントを提供。複数Issueの並列実行に対応
 agent: sisyphus
+implementation_pattern: manager-orchestrator
 load_skills:
   - agentdev-req-analysis
   - agentdev-spec-compliance

--- a/.opencode/commands/agentdev/case-update.md
+++ b/.opencode/commands/agentdev/case-update.md
@@ -1,6 +1,7 @@
 ---
 description: 既存Caseの本文更新、コメント追加、またはREQファイル更新を行う
 agent: sisyphus
+implementation_pattern: file-pipeline
 load_skills:
   - agentdev-workflow-lifecycle
   - agentdev-workflow-reporting

--- a/.opencode/commands/agentdev/intake-capture.md
+++ b/.opencode/commands/agentdev/intake-capture.md
@@ -1,6 +1,7 @@
 ---
 description: 未分類の変更候補を手動入力から intake item として保存する
 agent: sisyphus
+implementation_pattern: capture-only
 load_skills:
   - agentdev-workflow-lifecycle
   - agentdev-workflow-reporting

--- a/.opencode/commands/agentdev/intake-from-github.md
+++ b/.opencode/commands/agentdev/intake-from-github.md
@@ -1,6 +1,7 @@
 ---
 description: クローズ済み GitHub Issue/PR から未回収の変更候補を intake item として保存する
 agent: sisyphus
+implementation_pattern: capture-only
 load_skills:
   - agentdev-workflow-lifecycle
   - agentdev-workflow-reporting

--- a/.opencode/commands/agentdev/intake-promote.md
+++ b/.opencode/commands/agentdev/intake-promote.md
@@ -1,6 +1,7 @@
 ---
 description: レビュー済み intake item を後続コマンド（req-backlog）に渡せる入力 artifact に整形する
 agent: sisyphus
+implementation_pattern: file-pipeline
 load_skills:
   - agentdev-workflow-lifecycle
   - agentdev-workflow-reporting

--- a/.opencode/commands/agentdev/intake-review.md
+++ b/.opencode/commands/agentdev/intake-review.md
@@ -1,6 +1,7 @@
 ---
 description: inbox 内の intake item をレビューし、採用・却下・保留の判定を行う
 agent: prometheus
+implementation_pattern: wall-session
 load_skills:
   - agentdev-workflow-lifecycle
   - agentdev-workflow-reporting

--- a/.opencode/commands/agentdev/integrity-check.md
+++ b/.opencode/commands/agentdev/integrity-check.md
@@ -1,6 +1,7 @@
 ---
 description: AgentDevFlow artifact 整合性検査
 agent: sisyphus
+implementation_pattern: read-only-diagnostic
 load_skills:
   - agentdev-integrity
   - agentdev-req-analysis

--- a/.opencode/commands/agentdev/learning-promote.md
+++ b/.opencode/commands/agentdev/learning-promote.md
@@ -1,6 +1,7 @@
 ---
 description: evaluation-report.mdとarchive.mdから昇華判定を行い、Requirement Source stubを生成する
 agent: sisyphus
+implementation_pattern: file-pipeline
 load_skills:
   - agentdev-learning-capture
   - agentdev-learning-pipeline

--- a/.opencode/commands/agentdev/learning-refine.md
+++ b/.opencode/commands/agentdev/learning-refine.md
@@ -1,6 +1,7 @@
 ---
 description: inbox.mdとarchive.mdをセマンティック分析し、evaluation-report.mdを出力後inbox→archive移動を行う
 agent: sisyphus
+implementation_pattern: file-pipeline
 load_skills:
   - agentdev-learning-capture
   - agentdev-learning-pipeline

--- a/.opencode/commands/agentdev/req-backlog.md
+++ b/.opencode/commands/agentdev/req-backlog.md
@@ -1,6 +1,7 @@
 ---
 description: promoted artifact を分析・統合し、Requirement Unit（RU）を生成する
 agent: sisyphus
+implementation_pattern: file-pipeline
 load_skills:
   - agentdev-workflow-lifecycle
   - agentdev-workflow-reporting

--- a/.opencode/commands/agentdev/req-define.md
+++ b/.opencode/commands/agentdev/req-define.md
@@ -1,6 +1,7 @@
 ---
 description: 要件を整理・定義する（機能追加・バグ修正共通）
 agent: prometheus
+implementation_pattern: wall-session
 load_skills:
   - agentdev-req-analysis
   - agentdev-req-file-manager

--- a/.opencode/commands/agentdev/req-restructure-review.md
+++ b/.opencode/commands/agentdev/req-restructure-review.md
@@ -1,6 +1,8 @@
 ---
 description: REQ体系の健全性を診断し、再構成の推奨アクションを提示する
 agent: prometheus
+implementation_pattern: read-only-diagnostic
+secondary_pattern: wall-session
 load_skills:
   - agentdev-workflow-lifecycle
   - agentdev-workflow-reporting

--- a/.opencode/commands/agentdev/req-save.md
+++ b/.opencode/commands/agentdev/req-save.md
@@ -1,6 +1,7 @@
 ---
 description: 壁打ち成果物をREQ/ADRファイルとしてdocs/に保存し、コミット・プッシュする
 agent: sisyphus
+implementation_pattern: file-pipeline
 load_skills:
   - agentdev-req-file-manager
   - agentdev-adr-file-manager

--- a/.opencode/skills/agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/agentdev-integrity/scripts/check_integrity.test.ts
@@ -120,6 +120,7 @@ function buildValidFixture(root: string): void {
     "---",
     "description: Test command",
     "agent: test-agent",
+    "implementation_pattern: wall-session",
     "load_skills:",
     "  - agentdev-test-skill",
     "  - agentdev-workflow-reporting",
@@ -772,7 +773,373 @@ describe("checkLifecycleBoundary: active/retired ID duplication", () => {
     );
     expect(hit).toBeDefined();
     expect(hit.level).toBe("ng");
-    expect(hit.route).toBe("intake");
+  });
+});
+
+// ─── Implementation pattern check tests (REQ-0108-022~024) ────────────────
+
+describe("E1: checkImplementationPattern — all valid", () => {
+  const ROOT = join(TEMP_ROOT, "e1-ok");
+
+  beforeAll(() => {
+    mkdirp(ROOT);
+    buildValidFixture(ROOT);
+    const cmdDir = join(ROOT, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test command",
+      "agent: test-agent",
+      "implementation_pattern: wall-session",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "  - agentdev-workflow-reporting",
+      "---",
+      "",
+      "Test command body.",
+      "",
+    ].join("\n"), "utf-8");
+    copyScripts(ROOT);
+  });
+
+  it("passes when all commands have valid implementation_pattern", () => {
+    const r = runScript(ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string }) => res.check === "implementation-pattern"
+    );
+    expect(hit).toBeDefined();
+    expect(hit.level).toBe("ok");
+  });
+});
+
+describe("E2: checkImplementationPattern — missing implementation_pattern", () => {
+  const ROOT = join(TEMP_ROOT, "e2-missing");
+
+  beforeAll(() => {
+    mkdirp(ROOT);
+    buildValidFixture(ROOT);
+    // Override test-cmd.md to NOT have implementation_pattern
+    const cmdDir = join(ROOT, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test command",
+      "agent: test-agent",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "  - agentdev-workflow-reporting",
+      "---",
+      "",
+      "Test command body.",
+      "",
+    ].join("\n"), "utf-8");
+    copyScripts(ROOT);
+  });
+
+  it("detects missing implementation_pattern", () => {
+    const r = runScript(ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string; message: string }) =>
+        res.check === "implementation-pattern" &&
+        res.message.includes("implementation_pattern が定義されていない")
+    );
+    expect(hit).toBeDefined();
+    expect(hit.level).toBe("ng");
+  });
+});
+
+describe("E3: checkImplementationPattern — unknown pattern", () => {
+  const ROOT = join(TEMP_ROOT, "e3-unknown");
+
+  beforeAll(() => {
+    mkdirp(ROOT);
+    buildValidFixture(ROOT);
+    const cmdDir = join(ROOT, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test command",
+      "agent: test-agent",
+      "implementation_pattern: unknown-pattern",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "  - agentdev-workflow-reporting",
+      "---",
+      "",
+      "Test command body.",
+      "",
+    ].join("\n"), "utf-8");
+    copyScripts(ROOT);
+  });
+
+  it("detects unknown implementation_pattern", () => {
+    const r = runScript(ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string; message: string }) =>
+        res.check === "implementation-pattern" &&
+        res.message.includes("未知のパターン")
+    );
+    expect(hit).toBeDefined();
+    expect(hit.level).toBe("ng");
+  });
+});
+
+describe("E4: checkImplementationPattern — valid secondary_pattern", () => {
+  const ROOT = join(TEMP_ROOT, "e4-secondary-ok");
+
+  beforeAll(() => {
+    mkdirp(ROOT);
+    buildValidFixture(ROOT);
+    const cmdDir = join(ROOT, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test command",
+      "agent: test-agent",
+      "implementation_pattern: read-only-diagnostic",
+      "secondary_pattern: wall-session",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "  - agentdev-workflow-reporting",
+      "---",
+      "",
+      "Test command body.",
+      "",
+    ].join("\n"), "utf-8");
+    copyScripts(ROOT);
+  });
+
+  it("passes when secondary_pattern is valid", () => {
+    const r = runScript(ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string }) => res.check === "implementation-pattern"
+    );
+    expect(hit).toBeDefined();
+    expect(hit.level).toBe("ok");
+  });
+});
+
+describe("E5: checkImplementationPattern — unknown secondary_pattern", () => {
+  const ROOT = join(TEMP_ROOT, "e5-secondary-ng");
+
+  beforeAll(() => {
+    mkdirp(ROOT);
+    buildValidFixture(ROOT);
+    const cmdDir = join(ROOT, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test command",
+      "agent: test-agent",
+      "implementation_pattern: read-only-diagnostic",
+      "secondary_pattern: bogus",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "  - agentdev-workflow-reporting",
+      "---",
+      "",
+      "Test command body.",
+      "",
+    ].join("\n"), "utf-8");
+    copyScripts(ROOT);
+  });
+
+  it("detects unknown secondary_pattern", () => {
+    const r = runScript(ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string; message: string }) =>
+        res.check === "implementation-pattern" &&
+        res.message.includes("secondary_pattern")
+    );
+    expect(hit).toBeDefined();
+    expect(hit.level).toBe("ng");
+  });
+});
+
+describe("E6: checkPatternProhibitions — no violations", () => {
+  const ROOT = join(TEMP_ROOT, "e6-ok");
+
+  beforeAll(() => {
+    mkdirp(ROOT);
+    buildValidFixture(ROOT);
+    const cmdDir = join(ROOT, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test command",
+      "agent: test-agent",
+      "implementation_pattern: file-pipeline",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "  - agentdev-workflow-reporting",
+      "---",
+      "",
+      "Test command body.",
+      "",
+    ].join("\n"), "utf-8");
+    copyScripts(ROOT);
+  });
+
+  it("passes when no pattern prohibition violations", () => {
+    const r = runScript(ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string }) => res.check === "pattern-prohibitions"
+    );
+    expect(hit).toBeDefined();
+    expect(hit.level).toBe("ok");
+  });
+});
+
+describe("E7: checkPatternProhibitions — capture-only with prohibited skill", () => {
+  const ROOT = join(TEMP_ROOT, "e7-violation");
+
+  beforeAll(() => {
+    mkdirp(ROOT);
+    buildValidFixture(ROOT);
+    const cmdDir = join(ROOT, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test command",
+      "agent: test-agent",
+      "implementation_pattern: capture-only",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "  - agentdev-workflow-reporting",
+      "  - agentdev-workflow-orchestration",
+      "---",
+      "",
+      "Test command body.",
+      "",
+    ].join("\n"), "utf-8");
+    copyScripts(ROOT);
+  });
+
+  it("detects prohibited skill in capture-only command", () => {
+    const r = runScript(ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string; message: string }) =>
+        res.check === "pattern-prohibitions" &&
+        res.message.includes("禁止 skill")
+    );
+    expect(hit).toBeDefined();
+    expect(hit.level).toBe("ng");
+  });
+});
+
+describe("E8: checkPatternProhibitions — manager-orchestrator on non-case-run", () => {
+  const ROOT = join(TEMP_ROOT, "e8-mgr");
+
+  beforeAll(() => {
+    mkdirp(ROOT);
+    buildValidFixture(ROOT);
+    const cmdDir = join(ROOT, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "other-cmd.md"), [
+      "---",
+      "description: Other command",
+      "agent: test-agent",
+      "implementation_pattern: manager-orchestrator",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "  - agentdev-workflow-reporting",
+      "  - agentdev-workflow-orchestration",
+      "---",
+      "",
+      "Other command body.",
+      "",
+    ].join("\n"), "utf-8");
+    // Also update README to include other-cmd
+    writeFileSync(join(cmdDir, "README.md"), [
+      "# Commands",
+      "",
+      "| Command | Description | Agent | Skills |",
+      "|---------|-------------|-------|--------|",
+      "| `agentdev/test-cmd` | Test command | test-agent | agentdev-test-skill |",
+      "| `agentdev/other-cmd` | Other command | test-agent | agentdev-test-skill |",
+      "",
+    ].join("\n"), "utf-8");
+    copyScripts(ROOT);
+  });
+
+  it("detects manager-orchestrator on non-case-run file", () => {
+    const r = runScript(ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string; message: string }) =>
+        res.check === "pattern-prohibitions" &&
+        res.message.includes("manager-orchestrator")
+    );
+    expect(hit).toBeDefined();
+    expect(hit.level).toBe("ng");
+  });
+});
+
+describe("E9: checkLoadSkillsConsistency — all consistent", () => {
+  const ROOT = join(TEMP_ROOT, "e9-ok");
+
+  beforeAll(() => {
+    mkdirp(ROOT);
+    buildValidFixture(ROOT);
+    const cmdDir = join(ROOT, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test command",
+      "agent: test-agent",
+      "implementation_pattern: wall-session",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "  - agentdev-workflow-reporting",
+      "---",
+      "",
+      "Test command body.",
+      "",
+    ].join("\n"), "utf-8");
+    copyScripts(ROOT);
+  });
+
+  it("passes when all commands have consistent load_skills", () => {
+    const r = runScript(ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string }) => res.check === "load-skills-consistency"
+    );
+    expect(hit).toBeDefined();
+    expect(hit.level).toBe("ok");
+  });
+});
+
+describe("E10: checkLoadSkillsConsistency — missing workflow-reporting", () => {
+  const ROOT = join(TEMP_ROOT, "e10-missing");
+
+  beforeAll(() => {
+    mkdirp(ROOT);
+    buildValidFixture(ROOT);
+    const cmdDir = join(ROOT, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test command",
+      "agent: test-agent",
+      "implementation_pattern: wall-session",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "---",
+      "",
+      "Test command body.",
+      "",
+    ].join("\n"), "utf-8");
+    copyScripts(ROOT);
+  });
+
+  it("warns when agentdev-workflow-reporting is missing from load_skills", () => {
+    const r = runScript(ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string; message: string }) =>
+        res.check === "load-skills-consistency" &&
+        res.message.includes("agentdev-workflow-reporting")
+    );
+    expect(hit).toBeDefined();
+    expect(hit.level).toBe("warning");
   });
 });
 

--- a/.opencode/skills/agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/agentdev-integrity/scripts/check_integrity.ts
@@ -198,6 +198,48 @@ const LEGACY_PATTERNS = [
   { pattern: /\belevate時prune\b/g, name: "elevate時prune (old terminology: should be promote時prune)" },
 ];
 
+const IMPLEMENTATION_PATTERNS = [
+  "wall-session",
+  "file-pipeline",
+  "manager-orchestrator",
+  "capture-only",
+  "read-only-diagnostic",
+] as const;
+
+const PATTERN_PROHIBITED_SKILLS: Record<string, string[]> = {
+  "capture-only": [
+    "agentdev-workflow-orchestration",
+    "agentdev-workflow-routing",
+    "agentdev-req-file-manager",
+    "agentdev-adr-file-manager",
+    "agentdev-workflow-templates",
+    "agentdev-spec-compliance",
+    "agentdev-epic-tracker",
+    "agentdev-learning-pipeline",
+  ],
+  "read-only-diagnostic": [
+    "agentdev-workflow-orchestration",
+    "agentdev-workflow-routing",
+    "agentdev-req-file-manager",
+    "agentdev-adr-file-manager",
+    "agentdev-workflow-templates",
+    "agentdev-spec-compliance",
+    "agentdev-epic-tracker",
+    "agentdev-learning-pipeline",
+    "agentdev-git-worktree",
+    "agentdev-gh-cli",
+    "agentdev-conventional-commits",
+    "agentdev-learning-capture",
+  ],
+  "wall-session": [
+    "agentdev-workflow-orchestration",
+    "agentdev-workflow-routing",
+    "agentdev-gh-cli",
+    "agentdev-git-worktree",
+    "agentdev-conventional-commits",
+  ],
+};
+
 function checkReqFrontmatterFilename(reqDir: string, root: string): CheckResult[] {
   const results: CheckResult[] = [];
   const files = listFiles(reqDir).filter((f) => f.startsWith("REQ-") && f !== "README.md");
@@ -1608,6 +1650,120 @@ function checkAdrReadmeIndexSync(adrDir: string, root: string): CheckResult[] {
   return results;
 }
 
+// ─── Implementation pattern checks (REQ-0108-022~024) ─────────────────────
+
+function checkImplementationPattern(cmdDir: string, root: string): CheckResult[] {
+  const results: CheckResult[] = [];
+  const cmdFiles = listFiles(cmdDir).filter((f) => f !== "README.md");
+
+  for (const file of cmdFiles) {
+    const fullPath = path.join(cmdDir, file);
+    const content = readText(fullPath);
+    if (!content) continue;
+    const fm = parseFrontmatter(content);
+    if (!fm) continue;
+
+    const pattern = fm["implementation_pattern"];
+    if (!pattern || (typeof pattern === "string" && pattern.trim() === "")) {
+      results.push(
+        ng("Implementation Pattern", "implementation-pattern", `command ${file} に implementation_pattern が定義されていない`, resolveRelative(fullPath, root), undefined, { evidence: "implementation_pattern field missing", route: "req-define" })
+      );
+      continue;
+    }
+
+    if (typeof pattern !== "string" || !IMPLEMENTATION_PATTERNS.includes(pattern as any)) {
+      results.push(
+        ng("Implementation Pattern", "implementation-pattern", `command ${file} の implementation_pattern '${pattern}' は未知のパターン`, resolveRelative(fullPath, root), undefined, { evidence: String(pattern), expected: `one of: ${IMPLEMENTATION_PATTERNS.join(", ")}`, route: "req-define" })
+      );
+    }
+
+    const secondaryPattern = fm["secondary_pattern"];
+    if (secondaryPattern && typeof secondaryPattern === "string" && secondaryPattern.trim() !== "") {
+      if (!IMPLEMENTATION_PATTERNS.includes(secondaryPattern as any)) {
+        results.push(
+          ng("Implementation Pattern", "implementation-pattern", `command ${file} の secondary_pattern '${secondaryPattern}' は未知のパターン`, resolveRelative(fullPath, root), undefined, { evidence: String(secondaryPattern), expected: `one of: ${IMPLEMENTATION_PATTERNS.join(", ")}`, route: "req-define" })
+        );
+      }
+    }
+  }
+
+  if (results.filter((r) => r.level === "ng").length === 0) {
+    results.push(ok("Implementation Pattern", "implementation-pattern", "All commands have valid implementation patterns"));
+  }
+  return results;
+}
+
+function checkPatternProhibitions(cmdDir: string, root: string): CheckResult[] {
+  const results: CheckResult[] = [];
+  const cmdFiles = listFiles(cmdDir).filter((f) => f !== "README.md");
+
+  for (const file of cmdFiles) {
+    const fullPath = path.join(cmdDir, file);
+    const content = readText(fullPath);
+    if (!content) continue;
+    const fm = parseFrontmatter(content);
+    if (!fm) continue;
+
+    const pattern = fm["implementation_pattern"];
+    if (typeof pattern !== "string") continue;
+
+    const prohibited = PATTERN_PROHIBITED_SKILLS[pattern];
+    if (prohibited) {
+      const loadSkills = extractLoadSkills(fm);
+      const violations = loadSkills.filter((s) => prohibited.includes(s));
+      for (const violating of violations) {
+        results.push(
+          ng("Implementation Pattern", "pattern-prohibitions", `${pattern} command '${file}' が禁止 skill '${violating}' を load_skills に含んでいる`, resolveRelative(fullPath, root), undefined, { evidence: violating, route: "req-define" })
+        );
+      }
+    }
+
+    if (pattern === "manager-orchestrator" && file !== "case-run.md") {
+      results.push(
+        ng("Implementation Pattern", "pattern-prohibitions", `command '${file}' に manager-orchestrator が設定されているが、manager-orchestrator は case-run.md のみ使用可能`, resolveRelative(fullPath, root), undefined, { evidence: file, expected: "case-run.md", route: "req-define" })
+      );
+    }
+  }
+
+  if (results.filter((r) => r.level === "ng").length === 0) {
+    results.push(ok("Implementation Pattern", "pattern-prohibitions", "No pattern prohibition violations"));
+  }
+  return results;
+}
+
+function checkLoadSkillsConsistency(cmdDir: string, root: string): CheckResult[] {
+  const results: CheckResult[] = [];
+  const cmdFiles = listFiles(cmdDir).filter((f) => f !== "README.md");
+
+  for (const file of cmdFiles) {
+    const fullPath = path.join(cmdDir, file);
+    const content = readText(fullPath);
+    if (!content) continue;
+    const fm = parseFrontmatter(content);
+    if (!fm) continue;
+
+    const loadSkills = extractLoadSkills(fm);
+
+    if (!loadSkills.includes("agentdev-workflow-reporting")) {
+      results.push(
+        warn("Implementation Pattern", "load-skills-consistency", `command '${file}' に agentdev-workflow-reporting が load_skills に含まれていない`, resolveRelative(fullPath, root))
+      );
+    }
+
+    const pattern = fm["implementation_pattern"];
+    if (pattern === "manager-orchestrator" && !loadSkills.includes("agentdev-workflow-orchestration")) {
+      results.push(
+        warn("Implementation Pattern", "load-skills-consistency", `command '${file}' は manager-orchestrator パターンだが agentdev-workflow-orchestration が load_skills に含まれていない`, resolveRelative(fullPath, root))
+      );
+    }
+  }
+
+  if (results.filter((r) => r.level === "warning").length === 0) {
+    results.push(ok("Implementation Pattern", "load-skills-consistency", "All commands have consistent load_skills"));
+  }
+  return results;
+}
+
 function checkSpecReadmeIndexSync(root: string): CheckResult[] {
   const results: CheckResult[] = [];
   const specsDir = path.join(root, "docs", "specs");
@@ -1717,6 +1873,9 @@ async function main(): Promise<void> {
     ...checkDocMapGuideSync(root),
     ...checkAdrReadmeIndexSync(adrDir, root),
     ...checkSpecReadmeIndexSync(root),
+    ...checkImplementationPattern(cmdDir, root),
+    ...checkPatternProhibitions(cmdDir, root),
+    ...checkLoadSkillsConsistency(cmdDir, root),
   ];
 
   const summary = computeSummary(results);

--- a/.opencode/skills/agentdev-workflow-lifecycle/reference/command-map.md
+++ b/.opencode/skills/agentdev-workflow-lifecycle/reference/command-map.md
@@ -158,6 +158,56 @@ L2（ファイル衝突）を検知した場合、以下の措置を講じる。
 - 依存関係分析結果は実行前に表示するが、ユーザー承認待ちで停止しない（自律実行）
 - specs更新は親エージェントのみ（直列・Issue番号昇順）
 
+## Implementation Pattern Taxonomy
+
+コマンドの内部構造に基づく分類軸（REQ-0103-016）。各 implementation pattern はコマンドの責務境界と許容副作用を定義し、スキル参照制約を規定する。
+
+### Pattern A/B/C/D との区別（REQ-0103-016）
+
+Implementation pattern は command の内部構造に基づく分類軸であり、REQ-0104 で定義される Pattern A/B/C/D（Issue 種別分類）とは直交する概念である。Pattern A/B/C/D は Issue 種別とワークフロー分岐を示し、implementation pattern は command の責務境界と許容副作用を示す。
+
+### Pattern Definitions
+
+| Pattern | 主責務 | 許可される副作用 | 禁止される副作用 | 参照すべき skill の性質 | 完了報告で示すべき情報 |
+|---------|--------|----------------|----------------|---------------------|-------------------|
+| **wall-session** | ユーザーとの対話セッションを通じて構造化成果物を生成する | ドラフトファイルの作成 (`.sisyphus/drafts/`)、任意のアーティファクトの読み取り、ユーザーへの対話的な質問・確認 | 既存アーティファクトの変更 (REQ, ADR, specs, Issue)、git操作 (commit, push, branch)、外部API呼び出しによるリソース作成 (Issue, PR) | 分析・ガイドライン・フォーマット系 skill、完了報告 skill | セッション成果の概要、生成ファイルのパス（ある場合）、推奨される次コマンド |
+| **file-pipeline** | 定義されたステップに従いファイルを変換・生成するパイプライン処理 | 指定ディレクトリへのファイル作成・更新、git操作 (commit, push)、外部API呼び出し (Issue更新, PR操作)、テンプレート適用 | 大規模な状態機械の実行、サブエージェントの起動、再開ポイント検出 | ファイル管理・バリデーション・テンプレート系 skill、完了報告 skill、git/gh系 skill (外部API操作時) | 入力→出力マッピング、作成・更新ファイル一覧、git操作結果（ある場合） |
+| **manager-orchestrator** | 複数フェーズ構成の状態機械・自己修復ループ・サブエージェントプロトコルによる複雑な実行管理 | すべてのファイル操作、git操作 (worktree, commit, push, merge)、外部API呼び出し (Issue, PR, CI)、サブエージェントの起動・管理、Wave scheduling | （制限なし — 最も広いスコープを持つ） | オーケストレーション系 skill、worktree/git系 skill、仕様適合性 skill、完了報告 skill | 実行フェーズ完了状況、作成・更新アーティファクト一覧、検証結果、サブエージェント実行結果（並列実行時） |
+| **capture-only** | データを収集・記録し、指定 inbox に保存する（変換なし） | inbox ディレクトリへの新規ファイル作成のみ、外部APIからの読み取り | レビュー・プロモート・Issue作成、既存ファイルの変更・削除、git操作 (commit, push)、分析・評価・判定 | ライフサイクル文脈 skill、完了報告 skill | キャプチャ項目数、inbox保存パス |
+| **read-only-diagnostic** | アーティファクトを分析し、結果をレポートとして出力する（一切の変更なし） | レポートファイルの新規作成 (`.agentdev/integrity/reports/` 等)、intake item の新規作成（ユーザー承認時のみ） | 検査対象アーティファクトの変更 (REQ, ADR, specs, command, skill等)、git操作 (commit, push)、外部API呼び出しによるリソース変更 | 分析・診断系 skill、完了報告 skill | 検査結果サマリ (OK/NG/Warning/Info)、検出問題一覧、レポートファイルパス |
+
+### Command ↔ Pattern Correspondence
+
+| コマンド | Primary Pattern | Secondary Pattern |
+|---------|----------------|-------------------|
+| `/agentdev/req-define` | wall-session | — |
+| `/agentdev/req-save` | file-pipeline | — |
+| `/agentdev/case-open` | file-pipeline | — |
+| `/agentdev/case-run` | manager-orchestrator | — |
+| `/agentdev/case-update` | file-pipeline | — |
+| `/agentdev/case-close` | file-pipeline | — |
+| `/agentdev/learning-refine` | file-pipeline | — |
+| `/agentdev/learning-promote` | file-pipeline | — |
+| `/agentdev/intake-capture` | capture-only | — |
+| `/agentdev/intake-from-github` | capture-only | — |
+| `/agentdev/intake-review` | wall-session | — |
+| `/agentdev/intake-promote` | file-pipeline | — |
+| `/agentdev/req-backlog` | file-pipeline | — |
+| `/agentdev/integrity-check` | read-only-diagnostic | — |
+| `/agentdev/req-restructure-review` | read-only-diagnostic | wall-session |
+
+### Pattern ごとの禁止 load_skills
+
+integrity-check による検証で使用する、各 pattern が禁止する skill セット。
+
+| Pattern | 禁止される load_skills |
+|---------|---------------------|
+| capture-only | `agentdev-workflow-orchestration`, `agentdev-workflow-routing`, `agentdev-req-file-manager`, `agentdev-adr-file-manager`, `agentdev-workflow-templates`, `agentdev-spec-compliance`, `agentdev-epic-tracker`, `agentdev-learning-pipeline` |
+| read-only-diagnostic | （capture-only の禁止セットに加え）`agentdev-git-worktree`, `agentdev-gh-cli`, `agentdev-conventional-commits`, `agentdev-learning-capture` |
+| wall-session | `agentdev-workflow-orchestration`, `agentdev-workflow-routing`, `agentdev-gh-cli`, `agentdev-git-worktree`, `agentdev-conventional-commits` |
+| file-pipeline | （なし） |
+| manager-orchestrator | （なし — case-run 専用、最も広いスコープ） |
+
 ## 参照
 
 - **フェーズ体系**: [`reference/phases.md`](./phases.md)

--- a/.opencode/skills/agentdev-workflow-lifecycle/reference/pattern-registry.md
+++ b/.opencode/skills/agentdev-workflow-lifecycle/reference/pattern-registry.md
@@ -2,6 +2,10 @@
 
 Issueラベルの定義、パターン判定、およびパターン固有の動作ルールを定義する。
 
+## Implementation Pattern との区別
+
+Pattern A/B/C/D は Issue 種別分類（REQ-0104）であり、implementation pattern は command 内部構造分類（REQ-0103）である。両者は直交する概念である（REQ-0103-016）。Implementation pattern の定義は [`reference/command-map.md`](./command-map.md) の「Implementation Pattern Taxonomy」セクションを参照。
+
 ## 内部分類コード宣言
 
 `Pattern A/B/C/D` は内部処理用の分類コードである。ユーザー向け文書（README、コマンド説明、完了報告、Issue本文、テンプレート）では、各Patternに対応する日本語名称を主表記とする。

--- a/docs/specs/patterns.md
+++ b/docs/specs/patterns.md
@@ -28,6 +28,22 @@ load_skills:
 
 **理由**: デフォルトエージェント（Plan/Prometheus）の誤用を防止するため。PlanエージェントはRead-only権限であり、ファイル書込やコマンド実行ができない。
 
+### Implementation Pattern 指定
+
+各コマンドのfrontmatterに `implementation_pattern` を指定する（REQ-0103-015）。定義と対応表は [`reference/command-map.md`](../../.opencode/skills/agentdev-workflow-lifecycle/reference/command-map.md) の「Implementation Pattern Taxonomy」セクションが SSoT である。
+
+```yaml
+---
+description: ...
+agent: sisyphus
+implementation_pattern: file-pipeline
+load_skills:
+  - ...
+---
+```
+
+5パターン（wall-session, file-pipeline, manager-orchestrator, capture-only, read-only-diagnostic）は REQ-0103-016 において Pattern A/B/C/D（Issue 種別分類）と直交する。integrity-check が `implementation_pattern` の有無・妥当性（REQ-0108-022）、禁止 skill の検査（REQ-0108-023）、load_skills 整合性（REQ-0108-024）を自動検証する。
+
 ## .sisyphus/ 命名規則
 
 `.sisyphus/` 配下の7カテゴリ（plans, drafts, evidence, execution, notepads, tasks, reports）のファイル・ディレクトリ命名は plan 名を基準とする。詳細なルール・例は `AGENTS.md` の「Sisyphus 命名規則」セクションを参照。


### PR DESCRIPTION
## 概要

Command Implementation Pattern Taxonomy を導入し、15の agentdev コマンドを内部構造に基づく5つの実装パターンに分類する（REQ-0103-015~020, REQ-0108-022~025）。

## 実装内容

### Implementation Pattern Taxonomy 定義（5パターン）

| Pattern | 主責務 | 対象コマンド |
|---------|--------|-------------|
| wall-session | 対話セッション → 構造化成果物 | req-define, intake-review |
| file-pipeline | ファイル変換パイプライン | req-save, case-open, case-update, case-close, learning-refine, learning-promote, intake-promote, req-backlog |
| manager-orchestrator | 状態機械 + サブエージェントプロトコル | case-run |
| capture-only | inbox へのデータ収集（変換なし） | intake-capture, intake-from-github |
| read-only-diagnostic | 分析・レポート出力（変更なし） | integrity-check, req-restructure-review |

### 変更ファイル

- **command-map.md**: Implementation Pattern Taxonomy セクション追加（Pattern定義表、Command↔Pattern対応表、禁止load_skills表）
- **pattern-registry.md**: Implementation Pattern と Pattern A/B/C/D の区別注記追加
- **15コマンドファイル**: `implementation_pattern` frontmatter フィールド追加（req-restructure-review に `secondary_pattern: wall-session` も追加）
- **check_integrity.ts**: 3つの検査関数追加（checkImplementationPattern, checkPatternProhibitions, checkLoadSkillsConsistency）
- **check_integrity.test.ts**: 10テスト追加
- **patterns.md**: Implementation Pattern 指定セクション追加

## 完了条件

- [x] implementation pattern taxonomy が lifecycle/command-map reference に定義されている
- [x] 全 agentdev command に primary implementation pattern が付与されている
- [x] command ↔ pattern 対応表が作成されている
- [x] integrity-check に implementation pattern 関連の検査観点が追加されている
- [x] 各 pattern の主責務・許可副作用・禁止副作用・参照 skill 性質が定義されている
- [x] command 定義ファイルに最小限の pattern 参照が追加されている

### テスト戦略

- [x] integrity-check ユニットテスト: pattern 定義有無検査、禁止事項抵触検出、load_skills 整合性検出
- [x] 既存 integrity-check テストの回帰確認

## テスト結果

`bun test` — 67 pass, 0 fail（57 既存テスト + 10 新規テスト）

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| ユニットテスト | 67/67 pass | 全テスト通過 | ✅ |
| 回帰テスト | 57/57 既存テスト通過 | 既存テスト全通過 | ✅ |
| LSP diagnostics | エラーなし | エラーなし | ✅ |

## Findings / Intake候補

該当なし

Closes #472
