### PR TITLE
feat: req-define全work_type draft保存 + case-auto Standard flow複数OU逐次処理

### DIFF
--- a/.agentdev/README.md
+++ b/.agentdev/README.md
@@ -17,7 +17,7 @@ AgentDevFlow の永続 domain state を格納するディレクトリ（REQ-0101
 | `learning/evaluation-report.md` | 境界 artifact | `learning-promote` | `learning-promote` | 毎回上書き |
 | `learning/promoted/*.md` | promoted artifact | `learning-promote` | `backlog-review` | `backlog-review` による RU 化成功後に削除 |
 | `backlog/req-units/RU-*.md` | RU（Requirement Unit） | `backlog-review`, session-sourced | `req-define`, `case-open` | `case-open` の Issue 作成 + VERIFY 成功後に削除 |
-| `drafts/req-draft-*.md` | working draft | `req-define` | `req-save` | `case-open` の Issue 作成 + VERIFY 成功後に削除 |
+| `drafts/req-draft-*.md` | working draft | `req-define` | `req-save`（feature） / `case-open`（bugfix/maintenance/docs_chore） | `case-open` の Issue 作成 + VERIFY 成功後に削除 |
 | `drafts/requirements-review-finding-*.md` | review finding | `req-save`（SPLIT 検出時） | `req-define` | `req-define` の消化後に削除 |
 | `integrity/reports/*.md` | 検証レポート（非永続） | `docs-check` | `docs-check`（intake化）・ユーザー参照 | 非永続・git管理対象外（`.gitignore` で除外） |
 | `inspect/inbox/*.md` | 未分類 inspect finding | `inspect-docs`, `inspect-skills` | `inspect-promote` | `inspect-promote` 成功後に `promoted/` または `archive/` へ移動 |

--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -18,7 +18,7 @@ agent: sisyphus
 
 ## Steps
 
-1. **入力解決**: 明示パス→draft単一検出→セッション内要件docの順で入力を特定する。不明時は停止しreq-define実行またはパス指定を求める
+1. **入力解決**: 明示パス→draft検出（複数件含む全件処理対象）→セッション内要件docの順で入力を特定する。`.agentdev/drafts/req-draft-*.md` が2件以上存在する場合、全draftを処理対象として検出し、各draftの `operation_units` から `recommended_order` と `depends_on` に基づいて全OUの処理順序を決定する。不明時は停止しreq-define実行またはパス指定を求める
 2. **work_type 読取**: 入力要件docの draft-meta セクションから work_type を取得する
 3. **工程分岐**:
    - feature: req-save → case-open → case-run → case-close
@@ -60,6 +60,12 @@ agent: sisyphus
    - (9) 作成元不明branch / user-owned branch / 他作業branchの削除検出
    - (10) 未コミット変更の帰属不明
 8. **完了報告**: 最終工程（case-close）の完了報告をそのまま出力する。Epic Issue を伴うキュー実行時は、完了・失敗・スキップ子Issue一覧を含める。停止時は完了済み OU、進行中 OU、未実行 OU、再開可能な次コマンドを報告する（REQ-0114-056）
+8-1. **Standard flow 逐次OU処理ループ**: Standard flow の case-close 完了後、未処理 OU が残存する場合は次 OU の処理を自動的に開始する（REQ-0114-065〜067）:
+   - 処理対象の全 OU から次の未処理 OU を特定する（`recommended_order`, `depends_on` に基づく）
+   - 次 OU が存在する場合: 当該 OU の work_type に応じた工程分岐で Step 2 に戻る（feature: req-save → case-open → …、bugfix/maintenance/docs_chore: case-open → …）
+   - 全 OU の処理が完了した場合のみ全体完了報告を出力する（REQ-0114-067）
+   - 次 OU の draft ファイルが存在しない場合: 停止し完了済み OU・未実行 OU・再開コマンドを報告する（REQ-0114-066）
+   - 逐次OU処理中に停止条件（Step 7）を検出した場合: 完了済み OU・進行中 OU・未実行 OU・再開可能な次コマンドを報告する
 
 ## Guardrails
 

--- a/src/opencode/commands/agentdev/req-define.md
+++ b/src/opencode/commands/agentdev/req-define.md
@@ -19,8 +19,7 @@ agent: sisyphus
 
 ## Output
 
-- `.agentdev/drafts/req-draft-{topic-slug}.md`（機能追加の場合のみ）
-- セッション内要件doc（バグ修正・軽微変更の場合）
+- `.agentdev/drafts/req-draft-{topic-slug}.md`（全 work_type 共通）
 
 ## Steps
 
@@ -58,8 +57,7 @@ agent: sisyphus
 8. **Scale判断**（feature のみ）: `agentdev-workflow-lifecycle` で standard/large を判定。large 時はユーザーと分解計画を協議
 
 9. **ドラフト保存**:
-   - 機能追加: `.agentdev/drafts/req-draft-{topic-slug}.md` に保存。draft-meta セクション（work_type/req-operation/target-req/adr-required/topic-slug/scale/status 等）を追加。Step 6-1 で生成した `operation_units` セクションと Step 6-2 で生成した `execution_groups` セクションを含める
-   - バグ修正・軽微変更/リファクタリング・保守/ドキュメント・雑務: ドラフト保存不要。セッション内で完結
+   全 work_type（feature / bugfix / maintenance / docs_chore）で `.agentdev/drafts/req-draft-{topic-slug}.md` に保存。draft-meta セクション（work_type/req-operation/target-req/adr-required/topic-slug/scale/status 等）を追加。Step 6-1 で生成した `operation_units` セクションと Step 6-2 で生成した `execution_groups` セクションを含める。draft-meta の work_type が後続コマンドの消費パターンを決定する（feature: req-save が消費、bugfix/maintenance/docs_chore: req-save をスキップして case-open が消費）
 
 10. **要件doc確認**: 生成した要件docをユーザーに提示（承認は求めず提示のみ）。差し戻し時は壁打ち継続（Step 1 へ）。次コマンド実行を確定の意思表示として扱う
 


### PR DESCRIPTION
## 概要

req-define の全 work_type draft 保存対応と case-auto の Standard flow 複数OU逐次処理対応を実装する。

## 変更内容

### #816: req-define全work_type draft保存（REQ-0102-045-048）

- `src/opencode/commands/agentdev/req-define.md` Output + Step 9: 全 work_type でドラフト保存するよう変更。bugfix/maintenance/docs_chore の「ドラフト保存不要」を撤廃
- `.agentdev/README.md`: drafts lifecycle の Consumer を `req-save`（feature）/ `case-open`（bugfix/maintenance/docs_chore）に拡張

### #817: case-auto Standard flow複数OU逐次処理（REQ-0114-004 update + 064-067）

- `src/opencode/commands/agentdev/case-auto.md` Step 1: 複数draft検出時の「候補一覧表示して停止」から「全draft処理対象として検出 + 処理順序決定」へ変更
- `src/opencode/commands/agentdev/case-auto.md` Step 8-1: Standard flow case-close 完了後の逐次OU処理ループを追加

## 検証

- req-define.md Step 9 の「ドラフト保存不要」記述が削除され、全 work_type で draft 保存することが明記された
- case-auto.md Step 1 で複数draftを全件処理対象とすることが明記された
- case-auto.md Step 8-1 で Standard flow の逐次OU処理（次OU自動進行・不在時停止・全体完了判定）が追加された
- .agentdev/README.md の drafts lifecycle が全 work_type の Producer/Consumer を反映した

Closes #816, #817

## Findings / Capture候補

（該当なし）
