### PR TITLE
fix: remove tags from REQ frontmatter required fields (#776)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -384,7 +384,7 @@ function checkReqFrontmatterFilename(
 
 function checkReqRequiredFields(reqDir: string, root: string): CheckResult[] {
   const results: CheckResult[] = [];
-  const required = ["id", "title", "created", "updated", "tags"];
+  const required = ["id", "title", "created", "updated"];
   const files = listFiles(reqDir).filter(
     (f) => f.startsWith("REQ-") && f !== "README.md",
   );
@@ -3102,7 +3102,7 @@ function checkRetiredFrontmatter(reqDir: string, root: string): CheckResult[] {
   const retiredFiles = listFiles(retiredDir).filter((f) =>
     f.startsWith("REQ-"),
   );
-  const required = ["id", "title", "created", "updated", "tags"];
+  const required = ["id", "title", "created", "updated"];
 
   for (const file of retiredFiles) {
     const fullPath = path.join(retiredDir, file);


### PR DESCRIPTION
Remove 'tags' from required array in check_integrity.ts (L387, L3105). Aligns validator with REQ-0101-005 and patterns.md (4 fields only). Resolves NG 22件.

Closes #776