### PR TITLE
feat: command/skill 参照パス不整合修正と integrity-check 存在検査追加

### DIFF
--- a/.opencode/commands/agentdev/backlog-review.md
+++ b/.opencode/commands/agentdev/backlog-review.md
@@ -23,7 +23,7 @@ agent: sisyphus
 
 ### Step 0: 実行前同期
 
-`git pull --ff-only` を実行する。失敗時は構造化エラーメッセージを表示して停止する（`req-backlog` と同一のエラー形式）。
+`git pull --ff-only` を実行する。失敗時は構造化エラーメッセージを表示して停止する（`agentdev-git-worktree` の git-common-procedures.md Section 2 と同一のエラー形式）。
 
 ### Step 1: Artifact 検出
 

--- a/.opencode/commands/agentdev/case-update.md
+++ b/.opencode/commands/agentdev/case-update.md
@@ -26,7 +26,7 @@ agent: sisyphus
    - 検出できない場合はユーザーに番号の指定を求めて停止
 2. 現在のIssue状態を取得 → `agentdev-workflow-lifecycle` のフェーズ体系で現在フェーズを判定
 3. 更新内容に応じて分岐:
-   - **`--body`**: Issue作成時に使用されたテンプレート（`issue_desc_bug.md` / `issue_desc_feature.md` / `issue_desc_epic.md` / `issue_desc_child.md` / `issue_desc_backlog_*.md`）に従って更新。該当テンプレートの【必須】セクションが全て本文に含まれること → `gh issue edit`
+    - **`--body`**: Issue作成時に使用されたテンプレート（`issue_desc_bug.md` / `issue_desc_feature.md` / `issue_desc_epic.md` / `issue_desc_child.md`）に従って更新。該当テンプレートの【必須】セクションが全て本文に含まれること → `gh issue edit`
    - **`--comment`**: テンプレート `.opencode/skills/agentdev-workflow-templates/templates/issue_comment_update.md` を Read tool で読み込み → `gh issue comment`
      - **テンプレート準拠要件**: テンプレートの `【必須】` セクションが全てコメント本文に含まれること。必須セクションが欠落している場合、生成をやり直すこと。
     - **`--req`**: REQファイル更新（詳細フロー以下）。case-update --req は直接 commit+push を行う（req-save への委譲は行わない）:

--- a/.opencode/commands/agentdev/integrity-check.md
+++ b/.opencode/commands/agentdev/integrity-check.md
@@ -22,7 +22,7 @@ AgentDevFlow 管理下の artifact（REQ、ADR、skill、command、spec）の整
 
 ## Steps
 
-1. **スクリプト実行**: `agentdev-integrity` の検査スクリプト（`scripts/check_integrity.ts`）を実行。検査カテゴリ・対象パス・検出結果の分類は `agentdev-integrity` SKILL.md の検査カテゴリ定義に準拠
+1. **スクリプト実行**: `agentdev-integrity` の検査スクリプト（`.opencode/skills/agentdev-integrity/scripts/check_integrity.ts`）を実行。検査カテゴリ・対象パス・検出結果の分類は `agentdev-integrity` SKILL.md の検査カテゴリ定義に準拠
    - 検査カテゴリ: REQ frontmatter ↔ ファイル名、ADR ↔ REQ 相互参照、Skill ↔ command 参照、frontmatter 許可フィールド（description + agent のみ）、旧 namespace 残存、完了報告フォーマット（結果欄の責務混在検出・git永続化欄の限定確認・同一事実の重複検出・固定`該当なし`variantの誤用検出・SKILL.md variant数とregistryの一致確認・存在しないvariant参照の検出）、DOC-MAP 存在性・参照整合性、Views 残存、README ↔ ファイル整合性
    - Finding 分類: `document-drift` / `broken-reference` / `obsolete-structure` / `canonical-conflict` / `workflow-gap` / `integrity-rule-gap`（`agentdev-integrity` SKILL.md 参照）
    - Finding ルート: `intake` / `learning` / `intake+learning` / `req-define` / `none`

--- a/.opencode/commands/agentdev/req-define.md
+++ b/.opencode/commands/agentdev/req-define.md
@@ -52,9 +52,7 @@ agent: prometheus
 11. **完了報告**: `agentdev-workflow-reporting` の完了報告variantに従って出力。Pattern に応じたvariantを選択:
     - feature standard → completion-reports/req-define/feature.md
     - feature large (Epic)規模 → completion-reports/req-define/feature-epic.md
