### PR TITLE
docs: add ADR-0010/0011/0012 — architecture policy for HITL, manager pattern, pipeline

### DIFF
--- a/docs/adr/ADR-0010.md
+++ b/docs/adr/ADR-0010.md
@@ -1,0 +1,57 @@
+---
+id: ADR-0010
+title: "HITL boundary — 全 agentdev command の Human-in-the-Loop 境界原則"
+status: proposed
+created: "2026-06-02"
+updated: "2026-06-02"
+---
+
+# ADR-0010: HITL boundary — 全 agentdev command の Human-in-the-Loop 境界原則
+
+## 背景
+
+AgentDevFlow の command は、ユーザー（人間）との対話を挟む前段と、自律実行する次段に大別される。しかし、どの command で HITL（Human-in-the-Loop）境界を設けるべきか、また境界の設計原則が明文化されていない。これにより、command 間の責務境界が曖昧になり、ユーザー承認タイミングの不整合や command 肥大化のリスクが生じている。
+
+既存の ADR-0001（責務分界）は Command/Skill/Template/Script の責務境界を定義するが、HITL 境界という観点からの command 分割基準は提供していない。REQ-0104（Workflow/Command Protocol）は command 実行プロトコルを規定するが、HITL 境界の上位原則は規定していない。
+
+## 決定
+
+全 agentdev command に HITL boundary 基準を適用する。対象は workflow command（case-open, case-run, case-update, case-close）に限らず、intake（intake-capture, intake-from-github, intake-review, intake-promote）、learning（learning-refine, learning-promote）、backlog（backlog-review, backlog-save）、integrity（integrity-check）、requirement（req-define, req-save, req-restructure-review）を含む。
+
+### 原則
+
+1. **1 command = 前段（HITL入力）→ 次段（HITL出力）**: 各 command は、ユーザーからの入力を受け取る前段と、処理結果をユーザーに提示する次段の 2 段構成を基本とする。前段の終了時点でユーザー承認を挟むことで、次段の自律実行に移る。
+
+2. **command 間境界の上位原則**: 複数 command にまたがる HITL 境界は、command 間の受け渡し点でユーザー承認を必須とする。ある command の出力が次 command の入力となる場合、その受け渡し時点でユーザーが内容を確認・修正できる構造とする。
+
+3. **HITL 無しの自律実行**: HITL 境界を越えない完全自律実行（例: integrity-check の検証のみ実行）は、ユーザーが明示的に指定した場合のみ許可する。
+
+### 適用範囲
+
+- 全 agentdev command に均一に適用する（workflow / intake / learning / backlog / integrity / requirement を含む）
+- ADR-0001（責務分界）を HITL 観点で補完する
+- REQ-0104（Workflow/Command Protocol）の command 実行プロトコルを HITL 境界の観点で補完する
+
+## 代替案
+
+1. **workflow command のみ適用**: intake/learning/backlog 系には HITL 境界を設けない → 軽微な変更がユーザー確認なしに進行するリスク
+2. **command 内 HITL のみ**: command 間の受け渡し点でのユーザー承認を不要とする → 連鎖的な自動実行で意図しない結果が生じるリスク
+3. **現状維持**: 各 command の HITL 有無を個別判断 → 一貫性の欠如
+
+## 結果・影響
+
+- 全 command で一貫した HITL 境界パターンが確立される
+- ユーザーは各 command の実行前後に必ず介入ポイントを持つ
+- 既存 command の多くは既にこの原則に合致している（追認扱い）
+- 新規 command 設計時の指針として機能する
+
+## 関連する決定
+
+- ADR-0001: Command/Skill/Template/Script責務分界の正式定義（責務分界 → HITL境界の補完関係）
+- ADR-0002: Orchestration skill作成基準の導入（HITL境界が orchestration skill 化の判断に影響）
+- ADR-0011: Manager/orchestrator パターンの限定採用（manager pattern と HITL境界の相互作用）
+- ADR-0012: Requirement Source pipeline の正式定義（pipeline 各段階の HITL境界）
+
+## 実装後の記録
+
+（実装後に記載）

