### PR TITLE
fix: separate common termination and add cleanup verification gate

### DIFF
--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -28,7 +28,10 @@ agent: sisyphus
    - case-auto は OU の統合・分割、REQ 操作分類、Issue 階層判定を再評価しないこと（REQ-0114-054）
    - case-open 相当処理の完了後、出力を確認して以下のいずれかに分岐する:
      - **Standard flow（単一 Issue）**: 既存の直列フロー（case-run → case-close）をそのまま実行
-     - **Epic Issue（マルチREQ または 単一REQ Epic flow）**: Step 4-1〜4-3 のキュー処理に進む
+     - **Epic Issue（マルチREQ または 単一REQ Epic flow）**:
+       1. case-open の共通終了処理（Step 17〜18-2: コメント追加・ドラフト削除・RU削除・完了報告）の完了を確認すること（REQ-0104-045〜047）
+       2. **クリーンアップ検証ゲート**を実行し、ドラフトファイル・RUファイルの残存がないことを確認すること（REQ-0114-060〜062）。残存時は停止すること
+       3. Step 4-1〜4-3 のキュー処理に進む
      - **Step 4-1 キュー開始**: ドラフトの `operation_units` セクションから OU 構造を読み取り、処理順序を決定する（`recommended_order`, `depends_on` に基づく）。Epic Issue 番号を記録する。Epic Issue の子Issue一覧（Wave 構成含む）を読み取る。case-run 相当処理に Epic Issue 番号を渡す。case-run の Epic Orchestrator モードが全 Wave の子Issue実行を処理する。case-auto は Wave 実行プロトコルを実装しない（`agentdev-workflow-orchestration` を参照）
      - **Step 4-2 case-close ループ**: case-run 相当処理の完了後、その出力（成功/失敗/スキップされた子Issue一覧）から case-close 対象を決定する:
       - 正常完了した子Issue: case-close 相当処理を実行
@@ -39,6 +42,10 @@ agent: sisyphus
      - Epic Issue の子Issue全ステータスが CLOSED の場合 → Epic 自動クローズ確認（case-close Step 8 相当） → 全体完了報告
       - 未クローズの子Issue が残る場合（失敗/スキップ） → 部分完了報告
      - 停止時は完了済み OU、進行中 OU、未実行 OU、再開可能な次コマンドを報告すること（REQ-0114-056）
+   - **クリーンアップ検証ゲート**: Epic Issue の Step 4-1 キュー処理開始前に、以下を検証する（REQ-0114-060〜063）:
+     - ドラフトファイル（`.agentdev/drafts/req-draft-*.md`）が削除されていること。残存する場合は停止し手動削除を依頼すること
+     - 当該ケースで消費した RU ファイル（`.agentdev/backlog/req-units/RU-*.md`）が削除されていること。残存する場合は停止し手動削除を依頼すること
+     - 検証結果（成功・残存ファイル一覧）を case-auto 完了報告（Step 8）に含めること
 5. **工程間の状態引き継ぎ**: 各工程の成果物（Issue番号、PR番号）を次工程の入力として渡す。加えて以下の引き継ぎ情報を最終工程まで保持すること: (1) 要件docの Requirement Source セクション内容（RU 削除判定に使用） (2) RU ファイルパス（case-open 相当処理の RU 削除で使用） (3) capture 対象情報（case-close 相当処理の learning/intake capture で使用）
 6. **複数REQ対応**: req-save 相当処理の出力から複数 REQ doc または scale:large を検出した場合、case-auto は case-open の Issue 構造ルールをそのまま使用する。case-auto 自体に Issue 階層決定ロジックを持ってはならない。req-save 相当処理から case-open 相当処理へ状態を引き継ぐ際、case-auto は複数 REQ doc の保存結果をフィルタリングや再評価なしでそのまま渡す。case-auto は Epic Issue 化の判定に関与しないこと（REQ-0114-057）。case-open の判定結果に従うこと
 7. **停止条件の検出**: 以下のいずれかを検出した場合、実行を停止し停止理由・現在地点・再開可能な次コマンドを報告する:

