### PR TITLE
docs(#521): ADR/SPEC reclassification and runtime/authoring separation

### DIFF
--- a/docs/adr/ADR-0013.md
+++ b/docs/adr/ADR-0013.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0013
 title: "runtime / authoring 関心分離"
-status: proposed
+status: accepted
 created: "2026-06-02"
 updated: "2026-06-02"
 ---

--- a/docs/adr/ADR-0014.md
+++ b/docs/adr/ADR-0014.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0014
 title: "ADR / SPEC 再分類基準"
-status: proposed
+status: accepted
 created: "2026-06-02"
 updated: "2026-06-02"
 ---

--- a/docs/adr/ADR-0015.md
+++ b/docs/adr/ADR-0015.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0015
 title: "docs/specs 非runtime依存宣言"
-status: proposed
+status: accepted
 created: "2026-06-02"
 updated: "2026-06-02"
 ---

--- a/docs/adr/ADR-0016.md
+++ b/docs/adr/ADR-0016.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0016
 title: "skill references runtime-only 制約"
-status: proposed
+status: accepted
 created: "2026-06-02"
 updated: "2026-06-02"
 ---

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,10 +18,10 @@
 | ADR-0010 | HITL boundary — 全 agentdev command の Human-in-the-Loop 境界原則 | proposed | 2026-06-02 |
 | ADR-0011 | Manager/orchestrator パターンの限定採用 — 標準構造とはしない | proposed | 2026-06-02 |
 | ADR-0012 | Requirement Source pipeline の正式定義 — promoted→RU→req-define の一貫流 | proposed | 2026-06-02 |
-| ADR-0013 | runtime / authoring 関心分離 | proposed | 2026-06-02 |
-| ADR-0014 | ADR / SPEC 再分類基準 | proposed | 2026-06-02 |
-| ADR-0015 | docs/specs 非runtime依存宣言 | proposed | 2026-06-02 |
-| ADR-0016 | skill references runtime-only 制約 | proposed | 2026-06-02 |
+| ADR-0013 | runtime / authoring 関心分離 | accepted | 2026-06-02 |
+| ADR-0014 | ADR / SPEC 再分類基準 | accepted | 2026-06-02 |
+| ADR-0015 | docs/specs 非runtime依存宣言 | accepted | 2026-06-02 |
+| ADR-0016 | skill references runtime-only 制約 | accepted | 2026-06-02 |
 
 > この README は分類ビューであり、ADR本文のSSoTではない。基準は各 `ADR-{NNNN}.md` ファイルである（REQ-0101）。
 
@@ -37,15 +37,15 @@
 - [ADR-0010](ADR-0010.md) — HITL boundary — 全 agentdev command の Human-in-the-Loop 境界原則
 - [ADR-0011](ADR-0011.md) — Manager/orchestrator パターンの限定採用 — 標準構造とはしない
 - [ADR-0012](ADR-0012.md) — Requirement Source pipeline の正式定義 — promoted→RU→req-define の一貫流
-- [ADR-0013](ADR-0013.md) — runtime / authoring 関心分離
-- [ADR-0014](ADR-0014.md) — ADR / SPEC 再分類基準
-- [ADR-0015](ADR-0015.md) — docs/specs 非runtime依存宣言
-- [ADR-0016](ADR-0016.md) — skill references runtime-only 制約
 
 ### accepted
 
 - [ADR-0005](ADR-0005.md) — AgentDevFlow plugin namespace 統一
 - [ADR-0009](ADR-0009.md) — REQ体系再基準化 — 旧REQ分類モデル・対応表・分類ゲート導入
+- [ADR-0013](ADR-0013.md) — runtime / authoring 関心分離
+- [ADR-0014](ADR-0014.md) — ADR / SPEC 再分類基準
+- [ADR-0015](ADR-0015.md) — docs/specs 非runtime依存宣言
+- [ADR-0016](ADR-0016.md) — skill references runtime-only 制約
 
 ### superseded
 

--- a/docs/specs/design-principles.md
+++ b/docs/specs/design-principles.md
@@ -76,7 +76,7 @@
 - ユーザー向け入口
 - Input / Output
 - 高レベル Steps（5〜12個）
-- 使用する Skill（frontmatter load_skills + Steps 内参照）
+- 使用する Skill（Steps 内参照）
 - 成果物の読み書き対象
 - command 固有 Guardrails
 
@@ -88,6 +88,7 @@
 - script
 - 共通安全手順
 - 複数 command で使う workflow protocol
+- frontmatter の dev メタデータ（implementation_pattern, secondary_pattern, load_skills 等）
 
 ### Skill
 
@@ -126,4 +127,22 @@
 - Wave scheduling を含む
 - サブエージェント protocol を含む
 
-詳細は `artifact-boundaries.md`（REQ-0103〜007）を参照。
+詳細は `artifact-contracts.md`（REQ-0103）を参照。
+
+---
+
+## 6. Runtime / Authoring 関心分離
+
+AgentDevFlow の配布物は runtime（個別プロジェクトで実行可能）と authoring（agent-dev-flow レポジトリ開発用）に明確に分離する（ADR-0013）。
+
+**Runtime 配布物**は自己完結し、agent-dev-flow レポジトリの dev メタデータに依存しないことを保証する:
+- Command frontmatter は `description` と `agent` のみ（REQ-0103-015, ADR-0013）
+- Skill `references/` は runtime 配布物のみを含める（ADR-0016）
+- `docs/specs/` は agent-dev-flow レポジトリ専用の管理文書であり、runtime 配布物の依存先ではない（ADR-0015）
+
+**Authoring 専用物**は agent-dev-flow レポジトリ内でのみ参照される:
+- implementation_pattern 分類定義（design-principles.md）
+- command-authoring / skill-authoring ガイド
+- integrity-check の検査ルール定義
+
+この分離の意図は、**runtime 配布物の移植性と安定性の確保**にある。個別プロジェクトが agent-dev-flow レポジトリの内部構造や開発用メタデータに依存することを防ぐ。


### PR DESCRIPTION
## 変更内容

Issue #521: ADR/SPEC 再分類

ADR-0013〜0016 の内容を SPEC に反映し、design-principles.md に runtime/authoring 分離原則を追記した。

## 変更ファイル

| ファイル | 変更種別 | 内容 |
|---|---|---|
| `docs/adr/ADR-0013.md` | 更新 | status: proposed → accepted |
| `docs/adr/ADR-0014.md` | 更新 | status: proposed → accepted |
| `docs/adr/ADR-0015.md` | 更新 | status: proposed → accepted |
| `docs/adr/ADR-0016.md` | 更新 | status: proposed → accepted |
| `docs/adr/README.md` | 更新 | Status View: 4 ADR を proposed → accepted に移動 |
| `docs/specs/design-principles.md` | 更新 | Section 5 更新（frontmatter dev metadata 除外）、Section 6 追加（runtime/authoring 分離） |

## 完了条件

- [x] design-principles.md Section 5 が runtime/authoring 分離を反映している
- [x] orchestration skill 判定基準が更新されている
- [x] 既存 ADR との整合性が確認されている

## Findings / Intake候補

該当なし

Parent: #519
Wave: 2