--- a/docs/adr/ADR-0011.md
+++ b/docs/adr/ADR-0011.md
@@ -1,0 +1,65 @@
+---
+id: ADR-0011
+title: "Manager/orchestrator パターンの限定採用 — 標準構造とはしない"
+status: proposed
+created: "2026-06-02"
+updated: "2026-06-02"
+---
+
+# ADR-0011: Manager/orchestrator パターンの限定採用 — 標準構造とはしない
+
+## 背景
+
+ADR-0002（Orchestration skill作成基準の導入）は、orchestration skill の作成条件（大きな状態機械、再開ポイント、CI loop、Wave scheduling、サブエージェント protocol）を定義した。しかし、skill化の基準と manager/orchestrator パターンの採用可否は別の問題である。全 command に manager/orchestrator パターンを適用すべきか、特定ケースに限定すべきかが明文化されていない。
+
+現状、manager/orchestrator パターンを必要とするのは case-run の Epic Orchestrator モード（複数 Issue の Wave scheduling、サブエージェント起動、障害伝播）が主たる対象である。
+
+## 決定
+
+Manager/orchestrator パターンを標準構造とはしない。以下の条件に該当する場合にのみ採用する:
+
+### 採用条件
+
+1. **複数 Issue の並列・依存管理**: 複数 Issue を Wave 単位で順次実行する必要がある場合
+2. **サブエージェント起動・障害伝播**: 複数サブエージェントを起動し、障害を伝播・ハンドリングする必要がある場合
+3. **状態機準の複雑性**: 再開ポイント検出や self-healing loop を持つ場合
+
+### 主対象
+
+- **case-run Epic Orchestrator**: 上記 3 条件を全て満たすため、manager/orchestrator パターンの主たる適用対象である
+
+### 採用しないケース
+
+- 単一 Issue の case-run（標準フロー）
+- intake / learning / backlog / integrity / requirement の各 command
+- 上記条件を満たさない新規 command
+
+### ADR-0002 との補完関係
+
+ADR-0002 は「orchestration skill を作成する条件」を定義する。本 ADR は「manager/orchestrator パターンを採用する条件」を定義する。skill化 ≠ pattern採用であり、この 2 つを区別する。
+
+- orchestration skill を持つ command が必ずしも manager/orchestrator パターンを採用するとは限らない
+- manager/orchestrator パターンを採用する command は、orchestration skill を持つことが多い（が必須ではない）
+
+## 代替案
+
+1. **全 command に manager パターン適用**: 一貫性はあるが過剰な抽象化
+2. **pattern 採用基準なし**: 現場判断 → 一貫性なし、過剰適用のリスク
+3. **skill化 = pattern採用**: 区別を設けない → 小さい command に不要な抽象化
+
+## 結果・影響
+
+- manager/orchestrator パターンの適用が明確に限定される
+- case-run Epic Orchestrator 以外への不用意な適用を防ぐ
+- 新規 command 設計時に「このパターンが必要か」の判断基準が提供される
+- ADR-0002 の skill化基準と本 ADR の pattern採用基準が明確に区別される
+
+## 関連する決定
+
+- ADR-0002: Orchestration skill作成基準の導入（skill化基準の定義、補完関係）
+- ADR-0010: HITL boundary（manager パターン内の HITL 境界）
+- ADR-0006: Epic Issue 本文を実行順序 SSoT とする設計（Epic Orchestrator の SSoT 基盤）
+
+## 実装後の記録
+
+（実装後に記載）

