### PR TITLE
feat: 適用プロジェクト導入モデル・runtime package境界 (#601)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@
 - [Artifact Contracts](specs/artifact-contracts.md)
 - [Integrity Contracts](specs/integrity-contracts.md)
 - [Workflow Contracts](specs/workflow-contracts.md)
+- [Runtime Package Boundary](specs/runtime-package-boundary.md)
 
 ## ADR
 
@@ -50,6 +51,7 @@
 - [診断・メンテナンス](guides/diagnostics-and-maintenance.md)
 - [成果物・状態モデル](guides/artifacts-and-state.md)
 - [プロジェクトドキュメントと SPEC](guides/project-docs-and-specs.md)
+- [Consumer Project 導入](guides/consumer-project-setup.md)
 - [トラブルシューティング](guides/troubleshooting.md)
 - [用語集](guides/glossary.md)
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -15,5 +15,6 @@
 | [診断・メンテナンス](diagnostics-and-maintenance.md) | integrity-check / req-restructure-review |
 | [成果物・状態モデル](artifacts-and-state.md) | 成果物の種別・配置・ライフサイクル |
 | [プロジェクトドキュメントと SPEC](project-docs-and-specs.md) | REQ / ADR / SPEC / DOC-MAP の関係 |
+| [Consumer Project 導入](consumer-project-setup.md) | AgentDevFlow の適用プロジェクト導入手順 |
 | [トラブルシューティング](troubleshooting.md) | よくある問題と対処法 |
 | [用語集](glossary.md) | AgentDevFlow の用語定義 |

--- a/docs/guides/consumer-project-setup.md
+++ b/docs/guides/consumer-project-setup.md
@@ -1,0 +1,143 @@
+# Consumer Project 導入モデル
+
+AgentDevFlow を適用プロジェクトに導入する際の model を定義する（REQ-0103-061~065）。
+
+## 4 種の Repo Type
+
+| Type | 説明 | `.opencode/` の意味 | 例 |
+|------|------|---------------------|-----|
+| **self-hosting** | AgentDevFlow 本体開発 repo。source と projection が同一 repo に存在 | `.opencode/` = runtime projection（junction → `src/opencode/`） | agent-dev-flow |
+| **consumer-with-agentdev** | AgentDevFlow を導入する製品 repo。AgentDevFlow 提供 skill/command を利用 | `.opencode/` = project-local customization 入口 + AgentDevFlow 提供 command/skill の runtime 位置 | 各種製品開発 repo |
+| **consumer-local** | AgentDevFlow を利用しない OpenCode プロジェクト。独自 command/skill のみ | `.opencode/` = project-local customization 専用。`agentdev` namespace は使用しない | 実験的 repo |
+| **plugin-future** | 将来の plugin/npm/package 配布形態（現在は未対応） | `.opencode/` = plugin が管理する runtime 位置 | （将来） |
+
+## `.opencode/` の意味の違い
+
+### Self-hosting (AgentDevFlow 本体)
+
+```
+.opencode/           → junction → src/opencode/ (runtime projection)
+src/opencode/
+  commands/agentdev/  → canonical source (18 commands)
+  skills/agentdev-*/  → canonical source (21 skills)
+```
+
+- source 編集は `src/opencode/` で行う
+- `.opencode/` は junction/symlink による runtime projection
+- `sync-opencode.ps1` で source↔projection 同期を管理
+
+### Consumer-with-agentdev (適用プロジェクト)
+
+```
+.opencode/
+  commands/agentdev/  → AgentDevFlow 提供 command (symlink or copy)
+  commands/{local}/   → project-local command
+  skills/agentdev-*/  → AgentDevFlow 提供 skill (symlink or copy)
+  skills/{local}-*/   → project-local skill
+```
+
+- `.opencode/` は AgentDevFlow 提供 command/skill と project-local customization の混在場所
+- AgentDevFlow 提供 file は symlink 推奨、copy 非推奨
+- project-local file は直接管理
+
+### Consumer-local (非AgentDevFlow プロジェクト)
+
+```
+.opencode/
+  commands/{local}/   → project-local command のみ
+  skills/{local}-*/   → project-local skill のみ
+```
+
+- AgentDevFlow namespace を使用しない
+- 自由に `.opencode/` を管理
+
+## Reserved Names
+
+| 名前 | 種別 | 使用可能な Repo Type |
+|------|------|---------------------|
+| `agentdev` | command namespace | self-hosting, consumer-with-agentdev |
+| `agentdev-*` | skill prefix | self-hosting, consumer-with-agentdev |
+| `.agentdev/` | domain state directory | self-hosting, consumer-with-agentdev |
+| `agentdev-integrity` | integrity skill | self-hosting, consumer-with-agentdev |
+
+**禁止事項**:
+- consumer-local での `agentdev` namespace 使用（REQ-0103-056）
+- consumer-with-agentdev での AgentDevFlow 提供 file の直接編集（上書きされる可能性）
+
+## Installation Method Policy
+
+| Method | 対応 | 推奨 | 備考 |
+|--------|------|------|------|
+| Symlink (junction on Windows) | ✅ | **推奨** | 更新が自動反映、source が単一 |
+| Copy | ⚠️ | 非推奨 | 手動更新が必要、drift リスク |
+| Git submodule | ⚠️ | 検討可能 | 複雑性が増す |
+| Plugin/npm/package | ❌ | 将来対応 | REQ-0103-064 で将来 option 扱い |
+
+### Symlink-based installation (推奨)
+
+```powershell
+# Windows (junction)
+cmd /c "mklink /J .opencode\commands\agentdev <agentdev-path>\src\opencode\commands\agentdev"
+cmd /c "mklink /J .opencode\skills\agentdev-gh-cli <agentdev-path>\src\opencode\skills\agentdev-gh-cli"
+
+# Unix (symlink)
+ln -s <agentdev-path>/src/opencode/commands/agentdev .opencode/commands/agentdev
+ln -s <agentdev-path>/src/opencode/skills/agentdev-gh-cli .opencode/skills/agentdev-gh-cli
+```
+
+### Copy-based installation (非推奨)
+
+- 初回は手動コピーで動作するが、AgentDevFlow 更新時に再コピーが必要
+- integrity-check で drift を検出可能（IR-016）
+
+## Sync Script Scope
+
+| Repo Type | sync-opencode.ps1 の適用範囲 |
+|-----------|------------------------------|
+| self-hosting | `src/opencode/` ↔ `.opencode/` の全体同期 |
+| consumer-with-agentdev | AgentDevFlow 提供 file のみ同期（project-local file は対象外） |
+| consumer-local | 適用対象外 |
+
+### Self-hosting での sync
+
+```powershell
+./sync-opencode.ps1 -Mode apply   # src/opencode/ → .opencode/ 同期
+./sync-opencode.ps1 -Mode check   # divergence 検出
+./sync-opencode.ps1 -Mode dry-run # 変更予測
+```
+
+### Consumer-with-agentdev での sync
+
+Consumer では `sync-opencode.ps1` は AgentDevFlow 本体から提供されるファイルのみを同期対象とする。project-local customization は同期対象外。
+
+## Project-Local Naming Rules
+
+Consumer project で独自 command/skill を追加する場合:
+
+| Rule | 説明 |
+|------|------|
+| Namespace 衝突回避 | `agentdev` および `agentdev-*` は使用不可 |
+| kebab-case | skill 名は小文字・数字・ハイフンのみ（REQ-0103-011） |
+| 意味的命名 | project 名や domain 名を prefix に含めることを推奨 |
+| 独自 directory | 独自 skill は `.opencode/skills/{project}-*/` に配置 |
+
+例: プロジェクト `myapp` の場合:
+- command: `.opencode/commands/myapp/`
+- skill: `.opencode/skills/myapp-deployment/`
+
+## Migration Guide
+
+### 新規 Consumer 導入手順
+
+1. AgentDevFlow repo を clone または download
+2. `.opencode/commands/agentdev/` に junction/symlink を作成
+3. 必要な skill ごとに `.opencode/skills/agentdev-*/` に junction/symlink を作成
+4. `sync-opencode.ps1 -Mode check` で動作確認
+5. `.agentdev/` directory が存在することを確認
+
+### 既存プロジェクトへの導入手順
+
+1. 既存の `.opencode/` 内容を確認
+2. `agentdev` namespace との衝突がないことを確認
+3. AgentDevFlow 提供 file を symlink で追加
+4. integrity-check で整合性確認

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -17,6 +17,7 @@ They describe what the system *is* now, as opposed to REQ files that define what
 | [artifact-contracts.md](artifact-contracts.md) | アーティファクト契約 | Command/Skill/Template/Script の入出力・依存方向 |
 | [integrity-contracts.md](integrity-contracts.md) | 整合性契約 | strict/warning/observation 分類と検査カテゴリ |
 | [workflow-contracts.md](workflow-contracts.md) | ワークフロー契約 | コマンドパイプラインの入出力・前提条件 |
+| [runtime-package-boundary.md](runtime-package-boundary.md) | Runtime Package 境界 | Repo type 別 `.opencode/` 定義・命名規約・導入方式・sync 範囲 |
 
 ## Document Relationships (REQ-0101)
 

--- a/docs/specs/runtime-package-boundary.md
+++ b/docs/specs/runtime-package-boundary.md
@@ -1,0 +1,145 @@
+# Runtime Package Boundary Specification
+
+> **Scope**: This SPEC applies to the agent-dev-flow repository and its consumer projects.
+
+## Purpose
+
+AgentDevFlow の runtime package 境界を定義し、self-hosting repo と consumer project での `.opencode/` 役割・命名・導入方式・sync 範囲を明確化する（REQ-0103-061~065）。
+
+## 4 種の Repo Type
+
+| Type ID | 名称 | 説明 | `.opencode/` の意味 | 典型例 |
+|---------|------|------|---------------------|--------|
+| `self-hosting` | AgentDevFlow 本体開発 repo | source と projection が同一 repo に存在 | runtime projection（junction → `src/opencode/`） | `agent-dev-flow` |
+| `consumer-with-agentdev` | AgentDevFlow 導入製品 repo | AgentDevFlow 提供 skill/command を利用 | project-local customization 入口 + AgentDevFlow runtime 位置 | 各種製品開発 repo |
+| `consumer-local` | 非 AgentDevFlow OpenCode project | 独自 command/skill のみ | project-local customization 専用 | 実験的 repo |
+| `plugin-future` | 将来の plugin/npm/package 配布形態 | 現在は未対応 | plugin が管理する runtime 位置 | （将来） |
+
+### Repo Type 判定基準
+
+| 条件 | Repo Type |
+|------|-----------|
+| `src/opencode/` が存在し `.opencode/` が junction | `self-hosting` |
+| `.opencode/commands/agentdev/` または `.opencode/skills/agentdev-*/` が存在 | `consumer-with-agentdev` |
+| `.opencode/` が存在し `agentdev` namespace を含まない | `consumer-local` |
+| 上記いずれでもない | N/A（OpenCode 非使用 repo） |
+
+## `.opencode/` Semantics by Repo Type
+
+### Self-hosting
+
+```
+.opencode/           → junction → src/opencode/ (runtime projection)
+src/opencode/
+  commands/agentdev/  → canonical source
+  skills/agentdev-*/  → canonical source
+```
+
+- Source 編集は `src/opencode/` で実施
+- `.opencode/` は junction/symlink による runtime projection
+- `sync-opencode.ps1` で source↔projection 同期を管理
+- `.gitignore` に `.opencode/` を登録（junction はローカル runtime projection）
+
+### Consumer-with-agentdev
+
+```
+.opencode/
+  commands/agentdev/  → AgentDevFlow 提供 command (symlink or junction)
+  commands/{local}/   → project-local command
+  skills/agentdev-*/  → AgentDevFlow 提供 skill (symlink or junction)
+  skills/{local}-*/   → project-local skill
+```
+
+- AgentDevFlow 提供 file は symlink/junction 推奨、copy は非推奨
+- Project-local file は直接管理
+- `.agentdev/` domain state directory が存在
+
+### Consumer-local
+
+```
+.opencode/
+  commands/{local}/   → project-local command のみ
+  skills/{local}-*/   → project-local skill のみ
+```
+
+- `agentdev` namespace を使用しない（REQ-0103-056）
+- 自由に `.opencode/` を管理
+
+### Plugin-future（将来）
+
+現在は要件定義のみ。npm/package 配布時に `.opencode/` が plugin により管理される形態を想定。
+
+## Project-Local Naming Rules
+
+Consumer project で独自 command/skill を追加する際の命名規約（REQ-0103-063）。
+
+### 予約名（Reserved Names）
+
+| 名前 | 種別 | 使用可能 Repo Type |
+|------|------|-------------------|
+| `agentdev` | command namespace | `self-hosting`, `consumer-with-agentdev` |
+| `agentdev-*` | skill prefix | `self-hosting`, `consumer-with-agentdev` |
+| `.agentdev/` | domain state directory | `self-hosting`, `consumer-with-agentdev` |
+
+### 命名規約
+
+| Rule | 説明 | 根拠 |
+|------|------|------|
+| Namespace 衝突回避 | `agentdev` / `agentdev-*` / `.agentdev/` は使用不可 | REQ-0103-056 |
+| kebab-case | skill 名は小文字・数字・ハイフンのみ | REQ-0103-011 |
+| 意味的命名 | project 名や domain 名を prefix に含めることを推奨 | 運用規約 |
+| 独自 directory | 独自 skill は `.opencode/skills/{project}-*/` に配置 | 運用規約 |
+
+### 衝突検出
+
+`consumer-local` repo で `agentdev` namespace が検出された場合、integrity-check（IR-016）が NG として報告する。
+
+## Installation Method Policy
+
+| Method | Status | 推奨度 | 備考 |
+|--------|--------|--------|------|
+| Symlink / Junction | 対応済み | **推奨** | 更新自動反映、source 単一管理 |
+| Copy | 対応済み | 非推奨 | 手動更新必要、drift リスク |
+| Git submodule | 検討可能 | 実験的 | 複雑性増加 |
+| Plugin / npm / package | 未対応 | 将来対応 | REQ-0103-064 |
+
+### Symlink / Junction の制約
+
+| Platform | 方法 | 制約 |
+|----------|------|------|
+| Windows | Junction (`mklink /J`) | 管理者権限不要、ディレクトリのみ対応 |
+| Windows | Symlink (`mklink /D`) | 開発者モードまたは管理者権限が必要 |
+| Unix | Symlink (`ln -s`) | 権限不要 |
+
+### Copy の drift 検出
+
+Copy-based installation では AgentDevFlow 更新時に drift が発生する。integrity-check（IR-016）が divergence を検出・報告する。
+
+## Sync Script Scope by Repo Type
+
+`sync-opencode.ps1` の適用範囲（REQ-0103-065）。
+
+| Repo Type | 同期対象 | 非対象 |
+|-----------|----------|--------|
+| `self-hosting` | `src/opencode/` ↔ `.opencode/` の全体 | なし |
+| `consumer-with-agentdev` | AgentDevFlow 提供 file のみ | project-local customization |
+| `consumer-local` | なし（適用対象外） | 全体 |
+| `plugin-future` | （将来定義） | — |
+
+### Self-hosting での sync モード
+
+| Mode | 動作 |
+|------|------|
+| `apply` | `src/opencode/` → `.opencode/` の同期実行 |
+| `check` | divergence 検出（終了コードで判定） |
+| `dry-run` | 変更予測（実行なし） |
+
+### Consumer での sync
+
+Consumer では AgentDevFlow 本体から提供される file のみを同期対象とする。project-local customization は同期の影響を受けない。
+
+## See Also
+
+- [Consumer Project Setup Guide](../guides/consumer-project-setup.md) — Consumer 向け導入手順
+- [Artifact Contracts](artifact-contracts.md) — Command/Skill/Template/Script の責務境界
+- REQ-0103-061~065 — Repo type / `.opencode/` semantics / naming / installation / sync scope の要件定義


### PR DESCRIPTION
## 概要

consumer projectがAgentDevFlowを導入する際のmodelを定義し、self-hostingとconsumerの`.opencode/`意味を分離する。

## 実装内容

- `docs/guides/consumer-project-setup.md` 追加
- 4種 repo type 定義: self-hosting / consumer-with-agentdev / consumer-local / plugin-future
- `.opencode/` の意味を repo type ごとに明確化:
  - self-hosting: runtime projection (junction → src/opencode/)
  - consumer-with-agentdev: project-local customization 入口 + AgentDevFlow runtime
  - consumer-local: project-local customization 専用
- reserved names 文書化: agentdev, agentdev-*, .agentdev/
- installation method policy: symlink推奨、copy非推奨、plugin/npm将来対応
- sync script scope を repo type ごとに定義
- project-local naming rules 定義
- 新規/既存プロジェクト導入手順追加

## 完了条件

- [x] 4種の repo type が定義されている
- [x] `.opencode/` の意味が repo type ごとに明確化されている
- [x] reserved names が文書化されている
- [x] symlink-based installation が支持されている
- [x] sync script の適用範囲が repo type ごとに定義されている
- [x] consumer docs が存在する

## テスト結果

- 4 repo type 定義済み: self-hosting / consumer-with-agentdev / consumer-local / plugin-future
- Reserved names: 4種 (agentdev, agentdev-*, .agentdev/, agentdev-integrity)
- Installation methods: symlink(推奨) / copy(非推奨) / submodule(検討) / plugin(将来)

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| repo types | 4 | 4 | ✅ |
| reserved names | 4 | 全主要名 | ✅ |
| installation methods | 4 | symlink+copy+将来 | ✅ |

## Findings / Intake候補

該当なし

Closes #601
