### PR TITLE
feat(#525): guardrails classification and postflight diff checking

### DIFF
--- a/.opencode/skills/agentdev-integrity/SKILL.md
+++ b/.opencode/skills/agentdev-integrity/SKILL.md
@@ -64,6 +64,7 @@ AgentDevFlow 管理下の artifact の整合性検査を集約する skill。機
 | Implementation pattern | `check_integrity.ts` | pattern 定義妥当性、禁止 skill、command-map 一致性、load_skills 意味判断 |
 | Workflow template 構造 | `check_templates.ts` | frontmatter、必須セクション、placeholder、命名規則 |
 | Skill 構造 | `lint_skills.ts` | frontmatter name ↔ dir、USE FOR / DO NOT USE FOR、See Also |
+| Postflight diff | `check_postflight.ts` | read-only command 実行後のファイル変更検知、allowed-changes profile 検証 |
 
 ### Finding レベル（REQ-0108-100~105）
 

--- a/.opencode/skills/agentdev-integrity/scripts/check_postflight.test.ts
+++ b/.opencode/skills/agentdev-integrity/scripts/check_postflight.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "bun:test";
+import {
+  globToRegex,
+  matchesGlob,
+  matchesAnyGlob,
+  computeDiff,
+  verifyDiffs,
+  READ_ONLY_COMMANDS,
+  ALLOWED_CHANGES_PROFILES,
+} from "./check_postflight.ts";
+import type { Snapshot, FileEntry } from "./check_postflight";
+
+describe("globToRegex", () => {
+  it("matches exact file name", () => {
+    expect(globToRegex("README.md").test("README.md")).toBe(true);
+    expect(globToRegex("README.md").test("OTHER.md")).toBe(false);
+  });
+
+  it("matches single wildcard", () => {
+    const re = globToRegex("*.md");
+    expect(re.test("README.md")).toBe(true);
+    expect(re.test("docs/REQ.md")).toBe(false);
+  });
+
+  it("matches globstar (**)", () => {
+    const re = globToRegex("docs/**");
+    expect(re.test("docs/README.md")).toBe(true);
+    expect(re.test("docs/sub/deep.md")).toBe(true);
+    expect(re.test("other/file.md")).toBe(false);
+  });
+
+  it("matches globstar mid-pattern", () => {
+    const re = globToRegex(".agentdev/intake/inbox/**");
+    expect(re.test(".agentdev/intake/inbox/item-001.md")).toBe(true);
+    expect(re.test(".agentdev/intake/inbox/sub/item.md")).toBe(true);
+    expect(re.test(".agentdev/intake/archive/item.md")).toBe(false);
+  });
+
+  it("escapes special regex characters in path", () => {
+    const re = globToRegex("docs/DOC-MAP.md");
+    expect(re.test("docs/DOC-MAP.md")).toBe(true);
+    expect(re.test("docs/DOC+MAP.md")).toBe(false);
+  });
+});
+
+describe("matchesGlob", () => {
+  it("handles backslash paths on windows-style input", () => {
+    expect(matchesGlob("docs\\requirements\\REQ-0101.md", "docs/**")).toBe(true);
+  });
+
+  it("matches exact file with globstar", () => {
+    expect(matchesGlob("docs/DOC-MAP.md", "docs/DOC-MAP.md")).toBe(true);
+  });
+});
+
+describe("matchesAnyGlob", () => {
+  it("returns true when any pattern matches", () => {
+    expect(matchesAnyGlob("docs/requirements/REQ-0101.md", [
+      "docs/adr/**",
+      "docs/requirements/**",
+    ])).toBe(true);
+  });
+
+  it("returns false when no pattern matches", () => {
+    expect(matchesAnyGlob(".agentdev/inbox/item.md", [
+      "docs/**",
+      ".opencode/**",
+    ])).toBe(false);
+  });
+
+  it("returns false for empty patterns", () => {
+    expect(matchesAnyGlob("any/file.txt", [])).toBe(false);
+  });
+});
+
+describe("computeDiff", () => {
+  function makeSnapshot(files: [string, string][]): Snapshot {
+    return {
+      timestamp: "2026-01-01T00:00:00Z",
+      command: "test",
+      rootDir: "/test",
+      files: files.map(([relPath, hash]) => ({
+        relPath,
+        hash,
+        size: 100,
+        mtimeMs: 0,
+      })),
+    };
+  }
+
+  it("detects no changes for identical snapshots", () => {
+    const snap = makeSnapshot([["a.md", "abc123"], ["b.md", "def456"]]);
+    const diffs = computeDiff(snap, snap);
+    expect(diffs).toHaveLength(0);
+  });
+
+  it("detects added files", () => {
+    const before = makeSnapshot([["a.md", "abc123"]]);
+    const after = makeSnapshot([["a.md", "abc123"], ["b.md", "def456"]]);
+    const diffs = computeDiff(before, after);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].change).toBe("added");
+    expect(diffs[0].relPath).toBe("b.md");
+  });
+
+  it("detects removed files", () => {
+    const before = makeSnapshot([["a.md", "abc123"], ["b.md", "def456"]]);
+    const after = makeSnapshot([["a.md", "abc123"]]);
+    const diffs = computeDiff(before, after);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].change).toBe("removed");
+    expect(diffs[0].relPath).toBe("b.md");
+  });
+
+  it("detects modified files", () => {
+    const before = makeSnapshot([["a.md", "abc123"]]);
+    const after = makeSnapshot([["a.md", "changed"]]);
+    const diffs = computeDiff(before, after);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].change).toBe("modified");
+    expect(diffs[0].relPath).toBe("a.md");
+  });
+
+  it("sorts results by path", () => {
+    const before = makeSnapshot([["z.md", "z1"]]);
+    const after = makeSnapshot([["a.md", "a1"], ["z.md", "z2"]]);
+    const diffs = computeDiff(before, after);
+    expect(diffs[0].relPath).toBe("a.md");
+    expect(diffs[1].relPath).toBe("z.md");
+  });
+});
+
+describe("verifyDiffs", () => {
+  it("reports ok for read-only command with no diffs", () => {
+    const result = verifyDiffs("req-define", [], []);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].level).toBe("ok");
+  });
+
+  it("warns on read-only command modifying a file", () => {
+    const result = verifyDiffs("req-define", [
+      { relPath: "docs/README.md", change: "modified" },
+    ], []);
+    const violations = result.violations.filter((v) => v.level === "warning");
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+    expect(violations[0].check).toBe("read-only-violation");
+  });
+
+  it("warns on read-only command adding a file", () => {
+    const result = verifyDiffs("backlog-review", [
+      { relPath: "new-file.md", change: "added" },
+    ], []);
+    const violations = result.violations.filter((v) => v.level === "warning");
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("allows removals in read-only command without violation", () => {
+    const result = verifyDiffs("req-restructure-review", [
+      { relPath: "old-file.md", change: "removed" },
+    ], []);
+    const readOnlyViolations = result.violations.filter(
+      (v) => v.check === "read-only-violation",
+    );
+    expect(readOnlyViolations).toHaveLength(0);
+  });
+
+  it("warns on forbidden path change", () => {
+    const result = verifyDiffs("req-save", [
+      { relPath: ".agentdev/config.json", change: "modified" },
+    ], []);
+    const violations = result.violations.filter((v) => v.level === "warning");
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+    expect(violations[0].check).toBe("forbidden-change");
+  });
+
+  it("allows changes within allowed paths", () => {
+    const result = verifyDiffs("req-save", [
+      { relPath: "docs/requirements/REQ-0101.md", change: "modified" },
+    ], []);
+    const nonOk = result.violations.filter((v) => v.level !== "ok");
+    expect(nonOk).toHaveLength(0);
+  });
+
+  it("warns on unknown command", () => {
+    const result = verifyDiffs("unknown-cmd", [], []);
+    const warnings = result.violations.filter((v) => v.level === "warning");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].check).toBe("profile-lookup");
+  });
+
+  it("respects extra allowed patterns", () => {
+    const result = verifyDiffs("req-save", [
+      { relPath: "extra/file.txt", change: "modified" },
+    ], ["extra/**"]);
+    const nonOk = result.violations.filter((v) => v.level !== "ok" && v.level !== "info");
+    expect(nonOk).toHaveLength(0);
+  });
+});
+
+describe("READ_ONLY_COMMANDS", () => {
+  it("includes integrity-check", () => {
+    expect(READ_ONLY_COMMANDS).toContain("integrity-check");
+  });
+
+  it("includes req-restructure-review", () => {
+    expect(READ_ONLY_COMMANDS).toContain("req-restructure-review");
+  });
+
+  it("includes backlog-review", () => {
+    expect(READ_ONLY_COMMANDS).toContain("backlog-review");
+  });
+
+  it("includes req-define", () => {
+    expect(READ_ONLY_COMMANDS).toContain("req-define");
+  });
+});
+
+describe("ALLOWED_CHANGES_PROFILES", () => {
+  it("has a profile for every command mentioned in the SPEC", () => {
+    const commands = [
+      "req-define", "req-save", "case-open", "case-run", "case-close",
+      "case-update", "integrity-check", "intake-capture", "intake-from-github",
+      "intake-review", "intake-promote", "learning-refine", "learning-promote",
+      "backlog-review", "backlog-save", "req-restructure-review",
+    ];
+    const profiledCommands = ALLOWED_CHANGES_PROFILES.map((p) => p.command);
+    for (const cmd of commands) {
+      expect(profiledCommands).toContain(cmd);
+    }
+  });
+
+  it("read-only commands have minimal allowed lists", () => {
+    for (const cmd of READ_ONLY_COMMANDS) {
+      const profile = ALLOWED_CHANGES_PROFILES.find((p) => p.command === cmd);
+      expect(profile).toBeDefined();
+      if (cmd === "integrity-check") {
+        expect(profile!.allowed).toEqual([".agentdev/integrity/reports/**"]);
+      } else {
+        expect(profile!.allowed).toEqual([]);
+      }
+    }
+  });
+});

