### PR TITLE
fix(integrity-check): intake item 作成時の git 永続化 Step を追加

### DIFF
--- a/.opencode/commands/agentdev/integrity-check.md
+++ b/.opencode/commands/agentdev/integrity-check.md
@@ -245,7 +245,19 @@ Views 廃止後の残存構造を検出する:
 - **保存形式**: `/agentdev/intake-capture` の Intake Item 形式に従う
 - **ユーザーが intake item 化をスキップ**: レポートのみで終了
 
-### 10. 完了報告
+### 10. Git 永続化（条件付き）
+
+Step 9 で intake item を作成した場合、`.agentdev/intake/` 配下の変更を git 永続化する（SHALL）:
+
+1. `git status --porcelain -- .agentdev/intake/` で変更を検知
+2. **変更なし**（intake item 未作成）→ 完了報告へ（「変更なし」パターン）
+3. **変更あり**:
+   a. `git add .agentdev/intake/`（`.agentdev/intake/` 配下のみ。integrity report は commit 対象外）（SHALL）
+   b. `git commit -m "chore: add intake items from integrity-check"`
+   c. `git push`
+   d. **失敗時** → エラー報告・後続中止（SHALL）
+
+### 11. 完了報告
 
 完了報告 → `agentdev-workflow-reporting` の完了報告variantに従って出力。variant: completion-reports/integrity-check/standard.md
 
@@ -254,7 +266,7 @@ Views 廃止後の残存構造を検出する:
 ### Read-Only 制約
 - G01: 検査対象 artifact（REQ、ADR、skill、command、specs、README、DOC-MAP）を変更しない。レポート生成（`.agentdev/integrity/reports/`）および intake item の新規作成（`.agentdev/intake/inbox/`）はこの制約の例外として許容する（REQ-0101）
 - G02: レポート・intake item の新規作成のみ許容
-- G03: `git` コマンドは実行しない（コミット・プッシュ禁止）。git永続化なし。必要なら別途 commit
+- G03: `git` コマンドは intake item 作成時にのみ `.agentdev/intake/` 配下に限定して実行する（SHALL）。それ以外の git操作（コミット・プッシュ）は禁止する。検査対象の git変更は一切行わない
 
 ### Finding 分類制約（REQ-0105, REQ-0105, REQ-0101）
 - G10: finding（検出された不整合）は原則 intake 対象である（REQ-0105）

--- a/.opencode/skills/agentdev-workflow-lifecycle/reference/command-map.md
+++ b/.opencode/skills/agentdev-workflow-lifecycle/reference/command-map.md
@@ -174,7 +174,7 @@ Implementation pattern は command の内部構造に基づく分類軸であり
 | **file-pipeline** | 定義されたステップに従いファイルを変換・生成するパイプライン処理 | 指定ディレクトリへのファイル作成・更新、git操作 (commit, push)、外部API呼び出し (Issue更新, PR操作)、テンプレート適用 | 大規模な状態機械の実行、サブエージェントの起動、再開ポイント検出 | ファイル管理・バリデーション・テンプレート系 skill、完了報告 skill、git/gh系 skill (外部API操作時) | 入力→出力マッピング、作成・更新ファイル一覧、git操作結果（ある場合） |
 | **manager-orchestrator** | 複数フェーズ構成の状態機械・自己修復ループ・サブエージェントプロトコルによる複雑な実行管理 | すべてのファイル操作、git操作 (worktree, commit, push, merge)、外部API呼び出し (Issue, PR, CI)、サブエージェントの起動・管理、Wave scheduling | （制限なし — 最も広いスコープを持つ） | オーケストレーション系 skill、worktree/git系 skill、仕様適合性 skill、完了報告 skill | 実行フェーズ完了状況、作成・更新アーティファクト一覧、検証結果、サブエージェント実行結果（並列実行時） |
 | **capture-only** | データを収集・記録し、指定 inbox に保存する（変換なし） | inbox ディレクトリへの新規ファイル作成のみ、外部APIからの読み取り | レビュー・プロモート・Issue作成、既存ファイルの変更・削除、git操作 (commit, push)、分析・評価・判定 | ライフサイクル文脈 skill、完了報告 skill | キャプチャ項目数、inbox保存パス |
