### PR TITLE
docs(#520): Document model + SPEC + responsibility boundaries

### DIFF
--- a/docs/DOC-MAP.md
+++ b/docs/DOC-MAP.md
@@ -40,6 +40,10 @@
 | [patterns.md](specs/patterns.md) | 実装パターンと文書フォーマット |
 | [design-principles.md](specs/design-principles.md) | 設計原則 |
 | [quality-specs.md](specs/quality-specs.md) | 品質基準・検証ルール |
+| [document-model.md](specs/document-model.md) | 文書種別の責務マトリックス |
+| [artifact-contracts.md](specs/artifact-contracts.md) | アーティファクト間契約 |
+| [integrity-contracts.md](specs/integrity-contracts.md) | 整合性検査分類フレームワーク |
+| [workflow-contracts.md](specs/workflow-contracts.md) | ワークフロー契約の雛形 |
 
 ## ADR
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,10 @@
 - [Implementation Patterns](specs/patterns.md)
 - [Design Principles](specs/design-principles.md)
 - [Quality Specifications](specs/quality-specs.md)
+- [Document Model](specs/document-model.md)
+- [Artifact Contracts](specs/artifact-contracts.md)
+- [Integrity Contracts](specs/integrity-contracts.md)
+- [Workflow Contracts](specs/workflow-contracts.md)
 
 ## ADR
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -11,6 +11,10 @@ They describe what the system *is* now, as opposed to REQ files that define what
 | [patterns.md](patterns.md) | 実装パターン | コード規約と実装パターン |
 | [design-principles.md](design-principles.md) | 設計原則 | アーキテクチャ設計原則 |
 | [quality-specs.md](quality-specs.md) | 品質仕様 | 品質基準・検証ルール |
+| [document-model.md](document-model.md) | 文書モデル | REQ/ADR/SPEC/guides/DOC-MAP の責務マトリックス |
+| [artifact-contracts.md](artifact-contracts.md) | アーティファクト契約 | Command/Skill/Template/Script の入出力・依存方向 |
+| [integrity-contracts.md](integrity-contracts.md) | 整合性契約 | strict/warning/observation 分類と検査カテゴリ |
+| [workflow-contracts.md](workflow-contracts.md) | ワークフロー契約 | コマンドパイプラインの入出力・前提条件 |
 
 ## Document Relationships (REQ-0101)
 

--- a/docs/specs/artifact-contracts.md
+++ b/docs/specs/artifact-contracts.md
@@ -1,0 +1,71 @@
+# Artifact Contracts Specification
+
+> **Scope**: This SPEC applies to the agent-dev-flow repository only.
+
+## Purpose
+
+Command / Skill / Template / Script の入出力契約と依存方向を定義し、アーティファクト間の責務境界を明確にする（REQ-0103）。
+
+## Artifact Types
+
+| 種別 | 配置先 | 責務 | 入力 | 出力 |
+|---|---|---|---|---|
+| Command | `.opencode/commands/agentdev/` | ユーザー向け入口、入出力、ガードレール、高レベル Steps | ユーザー起動、GitHub Issue | PR、Issue 更新、完了報告 |
+| Skill | `.opencode/skills/` | 再利用可能な判断基準、domain knowledge | Command からの参照 | 判断結果の参照提供 |
+| Template | `.opencode/skills/*/templates/` | 出力構造とプレースホルダー | 変数バインド | Issue/PR 本文、コメント |
+| Script | `.opencode/skills/*/scripts/` | 決定的でテスト可能な実行ロジック | コマンドライン引数 | 標準出力（JSON/Markdown） |
+
+## Dependency Direction
+
+依存方向は Command → Skill の一方向とする。Skill は Command を参照しない。
+
+```
+Command ──→ Skill ──→ Reference (references/)
+   │             │
+   │             └──→ Script (scripts/)
+   │                    └──→ Template (templates/)
+   │
+   └──→ Template（直接参照の場合あり）
+```
+
+- Command は Skill を参照して判断基準を得る。
+- Skill は Reference（`references/`）に詳細を分離する。
+- Script は Skill 配下に配置し、Command から間接的に利用される。
+- Template は Skill 配下に配置し、Command または Skill から利用される。
+
+## Command Frontmatter Contract
+
+```yaml
+---
+description: コマンドの簡潔な説明
+agent: prometheus | sisyphus
+---
+```
+
+許可フィールドは `description` と `agent` のみ。`implementation_pattern`、`secondary_pattern`、`load_skills` 等の dev メタデータは含めない（REQ-0103-015, REQ-0103-044）。
+
+## Skill Structure Contract
+
+```
+<skill-name>/
+  SKILL.md              # 入口カード（目的・使用条件・禁止条件・参照先）
+  references/           # 詳細参照ファイル（runtime 配布物のみ）
+  scripts/              # 決定的処理スクリプト
+  templates/            # 出力構造テンプレート
+```
+
+- `SKILL.md` は progressive disclosure の入口。200 行超で分割を検討。
+- `references/`（複数形）が canonical。`reference/`（単数形）は obsolete 扱い。
+- `references/` は runtime 配布物のみを含める。authoring-only 資料は含めない（REQ-0103-045）。
+
+## Size Constraints
+
+| 種別 | 推奨上限 | 実運用上限 | 例外状態 |
+|---|---|---|---|
+| Command | 100 行 | 150 行 | 200 行超 |
+| SKILL.md | 200 行 | — | integrity-check で報告 |
+| Steps 数 | 5〜12 個 | — | — |
+
+## Scope Declaration
+
+`docs/specs/` は agent-dev-flow レポジトリ専用である。他プロジェクトへの適用を意図しない。

--- a/docs/specs/document-model.md
+++ b/docs/specs/document-model.md
@@ -1,0 +1,58 @@
+# Document Model Specification
+
+> **Scope**: This SPEC applies to the agent-dev-flow repository only.
+
+## Purpose
+
+REQ/ADR/SPEC/guides/DOC-MAP の責務マトリックスを定義し、各文書種別が何を記述し、何を記述しないかを明確にする（REQ-0101）。
+
+## Responsibility Matrix
+
+| 文書種別 | 記述するもの | 記述しないもの |
+|---|---|---|
+| REQ | 現行要件（WHAT: 何を満たすべきか） | 実装詳細、HOW、現在の動作記述 |
+| ADR | 取り返しのつかない技術判断とその理由（WHY） | 運用手順、状態遷移、形式定義 |
+| SPEC | 現在のアーキテクチャ基準（HOW it works now） | 新規要件、将来計画、判断根拠（ADR の管轄） |
+| DOC-MAP | 文書探索・参照経路の入口 | 基準内容の代替、要件定義 |
+| Guides | 人間向けナビゲーション層 | MUST/SHALL 規範表現、REQ/ADR/SPEC 内容の重複 |
+
+## Document Lifecycle
+
+```
+REQ（要件定義）
+  ↓ 判断が必要な場合
+ADR（技術判断記録）
+  ↓ 判断に基づく実装
+SPEC（現在仕様記述）
+  ↓ 探索支援
+DOC-MAP（索引）/ Guides（案内）
+```
+
+- REQ は領域別の総体として管理する。変更の都度 REQ を作成せず、既存 REQ への APPEND / UPDATE で対応する。
+- ADR は `proposed` → `accepted` / `superseded` / `deprecated` の状態遷移を持つ。
+- SPEC は実装とともに変化する「生きた文書」である。REQ や ADR の判断内容を代替しない。
+- DOC-MAP は非正規索引であり、REQ/ADR/SPEC の内容を代替しない。
+- Guides はナビゲーション層であり、規範文書ではない。
+
+## Scope Declaration
+
+`docs/specs/` は agent-dev-flow レポジトリ専用である。他プロジェクトへの適用を意図しない。
+
+## Source-of-Truth Priority
+
+文書間に矛盾がある場合の優先順位（REQ-0101-011）:
+
+1. active REQ
+2. ADR（accepted）
+3. SPEC
+4. DOC-MAP / guides
+
+## Configuration Rules
+
+| 規則 | 内容 |
+|---|---|
+| REQ ID | 4桁ゼロ埋めの安定ID。active/retired を問わず再利用しない |
+| ADR ID | 4桁ゼロ埋め。状態は frontmatter で管理 |
+| SPEC 配置 | `docs/specs/*.md` 直下 |
+| Guides 配置 | `docs/guides/*.md` 直下 |
+| Retired REQ | `docs/requirements/retired/` に配置。現行要件判断に使用しない |

--- a/docs/specs/integrity-contracts.md
+++ b/docs/specs/integrity-contracts.md
@@ -1,0 +1,78 @@
+# Integrity Contracts Specification
+
+> **Scope**: This SPEC applies to the agent-dev-flow repository only.
+
+## Purpose
+
+整合性検査の分類フレームワークを定義し、検査結果の深刻度と対応フローを規定する（REQ-0108）。
+
+## Severity Classification
+
+| 分類 | 意味 | 判定時の動作 | 例 |
+|---|---|---|---|
+| **strict** | 基準違反。即座に修正が必要 | NG として報告し、当該コマンドの完了をブロックする | frontmatter 禁止フィールド混入、必須セクション欠落、broken reference |
+| **warning** | 推奨からの逸脱。修正を推奨 | warning として報告し、完了はブロックしない | 行数超過、旧 namespace 残存、旧 terminology 使用 |
+| **observation** | 情報提供。改善の参考 | info として報告し、対応は任意 | 未使用 skill の発見、改善候補の提示、潜在的 drift |
+
+## Finding Classification
+
+検査で検出された問題の分類:
+
+| Finding 種別 | 説明 | 既定 severity |
+|---|---|---|
+| document-drift | 文書内容と実装の乖離 | warning |
+| broken-reference | リンク切れ・参照先不存在 | strict |
+| obsolete-structure | 廃止済み構造の残存 | warning |
+| canonical-conflict | 基準文書間の矛盾 | strict |
+| workflow-gap | workflow 定義の欠落 | warning |
+| integrity-rule-gap | 検査ルール自体の欠落 | observation |
+
+## Finding Route Map
+
+検出された Finding の対応先:
+
+| Finding 種別 | Route | 対応コマンド |
+|---|---|---|
+| document-drift | intake | `/agentdev/intake-capture` |
+| broken-reference | intake | `/agentdev/intake-capture` |
+| obsolete-structure | intake | `/agentdev/intake-capture` |
+| canonical-conflict | req-define | `/agentdev/req-define` |
+| workflow-gap | intake + learning | `/agentdev/intake-capture` + `learning-capture` |
+| integrity-rule-gap | learning | `learning-capture` |
+
+## Integrity Check Categories
+
+| カテゴリ | 検査対象 |
+|---|---|
+| REQ | frontmatter 整合性、ID 一意性、タグ妥当性 |
+| ADR | status 遷移妥当性、参照 REQ 存在確認 |
+| Skill | USE FOR / DO NOT USE FOR 整合性、references/ 存在確認 |
+| Command | frontmatter 許可フィールド、Steps 構造 |
+| Template | 必須セクション存在、プレースホルダー妥当性 |
+| Workflow | workflow route 定義の整合性 |
+| Link | 文書間リンクの到達性 |
+| Canonical | canonical 境界の遵守 |
+| Lifecycle | 状態遷移の妥当性 |
+| Namespace | 旧 namespace 残存確認 |
+| ImplementationPattern | pattern 定義妥当性（REQ-0108-026〜038） |
+
+## Report Format
+
+検査結果のレポート形式:
+
+- 出力先: `.agentdev/integrity/reports/`
+- 形式: JSON / Markdown
+- Schema: チェック項目ごとの status（OK / NG / warning / info）+ Finding 一覧
+
+## Script Contract
+
+整合性検査スクリプトは共通 CLI 契約に準拠する:
+
+- `--help`, `--json`, `--dry-run` オプションをサポート
+- exit code: 0（OK）、1（NG/warning）、2（error）
+- stdout = 機械可読出力、stderr = 診断メッセージ
+- 非対話実行、破壊的変更禁止
+
+## Scope Declaration
+
+`docs/specs/` は agent-dev-flow レポジトリ専用である。他プロジェクトへの適用を意図しない。

--- a/docs/specs/workflow-contracts.md
+++ b/docs/specs/workflow-contracts.md
@@ -1,0 +1,86 @@
+# Workflow Contracts Specification
+
+> **Scope**: This SPEC applies to the agent-dev-flow repository only.
+
+## Purpose
+
+Workflow 契約の雛形を定義し、コマンドパイプライン間の入出力関係と前提条件を明確にする（REQ-0104）。
+
+## Pipeline Overview
+
+AgentDevFlow は3つのパイプラインで構成される:
+
+| パイプライン | コマンド | 目的 |
+|---|---|---|
+| req/case | req-define → req-save → case-open → case-run → case-close → case-update | 要件定義から実装完了まで |
+| learning | learning-capture → learning-refine → learning-promote | 学びの蓄積・分析・昇華 |
+| intake | intake-capture / intake-from-github → intake-review → intake-promote | 改善候補の収集・審査・昇華 |
+
+## Command I/O Contracts
+
+### req/case Pipeline
+
+| コマンド | 入力 | 出力 | 前提 |
+|---|---|---|---|
+| `/agentdev/req-define` | ユーザー対話、既存要件情報 | 要件 doc（draft） | — |
+| `/agentdev/req-save` | 要件 doc（draft） | REQ/ADR ファイル | req-define 完了 |
+| `/agentdev/case-open` | REQ ファイルまたは要件 doc | GitHub Issue | req-save または req-define 完了 |
+| `/agentdev/case-run` | GitHub Issue | 実装済みブランチ + PR | case-open 完了 |
+| `/agentdev/case-close` | PR | マージ済み + クローズ済み | case-run 完了 |
+| `/agentdev/case-update` | Issue 番号 | 更新済み Issue | Issue 存在 |
+
+### learning Pipeline
+
+| コマンド/スキル | 入力 | 出力 | 前提 |
+|---|---|---|---|
+| `learning-capture`（スキル） | エージェント実行中の観測 | `inbox.md` エントリ | — |
+| `/agentdev/learning-refine` | `inbox.md` | `evaluation-report.md` + `archive/active.md` 更新 | inbox.md にエントリ |
+| `/agentdev/learning-promote` | `evaluation-report.md` | promoted artifact | refine 完了 |
+
+### intake Pipeline
+
+| コマンド | 入力 | 出力 | 前提 |
+|---|---|---|---|
+| `/agentdev/intake-capture` | 手動入力 | inbox item | — |
+| `/agentdev/intake-from-github` | クローズ済み Issue/PR | inbox item | — |
+| `/agentdev/intake-review` | inbox items | accepted / archive | inbox に item |
+| `/agentdev/intake-promote` | accepted items | promoted artifact | review 完了 |
+
+### 共通後段
+
+| コマンド | 入力 | 出力 | 前提 |
+|---|---|---|---|
+| `/agentdev/backlog-review` | promoted artifact | review draft | promoted 存在 |
+| `/agentdev/backlog-save` | review draft | RU（Requirement Unit） | review 完了 |
+
+## Workflow Routing
+
+work_type と scale により workflow_route を決定する:
+
+| work_type | scale | workflow_route |
+|---|---|---|
+| bug | any | req-define → case-open → case-run → case-close |
+| feature | standard | req-define → req-save → case-open → case-run → case-close |
+| feature | large | req-define → req-save → case-open（Epic + 子Issue）→ case-run（Wave）→ case-close |
+| maintenance | any | req-define → req-save → case-open → case-run → case-close |
+
+## Epic Orchestrator Contract
+
+scale: large の場合、Epic Orchestrator モードで実行する:
+
+- Epic Issue 本文の `## 実行順序` セクションを SSoT とする
+- Wave 単位で子 Issue を直列または並列実行
+- 親エージェントは orchestration のみ担当し、実装詳細を抱え込まない
+- 失敗時は依存する後続 Wave をスキップ
+
+## Self-Healing Contract
+
+`case-run` の検証失敗時に自律修正を試みる:
+
+- 最大3回の修正ループ（11a / 11c それぞれ独立カウント）
+- 修正範囲は既存要件範囲内に限定
+- 7項目の停止条件に該当した場合は即座停止・ユーザー報告
+
+## Scope Declaration
+
+`docs/specs/` は agent-dev-flow レポジトリ専用である。他プロジェクトへの適用を意図しない。


### PR DESCRIPTION
## 変更内容

Issue #520: Document model + SPEC + responsibility boundaries

REQ/ADR/SPEC/guides/DOC-MAP の責務マトリックスを定義し、新規 SPEC 4ファイルを作成した。

## 変更ファイル

| ファイル | 変更種別 | 内容 |
|---|---|---|
| `docs/specs/document-model.md` | 新規 | 文書種別の責務マトリックス・lifecycle・source-of-truth priority |
| `docs/specs/artifact-contracts.md` | 新規 | Command/Skill/Template/Script の入出力・依存方向・frontmatter 契約 |
| `docs/specs/integrity-contracts.md` | 新規 | strict/warning/observation 分類・finding 分類・route map・検査カテゴリ |
| `docs/specs/workflow-contracts.md` | 新規 | パイプライン I/O 契約・workflow routing・Epic Orchestrator 契約 |
| `docs/specs/README.md` | 更新 | 新規4 SPEC の索引追加 |
| `docs/DOC-MAP.md` | 更新 | 新規4 SPEC のナビゲーション追加 |
| `docs/README.md` | 更新 | 新規4 SPEC のリンク追加 |

## 完了条件

- [x] document-model.md が docs/specs/ に存在し責務マトリックスを含む
- [x] artifact-contracts.md が docs/specs/ に存在しアーティファクト間契約を定義する
- [x] integrity-contracts.md が docs/specs/ に存在し strict/warning/observation 分類を定義する
- [x] workflow-contracts.md が docs/specs/ に存在し workflow 契約の雛形を含む
- [x] 各 SPEC に docs/specs は agent-dev-flow レポジトリ専用の宣言が含まれる

## Findings / Intake候補

該当なし

Parent: #519
Wave: 1
