### PR TITLE
fix(agentdev): learning-promote の後続ルートを req-backlog 経由に修正

### DIFF
--- a/.opencode/commands/agentdev/README.md
+++ b/.opencode/commands/agentdev/README.md
@@ -63,7 +63,7 @@ AgentDevFlow の全ドメイン（req/case/learning/intake/integrity）パイプ
 ### learning パイプライン（学びの蓄積・分析・昇華）
 
 ```
-学び発生 → learning-capture（スキル）→ /agentdev/learning-refine → /agentdev/learning-promote → /agentdev/req-define（明示入力ファイル）
+学び発生 → learning-capture（スキル）→ /agentdev/learning-refine → /agentdev/learning-promote → /agentdev/req-backlog → /agentdev/req-define
 ```
 
 ### intake ワークフロー（気づき・課題の収集・レビュー・昇華）

--- a/.opencode/commands/agentdev/learning-promote.md
+++ b/.opencode/commands/agentdev/learning-promote.md
@@ -13,7 +13,7 @@ load_skills:
 
 `.agentdev/learning/evaluation-report.md` の問題クラスを主入力とし、`.agentdev/learning/archive.md` の過去エントリを参照して廃棄判定を行う。ユーザー承認後に `.agentdev/learning/promoted/` に Requirement Source 形式の stub を生成し、処理済みエントリを archive.md から pruning する。
 
-**重要**: `.opencode/` への直接配置・直接反映は行わない。生成した stub は `/agentdev/req-define` の明示入力ファイルとして扱い、`/agentdev/req-define → /agentdev/req-save → /agentdev/case-open → /agentdev/case-run` のルートで実装に移行する。
+**重要**: `.opencode/` への直接配置・直接反映は行わない。生成した stub は `/agentdev/req-backlog` が読み込み、RU 生成後に `/agentdev/req-define` に合流する。反映ルート: promoted → `/agentdev/req-backlog`（RU 生成）→ `/agentdev/req-define` → `/agentdev/req-save` → `/agentdev/case-open` → `/agentdev/case-run`。
 
 ## Input
 
@@ -86,7 +86,7 @@ load_skills:
    - 出力先: `.agentdev/learning/promoted/`（REQ-0105）
    - ファイル名: `{disposal-category}-{name}.md`
    - **`.opencode/` への直接書込は禁止**
-   - **`case-run` への直接受け渡しは禁止**（`req-define` を経由すること）
+   - **`case-run` への直接受け渡しは禁止**（`req-backlog` を経由して RU 化すること）
    - stub フォーマットは `agentdev-learning-pipeline` skill の「Requirement Source Staging Stub Schema」に従う
    - カテゴリ別の反映先パス例は `agentdev-learning-pipeline` skill を参照
 
@@ -130,7 +130,7 @@ load_skills:
 - G02: `evaluation-report.md` は読込専用: 変更・削除は禁止
 
 ### 実行制約
-- G03: `case-run` への直接受け渡し禁止: stub は `req-define` の明示入力ファイルとして扱う
+- G03: `case-run` への直接受け渡し禁止: stub は `/agentdev/req-backlog` が読み込み、RU 生成を経て `/agentdev/req-define` に合流する
 
 ### 品質ゲート
 - G04: 主入力は `evaluation-report.md`: raw learning item の再分類は禁止（REQ-0103）
@@ -167,7 +167,7 @@ promote が扱う3つの主要 artifact の役割・性格・lifecycle 振る舞
 |----------|------|------|-------------------|
 | `archive.md` | 過去エントリの living pool（終端保管ではない） | living | promote の主入力の一つとして参照される。promote 時の prune により staged/rejected/duplicate は除去され、deferred/未処理は保持される。`archive` は終端保管を意味しない。（REQ-0105/004/005/016） |
 | `evaluation-report.md` | refine/promote 間の境界 artifact | 読込専用 | 毎回上書きされるため長期履歴ではない。promote はこれを主入力とする。（REQ-0105/009） |
-| `promoted/` | Requirement Source stub の staging 領域 | staging | 生成された stub は `/agentdev/req-define` の明示入力ファイルとして扱う。`.opencode/` や実装コードへの直接反映は禁止。`case-run` への直接受け渡しも禁止。（REQ-0105/011/012, REQ-0105） |
+| `promoted/` | Requirement Source stub の staging 領域 | staging | 生成された stub は `/agentdev/req-backlog` が読み込み、RU 生成を経て `/agentdev/req-define` に合流する。`.opencode/` や実装コードへの直接反映は禁止。`case-run` への直接受け渡しも禁止。（REQ-0105/011/012, REQ-0105） |
 
 ### learning-promote の責務
 


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

learning-promote.md の後続ルート記述が req-backlog 導入前の古い状態（req-define 直行）のままとなっており、現行の反映ルート（promoted → req-backlog → req-define）と矛盾していた問題を修正。

## 実装内容
<!-- 【必須】 -->

以下の5箇所を修正:

1. **learning-promote.md L16**: `req-define の明示入力ファイルとして扱い` → `req-backlog が読み込み、RU 生成後に req-define に合流する。反映ルート: promoted → req-backlog → req-define → ...`
2. **learning-promote.md L89**: `req-define を経由すること` → `req-backlog を経由して RU 化すること`
3. **learning-promote.md L133**: G03 guardrail: `req-define の明示入力ファイルとして扱う` → `req-backlog が読み込み、RU 生成を経て req-define に合流する`
4. **learning-promote.md L170**: promoted/ artifact lifecycle: `req-define の明示入力ファイルとして扱う` → `req-backlog が読み込み、RU 生成を経て req-define に合流する`
5. **commands/agentdev/README.md L66**: `learning-promote → req-define（明示入力ファイル）` → `learning-promote → req-backlog → req-define`

## 完了条件

<!-- 【必須】 -->
- [x] learning-promote.md L16, L89, L133, L170 が `promoted → req-backlog → req-define` ルートに修正
- [x] commands/agentdev/README.md L66 の learning flow に `req-backlog` が含まれる
- [x] learning-promote.md 内に古い表現が残存しない（grep確認: `req-define.*明示入力` → 0件）
- [x] 修正後が system.md L40 の反映ルートと矛盾しない

## テスト結果
<!-- 【必須】 -->

- 回帰テスト: `req-define.*明示入力` grep → 0件 ✅
- 整合性テスト: `req-backlog` が learning-promote.md に4箇所登場 ✅
- 整合性テスト: commands README L66 に `req-backlog` 含まれる ✅

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 回帰テスト（古い表現残存） | 0件 | 0件 | ✅ |
| 整合性テスト（req-backlog 登場） | 4箇所 | ≥1箇所 | ✅ |
| 整合性テスト（README flow） | 含まれる | 含まれること | ✅ |
| 変更ファイル数 | 2ファイル | 最小限 | ✅ |

## Findings / Intake候補
<!-- 【必須】 -->

該当なし

<!-- 【必須】 -->
Closes #488