-| **read-only-diagnostic** | アーティファクトを分析し、結果をレポートとして出力する（一切の変更なし） | レポートファイルの新規作成 (`.agentdev/integrity/reports/` 等)、intake item の新規作成（ユーザー承認時のみ） | 検査対象アーティファクトの変更 (REQ, ADR, specs, command, skill等)、git操作 (commit, push)、外部API呼び出しによるリソース変更 | 分析・診断系 skill、完了報告 skill | 検査結果サマリ (OK/NG/Warning/Info)、検出問題一覧、レポートファイルパス |
+| **read-only-diagnostic** | アーティファットを分析し、結果をレポートとして出力する（一切の変更なし） | レポートファイルの新規作成 (`.agentdev/integrity/reports/` 等)、intake item の新規作成（ユーザー承認時のみ）、intake item 作成後の `.agentdev/intake/` 配下に限定した git 永続化（ユーザー承認時のみ） | 検査対象アーティファクトの変更 (REQ, ADR, specs, command, skill等)、無条件の git操作 (commit, push)、外部API呼び出しによるリソース変更 | 分析・診断系 skill、完了報告 skill | 検査結果サマリ (OK/NG/Warning/Info)、検出問題一覧、レポートファイルパス |
 
 ### Command ↔ Pattern Correspondence
 

--- a/.opencode/skills/agentdev-workflow-reporting/reference/completion-reports/integrity-check/standard.md
+++ b/.opencode/skills/agentdev-workflow-reporting/reference/completion-reports/integrity-check/standard.md
@@ -8,5 +8,8 @@
   - {違反なしの場合: 全 command 定義が completion-reports.md を参照}
   - {違反ありの場合: 違反内容のサマリ}
 検証結果: {✅ OK / ⚠️ 注意（違反あり）}
-git 永続化: 該当なし
+git 永続化:
+  - {intake item 作成あり・成功時: commit {hash}、push 済み（.agentdev/intake/ 配下）}
+  - {intake item 未作成時: 変更なし（intake item 未作成のため）}
+  - {intake item 作成あり・失敗時: 失敗Step（{Step名}）+ エラー内容}
 次のコマンド: なし


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

integrity-check コマンドが intake item を作成しても git commit/push されず、完了報告が git 永続化: 該当なし 固定になっていた不整合を修正する。REQ-0108-010 への違反。

## 実装内容
<!-- 【必須】 -->

以下の3ファイルを外科的修正:

1. **integrity-check.md** (コマンド定義)
   - G03: git禁止 → intake item 作成時にのみ .agentdev/intake/ 配下に限定して git 許可
   - Step 10「Git 永続化（条件付き）」を新規追加（git status → git add → commit → push）
   - 旧 Step 10「完了報告」→ Step 11 にリナンバー

2. **standard.md** (完了報告variant)
   - git 永続化: 該当なし → 3パターン分岐（成功/変更なし/失敗）

3. **command-map.md** (pattern定義)
   - read-only-diagnostic pattern に条件付き例外追加（intake item 作成後の .agentdev/intake/ 限定 git 永続化）
   - 禁止列: git操作 → 無条件の git操作 に変更

## 完了条件

<!-- 【必須】 -->
- [x] integrity-check コマンド定義に git 永続化 Step が追加されている
- [x] G03 が条件付き git 許可に修正されている
- [x] git add 対象が .agentdev/intake/ 配下に限定されている
- [x] 完了報告 variant が3パターン分岐に更新されている
- [x] command-map.md の read-only-diagnostic pattern に条件付き例外が追加されている

## テスト結果
<!-- 【必須】 -->

該当なし（Markdownファイルのみの変更）

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 変更ファイル数 | 3 | Min | ✅ |
| 差分行数 | +19/-4 | 外科的修正 | ✅ |
| 乖離検出 | 0件 | 0件 | ✅ |
| LSP診断 | N/A (Markdown) | — | — |

## Findings / Intake候補
<!-- 【必須】 -->

該当なし

Closes #483