--- a/docs/adr/ADR-0012.md
+++ b/docs/adr/ADR-0012.md
@@ -1,0 +1,71 @@
+---
+id: ADR-0012
+title: "Requirement Source pipeline の正式定義 — promoted→RU→req-define の一貫流"
+status: proposed
+created: "2026-06-02"
+updated: "2026-06-02"
+---
+
+# ADR-0012: Requirement Source pipeline の正式定義 — promoted→RU→req-define の一貫流
+
+## 背景
+
+AgentDevFlow には、変更候補の収集から要件定義までのパイプラインが存在する: intake→promote→backlog-review→backlog-save（RU生成）→req-define。REQ-0105（Intake/Learning/Backlog）はこのパイプラインの各段階の動作（「どう動くか」）を規定しているが、パイプライン全体を貫く architecture principle（「なぜこの設計か」）が ADR として記録されていない。
+
+Requirement Unit（RU）は、要件化前の正式な入力単位として backlog に格納されるが、RU の位置づけ（要件化前の正式入力 vs 暫定候補）が明確に定義されていない。
+
+## 決定
+
+### Pipeline 定義
+
+Requirement Source pipeline を以下の流れとして正式定義する:
+
+```
+promoted artifact
+  → backlog-review（HITL: 分析・統合）
+  → backlog-save（RU 生成・git 永続化）
+  → RU（.agentdev/backlog/req-units/RU-*.md）
+  → req-define（HITL: 要件壁打ち、要件doc生成）
+  → req-save（REQ/ADR ファイルとして保存）
+  → case-open（GitHub Issue 化、RU 削除）
+```
+
+### RU の位置づけ
+
+- **RU は要件化前の正式入力単位**である。暫定候補ではなく、backlog-review での分析・統合を経た正式な成果物
+- RU は req-define の明示入力として使用され、req-define の壁打ち結果（要件doc）に反映される
+- RU は case-open で Issue 化された後に削除される（ライフサイクルの終端）
+
+### REQ-0105 との補完関係
+
+- REQ-0105 はパイプライン各段階の動作仕様（「どう動くか」）を規定する
+- 本 ADR はパイプライン全体を貫く architecture principle（「なぜこの設計か」）を規定する
+- 両者は補完関係にあり、重複しない
+
+### Architecture principle
+
+1. **一貫流**: 変更候補は pipeline を通じて一方向に流れる。逆流や短絡は許可しない
+2. **段階的精緻化**: 各段階で情報が整理・統合され、次段階への入力品質が向上する
+3. **HITL 境界**: backlog-review と req-define が HITL 境界（ADR-0010 に従う）
+
+## 代替案
+
+1. **RU を暫定候補とする**: backlog-review の品質担保を弱める → 要件化品質の低下リスク
+2. **pipeline 定義なし**: 各段階を独立運用 → 段階間の整合性担保なし
+3. **REQ-0105 のみで規定**: architecture principle なし → 「なぜ」の記録なし
+
+## 結果・影響
+
+- 変更候補から要件定義までの一貫した流れが architecture principle として記録される
+- RU の位置づけが明確化され、backlog 運用の判断基準となる
+- REQ-0105 と本 ADR の補完関係により、「動作仕様」と「設計原理」の両面が担保される
+- intake/learning capture も pipeline の上流として位置づけられる（ただし本 ADR の直接対象外）
+
+## 関連する決定
+
+- ADR-0010: HITL boundary（pipeline 内の HITL 境界）
+- ADR-0011: Manager/orchestrator パターンの限定採用（pipeline 各段階の pattern 適用可否）
+
+## 実装後の記録
+
+（実装後に記載）

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,9 @@
 | ADR-0007 | REQ/ADR基準構造と分類ビュー運用の再定義 | superseded-by:[ADR-0008] | 2026-05-24 |
 | ADR-0008 | DOC-MAP導入と requirements/views 廃止 | proposed | 2026-05-28 |
 | ADR-0009 | REQ体系再基準化 — 旧REQ分類モデル・対応表・分類ゲート導入 | accepted | 2026-05-30 |
+| ADR-0010 | HITL boundary — 全 agentdev command の Human-in-the-Loop 境界原則 | proposed | 2026-06-02 |
+| ADR-0011 | Manager/orchestrator パターンの限定採用 — 標準構造とはしない | proposed | 2026-06-02 |
+| ADR-0012 | Requirement Source pipeline の正式定義 — promoted→RU→req-define の一貫流 | proposed | 2026-06-02 |
 
 > この README は分類ビューであり、ADR本文のSSoTではない。基準は各 `ADR-{NNNN}.md` ファイルである（REQ-0101）。
 
@@ -22,11 +25,14 @@
 
 ### proposed
 
-- [ADR-0001](ADR-0001.md) — Command/Skill/Template/Script責任分界の正式定義
+- [ADR-0001](ADR-0001.md) — Command/Skill/Template/Script責務分界の正式定義
 - [ADR-0002](ADR-0002.md) — Orchestration skill作成基準の導入
 - [ADR-0003](ADR-0003.md) — req-define入力の抽象化
 - [ADR-0006](ADR-0006.md) — Epic Issue 本文を実行順序 SSoT とする設計
 - [ADR-0008](ADR-0008.md) — DOC-MAP導入と requirements/views 廃止
