### PR TITLE
refactor(req-0102): add redundancy reduction criteria (029-032)

### DIFF
--- a/docs/requirements/REQ-0102.md
+++ b/docs/requirements/REQ-0102.md
@@ -2,7 +2,7 @@
 id: REQ-0102
 title: "要件定義・保存"
 created: "2026-05-30"
-updated: "2026-06-12"
+updated: "2026-06-13"
 tags: [req-define, req-save, requirement-source, classification-gate]
 ---
 
@@ -42,6 +42,10 @@ tags: [req-define, req-save, requirement-source, classification-gate]
 | REQ-0102-026 | SHOULD 相当の内容は必達要件として再定義できる場合のみ REQ 要件行に残す |
 | REQ-0102-027 | 必達要件として再定義できない SHOULD 相当の内容は、注記・SPEC・guide・backlog・report のいずれか適切な文書へ移す |
 | REQ-0102-028 | MAY 相当の内容は原則として REQ 要件行から除外し、許容仕様・設計余地・将来候補として適切な文書へ移す |
+| REQ-0102-029 | active REQ の要件行から、主語・適用範囲・既存 active REQ から一意に導ける再説明を削除対象とする |
+| REQ-0102-030 | 既存要件の言い換えに留まり、新しい判定基準・例外・対象外・検査境界・優先関係を追加しない文を削除対象とする |
+| REQ-0102-031 | 既存制約との関係説明（括弧内補足の「整合する」「追従する」等）が判定境界を増やさない場合、削除または要件本文外への整理対象とする |
+| REQ-0102-032 | 対象外条件・例外条件・検査対象範囲・finding条件・出力粒度・優先関係を実際に変える文は削除対象に含めない |
 
 ## 適用範囲
 
@@ -55,3 +59,4 @@ tags: [req-define, req-save, requirement-source, classification-gate]
 | 2026-06-07 | RU-01対応: 複数RU一括入力時のreq-define統合・分割基準(014-015)、多REQ操作出力(016)、scale:large判定(017)、wave候補記録(018)、Issue階層決定の責務分離(019)、req-save多REQ保存仕様(020-021)を追加 |
 | 2026-06-08 | REQ-0102-022-023 | APPEND: req-define 実装フェーズ活動禁止・要件行候補の実装指示禁止（#695 / 配布境界品質改善） |
 | 2026-06-12 | REQ-0102-024-028 | APPEND: REQ 要件行の検証可能な必達要件限定・RFC 2119 語非必須化・SHOULD/MAY 再分類（壁打ちセッション（2026-06-12）にて要件化） |
+| 2026-06-13 | REQ-0102-029-032 | APPEND: active REQ 自明・同値記述の削減基準（#738 / RU-20260613-01） |


### PR DESCRIPTION
## 概要

Issue #738: active REQ の要件行から自明・同値の再説明を削除するための基準を REQ-0102 に追加する。

## 実装内容

REQ-0102 の要件テーブルに4要件行（REQ-0102-029〜032）を APPEND した:
- 029: 主語・適用範囲・既存要件から一意に導ける再説明を削除対象とする
- 030: 言い換えに留まり新しい判定基準を追加しない文を削除対象とする
- 031: 関係説明が判定境界を増やさない場合の削除・整理対象
- 032: 検査境界を変える文は削除対象に含めない

あわせて frontmatter `updated` を更新し、Update Notes に変更履歴を追記した。

## 完了条件

- [x] REQ-0102 に REQ-0102-029〜032 の4要件行が追加されている
- [x] 各要件行が検証可能な必達要件として記述されている
- [x] REQ-0102 の frontmatter `updated` が現在日時に更新されている
- [x] docs/requirements/README.md が最新状態と整合している

## テスト結果

該当なし（ドキュメント変更のみ）

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| frontmatter バリデーション | id/file 一致、日付形式 OK | id/file 一致、created ≤ updated | ✅ |
| 要件行 ID 連番 | 028 → 032（欠番なし） | 欠番再利用禁止 | ✅ |
| 分類ゲート | 全要件行が「変更後仕様」 | 反映作業のみの行なし | ✅ |

## Findings / Capture候補

### intake

該当なし

### learning

該当なし

Closes #738
