### PR TITLE
fix: case-auto 工程間状態引き継ぎ・capture完了条件補強 (#593)

### DIFF
--- a/.opencode/commands/agentdev/case-auto.md
+++ b/.opencode/commands/agentdev/case-auto.md
@@ -23,8 +23,8 @@ agent: sisyphus
 3. **工程分岐**（REQ-0114-008〜009）:
    - feature: req-save → case-open → case-run → case-close
    - bugfix / maintenance / docs_chore: case-open → case-run → case-close（req-save をスキップ）
-4. **各工程の実行**（REQ-0114-006〜007）: 既存コマンド定義（req-save.md / case-open.md / case-run.md / case-close.md）を authoritative source として読み込み、各コマンドの Steps / Guardrails / Error handling に従って実行する。手順を再実装しない
-5. **工程間の状態引き継ぎ**（REQ-0114-020）: 各工程の成果物（Issue番号、PR番号）を次工程の入力として渡す
+4. **各工程の実行**（REQ-0114-006〜007）: 既存コマンド定義（req-save.md / case-open.md / case-run.md / case-close.md）を authoritative source として読み込み、各コマンドの Steps / Guardrails / Error handling に従って実行する。手順を再実装しない。各工程の後段処理（case-open の RU 削除、case-close の learning/intake capture・.agentdev/ commit/push 等）も含めて既存コマンド定義に従うこと
+5. **工程間の状態引き継ぎ**（REQ-0114-020）: 各工程の成果物（Issue番号、PR番号）を次工程の入力として渡す。加えて以下の引き継ぎ情報を最終工程まで保持すること: (1) 要件docの Requirement Source セクション内容（RU 削除判定に使用） (2) RU ファイルパス（case-open 相当処理の RU 削除で使用） (3) capture 対象情報（case-close 相当処理の learning/intake capture で使用）
 6. **停止条件の検出**（REQ-0114-016）: 以下のいずれかを検出した場合、実行を停止し停止理由・現在地点・再開可能な次コマンドを報告する:
    - (1) req-define合意要件からの逸脱
    - (2) 要件未合意のscope拡大

--- a/docs/requirements/REQ-0114.md
+++ b/docs/requirements/REQ-0114.md
@@ -38,6 +38,19 @@ repo に閉じる変更に限り、エージェントが自律的に実装・検
 | REQ-0114-020 | case-auto は各工程の入力解決、工程分岐、工程間の状態引き継ぎ、停止時の現在地点・再開コマンド報告を担うこと（SHALL） |
 | REQ-0114-021 | 自走対象に docs / REQ / ADR / SPEC / command reference / guide の更新を含めること（SHALL） |
 | REQ-0114-022 | 以下のドキュメント整備を行うこと（SHALL）: `.opencode/commands/agentdev/case-auto.md` 新規追加、`.opencode/commands/agentdev/README.md` への追加、`README.md` 入口表への追加、`docs/guides/command-selection.md` への追加、`docs/guides/req-case-flow.md` への最大自走モード追加 |
+| REQ-0114-023 | case-auto は要件doc の Requirement Source セクションを case-open 相当処理の完了まで保持すること（SHALL） |
+| REQ-0114-024 | case-open 相当処理において、case-open.md Step 13a と同一条件で RU ファイルを削除すること（SHALL） |
+| REQ-0114-025 | Issue 作成または VERIFY に失敗した場合、RU ファイルを残置し完了扱いにしないこと（SHALL） |
+| REQ-0114-026 | RU パターン（`.agentdev/backlog/req-units/RU-*.md`）に一致しない Requirement Source は削除しないこと（SHALL） |
+| REQ-0114-027 | RU ファイル削除後に同期確認を行うこと（SHALL）: (1) main 作業ディレクトリの HEAD と `origin/main` が一致していること (2) `git status --porcelain` に削除済み RU ファイルが残っていないこと |
+| REQ-0114-028 | 同期確認に失敗した場合、対象ファイル・現在の HEAD・`origin/main` を表示して完了扱いにせず停止すること（SHALL） |
+| REQ-0114-029 | case-close 相当処理において、`agentdev-learning-capture` スキルに従い learning capture を実行すること（SHALL） |
+| REQ-0114-030 | case-close 相当処理において、Post-run intake capture を実行すること（SHALL）: PR本文の `## Findings / Intake候補` セクションから回収し `.agentdev/intake/inbox/` に保存 |
+| REQ-0114-031 | learning と intake を別々の成果物として扱い、混合した単一成果物にしないこと（SHALL） |
+| REQ-0114-032 | learning/intake を `.agentdev/` 配下に commit/push すること（SHALL）: learning と intake を同一 commit に含める |
+| REQ-0114-033 | `.agentdev/` push 失敗時は完了扱いにしないこと（SHALL）: 失敗内容を報告して停止 |
+| REQ-0114-034 | `docs/specs/workflow-contracts.md` の case-auto intake 欄を `WRITE（capture）` に修正すること（SHALL） |
+| REQ-0114-035 | case-auto の参照フローが case-close 相当処理と矛盾しない内容であること（SHALL） |
 
 ## 適用範囲
 
@@ -63,7 +76,7 @@ repo に閉じる変更に限り、エージェントが自律的に実装・検
 
 ### 直接矛盾（要更新）
 
-なし（新規 REQ のため）
+- `docs/specs/workflow-contracts.md` — case-auto intake 欄が `—`（未処理）となっており `WRITE（capture）` への修正が必要（REQ-0114-034）
 
 ### 更新候補（影響確認必要）
 
@@ -71,6 +84,7 @@ repo に閉じる変更に限り、エージェントが自律的に実装・検
 - `docs/requirements/REQ-0103.md` — orchestration command の責務境界に関する追記候補
 - `docs/requirements/REQ-0106.md` — case 実行・完了処理における case-auto との関係に関する追記候補
 - `docs/specs/workflow-contracts.md` — case-auto の自走境界・停止条件に関する追記候補
+- `docs/guides/artifacts-and-state.md` — case-auto 成果物に learning/intake を含むか確認（REQ-0114-029〜033）
 - `docs/specs/system.md` — コマンド一覧への case-auto 追加候補
 - `docs/DOC-MAP.md` — 新規コマンドに伴う索引更新候補
 - `docs/guides/artifacts-and-state.md` — case-auto の成果物に関する追記候補

--- a/docs/specs/workflow-contracts.md
+++ b/docs/specs/workflow-contracts.md
@@ -129,7 +129,7 @@ draft（`.sisyphus/drafts/req-draft-*.md`）は壁打ちフェーズ内の一時
 | `/agentdev/case-open` | READ | READ | READ | — | — | — | — |
 | `/agentdev/case-run` | READ+WRITE | READ | READ | — | — | — | — |
 | `/agentdev/case-close` | — | — | READ | — | WRITE（capture） | WRITE（capture） | — |
-| `/agentdev/case-auto` | READ+WRITE | READ+WRITE | READ+WRITE | — | WRITE（capture） | — | — |
+| `/agentdev/case-auto` | READ+WRITE | READ+WRITE | READ+WRITE | — | WRITE（capture） | WRITE（capture） | — |
 | `/agentdev/case-update` | — | — | READ+WRITE | — | — | — | — |
 
 ## Workflow Routing


### PR DESCRIPTION
## 概要

case-auto が case-open/case-close 相当処理を実行する際の工程間状態引き継ぎ不足を修正する。RU 削除、learning/intake capture の漏れを防止し、workflow-contracts.md の intake 欄矛盾を解消する。

## 実装内容

- `docs/requirements/REQ-0114.md`: REQ-0114-023〜035 の 13 要件行を APPEND（RU 削除条件、同期確認、learning/intake capture、完了条件を規定）
- `.opencode/commands/agentdev/case-auto.md`: Step 4 に後段処理参照の補足追記、Step 5 に状態引き継ぎ項目（Requirement Source / RU パス / capture 対象情報）を追加
- `docs/specs/workflow-contracts.md`: case-auto intake 欄を `—` → `WRITE（capture）` に修正

## 完了条件

- [x] REQ-0114.md に REQ-0114-023〜035 の 13 要件行が APPEND されている
- [x] case-auto.md Step 4 に case-open/case-close 後段処理の補足が追記されている
- [x] case-auto.md Step 5 に状態引き継ぎ項目の補足が追記されている
- [x] workflow-contracts.md の case-auto intake 欄が `WRITE（capture）` に修正されている

## テスト結果

差分レビューにより 3 ファイル全変更箇所が要件 doc と一致することを確認。

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 差分-要件 doc 整合性 | 3/3 ファイル一致 | 全ファイル一致 | ✅ |
| REQ ID 採番連番 | 023〜035 連番 | 連番 | ✅ |
| workflow-contracts.md intake 欄 | WRITE（capture） | WRITE（capture） | ✅ |

## Findings / Intake候補

該当なし

Closes #593
