### PR TITLE
fix: add 6 missing categories to categoryToCheckPattern Map (#780)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -5299,6 +5299,12 @@ function checkSkillCategoryGap(
     ["Workflow template 構造", ["checkNaming", "checkFrontmatter", "checkSectionMarkers"]],
     ["Skill 構造", ["lintSkill"]],
     ["Junction 整合性", ["BrokenJunctions"]],
+    ["Capture boundary", ["CaptureBoundaryReference", "PrTemplateCaptureSection", "CommandCaptureDuties"]],
+    ["語彙ポリシー", ["VocabularyCompliance", "OldStatusVocabulary", "VocabularyRegistrySync"]],
+    ["Cross-REQ vocab", ["CrossReqVocabularyConsistency"]],
+    ["Mapping table history", ["MappingTableHistoryLabels"]],
+    ["REQ verification basis", ["ReqVerificationBasis"]],
+    ["Skill-internal section ref", ["SkillInternalSectionRef"]],
   ]);
 
   let foundGap = false;


### PR DESCRIPTION
Add 6 SKILL.md categories to gap detector Map. Eliminates false gap reports for Capture boundary, 語彙ポリシー, Cross-REQ vocab, Mapping table history, REQ verification basis, Skill-internal section ref.

Closes #780