### PR TITLE
fix: listDirs() handle Windows junctions/reparse points (#778)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -110,7 +110,15 @@ function listDirs(dirPath: string): string[] {
     return (
       fs.readdirSync(dirPath, { withFileTypes: true }) as import("fs").Dirent[]
     )
-      .filter((d) => d.isDirectory())
+      .filter((d) => {
+        if (d.isDirectory()) return true;
+        // Windows junctions: isDirectory() returns false (libuv reparse point behavior)
+        try {
+          return fs.statSync(path.join(dirPath, d.name)).isDirectory();
+        } catch {
+          return false;
+        }
+      })
       .map((d) => d.name)
       .sort();
   } catch {


### PR DESCRIPTION
listDirs() used d.isDirectory() which returns false for Windows junctions. Add fs.statSync fallback to follow junctions and check target directory status. Fixes source-projection-sync false positive 21件.

Closes #778
REQ: REQ-0108-210