+- [ADR-0010](ADR-0010.md) — HITL boundary — 全 agentdev command の Human-in-the-Loop 境界原則
+- [ADR-0011](ADR-0011.md) — Manager/orchestrator パターンの限定採用 — 標準構造とはしない
+- [ADR-0012](ADR-0012.md) — Requirement Source pipeline の正式定義 — promoted→RU→req-define の一貫流
 
 ### accepted
 
@@ -64,6 +70,12 @@
 
 - [ADR-0006](ADR-0006.md) — Epic Issue 本文を実行順序 SSoT とする設計
 
+### アーキテクチャ方針
+
+- [ADR-0010](ADR-0010.md) — HITL boundary — 全 agentdev command の Human-in-the-Loop 境界原則
+- [ADR-0011](ADR-0011.md) — Manager/orchestrator パターンの限定採用 — 標準構造とはしない
+- [ADR-0012](ADR-0012.md) — Requirement Source pipeline の正式定義 — promoted→RU→req-define の一貫流
+
 ## Decision Map
 
 | ADR | 関係 | 対象 | 説明 |
@@ -81,6 +93,15 @@
 | [ADR-0008](ADR-0008.md) | relates-to | [ADR-0004](ADR-0004.md) | area-based移行方針の最終撤回（ADR-0007経由） |
 | [ADR-0009](ADR-0009.md) | relates-to | [ADR-0008](ADR-0008.md) | DOC-MAP再構成の基盤 |
 | [ADR-0009](ADR-0009.md) | relates-to | [ADR-0007](ADR-0007.md) | REQ基準構造の前段（ADR-0007→0008→0009の系譜） |
+| [ADR-0010](ADR-0010.md) | relates-to | [ADR-0001](ADR-0001.md) | 責務分界 → HITL境界の補完関係 |
+| [ADR-0010](ADR-0010.md) | relates-to | [ADR-0002](ADR-0002.md) | HITL境界が orchestration skill 化の判断に影響 |
+| [ADR-0010](ADR-0010.md) | relates-to | [ADR-0011](ADR-0011.md) | manager pattern と HITL境界の相互作用 |
+| [ADR-0010](ADR-0010.md) | relates-to | [ADR-0012](ADR-0012.md) | pipeline 各段階の HITL境界 |
+| [ADR-0011](ADR-0011.md) | relates-to | [ADR-0002](ADR-0002.md) | skill化基準と pattern採用基準の区別 |
+| [ADR-0011](ADR-0011.md) | relates-to | [ADR-0010](ADR-0010.md) | HITL境界 |
+| [ADR-0011](ADR-0011.md) | relates-to | [ADR-0006](ADR-0006.md) | Epic Orchestrator の SSoT 基盤 |
+| [ADR-0012](ADR-0012.md) | relates-to | [ADR-0010](ADR-0010.md) | pipeline 内の HITL境界 |
+| [ADR-0012](ADR-0012.md) | relates-to | [ADR-0011](ADR-0011.md) | pipeline 各段階の pattern 適用可否 |
 
 ## Related REQ
 
@@ -95,3 +116,6 @@
 | [ADR-0007](ADR-0007.md) | [REQ-0004 (retired)](../requirements/retired/REQ-0004.md) | 要件・ADRドキュメントシステム（ADR-0007本文に明示参照） |
 | [ADR-0008](ADR-0008.md) | [REQ-0004 (retired)](../requirements/retired/REQ-0004.md), [REQ-0035 (retired)](../requirements/retired/REQ-0035.md) | REQ-0004: views関連要件のsupersede、REQ-0035: DOC-MAP導入とviews廃止 |
 | [ADR-0009](ADR-0009.md) | [REQ-0041 (retired)](../requirements/retired/REQ-0041.md) | REQ体系再基準化 — 旧REQ分類・新基準REQ群・分類ゲート（ADR-0009本文に明示参照） |
+| [ADR-0010](ADR-0010.md) | [REQ-0104](../requirements/REQ-0104.md) | Workflow/Command Protocol（HITL境界の観点で補完） |
+| [ADR-0011](ADR-0011.md) | — | 対応REQなし（architecture principle として新規定義） |
+| [ADR-0012](ADR-0012.md) | [REQ-0105](../requirements/REQ-0105.md) | Intake/Learning/Backlog（pipeline の動作仕様を architecture principle で裏付け） |


### PR DESCRIPTION
# 概要

Issue #517 — AgentDevFlow の今後の開発方針に継続的に影響する3つのアーキテクチャ判断をADRとして明文化。

