### PR TITLE
refactor: intake-review の採用後続ルートを intake-promote のみに一本化

### DIFF
--- a/.opencode/commands/agentdev/intake-review.md
+++ b/.opencode/commands/agentdev/intake-review.md
@@ -30,7 +30,7 @@ intake-review の判定値は以下の 3 値とする（REQ-0103）:
 
 | 判定 | 意味 | 後続 |
 |------|------|------|
-| `採用` | 対応すべきと判断。req-define または intake-promote に進む | `/agentdev/req-define` または `/agentdev/intake-promote` |
+| `採用` | 対応すべきと判断。intake-promote に進む | `/agentdev/intake-promote` |
 | `保留` | 判断を保留。再度 review 対象として inbox に残す | 再度 `/agentdev/intake-review` |
 | `却下` | 対応不要と判断 | アーカイブ |
 
@@ -64,7 +64,7 @@ intake-review の判定値は以下の 3 値とする（REQ-0103）:
 
     | # | タイトル | 判定 | 後続 | 備考 |
     |---|----------|------|------|------|
-    | 1 | ... | 採用 | req-define | ... |
+    | 1 | ... | 採用 | intake-promote | ... |
     | 2 | ... | 採用 | intake-promote | ... |
     | 3 | ... | 保留 | - | ... |
     | 4 | ... | 却下 | - | ... |
@@ -128,7 +128,7 @@ intake-review の判定値は以下の 3 値とする（REQ-0103）:
 - G01: GitHub Issue の作成を行わない（`case-open` が担当）
 - G02: 直接 `case-run` を起動しない（REQ-0103）
 - G03: item の内容を変更・更新しない（判定に基づく振り分けのみ）
-- G04: `intake-promote` や `req-define` を自動起動しない（次ステップの提示のみ）
+- G04: `intake-promote` を自動起動しない（次ステップの提示のみ）
 - G05: learning item を作成しない（REQ-0105）。learning に分けるべきと判断した item は learning pipeline への委ねを推奨するにとどめる
 - G06: learning item の保存・分類・昇華を担当しない（REQ-0105）
 


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

intake-review の採用後続ルートを intake-promote のみに一本化する（REQ-0105-025〜030）。

## 実装内容
<!-- 【必須】 -->

`.opencode/commands/agentdev/intake-review.md` の 3 箇所を修正:

1. **判定表 (L33)**: `採用` 行の後続を `req-define または intake-promote` → `intake-promote` のみに修正
2. **結果レポート例 (L67)**: 採用行の後続 `req-define` → `intake-promote` に修正
3. **guardrail G04 (L131)**: `intake-promote や req-define` → `intake-promote` のみに修正

## 完了条件
<!-- 【必須】 -->

- [x] intake-review の判定表で採用後続を `intake-promote` のみに修正
- [x] 結果レポート例から req-define 直行ルートを削除
- [x] guardrail G04 から req-define 後続候補を削除

## テスト結果
<!-- 【必須】 -->

該当なし（Markdown コマンド定義のテキスト修正のみ）

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 乖離検出 | 0件 | 0件 | ✅ |
| 関連doc整合性 | 矛盾なし | 矛盾なし | ✅ |

## Findings / Intake候補
<!-- 【必須】 -->

該当なし

<!-- 【必須】 -->
Closes #486