### PR TITLE
feat(#561): integrity-contracts.md に廃止済みskill検知・command-local template検査を追加

### DIFF
--- a/docs/specs/integrity-contracts.md
+++ b/docs/specs/integrity-contracts.md
@@ -25,6 +25,9 @@
 | accepted ADR のみ引用 | 検査対象外 | proposed / superseded / deprecated ADR 引用を warning として検出 | REQ-0108-125 |
 | reference-path OK診断 | OK結果にfile/line/evidenceなし | per-reference OKにfile/line/evidenceを出力 | REQ-0108-117 |
 | cross-skill裸参照 | 裸参照のcross-skill誤検知なし | 同一skill内になく別skillにある裸参照をstrict NG検出 | REQ-0108-119 |
+| abolished-skill-reference | N/A (検査対象外) | 廃止済み skill (agentdev-workflow-reporting) への参照を strict として検出 | REQ-0108-126 |
+| command-local-template-existence | completion report templates in skill directory | completion report templates in `.opencode/commands/agentdev/templates/{command}/{variant}.md` | REQ-0108-127 |
+| skill-spec-dependency | N/A (検査対象外) | runtime skill から docs/specs/ への直接依存を warning として検出 | REQ-0108-128 |
 
 ## Severity Classification
 
@@ -79,6 +82,9 @@
 | RuidGroundReference | docs 永続文書内の RU-ID 参照検出（REQ-0108-122） |
 | WorkflowStatusProhibition | workflow status / 6 マイクロフェーズ検出（REQ-0108-123） |
 | AcceptedAdrCitation | accepted 以外の ADR 引用検出（REQ-0108-125, SHOULD） |
+| AbolishedSkillReference | 廃止済み skill への参照検知（REQ-0108-126） |
+| CommandLocalTemplate | command-local template 存在・整合性検査（REQ-0108-127） |
+| SkillSpecDependency | runtime skill から docs/specs/ への直接依存検出（REQ-0108-128） |
 
 ## Report Format
 


### PR DESCRIPTION
# PR本文テンプレート

## 概要

Issue #561: `docs/specs/integrity-contracts.md` に reporting skill 廃止に伴う新検査カテゴリ・前提逆転記録を追加する。

Parent Epic: #559 "reporting skill 廃止と skill/SPEC 責務分離"

## 実装内容

### Premise Reversal Record に3件追加

| 検査 | 旧前提 | 新前提 | 根拠 REQ |
|---|---|---|---|
| abolished-skill-reference | N/A (検査対象外) | 廃止済み skill (agentdev-workflow-reporting) への参照を strict として検出 | REQ-0108-126 |
| command-local-template-existence | completion report templates in skill directory | completion report templates in `.opencode/commands/agentdev/templates/{command}/{variant}.md` | REQ-0108-127 |
| skill-spec-dependency | N/A (検査対象外) | runtime skill から docs/specs/ への直接依存を warning として検出 | REQ-0108-128 |

### Integrity Check Categories に3件追加

| カテゴリ | 検査対象 |
|---|---|
| AbolishedSkillReference | 廃止済み skill への参照検知（REQ-0108-126） |
| CommandLocalTemplate | command-local template 存在・整合性検査（REQ-0108-127） |
| SkillSpecDependency | runtime skill から docs/specs/ への直接依存検出（REQ-0108-128） |

## 完了条件

- [x] Premise Reversal Record に reporting skill 廃止が記録されていること
- [x] 新検査カテゴリ（abolished-skill-detection・command-local-template-check）が追加されていること
- [x] completion report 検査の基準パスが新配置に更新されていること
- [x] 旧 load_skills 前提の記述が削除されていること

## テスト結果

SPEC ファイルの更新のみ。表形式の一貫性を確認済み。

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 変更ファイル数 | 1 | 1のみ | ✅ |
| 表形式整合性 | 全表の列数一致 | 列数一致 | ✅ |
| REQ参照正確性 | REQ-0108-126~128 | 根拠REQあり | ✅ |

## Findings / Intake候補

該当なし

Closes #561
