### PR TITLE
fix: remove forbidden frontmatter keys from command files

### DIFF
--- a/src/opencode/commands/agentdev/case-close.md
+++ b/src/opencode/commands/agentdev/case-close.md
@@ -1,8 +1,6 @@
 ---
 description: PRをマージし、対応記録を追記し、Caseをクローズしてブランチを削除する
 agent: sisyphus
-load_skills:
-  - agentdev-gh-cli
 ---
 
 # 完了処理

--- a/src/opencode/commands/agentdev/case-open.md
+++ b/src/opencode/commands/agentdev/case-open.md
@@ -1,8 +1,6 @@
 ---
 description: 要件定義をもとにGitHub Issueを作成する
 agent: sisyphus
-load_skills:
-  - agentdev-gh-cli
 ---
 
 # Case登録

--- a/src/opencode/commands/agentdev/case-run.md
+++ b/src/opencode/commands/agentdev/case-run.md
@@ -1,8 +1,6 @@
 ---
 description: 計画立案からコミットまでを一気通貫で実行する。3フェーズ構成でべき等性・再開ポイントを提供。複数Issueの並列実行に対応
 agent: sisyphus
-load_skills:
-  - agentdev-gh-cli
 ---
 
 # 実装パイプライン

--- a/src/opencode/commands/agentdev/case-update.md
+++ b/src/opencode/commands/agentdev/case-update.md
@@ -1,8 +1,6 @@
 ---
 description: 既存Caseの本文更新、コメント追加、またはREQファイル更新を行う
 agent: sisyphus
-load_skills:
-  - agentdev-gh-cli
 ---
 
 # Case更新

--- a/src/opencode/commands/agentdev/intake-promote.md
+++ b/src/opencode/commands/agentdev/intake-promote.md
@@ -1,7 +1,6 @@
 ---
 description: inbox 内の intake item をレビュー・分類し、採用 item を backlog-review 向け promoted artifact に整形する
 agent: sisyphus
-implementation_pattern: file-pipeline
 ---
 
 # Intake Promote

--- a/src/opencode/commands/agentdev/learning-promote.md
+++ b/src/opencode/commands/agentdev/learning-promote.md
@@ -1,7 +1,6 @@
 ---
 description: inbox.mdから正規化・分類・8軸評価・HITL確定を経てRequirement Source stubを生成する
 agent: sisyphus
-implementation_pattern: file-pipeline
 ---
 
 # 学びの正規化・評価・昇華判定と Requirement Source stub 生成


### PR DESCRIPTION
## 概要

case-auto の Epic Issue 制御単位要件追加（REQ-0114-038〜043）と、6コマンドファイルの frontmatter 禁止キー除去。

## 実装内容

### RU-01: REQ-0114 APPEND（main 直コミット済み: 722170e）

REQ-0114 に以下の要件行を追加:
- 038: case-auto は Epic Issue番号を制御単位として保持
- 039: Epic Issue から Wave構成・子Issue一覧・合意済み方針・状態を読み取り
- 040: 合意済み方針がある場合、ユーザーに再確認しない
- 041: case-open相当処理は Epic Issue に実行制御情報を構造化して残す
- 042: Wave構成に基づいて次工程を判断
- 043: case-close相当処理到達前にPRと子Issue状態を確認

### RU-02: frontmatter 禁止キー除去（本PR）

| ファイル | 除去キー |
|----------|---------|
| case-close.md | load_skills |
| case-open.md | load_skills |
| case-run.md | load_skills |
| case-update.md | load_skills |
| intake-promote.md | implementation_pattern |
| learning-promote.md | implementation_pattern |

## 完了条件

- [x] REQ-0114 に 038〜043 が追加されている
- [x] case-close.md の load_skills が削除されている
- [x] case-open.md の load_skills が削除されている
- [x] case-run.md の load_skills が削除されている
- [x] case-update.md の load_skills が削除されている
- [x] intake-promote.md の implementation_pattern が削除されている
- [x] learning-promote.md の implementation_pattern が削除されている

## テスト結果

該当なし（ドキュメント変更のみ）。frontmatter 規約検査は既存 integrity テストでカバー。

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| frontmatter 禁止キー | 0件 | 0件 | ✅ |
| 変更ファイル数 | 6 | — | ✅ |
| 削除行数 | 10 | — | ✅ |

## Findings / Intake候補

該当なし

Closes #658
