### PR TITLE
fix: worktree削除時のPermission deniedリトライ機構を追加 (#494)

### DIFF
--- a/.opencode/skills/agentdev-git-worktree/SKILL.md
+++ b/.opencode/skills/agentdev-git-worktree/SKILL.md
@@ -126,6 +126,15 @@ rm -rf ".worktrees/{N}-{type}/.sisyphus/"
 git worktree remove ".worktrees/{N}-{type}"
 ```
 
+#### Permission denied 時のリトライ
+
+`git worktree remove` が Permission denied で失敗した場合、ファイルハンドル解放待ちのため短い待機を挟んでリトライする。
+
+- **最大リトライ回数**: 2回
+- **待機間隔**: 短い間隔（数秒程度）
+- **リトライ条件**: `git worktree remove` の終了コードが非ゼロで、エラーメッセージに "Permission denied" が含まれる場合のみ。それ以外のエラーはリトライしない
+- **リトライ上限到達時**: 警告を表示して停止する。ユーザーの判断を待つ
+
 ### 3. クリーンアップ
 
 ```bash


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

`git worktree remove` 実行時に Permission denied エラーが発生した場合のリトライ機構を追加する（#494）。

## 実装内容
<!-- 【必須】 -->

`agentdev-git-worktree/SKILL.md` の worktree 削除手順 Step 2 に「Permission denied 時のリトライ」サブセクションを追加:

- 最大リトライ回数: 2回
- 待機間隔: 短い間隔（数秒程度）
- リトライ条件: 終了コード非ゼロかつ "Permission denied" 含有の場合のみ
- リトライ上限到達時: 警告表示して停止

## 完了条件

<!-- 【必須】 -->
- [x] Permission denied 時にリトライが実行されること
- [x] リトライ上限到達時に警告表示して停止すること
- [x] リトライ記述が OS 非依存であること

## テスト結果
<!-- 【必須】 -->

該当なし（スキル定義ファイルの変更のため、自動テスト対象外）

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 乖離検出 | 重大0件 / 軽微0件 | 重大0件 | ✅ |
| チェックボックス | 3/3 完了 | 全完了 | ✅ |
| LSP diagnostics | 対象外（.md） | エラー0件 | ✅ |

## Findings / Intake候補
<!-- 【必須】 -->

該当なし

<!-- 【必須】 -->
Closes #494