--- a/src/opencode/commands/agentdev/case-open.md
+++ b/src/opencode/commands/agentdev/case-open.md
@@ -46,7 +46,7 @@ agent: sisyphus
 - **VERIFY**: gh CLI書込後は毎回 `agentdev-gh-cli` の VERIFY操作に従い検証
 - **テンプレート準拠**: テンプレート読込後は毎回【必須】セクションの完備を確認（【任意】は内容がある場合のみ含める）、欠落時は再生成
 
-### Epic flow（Step 4〜8）
+### Epic flow（Step 4〜8-1）
 
 Epic flow は Step 2 または Step 3 のルーティングにより開始。マルチREQ / 単一REQ の差分:
 
@@ -72,7 +72,9 @@ Epic flow は Step 2 または Step 3 のルーティングにより開始。マ
 
 8-1. **OU 結果の書き戻し**: ドラフトに `operation_units` セクションがある場合、作成した Issue / Epic 番号を当該 OU の `result` に書き戻す（REQ-0104-038）
 
-### Standard flow + 共通終了（Step 14〜）
+**Epic flow 完了後、共通終了処理（Step 17〜18-2）を必ず実行すること。**
+
+### Standard flow（Step 14〜16-1）
 
 14. **[Standard]** `docs/adr/README.md` から関連ADRを特定（単一REQ Epic flowの内容反映にも活用）
 15. **[Standard]** ラベル付与 → `agentdev-workflow-lifecycle` に従う
@@ -80,11 +82,13 @@ Epic flow は Step 2 または Step 3 のルーティングにより開始。マ
 
 16-1. **[Standard] OU 結果の書き戻し**: ドラフトに `operation_units` セクションがある場合、作成した Issue 番号を当該 OU の `result` に書き戻す（REQ-0104-038）
 
+### 共通終了処理（全フロー共通・Step 17〜18-2）
+
 17. コメント追加: `agentdev-workflow-templates` の選定ルールに従いコメント用テンプレートを読み込む（Epic flowではEpic Issueにコメント追加）→ VERIFY
 
- 18. ドラフトが存在する場合、`.agentdev/drafts/req-draft-{topic-slug}.md` を削除
+ 18. ドラフトが存在する場合、`.agentdev/drafts/req-draft-{topic-slug}.md` を削除（Standard / Epic 全フロー共通）
 
- 18-1. **RU ファイル削除**。詳細は `agentdev-req-file-manager` を参照。委譲接続点: 親エージェントのみが削除・同期確認を行う。サブエージェントへ委譲する場合は削除対象候補の抽出までとする
+ 18-1. **RU ファイル削除**（Standard / Epic 全フロー共通）。詳細は `agentdev-req-file-manager` を参照。委譲接続点: 親エージェントのみが削除・同期確認を行う。サブエージェントへ委譲する場合は削除対象候補の抽出までとする
 
 18-2. 完了報告 → template variant:
    - Standard → `templates/case-open/standard.md`


### PR DESCRIPTION
## 概要

case-auto Epic flow 実行時に case-open の共通終了処理がスキップされる問題を修正し、クリーンアップ検証ゲートを追加する。

Closes #812

## 変更内容

### case-open.md
- **セクション分離**: "Standard flow + 共通終了" を "Standard flow（Step 14〜16-1）" と "共通終了処理（全フロー共通・Step 17〜18-2）" に分離
- **Epic flow ルーティング**: Epic flow（Step 4〜8-1）完了後に共通終了処理を実行する旨の明示的ルーティングを追加
- **全フロー共通注記**: Step 18（ドラフト削除）・18-1（RU削除）に "Standard / Epic 全フロー共通" の注記を追加

### case-auto.md
- **共通終了の確実実行**: Epic Issue 分岐で "case-open相当処理" に共通終了処理（コメント追加・ドラフト削除・RU削除・完了報告）の完了確認を追加
- **クリーンアップ検証ゲート**: Epic Issue Step 4-1 キュー処理開始前にドラフト・RUファイルの残存を検証するゲートを追加。残存時は停止

## テスト戦略

- [x] case-open.md セクション構造検証: 共通終了が独立セクション、Epic flow にルーティング明記、Step 18/18-1 に全フロー共通注記
- [x] case-auto.md 分岐ロジック検証: 共通終了含む、検証ゲートあり、ドラフト/RU残存時の停止動作
- [x] docs-check: REQ-0104/0114 の整合性確認、既存要件との矛盾なし

## Findings / Capture候補

（なし）