--- a/.opencode/skills/agentdev-integrity/scripts/check_postflight.ts
+++ b/.opencode/skills/agentdev-integrity/scripts/check_postflight.ts
@@ -1,0 +1,490 @@
+/**
+ * Postflight diff checking script for AgentDevFlow.
+ *
+ * Verifies that read-only commands do not modify local files after execution.
+ * This implements Phase 1 of the postflight diff checking plan defined in
+ * docs/specs/integrity-contracts.md.
+ *
+ * Usage:
+ *   snapshot phase:
+ *     bun run check_postflight.ts snapshot [--json] [--output <path>]
+ *   verify phase:
+ *     bun run check_postflight.ts verify --snapshot <path> [--json] [--allow <glob>]
+ *   diff phase (standalone):
+ *     bun run check_postflight.ts diff --snapshot <path> [--json]
+ *
+ * Allowed changes profiles are defined per-command in the Allowed Changes
+ * Profile section of docs/specs/integrity-contracts.md.
+ */
+
+import {
+  EXIT_OK,
+  EXIT_NG,
+  EXIT_ERROR,
+  parseArgs,
+  printHelp,
+  ok,
+  warn,
+  ng,
+  computeSummary,
+  formatJsonReport,
+  formatMarkdownReport,
+  determineExitCode,
+  findRepoRoot,
+} from "./cli_utils.ts";
+
+import type {
+  CheckResult,
+  ScanSummary,
+  IntegrityReport,
+} from "./cli_utils.ts";
+
+const SCRIPT_NAME = "check_postflight.ts";
+const SCRIPT_DESCRIPTION = "Postflight diff checker for read-only commands";
+const SCRIPT_USAGE =
+  "bun run .opencode/skills/agentdev-integrity/scripts/check_postflight.ts <snapshot|verify|diff> [options]";
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FileEntry {
+  relPath: string;
+  hash: string;
+  size: number;
+  mtimeMs: number;
+}
+
+interface Snapshot {
+  timestamp: string;
+  command: string;
+  rootDir: string;
+  files: FileEntry[];
+}
+
+interface AllowedChangesProfile {
+  command: string;
+  allowed: string[];
+  forbidden: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Allowed Changes Profiles (from docs/specs/integrity-contracts.md)
+// ---------------------------------------------------------------------------
+
+const READ_ONLY_COMMANDS: string[] = [
+  "req-define",
+  "backlog-review",
+  "req-restructure-review",
+  "integrity-check",
+];
+
+const ALLOWED_CHANGES_PROFILES: AllowedChangesProfile[] = [
+  { command: "req-define", allowed: [], forbidden: ["**"] },
+  { command: "req-save", allowed: ["docs/requirements/**", "docs/adr/**", "docs/DOC-MAP.md"], forbidden: [".agentdev/**", ".opencode/**"] },
+  { command: "case-open", allowed: [], forbidden: [] }, // GitHub only
+  { command: "case-run", allowed: ["**"], forbidden: [".agentdev/**"] },
+  { command: "case-close", allowed: [], forbidden: [".agentdev/intake/inbox/**"] }, // GitHub + worktree
+  { command: "case-update", allowed: [], forbidden: [] }, // GitHub only
+  { command: "integrity-check", allowed: [".agentdev/integrity/reports/**"], forbidden: [] },
+  { command: "intake-capture", allowed: [".agentdev/intake/inbox/**"], forbidden: [] },
+  { command: "intake-from-github", allowed: [".agentdev/intake/inbox/**"], forbidden: [] },
+  { command: "intake-review", allowed: [".agentdev/intake/inbox/**", ".agentdev/intake/archive/**"], forbidden: [] },
+  { command: "intake-promote", allowed: [".agentdev/intake/promoted/**"], forbidden: [] },
+  { command: "learning-refine", allowed: [".agentdev/learning/**"], forbidden: [] },
+  { command: "learning-promote", allowed: [".agentdev/learning/promoted/**"], forbidden: [] },
+  { command: "backlog-review", allowed: [], forbidden: ["**"] },
+  { command: "backlog-save", allowed: ["docs/requirements/**"], forbidden: [".opencode/**"] },
+  { command: "req-restructure-review", allowed: [], forbidden: ["**"] },
+];
+
+// ---------------------------------------------------------------------------
+// Glob matching (minimal implementation)
+// ---------------------------------------------------------------------------
+
+function globToRegex(pattern: string): RegExp {
+  let regex = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "{{GLOBSTAR}}")
+    .replace(/\*/g, "[^/]*")
+    .replace(/\?/g, "[^/]")
+    .replace(/\{\{GLOBSTAR\}\}/g, ".*");
+  return new RegExp(`^${regex}$`);
+}
+
+function matchesGlob(filePath: string, pattern: string): boolean {
+  return globToRegex(pattern).test(filePath.replace(/\\/g, "/"));
+}
+
+function matchesAnyGlob(filePath: string, patterns: string[]): boolean {
+  return patterns.some((p) => matchesGlob(filePath, p));
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot operations
+// ---------------------------------------------------------------------------
+
+function hashFile(filePath: string): string {
+  const content = fs.readFileSync(filePath);
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+function collectFiles(rootDir: string): FileEntry[] {
+  const entries: FileEntry[] = [];
+  const ignoreDirs = new Set([
+    "node_modules", ".git", ".sisyphus", "tmp",
+  ]);
+
+  function walk(dir: string): void {
+    const items = fs.readdirSync(dir, { withFileTypes: true });
+    for (const item of items) {
+      if (item.isDirectory()) {
+        if (ignoreDirs.has(item.name)) continue;
+        walk(path.join(dir, item.name));
+      } else if (item.isFile()) {
+        const fullPath = path.join(dir, item.name);
+        const stat = fs.statSync(fullPath);
+        entries.push({
+          relPath: path.relative(rootDir, fullPath).replace(/\\/g, "/"),
+          hash: hashFile(fullPath),
+          size: stat.size,
+          mtimeMs: stat.mtimeMs,
+        });
+      }
+    }
+  }
+
+  walk(rootDir);
+  return entries;
+}
+
+function takeSnapshot(rootDir: string, command: string): Snapshot {
+  return {
+    timestamp: new Date().toISOString(),
+    command,
+    rootDir: rootDir,
+    files: collectFiles(rootDir),
+  };
+}
+
+function writeSnapshot(snapshot: Snapshot, outputPath: string): void {
+  const dir = path.dirname(outputPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(outputPath, JSON.stringify(snapshot, null, 2), "utf-8");
+}
+
+function readSnapshot(inputPath: string): Snapshot {
+  const content = fs.readFileSync(inputPath, "utf-8");
+  return JSON.parse(content) as Snapshot;
+}
+
+// ---------------------------------------------------------------------------
+// Diff computation
+// ---------------------------------------------------------------------------
+
+interface DiffEntry {
+  relPath: string;
+  change: "added" | "removed" | "modified";
+  beforeHash?: string;
+  afterHash?: string;
+}
+
+function computeDiff(before: Snapshot, after: Snapshot): DiffEntry[] {
+  const diffs: DiffEntry[] = [];
+  const beforeMap = new Map<string, FileEntry>();
+  const afterMap = new Map<string, FileEntry>();
+
+  for (const f of before.files) beforeMap.set(f.relPath, f);
+  for (const f of after.files) afterMap.set(f.relPath, f);
+
+  // Files in after but not before = added
+  for (const [relPath, entry] of afterMap) {
+    if (!beforeMap.has(relPath)) {
+      diffs.push({ relPath, change: "added", afterHash: entry.hash });
+    }
+  }
+
+  // Files in before but not after = removed
+  for (const [relPath, entry] of beforeMap) {
+    if (!afterMap.has(relPath)) {
+      diffs.push({ relPath, change: "removed", beforeHash: entry.hash });
+    }
+  }
+
+  // Files in both = check hash
+  for (const [relPath, beforeEntry] of beforeMap) {
+    const afterEntry = afterMap.get(relPath);
+    if (afterEntry && beforeEntry.hash !== afterEntry.hash) {
+      diffs.push({
+        relPath,
+        change: "modified",
+        beforeHash: beforeEntry.hash,
+        afterHash: afterEntry.hash,
+      });
+    }
+  }
+
+  return diffs.sort((a, b) => a.relPath.localeCompare(b.relPath));
+}
+
+// ---------------------------------------------------------------------------
+// Verification against allowed-changes profile
+// ---------------------------------------------------------------------------
+
+interface VerifyResult {
+  command: string;
+  diffs: DiffEntry[];
+  violations: CheckResult[];
+}
+
+function verifyDiffs(
+  command: string,
+  diffs: DiffEntry[],
+  extraAllowed: string[],
+): VerifyResult {
+  const profile = ALLOWED_CHANGES_PROFILES.find((p) => p.command === command);
+  const results: CheckResult[] = [];
+
+  if (!profile) {
+  results.push(warn(
+      "Postflight",
+      "profile-lookup",
+      `No allowed-changes profile for command "${command}"`,
+    ));
+  }
+
+  const allowed = [...(profile?.allowed || []), ...extraAllowed];
+  const forbidden = profile?.forbidden || [];
+
+  if (diffs.length === 0) {
+    results.push(ok(
+      "Postflight",
+      "file-changes",
+      `No file changes detected for "${command}" command`,
+    ));
+    return { command, diffs, violations: results };
+  }
+
+  for (const diff of diffs) {
+    const isAllowed = matchesAnyGlob(diff.relPath, allowed);
+    const isForbidden = matchesAnyGlob(diff.relPath, forbidden);
+    const isReadOnly = READ_ONLY_COMMANDS.includes(command);
+
+    if (isReadOnly && diff.change !== "removed") {
+      results.push(warn(
+        "Postflight",
+        "read-only-violation",
+        `Read-only command "${command}" modified file: ${diff.relPath} (${diff.change})`,
+        diff.relPath,
+      ));
+    } else if (isForbidden && !isAllowed) {
+      results.push(warn(
+        "Postflight",
+        "forbidden-change",
+        `Command "${command}" modified forbidden path: ${diff.relPath} (${diff.change})`,
+        diff.relPath,
+      ));
+    } else if (!isAllowed && forbidden.length > 0) {
+      results.push(info(
+        "Postflight",
+        "unlisted-change",
+        `Command "${command}" changed unlisted path: ${diff.relPath} (${diff.change})`,
+        diff.relPath,
+      ));
+    } else {
+      results.push(ok(
+        "Postflight",
+        "allowed-change",
+        `Change to ${diff.relPath} is within allowed profile for "${command}"`,
+      ));
+    }
+  }
+
+  return { command, diffs, violations: results };
+}
+
+// ---------------------------------------------------------------------------
+// CLI subcommands
+// ---------------------------------------------------------------------------
+
+function cmdSnapshot(options: ReturnType<typeof parseArgs>): void {
+  const rootDir = findRepoRoot(process.cwd());
+  const command = options.paths[0] || "unknown";
+
+  const snapshot = takeSnapshot(rootDir, command);
+  const defaultOutput = path.join(
+    rootDir, ".sisyphus", "tmp",
+    `postflight-snapshot-${Date.now()}.json`,
+  );
+  const outputPath = options.paths[1] || defaultOutput;
+
+  writeSnapshot(snapshot, outputPath);
+
+  if (options.json) {
+    console.log(JSON.stringify({
+      status: "ok",
+      snapshotPath: outputPath,
+      fileCount: snapshot.files.length,
+      timestamp: snapshot.timestamp,
+    }, null, 2));
+  } else {
+    console.log(`Snapshot saved: ${outputPath}`);
+    console.log(`Files: ${snapshot.files.length}`);
+    console.log(`Command: ${command}`);
+    console.log(`Timestamp: ${snapshot.timestamp}`);
+  }
+}
+
+function cmdVerify(options: ReturnType<typeof parseArgs>): void {
+  const snapshotPath = options.paths[0];
+  if (!snapshotPath) {
+    console.error("Error: snapshot path required for verify command");
+    process.exit(EXIT_ERROR);
+  }
+
+  if (!fs.existsSync(snapshotPath)) {
+    console.error(`Error: snapshot file not found: ${snapshotPath}`);
+    process.exit(EXIT_ERROR);
+  }
+
+  const beforeSnapshot = readSnapshot(snapshotPath);
+  const rootDir = findRepoRoot(process.cwd());
+  const afterSnapshot = takeSnapshot(rootDir, beforeSnapshot.command);
+
+  const diffs = computeDiff(beforeSnapshot, afterSnapshot);
+  const extraAllowed: string[] = [];
+  const allowIdx = process.argv.indexOf("--allow");
+  if (allowIdx !== -1 && process.argv[allowIdx + 1]) {
+    extraAllowed.push(...process.argv[allowIdx + 1].split(","));
+  }
+
+  const verifyResult = verifyDiffs(beforeSnapshot.command, diffs, extraAllowed);
+
+  const summary = computeSummary(verifyResult.violations);
+  const report: IntegrityReport = {
+    timestamp: new Date().toISOString(),
+    script: SCRIPT_NAME,
+    scanned: { "snapshot-files": beforeSnapshot.files.length, "current-files": afterSnapshot.files.length },
+    summary,
+    results: verifyResult.violations,
+  };
+
+  if (options.json) {
+    console.log(formatJsonReport(report));
+  } else {
+    console.log(formatMarkdownReport(report));
+    if (diffs.length > 0) {
+      console.log("## 変更ファイル一覧");
+      console.log("");
+      for (const d of diffs) {
+        console.log(`- ${d.change}: ${d.relPath}`);
+      }
+      console.log("");
+    }
+  }
+
+  process.exit(determineExitCode(summary));
+}
+
+function cmdDiff(options: ReturnType<typeof parseArgs>): void {
+  const snapshotPath = options.paths[0];
+  if (!snapshotPath) {
+    console.error("Error: snapshot path required for diff command");
+    process.exit(EXIT_ERROR);
+  }
+
+  if (!fs.existsSync(snapshotPath)) {
+    console.error(`Error: snapshot file not found: ${snapshotPath}`);
+    process.exit(EXIT_ERROR);
+  }
+
+  const beforeSnapshot = readSnapshot(snapshotPath);
+  const rootDir = findRepoRoot(process.cwd());
+  const afterSnapshot = takeSnapshot(rootDir, beforeSnapshot.command);
+
+  const diffs = computeDiff(beforeSnapshot, afterSnapshot);
+
+  if (options.json) {
+    console.log(JSON.stringify({
+      command: beforeSnapshot.command,
+      diffCount: diffs.length,
+      diffs,
+    }, null, 2));
+  } else {
+    console.log(`Postflight diff for command: ${beforeSnapshot.command}`);
+    console.log(`Changes detected: ${diffs.length}`);
+    console.log("");
+    if (diffs.length === 0) {
+      console.log("No file changes detected.");
+    } else {
+      for (const d of diffs) {
+        const icon = d.change === "added" ? "+" : d.change === "removed" ? "-" : "~";
+        console.log(`  ${icon} ${d.relPath}`);
+      }
+    }
+  }
+
+  process.exit(diffs.length > 0 ? EXIT_NG : EXIT_OK);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const subcommand = args[0];
+
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    printHelp(SCRIPT_NAME, SCRIPT_DESCRIPTION, SCRIPT_USAGE);
+    console.log("SUBCOMMANDS:");
+    console.log("  snapshot [command] [output]   Take a file state snapshot");
+    console.log("  verify <snapshot-path>        Verify no unexpected changes since snapshot");
+    console.log("  diff <snapshot-path>          Show raw diff since snapshot");
+    process.exit(subcommand ? EXIT_OK : EXIT_ERROR);
+  }
+
+  const remainingArgs = args.slice(1);
+  const options = parseArgs(remainingArgs);
+
+  switch (subcommand) {
+    case "snapshot":
+      cmdSnapshot(options);
+      break;
+    case "verify":
+      cmdVerify(options);
+      break;
+    case "diff":
+      cmdDiff(options);
+      break;
+    default:
+      console.error(`Unknown subcommand: ${subcommand}`);
+      console.error("Use --help for usage information");
+      process.exit(EXIT_ERROR);
+  }
+}
+
+// Export for testing
+export {
+  globToRegex,
+  matchesGlob,
+  matchesAnyGlob,
+  collectFiles,
+  computeDiff,
+  verifyDiffs,
+  takeSnapshot,
+  readSnapshot,
+  READ_ONLY_COMMANDS,
+  ALLOWED_CHANGES_PROFILES,
+};
+
+const isMainModule = typeof Bun !== "undefined"
+  && typeof Bun.main === "string"
+  && import.meta.path === Bun.main;
+if (isMainModule) main();

--- a/docs/specs/integrity-contracts.md
+++ b/docs/specs/integrity-contracts.md
@@ -89,3 +89,51 @@
 ## Scope Declaration
 
 `docs/specs/` は agent-dev-flow レポジトリ専用である。他プロジェクトへの適用を意図しない。
+
+## Guardrails Classification
+
+command guardrails を以下の6カテゴリに分類する:
+
+| カテゴリ | 意味 | 例 |
+|---|---|---|
+| **KEEP_AS_GUARDRAIL** | ユーザー安全性に関わる制約。command 定義に残置 | ファイル操作制限、ユーザー承認必須、破壊的操作禁止 |
+| **STATIC_CHECK** | 機械的検証可能な検査。integrity-check に移行 | frontmatter 規約、必須セクション存在、行数上限 |
+| **POSTFLIGHT_DIFF** | 実行後の diff 検証。postflight スクリプトで検査 | 意図しないファイル変更、スコープ外の編集 |
+| **HELPER_SCRIPT** | 補助的処理。script に移行 | 検査・変換・フォーマット処理 |
+| **MOVE_TO_SPEC** | SPEC へ移譲すべき内容。SPEC 定義に委譲 | アーティファクト構造定義、命名規則の詳細 |
+| **DELETE_AS_OBVIOUS** | 自明な制約。削除可能 | LLM 既知の常識的内容 |
+
+## Allowed Changes Profiles
+
+各 command の allowed changes（許可されるファイル変更範囲）:
+
+| Command | Allowed Changes | Forbidden |
+|---|---|---|
+| `req-define` | なし（read-only 対話） | 全ファイル書込 |
+| `req-save` | `docs/requirements/`, `docs/adr/`, `docs/DOC-MAP.md` | `.agentdev/`, `.opencode/` |
+| `case-open` | GitHub Issue/PR のみ | ローカルファイル |
+| `case-run` | worktree 内の全ファイル | worktree 外、`.agentdev/` |
+| `case-close` | GitHub Issue/PR, worktree 削除 | `.agentdev/intake/inbox/` 直接書込 |
+| `case-update` | GitHub Issue のみ | ローカルファイル |
+| `integrity-check` | `.agentdev/integrity/reports/`, `.agentdev/intake/inbox/`（承認時） | 検査対象 artifact |
+| `intake-capture` | `.agentdev/intake/inbox/` | 他 `.agentdev/` パス |
+| `intake-from-github` | `.agentdev/intake/inbox/` | 他 `.agentdev/` パス |
+| `intake-review` | `.agentdev/intake/inbox/`, `archive/` | 他パス |
+| `intake-promote` | `.agentdev/intake/promoted/` | 他パス |
+| `learning-refine` | `.agentdev/learning/` | 他パス |
+| `learning-promote` | `.agentdev/learning/promoted/` | 他パス |
+| `backlog-review` | なし（read-only 対話） | 全ファイル書込 |
+| `backlog-save` | `docs/requirements/` | `.opencode/` |
+| `req-restructure-review` | なし（read-only 診断） | 全ファイル書込 |
+
+## Postflight Diff Checking
+
+postflight diff checking は read-only command から段階導入する:
+
+**Phase 1 — read-only command 検証**:
+- `integrity-check`, `req-restructure-review`, `backlog-review` は実行後にローカルファイル変更がないことを確認
+- 変更が検出された場合は warning として報告
+
+**Phase 2 — 拡張適用**（将来）:
+- `case-run` の実行後、意図しないスコープ外ファイル変更を検出
+- allowed changes profile に基づく diff フィルタリング


### PR DESCRIPTION
## 概要

Epic #519 Wave 6: guardrails 分類体系の定義と postflight diff checking の実装。

Closes #525

## 変更内容

### 1. guardrails 分類定義 (SPEC)

`docs/specs/integrity-contracts.md` に6カテゴリの guardrails 分類を追加:

| カテゴリ | 意味 |
|---|---|
| KEEP_AS_GUARDRAIL | ユーザー安全性に関わる制約 |
| STATIC_CHECK | 機械的検証可能な検査 |
| POSTFLIGHT_DIFF | 実行後の diff 検証 |
| HELPER_SCRIPT | 補助的処理 |
| MOVE_TO_SPEC | SPEC へ移譲すべき内容 |
| DELETE_AS_OBVIOUS | 自明な制約 |

### 2. Allowed Changes Profiles

16コマンド分の allowed changes profile を定義。各コマンドの許可ファイル変更範囲と禁止パスを明示。

### 3. Postflight Diff Checking スクリプト

`check_postflight.ts` を追加:
- `snapshot` サブコマンド: ファイル状態のスナップショット取得
- `verify` サブコマンド: allowed-changes profile に基づく差分検証
- `diff` サブコマンド: 生差分表示
- read-only command (`req-define`, `backlog-review`, `req-restructure-review`, `integrity-check`) のファイル変更検知
- Phase 1 対応（read-only command 検証）

## テスト結果

| テスト | 結果 | 備考 |
|---|---|---|
| `check_postflight.test.ts` | ✅ 29/29 pass | glob, diff, verify, profiles の包括的テスト |
| guardrails categories grep | ✅ 6/6 found | KEEP_AS_GUARDRAIL, STATIC_CHECK, POSTFLIGHT_DIFF, HELPER_SCRIPT, MOVE_TO_SPEC, DELETE_AS_OBVIOUS |
| allowed-changes profiles grep | ✅ 16/16 commands | 全コマンドの profile 定義確認 |
| full integrity suite | ⚠️ 744 pass / 59 fail | 失敗は全て prior wave の既知事項（#524 premise reversal による load_skills frontmatter 削除後の test 追従未完了等）。#525 追加分は全て pass |

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| #525 テスト | 29/29 pass | 全 pass | ✅ |
| SPEC 定義 | 6 categories + 16 profiles + Phase 1/2 plan | 完備 | ✅ |
| prior wave failures | 59 (既知) | N/A (out of scope) | ⚠️ |

## Findings / Intake候補

なし

## Commits

1. `678df30` docs(#525): add guardrails classification and allowed changes profiles
2. `ade5256` feat(#525): add postflight diff checking script for read-only commands
3. `73f1174` docs(#525): register postflight diff checker in integrity skill
