### PR TITLE
fix: clarify runtime template resolution paths

### DIFF
--- a/docs/requirements/REQ-0108.md
+++ b/docs/requirements/REQ-0108.md
@@ -3,7 +3,7 @@ id: REQ-0108
 title: "Integrity / Validation / Tests"
 created: "2026-05-30"
 updated: "2026-06-06"
-tags: [integrity, validation, tests, integrity-check, regression, finding-level, script-backed, governance, authoring-gate, mapping-table, variant-path, frontmatter-validation, reference-path, cross-skill, command-local-template, abolished-skill-detection, vocabulary-registry, pattern-residual, req-backlog-residual, req-range-staleness, false-positive-handling, source-projection, rule-catalog, baseline, req-impact-map, meta-integrity, authoritative-source, finding-schema, routing-summary]
+tags: [integrity, validation, tests, integrity-check, regression, finding-level, script-backed, governance, authoring-gate, mapping-table, variant-path, frontmatter-validation, reference-path, cross-skill, command-local-template, abolished-skill-detection, vocabulary-registry, pattern-residual, req-backlog-residual, req-range-staleness, false-positive-handling, source-projection, rule-catalog, baseline, req-impact-map, meta-integrity, authoritative-source, finding-schema, routing-summary, runtime-path, template-resolution]
 ---
 
 ## 目的
@@ -182,6 +182,8 @@ AgentDevFlow 管理下の全文書 artifact（REQ/ADR/SPEC/DOC-MAP/guides/comman
 | REQ-0108-166 | report 末尾に routing summary（検査カテゴリ別の OK/NG/WARN 件数集計）を出力すること（SHALL） |
 | REQ-0108-167 | report formatter が文字化け・表示崩れを起こさないこと（SHALL）。特に Windows 環境でのエンコーディング、表組みの桁揃えを考慮すること |
 | REQ-0108-168 | 再発ケース（検査カテゴリ省略・finding 分類 route 欠落・完了報告テンプレート未使用等）を regression test に含めること（SHALL） |
+| REQ-0108-169 | integrity-check は runtime command 定義（`.opencode/commands/**/*.md`）と runtime skill 定義（`.opencode/skills/*/SKILL.md`）内の `src/opencode/` 固定参照を検出すること（SHALL）。runtime 実行時の Read/Glob において `src/opencode/...` を参照先として使用している記述を `canonical-conflict` finding として報告すること（SHALL） |
+| REQ-0108-170 | integrity-check は runtime command 定義内のテンプレート参照先がテンプレート種別に対応する正しい配置先（Issue コメント → `.opencode/skills/agentdev-workflow-templates/templates/issue_comment_*.md`、完了報告 → `.opencode/commands/agentdev/templates/{command}/{variant}.md`）であることを検査すること（SHALL）。種別と配置先の不一致を `canonical-conflict` finding として報告すること（SHALL） |
 
 ## 適用範囲
 
@@ -224,3 +226,4 @@ AgentDevFlow 管理下の全文書 artifact（REQ/ADR/SPEC/DOC-MAP/guides/comman
 | 2026-06-06 | REQ-0108-156-159 | APPEND: integrity-check の repo-local 化・skill 移管・vocabulary registry 移動・source/projection 検査スコープ限定（RU-0001） |
 | 2026-06-06 | REQ-0108-160-168 | APPEND: SKILL.md authoritative source化・command重複カテゴリ禁止・integrity-rule-gap検出・finding schema 4-field分離・ng/warning必須field・completion template repo-local・routing summary・report formatter文字化け解消・再発regression test（RU-0001 + RU-20260606） |
 | 2026-06-06 | REQ-0108-033 | UPDATE: learning-refine / intake-review 参照を learning-promote / intake-promote に更新（RU-0037） |
+| 2026-06-07 | REQ-0108-169-170 | APPEND: runtime path 誤参照検出・テンプレート種別配置先不整合検出（#625 / RU-20260606-01） |

--- a/docs/specs/artifact-contracts.md
+++ b/docs/specs/artifact-contracts.md
@@ -88,6 +88,18 @@ Template の配置先は以下の2種類を定義する（REQ-0103-046）。
 - **参照元**: 当該 Command が直接参照
 - **命名規則**: `{command}` はコマンド名（`case-close`, `case-run` 等）、`{variant}` はバリアント名（`standard`, `epic` 等）
 
