### PR TITLE
feat: abolish auto git checkout in case-close and add sync check in case-open

### DIFF
--- a/.opencode/commands/agentdev/case-close.md
+++ b/.opencode/commands/agentdev/case-close.md
@@ -152,8 +152,15 @@ PRをマージし、Caseに記録を追記し、クローズ後にworktreeとブ
         - 1件以上 "OPEN" の子Issueがある場合 → スキップ（完了報告に「Epic #{N}: N件未完了のためスキップ」と表示）
  8b. 実行前同期（git pull）:
     - `git pull --ff-only` 実行前に `git status --porcelain` でローカル変更の有無を確認すること（SHALL — REQ-0106）
-    - ローカル変更が検出された場合、当該ファイルを `git checkout --` でリセットしてから pull を実行すること（SHALL — REQ-0106）
-    - ローカル変更リセットはPRで削除されたファイルに限定して実行すること（SHALL — REQ-0106）
+    - ローカル変更が検出された場合、対象ファイル一覧と `git status --porcelain` の出力を表示し、以下の構造化エラーで停止すること（SHALL — REQ-0106）:
+      ```
+      ## ローカル変更検出エラー（pull 前同期不可）
+
+      **対象ファイル**:
+      {git status --porcelain output}
+      **停止理由**: pull 前にローカル変更が存在するため、安全に pull できない
+      **ユーザーアクション**: ローカル変更を確認し、`git stash` / `git checkout -- <file>` 等で対応後に case-close を再実行してください
+      ```
     - pull前のHEAD commit hash を記録する（`git rev-parse HEAD`）
     - カレントディレクトリで `git pull --ff-only` を実行する
     - pull後のHEAD commit hash を取得し、pull前のhashと一致することを確認する（hash一致 = リモートに新規コミットなし）

--- a/.opencode/commands/agentdev/case-open.md
+++ b/.opencode/commands/agentdev/case-open.md
@@ -83,6 +83,10 @@ load_skills:
     - Issue 本文の `## Requirement Source` セクションに記録されたパスのうち、`.agentdev/backlog/req-units/RU-*.md` に一致するファイルを削除する（REQ ファイルの Requirement Source セクション、またはセッション内要件docの Requirement Source セクションから抽出）
     - **削除条件**: Issue 作成 + VERIFY が正常完了した場合のみ（SHALL）。Issue 作成失敗・VERIFY 失敗時は RU を残置する
     - **削除対象外**: RU パターンに一致しない Requirement Source は削除しない
+    - **RU削除後の同期確認**（SHALL — REQ-0105）: RU ファイル削除を commit/push した場合、以下を確認すること:
+        1. main 作業ディレクトリの HEAD と `origin/main` が一致していること（`git rev-parse HEAD` と `git rev-parse origin/main` を比較）
+        2. `git status --porcelain` に削除済み RU ファイルが残っていないこと
+        - 同期確認に失敗した場合、対象ファイル・現在の HEAD・`origin/main` を表示して完了扱いにせず停止すること（SHALL — REQ-0105）
 14. 完了報告 → `agentdev-workflow-reporting` の完了報告variantに従って出力。実行フローに応じたvariantを選択:
     - Standard flow → completion-reports/case-open/standard.md
     - Epic flow → completion-reports/case-open/epic.md


### PR DESCRIPTION
## 概要

case-open の RU 削除後同期確認と case-close の pull 前ローカル変更検出時の動作を改善し、意図的に削除された RU ファイルが古い local HEAD から復元されるバグを防止する。

## 変更内容

### case-close.md (Step 8b)

- **廃止**: `git checkout --` による自動リセット（REQ-0106-015）
- **廃止**: 「PRで削除されたファイルに限定」する旧規則（REQ-0106-017）
- **追加**: ローカル変更検出時の構造化エラーによる停止（REQ-0106-016）

### case-open.md (Step 13a)

- **追加**: RU ファイル削除 commit/push 後の同期確認ステップ（REQ-0105-023）
  - HEAD と origin/main の一致確認
  - `git status --porcelain` に削除済み RU ファイルが残っていないことの確認
- **追加**: 同期確認失敗時の停止要件（REQ-0105-024）

## テスト結果

- case-open.md と REQ-0105-023/024 の整合性確認（テキストベース照合）: ✅
- case-close.md と REQ-0106-015〜017 の整合性確認（テキストベース照合）: ✅

## Findings / Intake候補

該当なし

Closes #480
