### PR TITLE
feat: 4コマンドのfrontmatter load_skillsにagentdev-gh-cliを追加

### DIFF
--- a/src/opencode/commands/agentdev/case-close.md
+++ b/src/opencode/commands/agentdev/case-close.md
@@ -1,6 +1,8 @@
 ---
 description: PRをマージし、対応記録を追記し、Caseをクローズしてブランチを削除する
 agent: sisyphus
+load_skills:
+  - agentdev-gh-cli
 ---
 
 # 完了処理

--- a/src/opencode/commands/agentdev/case-open.md
+++ b/src/opencode/commands/agentdev/case-open.md
@@ -1,6 +1,8 @@
 ---
 description: 要件定義をもとにGitHub Issueを作成する
 agent: sisyphus
+load_skills:
+  - agentdev-gh-cli
 ---
 
 # Case登録

--- a/src/opencode/commands/agentdev/case-run.md
+++ b/src/opencode/commands/agentdev/case-run.md
@@ -1,6 +1,8 @@
 ---
 description: 計画立案からコミットまでを一気通貫で実行する。3フェーズ構成でべき等性・再開ポイントを提供。複数Issueの並列実行に対応
 agent: sisyphus
+load_skills:
+  - agentdev-gh-cli
 ---
 
 # 実装パイプライン

--- a/src/opencode/commands/agentdev/case-update.md
+++ b/src/opencode/commands/agentdev/case-update.md
@@ -1,6 +1,8 @@
 ---
 description: 既存Caseの本文更新、コメント追加、またはREQファイル更新を行う
 agent: sisyphus
+load_skills:
+  - agentdev-gh-cli
 ---
 
 # Case更新


### PR DESCRIPTION
## 概要

4コマンド（case-open, case-run, case-update, case-close）のfrontmatter `load_skills` に `agentdev-gh-cli` を追加。

## 完了条件

- [x] 4コマンドのfrontmatterに `agentdev-gh-cli` を追加
  - [x] `src/opencode/commands/agentdev/case-open.md`
  - [x] `src/opencode/commands/agentdev/case-run.md`
  - [x] `src/opencode/commands/agentdev/case-update.md`
  - [x] `src/opencode/commands/agentdev/case-close.md`
- [x] コミット: `feat: 4コマンドのload_skillsにagentdev-gh-cliを追加`
- [x] PR作成
- [x] Issue #630のチェックボックスを更新

## 変更内容

各コマンドのfrontmatterに以下を追加:

```yaml
---
description: ...
agent: sisyphus
load_skills:
  - agentdev-gh-cli
---
```

## 関連Issue

Refs: #630