+### テンプレート種別別参照先
+
+| テンプレート種別 | 参照先（runtime path） | 参照元 |
+|---|---|---|
+| Issue 説明文 | `.opencode/skills/agentdev-workflow-templates/templates/issue_desc_*.md` | case-open |
+| Issue コメント | `.opencode/skills/agentdev-workflow-templates/templates/issue_comment_*.md` | case-close, case-update |
+| PR 説明文 | `.opencode/skills/agentdev-workflow-templates/templates/pr_desc.md` | case-run |
+| 完了報告 | `.opencode/commands/agentdev/templates/{command}/{variant}.md` | 各コマンド |
+
+- runtime command は上記 runtime path（`.opencode/...`）からテンプレートを参照すること（SHALL）
+- `src/opencode/...` は source 配置・install-sync 入力・authoring context に限定し、runtime 実行時の参照先として使用しない（SHALL）
+
 ### 移行メモ
 
 完了報告テンプレートは Skill-local（`.opencode/skills/agentdev-workflow-reporting/templates/`）から Command-local（`.opencode/commands/agentdev/templates/`）へ移行する。移行完了後、Skill-local の完了報告テンプレートは削除する。

--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -55,3 +55,7 @@ agent: sisyphus
 
 ### 出力制約
 - G10: サブエージェントの最終出力はverbatimで出力する（再フォーマット禁止）
+
+### Runtime path 制約
+- G11: 既存コマンド定義を読み込む際、`src/opencode/...` を runtime path に読み替えてはならない（SHALL）。コマンド定義内のパス参照は記述された通りに解釈し、`src/opencode/` を runtime 参照先として使用しない
+- G12: 委譲先コマンドの実行時 Read / Glob に `src/opencode/...` 固定参照を含めない（SHALL）

--- a/src/opencode/commands/agentdev/case-close.md
+++ b/src/opencode/commands/agentdev/case-close.md
@@ -41,7 +41,7 @@ PRをマージし、Caseに記録を追記し、クローズ後にworktreeとブ
      - Rebase workflow をユーザーに提示（承認が必要）:
        - `git rebase origin/main` → コンフリクト解決（あれば）→ `git push --force-with-lease`
      - `--force` は禁止（`--force-with-lease` のみ許可）
-   - 対応記録コメントをIssueに追記 → テンプレート: `agentdev-workflow-templates` から Read → `agentdev-gh-cli` の VERIFY 操作に従って内容検証
+   - 対応記録コメントをIssueに追記 → テンプレート: `.opencode/skills/agentdev-workflow-templates/templates/issue_comment_*.md` から Read（SHALL, runtime path） → `agentdev-gh-cli` の VERIFY 操作に従って内容検証
 
 5. **Post-merge テスト戦略検証**: マージ後のみ確認可能な項目（CI通過等）を反映。`agentdev-gh-cli` に従い `--body-file` で更新 → VERIFY
 


### PR DESCRIPTION
# 概要
<!-- 【必須】 -->

case-auto/case-close 実行時のテンプレート参照解決不備を是正する。2種類のバグ（Issueコメントテンプレートの誤探索、runtime実行時の src/opencode/ 参照）に対して、command定義・SPEC・REQに明示的なルールを追加する。

## 実装内容
<!-- 【必須】 -->

- **case-close.md**: Step 4 の Issueコメントテンプレート参照先を `.opencode/skills/agentdev-workflow-templates/templates/issue_comment_*.md` に明示
- **case-auto.md**: G11/G12 guardrail を追加し、`src/opencode/...` の runtime path 読み替えと固定参照を禁止
- **artifact-contracts.md**: テンプレート種別別参照先テーブル（Issue説明文・Issueコメント・PR説明文・完了報告）と `src/opencode/` の用途限定を明文化
- **REQ-0108**: REQ-0108-169（runtime command/skill 内の src/opencode/ 固定参照検出）と REQ-0108-170（テンプレート種別と配置先の不整合検出）を APPEND

## 完了条件

<!-- 【必須】 -->
- [x] case-close Step 4 に Issueコメントテンプレートの明示的 runtime path を追記
- [x] case-auto に runtime path 読み替え禁止 guardrail を追記
- [x] artifact-contracts にテンプレート種別別参照先テーブルを追加
- [x] REQ-0108 に runtime path 誤参照・template 種別誤探索検出ルールを APPEND

## テスト結果
<!-- 【必須】 -->

ドキュメント変更のみ。4ファイル21行追加・2行修正。既存テストへの影響なし。

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 変更ファイル数 | 4 | ≤ 10 | ✅ |
| REQ frontmatter 更新 | tags + Update Notes 追記 | なし | ✅ |
| 既存要件との整合 | ADR-0013/0017/0018/0019 準拠 | 準拠 | ✅ |

## Findings / Intake候補
<!-- 【必須】 -->

該当なし

<!-- 【必須】 -->
Closes #625