### PR TITLE
fix: integrity false-positive rule fixes (README index / completion report / retired REQ / link placeholder)

### DIFF
--- a/.opencode/skills/agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/agentdev-integrity/scripts/check_integrity.test.ts
@@ -2439,3 +2439,282 @@ describe("G6: Phase 3 candidate in messages", () => {
     expect(hit.message).toMatch(/\[recommendation: .+\]/);
   });
 });
+
+// ─── False-positive regression tests (Issue #504 / REQ-0108-041,042,043,045) ─
+
+describe("F1: extractReadmeTableReqIds — markdown link format [REQ-NNNN](REQ-NNNN.md)", () => {
+  const F1_ROOT = join(TEMP_ROOT, "f1-link-req");
+
+  beforeAll(() => {
+    mkdirp(F1_ROOT);
+    buildValidFixture(F1_ROOT);
+
+    const reqDir = join(F1_ROOT, "docs", "requirements");
+    writeFileSync(
+      join(reqDir, "README.md"),
+      [
+        "# Requirements",
+        "",
+        "| REQ ID | Title |",
+        "|--------|-------|",
+        "| [REQ-0001](REQ-0001.md) | Valid requirement |",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    copyScripts(F1_ROOT);
+  });
+
+  it("extracts REQ IDs from [REQ-NNNN](...) link format and does not report missing", () => {
+    const r = runScript(F1_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const missingHit = parsed.results.find(
+      (res: { check: string; message: string }) =>
+        res.check === "readme-index-sync" &&
+        res.message.includes("REQ-0001") &&
+        res.message.includes("missing from README")
+    );
+    expect(missingHit).toBeUndefined();
+  });
+
+  it("reports OK for readme-index-sync", () => {
+    const r = runScript(F1_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const okHit = parsed.results.find(
+      (res: { check: string; level: string }) =>
+        res.check === "readme-index-sync" && res.level === "ok"
+    );
+    expect(okHit).toBeDefined();
+  });
+});
+
+describe("F2: checkCompletionReportTemplates — variant directory on disk accepted", () => {
+  const F2_ROOT = join(TEMP_ROOT, "f2-variant-dir");
+
+  beforeAll(() => {
+    mkdirp(F2_ROOT);
+    buildValidFixture(F2_ROOT);
+
+    const reportingRefDir = join(F2_ROOT, ".opencode", "skills", "agentdev-workflow-reporting", "reference");
+    mkdirp(reportingRefDir);
+
+    writeFileSync(
+      join(reportingRefDir, "completion-reports.md"),
+      [
+        "# 完了報告フォーマット",
+        "",
+        "## Variant Registry",
+        "",
+        "| Command | Variant | File |",
+        "|---------|---------|------|",
+        "| other-cmd | standard | completion-reports/other-cmd/standard.md |",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const variantDir = join(reportingRefDir, "completion-reports", "other-cmd");
+    mkdirp(variantDir);
+    writeFileSync(join(variantDir, "standard.md"), "✅ other-cmd 完了\n", "utf-8");
+
+    const testCmdVariantDir = join(reportingRefDir, "completion-reports", "test-cmd");
+    mkdirp(testCmdVariantDir);
+    writeFileSync(join(testCmdVariantDir, "standard.md"), "✅ test-cmd 完了\n", "utf-8");
+
+    const cmdDir = join(F2_ROOT, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "other-cmd.md"), [
+      "---",
+      "description: Other command",
+      "agent: test-agent",
+      "implementation_pattern: file-pipeline",
+      "load_skills:",
+      "  - agentdev-workflow-reporting",
+      "  - agentdev-conventional-commits",
+      "  - agentdev-req-file-manager",
+      "  - agentdev-adr-file-manager",
+      "  - agentdev-no-ai-slop-writing",
+      "  - agentdev-gh-cli",
+      "---",
+      "",
+      "Other command body.",
+      "",
+    ].join("\n"), "utf-8");
+
+    writeFileSync(join(cmdDir, "README.md"), [
+      "# Commands",
+      "",
+      "| Command | Description | Agent | Skills |",
+      "|---------|-------------|-------|--------|",
+      "| `agentdev/test-cmd` | Test | test-agent | agentdev-workflow-reporting |",
+      "| `agentdev/other-cmd` | Other | test-agent | agentdev-workflow-reporting |",
+      "",
+    ].join("\n"), "utf-8");
+
+    copyScripts(F2_ROOT);
+  });
+
+  it("accepts command with variant directory on disk even without registry entry for test-cmd", () => {
+    const r = runScript(F2_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const templateHit = parsed.results.find(
+      (res: { check: string; level: string }) =>
+        res.check === "template-section-existence" && res.level === "ok"
+    );
+    expect(templateHit).toBeDefined();
+  });
+
+  it("does not report NG for test-cmd missing from registry", () => {
+    const r = runScript(F2_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const ngHit = parsed.results.find(
+      (res: { check: string; message: string; level: string }) =>
+        res.check === "template-section-existence" &&
+        res.message.includes("test-cmd") &&
+        res.level === "ng"
+    );
+    expect(ngHit).toBeUndefined();
+  });
+});
+
+describe("F3: retired-req-as-current — mapping-table.md excluded", () => {
+  const F3_ROOT = join(TEMP_ROOT, "f3-mapping-table");
+
+  beforeAll(() => {
+    mkdirp(F3_ROOT);
+    buildValidFixture(F3_ROOT);
+
+    const reqDir = join(F3_ROOT, "docs", "requirements");
+    const retiredDir = join(reqDir, "retired");
+    mkdirp(retiredDir);
+
+    writeFileSync(
+      join(retiredDir, "REQ-0050.md"),
+      "---\nid: REQ-0050\ntitle: Retired REQ\n---\n\nRetired content.\n",
+      "utf-8"
+    );
+
+    writeFileSync(
+      join(reqDir, "mapping-table.md"),
+      [
+        "# Migration Table",
+        "",
+        "| Old REQ | Status |",
+        "|---------|--------|",
+        "| REQ-0050 | retired-no-successor |",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    copyScripts(F3_ROOT);
+  });
+
+  it("does not warn about retired REQ in mapping-table.md (LinkIntegrity)", () => {
+    const r = runScript(F3_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string; message: string; file?: string }) =>
+        res.check === "retired-req-as-current" &&
+        (res.file ?? "").includes("mapping-table")
+    );
+    expect(hit).toBeUndefined();
+  });
+
+  it("does not warn about retired REQ in mapping-table.md (LifecycleBoundary)", () => {
+    const r = runScript(F3_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string; message: string; file?: string }) =>
+        res.check === "retired-req-primary-ref" &&
+        (res.file ?? "").includes("mapping-table")
+    );
+    expect(hit).toBeUndefined();
+  });
+});
+
+describe("F4: parseMarkdownLinks — [URL] placeholder excluded", () => {
+  const F4_ROOT = join(TEMP_ROOT, "f4-url-placeholder");
+
+  beforeAll(() => {
+    mkdirp(F4_ROOT);
+    buildValidFixture(F4_ROOT);
+
+    const reqDir = join(F4_ROOT, "docs", "requirements");
+    writeFileSync(
+      join(reqDir, "REQ-0001.md"),
+      [
+        "---",
+        "id: REQ-0001",
+        "title: Placeholder test",
+        "created: 2025-01-01",
+        "updated: 2025-01-02",
+        "tags:",
+        "  - test",
+        "---",
+        "",
+        "## Body",
+        "",
+        "Status: ✅ 完了 ([PR#N](URL))",
+        "See ADR-0001 for context.",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    copyScripts(F4_ROOT);
+  });
+
+  it("does not report [text](URL) as broken file link", () => {
+    const r = runScript(F4_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hit = parsed.results.find(
+      (res: { check: string; message: string }) =>
+        res.check === "broken-file-link" &&
+        res.message.includes("URL")
+    );
+    expect(hit).toBeUndefined();
+  });
+
+  it("still detects real broken links", () => {
+    const reqDir = join(F4_ROOT, "docs", "requirements");
+    writeFileSync(
+      join(reqDir, "REQ-0001.md"),
+      [
+        "---",
+        "id: REQ-0001",
+        "title: Real broken link test",
+        "created: 2025-01-01",
+        "updated: 2025-01-02",
+        "tags:",
+        "  - test",
+        "---",
+        "",
+        "## Body",
+        "",
+        "Status: ✅ 完了 ([PR#N](URL))",
+        "See [guide](../guides/nonexistent.md) for details.",
+        "See ADR-0001 for context.",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+    copyScripts(F4_ROOT);
+
+    const r = runScript(F4_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const urlHit = parsed.results.find(
+      (res: { check: string; message: string }) =>
+        res.check === "broken-file-link" &&
+        res.message.includes("URL")
+    );
+    const realHit = parsed.results.find(
+      (res: { check: string; message: string }) =>
+        res.check === "broken-file-link" &&
+        res.message.includes("nonexistent.md")
+    );
+    expect(urlHit).toBeUndefined();
+    expect(realHit).toBeDefined();
+    expect(realHit.level).toBe("ng");
+  });
+});

--- a/.opencode/skills/agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/agentdev-integrity/scripts/check_integrity.ts
@@ -121,8 +121,14 @@ function extractReadmeTableReqIds(content: string): Set<string> {
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed.startsWith("|")) continue;
-    const match = trimmed.match(/\|\s*(REQ-\d+)\s*\|/);
-    if (match) ids.add(match[1]);
+    // Extract from plain text in table cell: | REQ-NNNN | ...
+    const plainMatch = trimmed.match(/\|\s*(REQ-\d+)\s*\|/);
+    if (plainMatch) { ids.add(plainMatch[1]); continue; }
+    // Extract from markdown link in table cell: | [REQ-NNNN](...) | ...
+    const linkMatches = trimmed.matchAll(/\[(REQ-\d+)\]\([^)]+\)/g);
+    for (const m of linkMatches) {
+      ids.add(m[1]);
+    }
   }
   return ids;
 }
@@ -658,12 +664,18 @@ function checkCompletionReportTemplates(cmdDir: string, completionReportsPath: s
   const results: CheckResult[] = [];
   const sections = buildCompletionReportSections(completionReportsPath);
   const cmdFiles = listFiles(cmdDir).filter((f) => f !== "README.md");
+  const usesVariantRegistry = hasVariantRegistry(completionReportsPath);
+  const variantBaseDir = getCompletionReportsDir(completionReportsPath);
 
   for (const file of cmdFiles) {
     const cmdName = file.replace(".md", "");
     if (cmdName === "integrity-check") continue;
 
-    if (!sections.has(cmdName)) {
+    const hasRegistryEntry = sections.has(cmdName);
+    // When variant registry is used, also accept on-disk variant files as valid
+    const hasVariantDir = usesVariantRegistry && fs.existsSync(path.join(variantBaseDir, cmdName));
+
+    if (!hasRegistryEntry && !hasVariantDir) {
       results.push(
         ng(
           "CompletionReport",
@@ -1079,6 +1091,8 @@ function parseMarkdownLinks(content: string): { text: string; href: string }[] {
   while ((match = regex.exec(content)) !== null) {
     const href = match[2].trim();
     if (href.startsWith("http://") || href.startsWith("https://") || href.startsWith("#") || href.startsWith("mailto:")) continue;
+    // Skip placeholder hrefs like [text](URL) where href is an uppercase word with no path separators
+    if (/^[A-Z_]+$/.test(href)) continue;
     links.push({ text: match[1], href });
   }
   return links;
@@ -1202,7 +1216,7 @@ function checkLinkIntegrity(root: string): CheckResult[] {
     for (const ref of uniqueReqRefs) {
       const retiredPath = path.join(root, "docs", "requirements", "retired", `${ref}.md`);
       const activePath = path.join(root, "docs", "requirements", `${ref}.md`);
-      if (fs.existsSync(retiredPath) && !fs.existsSync(activePath) && !relPath.startsWith("docs/requirements/retired/")) {
+      if (fs.existsSync(retiredPath) && !fs.existsSync(activePath) && !relPath.startsWith("docs/requirements/retired/") && !relPath.endsWith("mapping-table.md")) {
         results.push(warn(
           "LinkIntegrity", "retired-req-as-current",
           `${ref} is retired but referenced in non-retired file`,
@@ -1338,7 +1352,7 @@ function checkLifecycleBoundary(root: string): CheckResult[] {
   for (const filePath of allDocFiles) {
     const relPath = resolveRelative(filePath, root);
     if (relPath.startsWith("docs/requirements/retired/")) continue;
-    const content = readText(filePath);
+    if (relPath.endsWith("mapping-table.md")) continue;    const content = readText(filePath);
     if (!content) continue;
     const refs = content.match(/\bREQ-\d{4}\b/g) || [];
     const uniqueRefs = [...new Set(refs)];


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

integrity-check の README index 抽出、completion report registry 判定、mapping-table retired REQ 参照、link placeholder 判定における4つの過検出を修正しました。

## 実装内容
<!-- 【必須】 -->

- `extractReadmeTableReqIds`: `[REQ-NNNN](REQ-NNNN.md)` 形式の Markdown link から REQ ID を抽出するよう変更
- `checkCompletionReportTemplates`: Variant Registry と on-disk variant directory の組み合わせを有効な completion report 定義として扱うよう変更
- retired REQ 参照検査: `docs/requirements/mapping-table.md` の migration 用参照を current-use warning の対象外に変更
- `parseMarkdownLinks`: `[PR#N](URL)` など大文字 placeholder href を実在ファイルリンク検査から除外
- `check_integrity.test.ts`: 4領域に対する回帰テストを8件追加

## 完了条件

<!-- 【必須】 -->
- [x] integrity-check 実行時に README に記載済みの REQ-0101〜0111 が missing として報告されないこと
- [x] completion report 存在確認が Variant Registry + variant files で判定されること
- [x] `mapping-table.md` 内の retired REQ 参照が current-use warning の対象外となること
- [x] `[URL]` 等 placeholder 記法が broken link として報告されないこと
- [x] 各修正に regression fixture/test が追加されていること

## テスト結果
<!-- 【必須】 -->

- `bun test .opencode/skills/agentdev-integrity/scripts/check_integrity.test.ts`: 92/92 pass
- `bun run .opencode/skills/agentdev-integrity/scripts/check_integrity.ts`: NG 84件 → 72件（12件の過検出を除去）
- PR body readback verification: required sections present

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 回帰テスト | 92/92 pass | 失敗0 | ✅ |
| integrity-check NG件数 | 84 → 72 | 対象過検出の削減 | ✅ |
| PRテンプレート必須セクション | 6/6 present | 全必須セクションあり | ✅ |

## Findings / Intake候補
<!-- 【必須】 -->

該当なし

Closes #504
