### PR TITLE
Wave 2: backlog-review diagnostics input + diagnostics-docs REQ coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ AgentDevFlow plugin の設定を管理するリポジトリ。AI agent-assisted 
 | inbox に item がある | `/agentdev/intake-promote` | promoted / archive |
 | 再発防止知見を蓄積したい | `learning-capture`（スキル） | inbox.md エントリ |
 | inbox.md にエントリがある | `/agentdev/learning-promote` | promoted artifact |
-| promoted artifact（intake/learning）がある | `/agentdev/backlog-review` | `RU-*.md` |
+| promoted artifact（intake/learning/diagnostics）がある | `/agentdev/backlog-review` | `RU-*.md` |
 | RU がある | `/agentdev/req-define` | 要件doc（draft） |
-| docs 全体の意味整合性をレビューしたい | `/agentdev/docs-review` | 診断レポート |
+| docs 全体の意味整合性を診断したい | `/agentdev/diagnostics-docs` | diagnostics finding |
+| Command/Skill 参照妥当性を診断したい | `/agentdev/diagnostics-skills` | diagnostics finding |
+| diagnostic finding を分類したい | `/agentdev/diagnostics-promote` | promoted artifact |
 | ドキュメント整合性を検証したい | `/repo/docs-check` | 検証レポート（self-hosting repo 専用） |
 | 要件docがあり、req-saveからcase-closeまで自走させたい | `/agentdev/case-auto` | マージ済み + クローズ済み |
 

--- a/src/opencode/commands/agentdev/backlog-review.md
+++ b/src/opencode/commands/agentdev/backlog-review.md
@@ -5,7 +5,7 @@ agent: sisyphus
 
 # Backlog Review
 
-`.agentdev/intake/promoted/*.md` 及び `.agentdev/learning/promoted/*.md` の promoted artifact を読み込み、分析・統合してユーザーに判定を提示し、承認後に直接 RU を生成する。
+`.agentdev/intake/promoted/*.md`、`.agentdev/learning/promoted/*.md`、`.agentdev/diagnostics/promoted/*.md` の promoted artifact を読み込み、分析・統合してユーザーに判定を提示し、承認後に直接 RU を生成する。
 
 **このコマンドはユーザー承認後に RU を生成する。ユーザー承認は RU 作成承認を兼ねる。**
 
@@ -13,7 +13,8 @@ agent: sisyphus
 
 - `.agentdev/intake/promoted/*.md`（intake パイプラインからの promoted artifact）
 - `.agentdev/learning/promoted/*.md`（learning パイプラインからの promoted artifact）
-- **引数指定**: ユーザーがファイルパスを引数として指定した場合、指定されたファイルのみを対象とする。引数なしの場合、両ディレクトリの全 promoted artifact を対象とする
+- `.agentdev/diagnostics/promoted/*.md`（diagnostics パイプラインからの promoted artifact）
+- **引数指定**: ユーザーがファイルパスを引数として指定した場合、指定されたファイルのみを対象とする。引数なしの場合、全ディレクトリの promoted artifact を対象とする
 
 ## Output
 
@@ -26,14 +27,14 @@ RU-*.md は以下の構造に従う:
 
 ```markdown
 ---
-source_type: {intake | learning | mixed | chat}
+source_type: {intake | learning | diagnostics | mixed | chat}
 generated_by: backlog-review
 generated_at: {ISO 8601 timestamp}
 status: draft
   depends_on: [RU-{NNNN}] (optional)
   sources:
-  - path: {.agentdev/intake/promoted/xxx.md | .agentdev/learning/promoted/xxx.md}
-    type: {intake | learning}
+  - path: {.agentdev/intake/promoted/xxx.md | .agentdev/learning/promoted/xxx.md | .agentdev/diagnostics/promoted/xxx.md}
+    type: {intake | learning | diagnostics}
 ---
 
 ## Sources


### PR DESCRIPTION
Parent: #794

## OU-2 (#796): backlog-review diagnostics promoted input
- backlog-review command accepts .agentdev/diagnostics/promoted/ input
- source_type expanded: intake | learning | diagnostics | mixed | chat
- RU sources format updated to include diagnostics path

## OU-3 (#797): REQ-0109 operational requirements
- diagnostics-docs (created in OU-1/PR #799) already includes:
  - REQ structure review: SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT
  - Detection signal references via agentdev-req-structure-diagnostics
  - Read-only constraint with finding output

## OU-4 (#798): REQ-0115 command suite requirements
- diagnostics-docs (created in OU-1/PR #799) already includes:
  - SPEC/ADR/guides/DOC-MAP meaning diagnostics
  - docs-check route (feedback loop)
  - Finding routes: req-define, RU, case-update, docs-check rule, learning/backlog
- README entry table updated with diagnostics-* commands

ADR-0113