-    - bugfix → completion-reports/req-define/bug-or-lightweight.md
-    - maintenance → completion-reports/req-define/maintenance.md
-    - docs_chore → completion-reports/req-define/docs-or-chore.md
+    - bugfix / maintenance / docs_chore → completion-reports/req-define/lightweight.md
 
 ## Guardrails
 

--- a/.opencode/skills/agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/agentdev-integrity/scripts/check_integrity.ts
@@ -2873,6 +2873,151 @@ function checkInlineCompletionReportsStrict(cmdDir: string, root: string): Check
   return results;
 }
 
+// ─── Script / Template / Reference path existence (REQ-0108-115, REQ-0108-116) ─
+
+/**
+ * Regex patterns for file path references in command and skill markdown files.
+ * Captures paths that reference scripts (.ts), templates (.md), or references (.md).
+ */
+const SCRIPT_TEMPLATE_REF_PATTERNS = [
+  // Repo-root-relative: .opencode/skills/agentdev-*/scripts/*.ts
+  /\.opencode\/skills\/(agentdev-[^/\s"')\]]+\/(?:scripts\/[^/\s"')\]]+\.ts|templates\/[^/\s"')\]]+\.md|references\/[^/\s"')\]]+\.md))/g,
+  // Skill-relative: scripts/*.ts, templates/*.md, references/*.md
+  /(?<![.\w/])(scripts\/[^/\s"')\]]+\.ts|templates\/[^/\s"')\]]+\.md|references\/[^/\s"')\]]+\.md)/g,
+];
+
+/**
+ * Check if a line is inside a code block.
+ * Returns true if the cumulative ``` count at that line position is odd.
+ */
+function isInsideCodeBlock(lines: string[], lineIndex: number): boolean {
+  let count = 0;
+  for (let i = 0; i < lineIndex; i++) {
+    if (lines[i].trimStart().startsWith("```")) count++;
+  }
+  // If the current line opens a block, it's not yet inside
+  if (lines[lineIndex].trimStart().startsWith("```")) return count % 2 === 1;
+  return count % 2 === 1;
+}
+
+/**
+ * Check if a matched path is a template placeholder like {xxx} or REQ-{NNNN}.
+ */
+function isTemplatePlaceholder(refPath: string): boolean {
+  if (/\{[^}]*\}/.test(refPath)) return true;
+  return false;
+}
+
+/**
+ * Resolve a referenced path to an absolute filesystem path.
+ * - Repo-root-relative paths start with `.opencode/`
+ * - Skill-relative paths (scripts/..., templates/..., references/...) are resolved
+ *   relative to the skill directory containing the source file.
+ */
+function resolveReferencePath(
+  refPath: string,
+  sourceFilePath: string,
+  root: string,
+  skillsDir: string,
+): string {
+  if (refPath.startsWith(".opencode/")) {
+    return path.join(root, refPath);
+  }
+  if (refPath.startsWith("agentdev-")) {
+    return path.join(skillsDir, refPath);
+  }
+  const relSource = resolveRelative(sourceFilePath, root);
+  const skillsPrefix = ".opencode/skills/";
+  if (relSource.startsWith(skillsPrefix)) {
+    const afterSkills = relSource.slice(skillsPrefix.length);
+    const slashIdx = afterSkills.indexOf("/");
+    if (slashIdx >= 0) {
+      const skillDir = afterSkills.slice(0, slashIdx);
+      return path.join(skillsDir, skillDir, refPath);
+    }
+  }
+  return path.join(root, refPath);
+}
+
+export function checkScriptTemplateReferencePaths(
+  cmdDir: string,
+  skillsDir: string,
+  root: string,
+): CheckResult[] {
+  const results: CheckResult[] = [];
+  const filesToCheck: { absPath: string; skillDir?: string }[] = [];
+
+  // Collect command files
+  for (const file of listFiles(cmdDir).filter((f) => f !== "README.md")) {
+    filesToCheck.push({ absPath: path.join(cmdDir, file) });
+  }
+
+  // Collect skill SKILL.md files and reference files
+  for (const dir of listDirs(skillsDir)) {
+    const skillMd = path.join(skillsDir, dir, "SKILL.md");
+    if (fs.existsSync(skillMd)) {
+      filesToCheck.push({ absPath: skillMd, skillDir: dir });
+    }
+  }
+
+  let foundViolation = false;
+
+  for (const { absPath, skillDir } of filesToCheck) {
+    const content = readText(absPath);
+    if (!content) continue;
+    const relPath = resolveRelative(absPath, root);
+    const lines = content.split("\n");
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+
+      // Skip lines inside code blocks
+      if (isInsideCodeBlock(lines, i)) continue;
+
+      for (const regex of SCRIPT_TEMPLATE_REF_PATTERNS) {
+        regex.lastIndex = 0;
+        let match;
+        while ((match = regex.exec(line)) !== null) {
+          const rawRef = match[1];
+
+          // Skip template placeholders
+          if (isTemplatePlaceholder(rawRef)) continue;
+
+          // Skip paths that are clearly glob patterns
+          if (rawRef.includes("*")) continue;
+
+          const resolvedPath = resolveReferencePath(rawRef, absPath, root, skillsDir);
+
+          if (fs.existsSync(resolvedPath)) {
+            results.push(ok(
+              "ReferencePath", "reference-path-existence",
+              `Referenced path exists: ${rawRef}`,
+            ));
+          } else {
+            foundViolation = true;
+            results.push(ng(
+              "ReferencePath", "reference-path-existence",
+              `Referenced path does not exist: ${rawRef}`,
+              relPath,
+              i + 1,
+              {
+                evidence: rawRef,
+                expected: `file must exist at ${resolveRelative(resolvedPath, root)}`,
+                route: "intake",
+              },
+            ));
+          }
+        }
+      }
+    }
+  }
+
+  if (!foundViolation) {
+    results.push(ok("ReferencePath", "reference-path-existence", "All script/template/reference paths exist"));
+  }
+  return results;
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const options = parseArgs(args);
@@ -2963,6 +3108,7 @@ async function main(): Promise<void> {
     ...checkMappingTable(reqDir, root),
     ...checkSkillFrontmatter(skillsDir, root),
     ...checkCommandFrontmatterDetailed(cmdDir, root),
+    ...checkScriptTemplateReferencePaths(cmdDir, skillsDir, root),
   ];
 
   for (const r of results) {

--- a/.opencode/skills/agentdev-integrity/scripts/check_reference_paths.test.ts
+++ b/.opencode/skills/agentdev-integrity/scripts/check_reference_paths.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdirSync, writeFileSync, copyFileSync, rmSync } from "fs";
+import { join } from "path";
+import type { IntegrityReport } from "./cli_utils.ts";
+
+const SCRIPT_DIR = import.meta.dir;
+const SCRIPT_FILE = join(SCRIPT_DIR, "check_integrity.ts");
+const CLI_UTILS_FILE = join(SCRIPT_DIR, "cli_utils.ts");
+
+const TEMP_BASE = join("C:", "WINDOWS", "TEMP", "opencode");
+const RUN_ID = `ref-paths-test-${crypto.randomUUID().slice(0, 8)}`;
+const TEMP_ROOT = join(TEMP_BASE, RUN_ID);
+
+function mkdirp(p: string): void {
+  mkdirSync(p, { recursive: true });
+}
+
+function copyScripts(fixtureRoot: string): void {
+  const dest = join(fixtureRoot, ".opencode", "skills", "agentdev-integrity", "scripts");
+  mkdirp(dest);
+  copyFileSync(SCRIPT_FILE, join(dest, "check_integrity.ts"));
+  copyFileSync(CLI_UTILS_FILE, join(dest, "cli_utils.ts"));
+}
+
+interface RunResult {
+  exitCode: number;
+  report: IntegrityReport | null;
+  stderr: string;
+}
+
+function runScriptJson(cwd: string): RunResult {
+  const scriptPath = join(cwd, ".opencode", "skills", "agentdev-integrity", "scripts", "check_integrity.ts");
+  const proc = Bun.spawnSync(["bun", "run", scriptPath, "--json"], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = proc.stdout?.toString("utf-8") ?? "";
+  const stderr = proc.stderr?.toString("utf-8") ?? "";
+  let report: IntegrityReport | null = null;
+  try {
+    report = JSON.parse(stdout);
+  } catch {
+  }
+  return { exitCode: proc.exitCode ?? -1, report, stderr };
+}
+
+function buildMinimalFixture(root: string): void {
+  const reqDir = join(root, "docs", "requirements");
+  mkdirp(reqDir);
+  writeFileSync(join(reqDir, "REQ-0001.md"), [
+    "---",
+    "id: REQ-0001",
+    "title: Test",
+    "created: 2025-01-01",
+    "updated: 2025-01-01",
+    "tags:",
+    "  - test",
+    "---",
+    "",
+    "Body.",
+    "",
+  ].join("\n"), "utf-8");
+  writeFileSync(join(reqDir, "README.md"), [
+    "# Requirements",
+    "",
+    "| ID | Title |",
+    "|----|-------|",
+    "| REQ-0001 | Test |",
+    "",
+  ].join("\n"), "utf-8");
+
+  const adrDir = join(root, "docs", "adr");
+  mkdirp(adrDir);
+  writeFileSync(join(adrDir, "ADR-0001.md"), [
+    "---",
+    "id: ADR-0001",
+    "title: Test ADR",
+    "---",
+    "",
+    "Relates to REQ-0001.",
+    "",
+  ].join("\n"), "utf-8");
+
+  const specsDir = join(root, "docs", "specs");
+  mkdirp(specsDir);
+  writeFileSync(join(specsDir, "system.md"), "# System\n\ntest-cmd\n", "utf-8");
+  writeFileSync(join(specsDir, "patterns.md"), "# Patterns\n", "utf-8");
+
+  const skillsDir = join(root, ".opencode", "skills");
+  const minimalSkills = ["agentdev-test-skill", "agentdev-workflow-reporting"];
+  for (const name of minimalSkills) {
+    mkdirp(join(skillsDir, name));
+  }
+  writeFileSync(join(skillsDir, "agentdev-test-skill", "SKILL.md"), "# agentdev-test-skill\n", "utf-8");
+  writeFileSync(join(skillsDir, "agentdev-workflow-reporting", "SKILL.md"), "# agentdev-workflow-reporting\n", "utf-8");
+
+  const reportingRefDir = join(skillsDir, "agentdev-workflow-reporting", "references");
+  mkdirp(reportingRefDir);
+  writeFileSync(join(reportingRefDir, "completion-reports.md"), [
+    "# 完了報告フォーマット",
+    "",
+    "## test-cmd 完了時",
+    "",
+    "```",
+    "✅ test-cmd 完了",
+    "```",
+    "",
+  ].join("\n"), "utf-8");
+
+  const cmdDir = join(root, ".opencode", "commands", "agentdev");
+  mkdirp(cmdDir);
+  writeFileSync(join(cmdDir, "README.md"), [
+    "# Commands",
+    "",
+    "| Command | Description | Agent | Skills |",
+    "|---------|-------------|-------|--------|",
+    "| `agentdev/test-cmd` | Test | test-agent | agentdev-test-skill |",
+    "",
+  ].join("\n"), "utf-8");
+}
+
+describe("checkScriptTemplateReferencePaths", () => {
+  beforeAll(() => {
+    mkdirp(TEMP_ROOT);
+  });
+
+  afterAll(() => {
+    rmSync(TEMP_ROOT, { recursive: true, force: true });
+  });
+
+  it("reports ok when referenced script path exists", () => {
+    const root = join(TEMP_ROOT, "existing-path");
+    buildMinimalFixture(root);
+    copyScripts(root);
+
+    const skillsDir = join(root, ".opencode", "skills");
+    mkdirp(join(skillsDir, "agentdev-test-skill", "scripts"));
+    writeFileSync(join(skillsDir, "agentdev-test-skill", "scripts", "run.ts"), "// ok", "utf-8");
+
+    writeFileSync(join(skillsDir, "agentdev-test-skill", "SKILL.md"), [
+      "---",
+      "name: agentdev-test-skill",
+      "---",
+      "",
+      "See scripts/run.ts for implementation.",
+      "",
+    ].join("\n"), "utf-8");
+
+    const cmdDir = join(root, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test",
+      "agent: oracle",
+      "implementation_pattern: file-pipeline",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "---",
+      "",
+      "Invoke .opencode/skills/agentdev-test-skill/scripts/run.ts.",
+      "",
+    ].join("\n"), "utf-8");
+
+    const result = runScriptJson(root);
+    expect(result.report).not.toBeNull();
+    const refResults = (result.report!.results || []).filter(
+      (r) => r.category === "ReferencePath" && r.check === "reference-path-existence",
+    );
+    const ngResults = refResults.filter((r) => r.level === "ng");
+    expect(ngResults.length).toBe(0);
+    expect(refResults.some((r) => r.level === "ok")).toBe(true);
+  });
+
+  it("reports ng when referenced script path is missing", () => {
+    const root = join(TEMP_ROOT, "missing-path");
+    buildMinimalFixture(root);
+    copyScripts(root);
+
+    const skillsDir = join(root, ".opencode", "skills");
+    mkdirp(join(skillsDir, "agentdev-test-skill", "scripts"));
+
+    const cmdDir = join(root, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test",
+      "agent: oracle",
+      "implementation_pattern: file-pipeline",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "---",
+      "",
+      "Run scripts/missing.ts to validate.",
+      "",
+    ].join("\n"), "utf-8");
+
+    const result = runScriptJson(root);
+    expect(result.report).not.toBeNull();
+    const refNg = (result.report!.results || []).filter(
+      (r) => r.category === "ReferencePath" && r.level === "ng",
+    );
+    expect(refNg.length).toBeGreaterThanOrEqual(1);
+    expect(refNg.some((r) => r.evidence?.includes("missing.ts"))).toBe(true);
+    expect(refNg.every((r) => r.route === "intake")).toBe(true);
+  });
+
+  it("resolves repo-root-relative paths", () => {
+    const root = join(TEMP_ROOT, "root-rel-path");
+    buildMinimalFixture(root);
+    copyScripts(root);
+
+    const skillsDir = join(root, ".opencode", "skills");
+    mkdirp(join(skillsDir, "agentdev-test-skill", "scripts"));
+    writeFileSync(join(skillsDir, "agentdev-test-skill", "scripts", "run.ts"), "// ok", "utf-8");
+
+    const cmdDir = join(root, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test",
+      "agent: oracle",
+      "implementation_pattern: file-pipeline",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "---",
+      "",
+      "Invoke .opencode/skills/agentdev-test-skill/scripts/run.ts.",
+      "",
+    ].join("\n"), "utf-8");
+
+    const result = runScriptJson(root);
+    expect(result.report).not.toBeNull();
+    const refNg = (result.report!.results || []).filter(
+      (r) => r.category === "ReferencePath" && r.level === "ng",
+    );
+    expect(refNg.length).toBe(0);
+  });
+
+  it("does not flag paths inside code blocks", () => {
+    const root = join(TEMP_ROOT, "codeblock-path");
+    buildMinimalFixture(root);
+    copyScripts(root);
+
+    const skillsDir = join(root, ".opencode", "skills");
+    mkdirp(join(skillsDir, "agentdev-test-skill", "scripts"));
+
+    const cmdDir = join(root, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test",
+      "agent: oracle",
+      "implementation_pattern: file-pipeline",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "---",
+      "",
+      "Example:",
+      "```",
+      "scripts/nonexistent.ts",
+      "```",
+      "",
+    ].join("\n"), "utf-8");
+
+    const result = runScriptJson(root);
+    expect(result.report).not.toBeNull();
+    const refNg = (result.report!.results || []).filter(
+      (r) => r.category === "ReferencePath" && r.level === "ng",
+    );
+    expect(refNg.length).toBe(0);
+  });
+
+  it("does not flag template placeholders with curly braces", () => {
+    const root = join(TEMP_ROOT, "placeholder-path");
+    buildMinimalFixture(root);
+    copyScripts(root);
+
+    const cmdDir = join(root, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test",
+      "agent: oracle",
+      "implementation_pattern: file-pipeline",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "---",
+      "",
+      "Run scripts/{script_name}.ts to validate.",
+      "",
+    ].join("\n"), "utf-8");
+
+    const result = runScriptJson(root);
+    expect(result.report).not.toBeNull();
+    const refNg = (result.report!.results || []).filter(
+      (r) => r.category === "ReferencePath" && r.level === "ng",
+    );
+    const placeholderNg = refNg.filter((r) => r.evidence?.includes("{"));
+    expect(placeholderNg.length).toBe(0);
+  });
+
+  it("reports ng for missing repo-root-relative references", () => {
+    const root = join(TEMP_ROOT, "root-rel-missing");
+    buildMinimalFixture(root);
+    copyScripts(root);
+
+    const cmdDir = join(root, ".opencode", "commands", "agentdev");
+    writeFileSync(join(cmdDir, "test-cmd.md"), [
+      "---",
+      "description: Test",
+      "agent: oracle",
+      "implementation_pattern: file-pipeline",
+      "load_skills:",
+      "  - agentdev-test-skill",
+      "---",
+      "",
+      "See .opencode/skills/agentdev-test-skill/scripts/absent.ts for logic.",
+      "",
+    ].join("\n"), "utf-8");
+
+    const result = runScriptJson(root);
+    expect(result.report).not.toBeNull();
+    const refNg = (result.report!.results || []).filter(
+      (r) => r.category === "ReferencePath" && r.level === "ng",
+    );
+    expect(refNg.length).toBeGreaterThanOrEqual(1);
+    expect(refNg.some((r) => r.evidence?.includes("absent.ts"))).toBe(true);
+  });
+
+  it("resolves skill-relative paths from SKILL.md", () => {
+    const root = join(TEMP_ROOT, "skill-relative");
+    buildMinimalFixture(root);
+    copyScripts(root);
+
+    const skillsDir = join(root, ".opencode", "skills");
+    mkdirp(join(skillsDir, "agentdev-test-skill", "scripts"));
+    writeFileSync(join(skillsDir, "agentdev-test-skill", "scripts", "validate.ts"), "// ok", "utf-8");
+
+    writeFileSync(join(skillsDir, "agentdev-test-skill", "SKILL.md"), [
+      "---",
+      "name: agentdev-test-skill",
+      "---",
+      "",
+      "See scripts/validate.ts for implementation.",
+      "",
+    ].join("\n"), "utf-8");
+
+    const result = runScriptJson(root);
+    expect(result.report).not.toBeNull();
+    const refNg = (result.report!.results || []).filter(
+      (r) => r.category === "ReferencePath" && r.level === "ng",
+    );
+    expect(refNg.length).toBe(0);
+  });
+});