## 実装内容

以下の3件のADRを新規作成し、`docs/adr/README.md` のインデックス（一覧・Status View・Topic View・Decision Map・Related REQ）を更新した。

### ADR-0010: HITL boundary

全 agentdev command の Human-in-the-Loop 境界原則を定義。1 command = 前段HITL入力→次段HITL出力の構造、command間境界の上位原則を明文化。ADR-0001（責務分界）とREQ-0104（Workflow/Command Protocol）を補完。

### ADR-0011: Manager/orchestrator パターンの限定採用

manager/orchestrator パターンを標準構造とはせず、複数Issue/Wave等の限定的場面でのみ採用する方針を定義。主対象は case-run Epic Orchestrator。ADR-0002（orchestration skill基準）を補完し、skill化≠pattern採用を区別。

### ADR-0012: Requirement Source pipeline

promoted→backlog-review→backlog-save→RU→req-define→req-save→case-open の一貫流を正式定義。RU = 要件化前正式入力。REQ-0105（Intake/Learning/Backlog）の動作仕様を architecture principle で裏付け。

## 完了条件

- [x] ADR-0010: 全 agentdev command に HITL boundary 基準を適用すること（SHALL）
- [x] ADR-0010: 1 command = 前段 HITL 入力→次段 HITL 出力の構造原則を定めること（SHALL）
- [x] ADR-0010: command 間境界の上位原則を示すこと（SHALL）
- [x] ADR-0010: ADR-0001（責務分界）および REQ-0104 を補完すること（SHALL）
- [x] ADR-0010: status = proposed で作成すること（SHALL）
- [x] ADR-0010: 適用対象を全 agentdev command（intake/learning/backlog/workflow/integrity 含む）とすること（SHALL）
- [x] ADR-0010: Related Decisions に ADR-0001, ADR-0002, ADR-0011, ADR-0012 を列挙すること（SHALL）
- [x] ADR-0011: manager/orchestrator パターンを標準構造としないことを定めること（SHALL）
- [x] ADR-0011: 複数 Issue / Wave 等の限定場面でのみ採用することを定めること（SHALL）
- [x] ADR-0011: 主対象を case-run Epic Orchestrator とすること（SHALL）
- [x] ADR-0011: ADR-0002 を補完し skill化≠pattern採用の区別を明示すること（SHALL）
- [x] ADR-0011: status = proposed で作成すること（SHALL）
- [x] ADR-0011: Related Decisions に ADR-0002, ADR-0010, ADR-0006 を列挙すること（SHALL）
- [x] ADR-0012: promoted→backlog-review→backlog-save→RU→req-define の流れを定義すること（SHALL）
- [x] ADR-0012: RU = 要件化前の正式入力であることを定義すること（SHALL）
- [x] ADR-0012: REQ-0105 を architecture principle として裏付けること（SHALL）
- [x] ADR-0012: status = proposed で作成すること（SHALL）
- [x] ADR-0012: Related Decisions に ADR-0010, ADR-0011 を列挙すること（SHALL）
- [x] docs/adr/README.md の全ビュー（一覧・Status・Topic・Decision Map・Related REQ）に3件を登録すること（SHALL）
- [x] 3件の ADR 粒度が方針レベル（実装詳細を含まない）であること（SHOULD）
- [x] 各 ADR の Related Decisions が相互に整合していること（SHALL）
- [x] 既存 ADR（ADR-0001, 0002, 0006, 0008, 0009）を列挙し補完関係を示すこと（SHALL）

## テスト結果

- ADR 内容レビュー: 3件ともテンプレート構造（Context/Decision/Consequences/Status/Related Decisions）に準拠 ✅
- README 整合性: ADR一覧・Status View・Topic View・Decision Map・Related REQ の全ビューに3件反映済み ✅
- 相互参照整合性: Decision Map の relates-to が双方向で整合 ✅
- > ℹ️ 別途確認: integrity-check による包括的整合性検証（単一PR外）

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| Spec compliance | 逸脱なし | 0件 | ✅ |
| ADR template compliance | 準拠 | 全項目 | ✅ |
| README integration | 3件全ビュー反映 | 全ビュー | ✅ |
| Related doc consistency | 更新不要（5件確認済み） | 全件確認 | ✅ |

## Findings / Intake候補

該当なし

Closes #517