--- a/.opencode/skills/agentdev-integrity/scripts/cli_utils.ts
+++ b/.opencode/skills/agentdev-integrity/scripts/cli_utils.ts
@@ -177,6 +177,7 @@ export function classifyFindingLevel(
     "skill-name-dir-match", "skill-use-for-boundary",
     "cmd-implementation-pattern", "cmd-secondary-pattern", "cmd-load-skills-array",
     "cmd-agent-name", "cmd-deprecated-in-inventory",
+    "reference-path-existence",
   ]);
 
   if (STRICT_CHECKS.has(checkType)) return "strict";


### PR DESCRIPTION
## 概要

Issue #544 の実装。command / skill の参照パス不整合を修正し、integrity-check に script / template / reference path の存在検査を追加する。

## 変更内容

### 参照不整合修正（4ファイル）

| ファイル | 修正内容 |
|----------|----------|
| `integrity-check.md` | ルート `scripts/check_integrity.ts` → `.opencode/skills/agentdev-integrity/scripts/check_integrity.ts` |
| `req-define.md` | 存在しない `bug-or-lightweight.md` / `maintenance.md` / `docs-or-chore.md` → `lightweight.md` に統合 |
| `case-update.md` | 存在しない `issue_desc_backlog_*.md` テンプレート参照を削除 |
| `backlog-review.md` | 削除済み `req-backlog` 参照 → 現行の共通 git 手順参照に置換 |

### integrity-check 検査追加

- **check_integrity.ts**: `checkScriptTemplateReferencePaths()` 追加（~145行）
  - REQ-0108-115: script / template / reference path の存在確認
  - REQ-0108-116: 不存在時の構造化 finding 出力（route=intake、manual fallback なし）
- **cli_utils.ts**: `reference-path-existence` を STRICT_CHECKS に追加
- **check_reference_paths.test.ts**: regression test 7件追加（7/7 pass）

## 検証結果

- ユニットテスト: 7/7 pass
- integrity-check 実行: 35 ReferencePath results（27 ok, 8 ng）
- 8 NG は cross-skill `references/` パスの false positive（今後のチューニング対象）

## 関連

- Closes: #544
- 対象 REQ: [REQ-0108](https://github.com/yogata/agent-dev-flow/blob/main/docs/requirements/REQ-0108.md)（REQ-0108-115, 116）
- 関連 ADR: [ADR-0013](https://github.com/yogata/agent-dev-flow/blob/main/docs/adr/ADR-0013.md), [ADR-0016](https://github.com/yogata/agent-dev-flow/blob/main/docs/adr/ADR-0016.md)
