### PR TITLE
refactor: OU-03 command REQ分割 - REQ-0105/0106 split + case-open/update新規 (#831)

### DIFF
--- a/docs/requirements/REQ-0105.md
+++ b/docs/requirements/REQ-0105.md
@@ -1,32 +1,22 @@
 ---
 id: REQ-0105
-title: "Intake / Learning / Backlog"
+title: "RU lifecycle / Requirement Unit 管理"
 created: "2026-05-30"
 updated: "2026-06-16"
 ---
 
 ## 目的
 
-作業候補、学び、要件化前の構造化入力を `.agentdev/` domain state として管理し、短期Issue化候補と要件化候補を混同しない。
+Requirement Unit（RU）の一時成果物としてのライフサイクル、session-sourced RU、RU frontmatter メタデータ、RU と docs 永続文書の境界を定義する。RU は case-open の Issue 作成 + VERIFY 成功後にのみ削除される一時成果物であり、docs 永続文書の根拠参照には使用しない。
 
 ## 要件
 
 | ID | 要件 |
 |---|---|
-| REQ-0105-001 | intake pipeline の domain state は `.agentdev/intake/` に配置すること |
-| REQ-0105-002 | `intake-capture` はユーザー入力から明示できる内容のみを intake item として整理すること |
-| REQ-0105-004 | `intake-promote` は `.agentdev/intake/inbox/` 内の intake item を直接読み込み、採用判定・HITL 確定を経て `.agentdev/intake/promoted/` または `.agentdev/intake/archive/` に配置すること |
-| REQ-0105-005 | learning pipeline の domain state は `.agentdev/learning/` に配置すること |
-| REQ-0105-006 | learning は再発防止・抽象化・反映価値のある知見を蓄積すること |
-| REQ-0105-007 | 同一観測から intake と learning の両方が発生する場合、成果物を分離すること |
-| REQ-0105-008 | `backlog-review` は intake / learning の promoted artifact を分析・統合し、ユーザー承認を経て RU を `.agentdev/backlog/req-units/` に生成すること。backlog-save を経由せず、backlog-review 内で直接 RU を生成する |
-| REQ-0105-009 | RU は promoted artifact の単純コピーではなく、要件化に向けた構造化内容とすること |
 | REQ-0105-010 | `req-define` は RU を Requirement Source として受け入れること |
 | REQ-0105-011 | `req-define` は promoted artifact を直接読み込まず、RU または明示入力ファイルを経由すること |
 | REQ-0105-012 | RU は case-open の Issue作成 + VERIFY 成功後にのみ削除されること |
-| REQ-0105-013 | REQ再構成intakeは通常の短期Issue化候補と区別し、`backlog-review` 向け短期候補として処理しないこと |
 | REQ-0105-014 | req-save は RU パスを docs 永続文書に記録しないこと。RU は一時成果物であり、docs の永続根拠に不適である |
-| REQ-0105-015 | case-open は Issue作成 + VERIFY 成功後に RU を削除する唯一のコマンドであること |
 | REQ-0105-016 | Issue作成失敗または VERIFY 失敗時、RU は `.agentdev/backlog/req-units/` に残存すること |
 | REQ-0105-017 | チャット内でユーザーと合意形成済みの内容は、session-sourced RU として .agentdev/backlog/req-units/ に保存できること |
 | REQ-0105-018 | session-sourced RU の frontmatter は source_type: chat, generated_by: session, sources[].type: chat を許容すること |
@@ -34,55 +24,36 @@ updated: "2026-06-16"
 | REQ-0105-020 | session-sourced RU の本文は後続工程（req-define）で必要な情報を自足していること |
 | REQ-0105-021 | session-sourced RU は req-define に渡せる粒度まで整理済みの内容に限定すること |
 | REQ-0105-022 | 未合意・未整理・採否未確定の内容は session-sourced RU 化しないこと |
-| REQ-0105-023 | `case-open` は RU ファイル削除を commit/push した場合、main 作業ディレクトリの HEAD と `origin/main` が一致し、`git status --porcelain` に削除済み RU ファイルが残っていないことを確認すること |
-| REQ-0105-024 | `case-open` は RU ファイル削除 commit/push 後の同期確認に失敗した場合、完了扱いにせず、対象ファイル・現在の HEAD・`origin/main` を表示して停止すること |
-| REQ-0105-028 | 通常 intake 起点の item が `/agentdev/req-define` に渡されるのは、`/agentdev/intake-promote`、`/agentdev/backlog-review` を経て RU 化された後であること |
-| REQ-0105-030 | REQ再構成intake の後続ルートは通常 intake の `/agentdev/intake-promote` ルートと混同せず、REQ-0109 に基づく独立した扱いを維持すること。`intake-promote` は内部で REQ再構成intake を分離処理する |
-| REQ-0105-031 | `backlog-review` は `.agentdev/intake/promoted/`、`.agentdev/learning/promoted/`、`.agentdev/inspect/promoted/` の promoted artifact を読み込み、統合・分割の可能性を分析し、判定をユーザーに提示して承認を得ること |
-| REQ-0105-032 | `backlog-review` は promoted artifact 間の矛盾を検出し、解決をユーザーに委ねること |
 | REQ-0105-045 | RU は case-open の Issue作成 + VERIFY 成功後にのみ削除される一時成果物であり、docs 永続文書の根拠参照としては使用しないこと |
-| REQ-0105-046 | `intake-promote` は `.agentdev/intake/inbox/` 内の intake item を入力とし、`.agentdev/intake/accepted/` を経由せず直接処理すること |
-| REQ-0105-047 | `intake-promote` は内部フェーズとして review 相当の採用・却下・保留判定を実行すること |
-| REQ-0105-048 | `intake-promote` は HITL（Human-in-the-Loop）確定ステップを持ち、ユーザーの明示的な承認なしに promoted artifact を生成してはならない |
-| REQ-0105-049 | `intake-promote` の完了報告は採用・却下・保留の判定結果と後続ルートを提示すること |
-| REQ-0105-050 | `.agentdev/intake/accepted/` ディレクトリは使用しないこと。既存ファイルは inbox/ または promoted/ に配置されること |
-| REQ-0105-052 | `learning-promote` は `.agentdev/learning/inbox.md` 内の learning item を入力とし、内部フェーズとして以下を実行すること: (1) normalize (2) classify (3) 8-axis evaluation (4) evaluation-report 生成 (5) HITL 確定 (6) promote/defer/reject/duplicate 判定 |
-| REQ-0105-053 | `learning-promote` の内部フェーズ（normalize → classify → 8-axis eval → evaluation-report）は独立したコマンドではなく、`learning-promote` 内の処理ステップであること |
-| REQ-0105-054 | evaluation-report.md（`.agentdev/learning/evaluation-report.md`）は `learning-promote` 内部の評価根拠として生成される中間成果物であること |
-| REQ-0105-055 | `learning-promote` は HITL 確定ステップを持ち、AI 単独で promote / prune の最終確定を行ってはならない |
-| REQ-0105-056 | `learning-promote` の完了報告は 8-axis 評価サマリ・判定結果（promote/defer/reject/duplicate）・後続ルートを提示すること |
-| REQ-0105-060 | RU 化に成功した promoted artifact のみが `promoted/` から削除されること。RU 化に失敗した promoted artifact は `promoted/` に残存すること。矛盾 artifact は RU 化されず `promoted/` に残存すること |
-| REQ-0105-065 | `backlog-review` 実行後、`.agentdev/` 配下の変更は git commit / push 済みであること |
-| REQ-0105-066 | RU frontmatter に `depends_on` を記述できること。`depends_on` の値はRU-IDに限定すること。promoted artifact path を依存先として扱わないこと |
-| REQ-0105-067 | `backlog-review` は、同時処理するRU群に `depends_on` が含まれる場合、依存先RUを先に処理すること |
-| REQ-0105-068 | `backlog-review` はRU保存前または処理前に以下を検証すること: (1) `depends_on` に記述されたRU-IDが同一バッチ内または処理対象として存在すること (2) 循環依存が存在しないこと (3) 依存順に並べ替え可能であること |
-| REQ-0105-069 | 未解決依存、循環依存、または同時処理対象外の依存がある場合、`backlog-review` は当該RUを処理せず理由を提示すること |
-| REQ-0105-075 | intake / learning capture の責務境界を `agentdev-workflow-orchestration/references/capture-boundaries.md` に一次参照として定義すること |
-| REQ-0105-076 | PR本文テンプレートの capture セクション名を `## Findings / Capture候補` とすること |
-| REQ-0105-077 | PR本文テンプレートの `## Findings / Capture候補` セクションに `### intake` と `### learning` 小見出しを含めること |
-| REQ-0105-078 | `case-run` は `.agentdev/intake/inbox/` および `.agentdev/learning/inbox.md` を直接変更してはならないこと |
-| REQ-0105-079 | `case-run` から `case-close` への capture 情報の引き継ぎは PR 本文のみを経由すること。一時会話コンテキスト・ローカル変数・中間ファイル経由の引き継ぎは禁止する |
-| REQ-0105-080 | `case-close` は PR本文から intake / learning を分離回収し、それぞれの domain state に保存すること |
-| REQ-0105-081 | `case-close` は case-run の一時会話コンテキストを capture の入力として使用しないこと。capture 情報の入力源は PR 本文のみとする |
-| REQ-0105-082 | `case-close` はユーザーに学びの有無を問うてはならないこと。学びの検知はエージェント自律とする |
-| REQ-0105-083 | `req-save` は intake / learning capture を行わないこと。例外: REQ再構成intake（`.agentdev/intake/inbox/req-restructure/**`）のみ生成可能 |
-| REQ-0105-084 | `case-open` は intake / learning capture を行わないこと |
-| REQ-0105-085 | `case-auto` は構成コマンド（case-run / case-close）の capture 責務境界に従い、case-auto 固有の capture 振る舞いを持たないこと |
-| REQ-0105-086 | 単一の観測から intake と learning の両方が得られる場合、別々の成果物に分離すること。intake/learning を混ぜた単一成果物の作成を禁止する |
-| REQ-0105-087 | `capture-boundaries.md` に capture 候補分類の判断質問を含めること |
-| REQ-0105-088 | `capture-boundaries.md` に intake / learning の代表例と非対象例を含めること |
-| REQ-0105-089 | `docs/specs/system.md` の Post-Run Capture 参照先が `capture-boundaries.md` を含むこと |
-| REQ-0105-090 | `docs/specs/integrity-contracts.md` の req-save Allowed Changes に capture 非関与（REQ再構成intake除く）が反映されていること |
 | REQ-0105-091 | RU frontmatter の `source_type` に `diagnostics` を含めること |
 | REQ-0105-092 | diagnostics promoted artifact を RU 化した場合、RU の `sources` に元 artifact path を記録すること |
 | REQ-0105-093 | `promoted/` の意味を intake / learning / diagnostics で「採用済み・RU 化対象」に統一すること |
 
 ## 適用範囲
 
-- **対象**: intake、learning、backlog-review、RU lifecycle、session-sourced RU、`.agentdev/` domain state、`intake-promote`（内部 review フェーズ）、`learning-promote`（内部 refine フェーズ）、HITL 確定ポイントの promote 内集約、backlog-review による RU 直接生成、`.agentdev/intake/accepted/` 不使用、depends_on
-- **対象外**: `.sisyphus/`（`backlog-review-*.md` を除く）、case実行、REQ本文の再構成手順、`intake-promote` の整形ロジック、`backlog-review` の RU 統合・分割判定の詳細ルール、`req-define` の RU 読み込み仕様、個別 intake item の内容、パイプライン全体構成の詳細、`req-define` の仕様変更、learning の 8-axis 評価ディメンションの変更、evaluation-report schema の変更（配置先変更のみ）、個別 learning item の内容、capture 境界の具体的な intake/learning 分類アルゴリズム
+- **対象**: RU lifecycle（生成・削除タイミング・一時成果物位置づけ）、session-sourced RU（chat 合意起点）、RU frontmatter メタデータ（source_type・sources・diagnostics）、RU と docs 永続文書の境界、promoted/ の RU 化対象としての統一意味、req-define / req-save の RU 受け入れ境界
+- **対象外**: intake pipeline（REQ-0127）、learning-promote（REQ-0128）、backlog-review の RU 生成・depends_on 検証（REQ-0129）、case-open の RU 削除実行責務（REQ-0132）、REQ本文の再構成手順、`req-define` の RU 読み込み仕様変更
 
 ## Update Notes
+
+### 2026-06-16: コマンドレベル分割（OU-03 / Issue #831）
+
+REQ-0105（旧 "Intake / Learning / Backlog"）のコマンドレベル分割を実施。intake / learning / backlog コマンド群の要件を新規 REQ に移行し、本 REQ は RU lifecycle に特化してスリム化した。
+
+**移行先**:
+
+| 移行先 REQ | タイトル | 移行元要件行 |
+|---|---|---|
+| REQ-0127 | Intake command群 (capture / from-github / promote) | 001, 002, 004, 007, 028, 030, 046-050, 075-077, 083, 085-090 |
+| REQ-0128 | Learning-promote | 005, 006, 052-056 |
+| REQ-0129 | Backlog-review | 008, 009, 013, 031, 032, 060, 065, 066, 067-069 |
+| REQ-0130 | case-run / 実装パイプライン | 078, 079（capture 責務境界） |
+| REQ-0131 | case-close / 完了処理 | 080, 081, 082（capture 責務境界） |
+| REQ-0132 | case-open / Issue作成 | 015, 023, 024, 084（RU削除責務・capture 非関与） |
+
+**本 REQ に残存**: 010, 011, 012, 014, 016, 017-022, 045, 091-093（RU lifecycle・session-sourced RU・RU frontmatter メタデータ）
+
+**title 変更**: "Intake / Learning / Backlog" → "RU lifecycle / Requirement Unit 管理"
 
 ### 2026-06-02: req-backlog 完全削除（Case 8）
 
@@ -138,3 +109,8 @@ updated: "2026-06-16"
 - **REQ-0105-060**: 更新: 「削除すること/残すこと」→「削除されること/残存すること」（状態化）
 - **REQ-0105-065**: 更新: 「commit / push すること」→「commit / push 済みであること」（状態化）
 - **適用範囲**: 廃止/統合作業表現を現在構成記述に置換
+
+## 関連情報
+
+- **Split to**: REQ-0127（Intake command群）、REQ-0128（Learning-promote）、REQ-0129（Backlog-review）、REQ-0130（case-run capture責務）、REQ-0131（case-close capture責務）、REQ-0132（case-open RU削除責務）
+- **Related REQs**: REQ-0102（要件定義・保存 - req-define/req-save）、REQ-0104（Workflow / Command Protocol）、REQ-0109（inspect-docs / REQ再構成運用）

--- a/docs/requirements/REQ-0106.md
+++ b/docs/requirements/REQ-0106.md
@@ -1,63 +1,46 @@
 ---
 id: REQ-0106
-title: "Case実行・完了"
+title: "Case実行オーケストレーション / Epic・Wave"
 created: "2026-05-30"
 updated: "2026-06-16"
 ---
 
 ## 目的
 
-case-run / case-close の実行信頼性、並列・Epic実行、完了ゲート、post-run回収を定義する。
+複数 Case の並列実行、Epic / Wave 実行の信頼性、委譲プロンプトの事後検証、Epic 子 Issue の終了状態管理を定義する。case-run / case-close の個別要件は REQ-0130 / REQ-0131 に移行し、本 REQ は実行オーケストレーションに特化する。
 
 ## 要件
 
 | ID | 要件 |
 |---|---|
-| REQ-0106-001 | `case-run` は準備・実装・提出の再開可能なフェーズを提供すること |
-| REQ-0106-002 | `case-run` は作業用 worktree で実装し、PRを作成すること |
 | REQ-0106-003 | 複数Caseの並列実行は依存関係を分析し、安全なWave単位で実行すること |
 | REQ-0106-004 | Epic実行では親Issueの実行順序をSSoTとし、子Issueの実行状態と整合させること |
-| REQ-0106-005 | `case-run` はチェックボックス更新など外部書き込みの成功を確認してから完了扱いにすること |
-| REQ-0106-006 | `case-run` は関連ドキュメント更新候補を実装計画に組み込むこと |
-| REQ-0106-007 | `case-run` は実装diffから関連キーワードを抽出し、SPEC等に矛盾がないか確認すること |
-| REQ-0106-008 | `case-run` は本筋外FindingをPR本文の `## Findings / Capture候補` セクションに `### intake` と `### learning` 小見出しで分類して記録すること |
-| REQ-0106-009 | `case-close` は未チェック項目の達成判定を実行し、達成済み項目を更新すること |
-| REQ-0106-010 | `case-close` は要件・成果物・SPEC・DOC-MAPの整合確認を行うこと |
-| REQ-0106-011 | `case-close` は ADR が必要な判断に対して ADR 作成済みかを確認すること |
-| REQ-0106-012 | `case-close` は PR merge、Issue close、domain state 永続化、branch / worktree cleanup の結果を分離して報告すること |
-| REQ-0106-013 | `case-close` は PR本文の `## Findings / Capture候補` セクションから intake / learning を分離回収し、intake 候補を `.agentdev/intake/inbox/` に、learning 候補を `.agentdev/learning/inbox.md` に保存すること |
-| REQ-0106-014 | branch / worktree 削除失敗時は警告して停止し、危険な自動削除を行わないこと |
-| REQ-0106-015 | `case-close` は `git pull --ff-only` 前にローカル変更を検出した場合、自動で `git checkout --` により変更をリセットしてはならないこと |
-| REQ-0106-016 | `case-close` は pull 前ローカル変更を検出した場合、対象ファイルと状態を表示し、構造化エラーで停止すること |
-| REQ-0106-017 | pull 前ローカル変更の自動リセット対象を「PRで削除されたファイル」に限定する旧規則は現行適用外であること |
 | REQ-0106-018 | Epic Orchestrator の全Wave完了後、子Issueのステータスを一括更新すること |
 | REQ-0106-019 | 後続Wave開始前に `git rebase origin/main` を実行し、コンフリクト時は停止してユーザー判断に委ねること |
 | REQ-0106-020 | 委譲プロンプトに Read tool による対象ファイルの事後検証（変更反映確認）を 必須 ステップとして含めること |
-| REQ-0106-021 | Step 8 乖離検出において、削除・変更対象キーワードの `docs/` 全体 grep を必須ステップとすること |
-| REQ-0106-022 | `case-close` Step 8 で Epic を検出した際、G04 自動クローズ判定を実行する前に全子 Issue の OPEN/CLOSED 状態を事前取得し、状態一覧をログ出力すること |
-| REQ-0106-023 | G04 自動クローズ判定のロジック自体は変更しないこと |
-| REQ-0106-024 | `case-close` Step 4 で squash merge が失敗した場合、5秒間隔で最大5回自動リトライすること |
-| REQ-0106-025 | リトライ全失敗後、rebase workflow（`git rebase origin/main` → force-push）へのフォールバックを提示し、ユーザー判断に委ねること |
-| REQ-0106-026 | push 操作において `--force` を禁止し、`--force-with-lease` のみを許可すること |
 | REQ-0106-027 | `agentdev-workflow-orchestration` スキルの Wave scheduling 手順にファイル変更範囲の非重複チェックが含まれること |
 | REQ-0106-028 | `agentdev-workflow-orchestration/references/self-healing-and-errors.md` にマージコンフリクト予防のガイダンスが含まれること |
 | REQ-0106-029 | SKILL.md は500行以下を維持すること。詳細は references/ に配置 |
 | REQ-0106-030 | Epic 子Issue ステータスに ⏭スキップ を終了状態として定義すること。⏭スキップ は前提条件未達・依存関係未充足等で子Issueの実行をスキップした場合に Orchestrator が設定する。スキップ理由は Epic 本文に記録すること。⏭スキップ の子Issueは case-close の完了判定・Epic自動クローズ判定で完了と同等の終了状態として扱うこと |
-| REQ-0106-031 | case-run の QG-3 が PR 作成直前の実装充足・乖離ゲートに限定されていること。品質メトリクス収集・docs全体grep・Document Classification Policy全体確認・case-update連携が QG-3 に含まれないこと |
-| REQ-0106-032 | Issue本文の完了条件チェックボックスの評価・更新が case-close の責務であり、case-run に含まれないこと |
+
+## 適用範囲
+
+- **対象**: Epic / Wave 並列実行オーケストレーション、親Issue SSoT・子Issue 実行状態整合、Wave rebase・コンフリクト時停止、委譲プロンプト事後検証、Wave scheduling ファイル非重複チェック、マージコンフリクト予防ガイダンス、SKILL.md 行数上限、Epic 子Issue ⏭スキップ終了状態
+- **対象外**: case-run の個別要件（REQ-0130）、case-close の個別要件（REQ-0131）、case-open（REQ-0132）、case-update（REQ-0133）、workflow基本契約・work_type分類（REQ-0104）、intake / learning pipeline（REQ-0127 / 0128）
 
 ## Update Notes
 
 | 日付 | 対象 | 変更内容 |
 |------|------|----------|
-| 2026-06-10 | REQ-0106-008, 013 | UPDATE: セクション名 `## Findings / Capture候補` 反映・intake/learning 分離回収の明文化（Issue #701） |
+| 2026-06-16 | REQ-0106 (全体) | コマンドレベル分割（OU-03 / Issue #831）。case-run 固有要件 → REQ-0130、case-close 固有要件 → REQ-0131 に移行。本 REQ は Case実行オーケストレーション（Epic/Wave・委譲安全性・子Issue終了状態）に特化。title を "Case実行・完了" → "Case実行オーケストレーション / Epic・Wave" に変更 |
+| 2026-06-10 | REQ-0106-008, 013 | UPDATE: セクション名 `## Findings / Capture候補` 反映・intake/learning 分離回収の明文化（Issue #701）→ REQ-0130-006 / REQ-0131-005 に移行 |
 | 2026-06-07 | REQ-0106-027-029 | APPEND: Wave scheduling ファイル非重複チェック・マージコンフリクト予防ガイダンス・SKILL.md 500行上限（8RU統合） |
 | 2026-06-09 | REQ-0106-030 | APPEND: Epic子Issue ⏭スキップ 終了状態の正式定義（Issue #697 docs-consistency-remediation） |
 | 2026-06-16 | REQ-0106-017,027,028 | 状態要件化（作業手段語除去） |
-| 2026-06-16 | REQ-0106-031 | APPEND: case-run QG-3 を PR作成直前ゲートに限定（agentdev-system-reorganization OU-09） |
-| 2026-06-16 | REQ-0106-032 | APPEND: Issue完了条件チェックボックス評価を case-close 責務に（agentdev-system-reorganization OU-09） |
+| 2026-06-16 | REQ-0106-031 | APPEND: case-run QG-3 を PR作成直前ゲートに限定 → REQ-0130-007 に移行 |
+| 2026-06-16 | REQ-0106-032 | APPEND: Issue完了条件チェックボックス評価を case-close 責務に → REQ-0131-016 に移行 |
 
-## 適用範囲
+## 関連情報
 
-- **対象**: case-run、case-close、Epic/Wave実行、完了ゲート、post-run capture、worktree cleanup
-- **対象外**: req-define / req-save、intake / learning の詳細処理
+- **Split to**: REQ-0130（case-run / 実装パイプライン）、REQ-0131（case-close / 完了処理）
+- **Related REQs**: REQ-0104（Workflow / Command Protocol）、REQ-0132（case-open）、REQ-0133（case-update）、REQ-0114（case-auto 最大自走モード）

--- a/docs/requirements/REQ-0127.md
+++ b/docs/requirements/REQ-0127.md
@@ -1,0 +1,74 @@
+---
+id: REQ-0127
+title: "Intake command群 (capture / from-github / promote)"
+created: "2026-06-16"
+updated: "2026-06-16"
+---
+
+## 目的
+
+ユーザー入力・クローズ済み Issue/PR からの作業候補を `.agentdev/intake/` に蓄積し、採用判定と HITL 確定を経て promoted artifact として要件化パイプラインに供給する。intake / learning capture の責務境界の一次定義と、他 command の capture 非関与を含む。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0127-001 | intake pipeline の domain state は `.agentdev/intake/` に配置すること |
+| REQ-0127-002 | `intake-capture` はユーザー入力から明示できる内容のみを intake item として整理すること |
+| REQ-0127-003 | `intake-promote` は `.agentdev/intake/inbox/` 内の intake item を直接読み込み、採用判定・HITL 確定を経て `.agentdev/intake/promoted/` または `.agentdev/intake/archive/` に配置すること |
+| REQ-0127-004 | `intake-promote` は `.agentdev/intake/inbox/` 内の intake item を入力とし、`.agentdev/intake/accepted/` を経由せず直接処理すること |
+| REQ-0127-005 | `intake-promote` は内部フェーズとして review 相当の採用・却下・保留判定を実行すること |
+| REQ-0127-006 | `intake-promote` は HITL（Human-in-the-Loop）確定ステップを持ち、ユーザーの明示的な承認なしに promoted artifact を生成してはならない |
+| REQ-0127-007 | `intake-promote` の完了報告は採用・却下・保留の判定結果と後続ルートを提示すること |
+| REQ-0127-008 | `.agentdev/intake/accepted/` ディレクトリは使用しないこと。既存ファイルは inbox/ または promoted/ に配置されること |
+| REQ-0127-009 | 通常 intake 起点の item が `/agentdev/req-define` に渡されるのは、`/agentdev/intake-promote`、`/agentdev/backlog-review` を経て RU 化された後であること |
+| REQ-0127-010 | REQ再構成intake の後続ルートは通常 intake の `/agentdev/intake-promote` ルートと混同せず、REQ-0109 に基づく独立した扱いを維持すること。`intake-promote` は内部で REQ再構成intake を分離処理する |
+| REQ-0127-011 | 同一観測から intake と learning の両方が発生する場合、成果物を分離すること |
+| REQ-0127-012 | 単一の観測から intake と learning の両方が得られる場合、別々の成果物に分離すること。intake/learning を混ぜた単一成果物の作成を禁止する |
+| REQ-0127-013 | intake / learning capture の責務境界を `agentdev-workflow-orchestration/references/capture-boundaries.md` に一次参照として定義すること |
+| REQ-0127-014 | PR本文テンプレートの capture セクション名を `## Findings / Capture候補` とすること |
+| REQ-0127-015 | PR本文テンプレートの `## Findings / Capture候補` セクションに `### intake` と `### learning` 小見出しを含めること |
+| REQ-0127-016 | `capture-boundaries.md` に capture 候補分類の判断質問を含めること |
+| REQ-0127-017 | `capture-boundaries.md` に intake / learning の代表例と非対象例を含めること |
+| REQ-0127-018 | `docs/specs/system.md` の Post-Run Capture 参照先が `capture-boundaries.md` を含むこと |
+| REQ-0127-019 | `docs/specs/integrity-contracts.md` の req-save Allowed Changes に capture 非関与（REQ再構成intake除く）が反映されていること |
+| REQ-0127-020 | `req-save` は intake / learning capture を行わないこと。例外: REQ再構成intake（`.agentdev/intake/inbox/req-restructure/**`）のみ生成可能 |
+| REQ-0127-021 | `case-auto` は構成コマンド（case-run / case-close）の capture 責務境界に従い、case-auto 固有の capture 振る舞いを持たないこと |
+
+## 適用範囲
+
+- **対象**: intake-capture、intake-from-github、intake-promote（内部 review フェーズ含む）、`.agentdev/intake/` domain state、`.agentdev/intake/accepted/` 不使用、intake / learning capture 責務境界（capture-boundaries.md）、PR template capture セクション、capture 非関与 command の制約（req-save・case-auto）、REQ再構成intake のルーティング分離
+- **対象外**: learning-promote の詳細処理（REQ-0128）、backlog-review の RU 生成（REQ-0129）、RU lifecycle（REQ-0105）、case-run / case-close / case-open の capture 振る舞い（REQ-0130 / 0131 / 0132）、`intake-promote` の整形ロジック、個別 intake item の内容、capture 境界の具体的な intake/learning 分類アルゴリズム
+
+## Update Notes
+
+### 2026-06-16: REQ-0105 からの分割（OU-03 / Issue #831）
+
+REQ-0105（旧 "Intake / Learning / Backlog"）のコマンドレベル分割により新設。以下の REQ-0105 要件行を再採番して移行:
+
+- REQ-0105-001 → REQ-0127-001
+- REQ-0105-002 → REQ-0127-002
+- REQ-0105-004 → REQ-0127-003
+- REQ-0105-046 → REQ-0127-004
+- REQ-0105-047 → REQ-0127-005
+- REQ-0105-048 → REQ-0127-006
+- REQ-0105-049 → REQ-0127-007
+- REQ-0105-050 → REQ-0127-008
+- REQ-0105-028 → REQ-0127-009
+- REQ-0105-030 → REQ-0127-010
+- REQ-0105-007 → REQ-0127-011
+- REQ-0105-086 → REQ-0127-012
+- REQ-0105-075 → REQ-0127-013
+- REQ-0105-076 → REQ-0127-014
+- REQ-0105-077 → REQ-0127-015
+- REQ-0105-087 → REQ-0127-016
+- REQ-0105-088 → REQ-0127-017
+- REQ-0105-089 → REQ-0127-018
+- REQ-0105-090 → REQ-0127-019
+- REQ-0105-083 → REQ-0127-020
+- REQ-0105-085 → REQ-0127-021
+
+## 関連情報
+
+- **Split from**: REQ-0105（旧 "Intake / Learning / Backlog"）
+- **Related REQs**: REQ-0128（Learning-promote）、REQ-0129（Backlog-review）、REQ-0105（RU lifecycle）

--- a/docs/requirements/REQ-0128.md
+++ b/docs/requirements/REQ-0128.md
@@ -1,0 +1,46 @@
+---
+id: REQ-0128
+title: "Learning-promote"
+created: "2026-06-16"
+updated: "2026-06-16"
+---
+
+## 目的
+
+再発防止・抽象化・反映価値のある知見を `.agentdev/learning/` に蓄積し、8-axis 評価と HITL 確定を経て promoted artifact として要件化パイプラインに供給する。learning pipeline の domain state 管理と promote 判定を定義する。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0128-001 | learning pipeline の domain state は `.agentdev/learning/` に配置すること |
+| REQ-0128-002 | learning は再発防止・抽象化・反映価値のある知見を蓄積すること |
+| REQ-0128-003 | `learning-promote` は `.agentdev/learning/inbox.md` 内の learning item を入力とし、内部フェーズとして以下を実行すること: (1) normalize (2) classify (3) 8-axis evaluation (4) evaluation-report 生成 (5) HITL 確定 (6) promote/defer/reject/duplicate 判定 |
+| REQ-0128-004 | `learning-promote` の内部フェーズ（normalize → classify → 8-axis eval → evaluation-report）は独立したコマンドではなく、`learning-promote` 内の処理ステップであること |
+| REQ-0128-005 | evaluation-report.md（`.agentdev/learning/evaluation-report.md`）は `learning-promote` 内部の評価根拠として生成される中間成果物であること |
+| REQ-0128-006 | `learning-promote` は HITL 確定ステップを持ち、AI 単独で promote / prune の最終確定を行ってはならない |
+| REQ-0128-007 | `learning-promote` の完了報告は 8-axis 評価サマリ・判定結果（promote/defer/reject/duplicate）・後続ルートを提示すること |
+
+## 適用範囲
+
+- **対象**: learning-promote、`.agentdev/learning/` domain state、learning inbox.md、evaluation-report.md、8-axis 評価、HITL 確定、promote/defer/reject/duplicate 判定
+- **対象外**: intake pipeline（REQ-0127）、backlog-review の RU 生成（REQ-0129）、RU lifecycle（REQ-0105）、learning の 8-axis 評価ディメンションの変更、evaluation-report schema の変更（配置先変更のみ）、個別 learning item の内容、case-run / case-close からの learning capture 回収（REQ-0130 / 0131）
+
+## Update Notes
+
+### 2026-06-16: REQ-0105 からの分割（OU-03 / Issue #831）
+
+REQ-0105（旧 "Intake / Learning / Backlog"）のコマンドレベル分割により新設。以下の REQ-0105 要件行を再採番して移行:
+
+- REQ-0105-005 → REQ-0128-001
+- REQ-0105-006 → REQ-0128-002
+- REQ-0105-052 → REQ-0128-003
+- REQ-0105-053 → REQ-0128-004
+- REQ-0105-054 → REQ-0128-005
+- REQ-0105-055 → REQ-0128-006
+- REQ-0105-056 → REQ-0128-007
+
+## 関連情報
+
+- **Split from**: REQ-0105（旧 "Intake / Learning / Backlog"）
+- **Related REQs**: REQ-0127（Intake command群）、REQ-0129（Backlog-review）、REQ-0105（RU lifecycle）

--- a/docs/requirements/REQ-0129.md
+++ b/docs/requirements/REQ-0129.md
@@ -1,0 +1,54 @@
+---
+id: REQ-0129
+title: "Backlog-review"
+created: "2026-06-16"
+updated: "2026-06-16"
+---
+
+## 目的
+
+intake / learning / diagnostics の promoted artifact を分析・統合し、ユーザー承認を経て RU（Requirement Unit）を `.agentdev/backlog/req-units/` に直接生成する。promoted artifact 間の矛盾検出と depends_on による依存順序制御を含む。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0129-001 | `backlog-review` は intake / learning の promoted artifact を分析・統合し、ユーザー承認を経て RU を `.agentdev/backlog/req-units/` に生成すること。backlog-save を経由せず、backlog-review 内で直接 RU を生成する |
+| REQ-0129-002 | RU は promoted artifact の単純コピーではなく、要件化に向けた構造化内容とすること |
+| REQ-0129-003 | REQ再構成intakeは通常の短期Issue化候補と区別し、`backlog-review` 向け短期候補として処理しないこと |
+| REQ-0129-004 | `backlog-review` は `.agentdev/intake/promoted/`、`.agentdev/learning/promoted/`、`.agentdev/inspect/promoted/` の promoted artifact を読み込み、統合・分割の可能性を分析し、判定をユーザーに提示して承認を得ること |
+| REQ-0129-005 | `backlog-review` は promoted artifact 間の矛盾を検出し、解決をユーザーに委ねること |
+| REQ-0129-006 | RU 化に成功した promoted artifact のみが `promoted/` から削除されること。RU 化に失敗した promoted artifact は `promoted/` に残存すること。矛盾 artifact は RU 化されず `promoted/` に残存すること |
+| REQ-0129-007 | `backlog-review` 実行後、`.agentdev/` 配下の変更は git commit / push 済みであること |
+| REQ-0129-008 | RU frontmatter に `depends_on` を記述できること。`depends_on` の値はRU-IDに限定すること。promoted artifact path を依存先として扱わないこと |
+| REQ-0129-009 | `backlog-review` は、同時処理するRU群に `depends_on` が含まれる場合、依存先RUを先に処理すること |
+| REQ-0129-010 | `backlog-review` はRU保存前または処理前に以下を検証すること: (1) `depends_on` に記述されたRU-IDが同一バッチ内または処理対象として存在すること (2) 循環依存が存在しないこと (3) 依存順に並べ替え可能であること |
+| REQ-0129-011 | 未解決依存、循環依存、または同時処理対象外の依存がある場合、`backlog-review` は当該RUを処理せず理由を提示すること |
+
+## 適用範囲
+
+- **対象**: backlog-review、RU 直接生成（backlog-save 経由なし）、promoted artifact 読込・統合・矛盾検出、RU の構造化内容、depends_on（RU-ID限定・依存順序・循環依存検証）、REQ再構成intake のルーティング分離、backlog-review 後の git 永続化
+- **対象外**: intake pipeline（REQ-0127）、learning-promote（REQ-0128）、RU lifecycle・RU 削除タイミング（REQ-0105）、`backlog-review` の RU 統合・分割判定の詳細ルール、req-define の RU 読み込み仕様（REQ-0102）
+
+## Update Notes
+
+### 2026-06-16: REQ-0105 からの分割（OU-03 / Issue #831）
+
+REQ-0105（旧 "Intake / Learning / Backlog"）のコマンドレベル分割により新設。以下の REQ-0105 要件行を再採番して移行:
+
+- REQ-0105-008 → REQ-0129-001
+- REQ-0105-009 → REQ-0129-002
+- REQ-0105-013 → REQ-0129-003
+- REQ-0105-031 → REQ-0129-004
+- REQ-0105-032 → REQ-0129-005
+- REQ-0105-060 → REQ-0129-006
+- REQ-0105-065 → REQ-0129-007
+- REQ-0105-066 → REQ-0129-008
+- REQ-0105-067 → REQ-0129-009
+- REQ-0105-068 → REQ-0129-010
+- REQ-0105-069 → REQ-0129-011
+
+## 関連情報
+
+- **Split from**: REQ-0105（旧 "Intake / Learning / Backlog"）
+- **Related REQs**: REQ-0127（Intake command群）、REQ-0128（Learning-promote）、REQ-0105（RU lifecycle）

--- a/docs/requirements/REQ-0130.md
+++ b/docs/requirements/REQ-0130.md
@@ -1,0 +1,53 @@
+---
+id: REQ-0130
+title: "case-run / 実装パイプライン"
+created: "2026-06-16"
+updated: "2026-06-16"
+---
+
+## 目的
+
+case-run の実行信頼性、作業用 worktree での実装、PR 作成、実装充足・乖離ゲート（QG-3）を定義する。case-run の capture 責務境界と、case-close への capture 情報引き継ぎ手段を含む。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0130-001 | `case-run` は準備・実装・提出の再開可能なフェーズを提供すること |
+| REQ-0130-002 | `case-run` は作業用 worktree で実装し、PRを作成すること |
+| REQ-0130-003 | `case-run` はチェックボックス更新など外部書き込みの成功を確認してから完了扱いにすること |
+| REQ-0130-004 | `case-run` は関連ドキュメント更新候補を実装計画に組み込むこと |
+| REQ-0130-005 | `case-run` は実装diffから関連キーワードを抽出し、SPEC等に矛盾がないか確認すること |
+| REQ-0130-006 | `case-run` は本筋外FindingをPR本文の `## Findings / Capture候補` セクションに `### intake` と `### learning` 小見出しで分類して記録すること |
+| REQ-0130-007 | case-run の QG-3 が PR 作成直前の実装充足・乖離ゲートに限定されていること。品質メトリクス収集・docs全体grep・Document Classification Policy全体確認・case-update連携が QG-3 に含まれないこと |
+| REQ-0130-008 | `case-run` は `.agentdev/intake/inbox/` および `.agentdev/learning/inbox.md` を直接変更してはならないこと |
+| REQ-0130-009 | `case-run` から `case-close` への capture 情報の引き継ぎは PR 本文のみを経由すること。一時会話コンテキスト・ローカル変数・中間ファイル経由の引き継ぎは禁止する |
+
+## 適用範囲
+
+- **対象**: case-run、作業用 worktree 実装、PR 作成、QG-3（PR作成直前ゲート）、本筋外 Finding の PR 本文記録、capture 責務境界（inbox 非変更・PR本文経由引き継ぎ）、チェックボックス外部書き込み確認、関連ドキュメント更新候補の実装計画組み込み、実装diff SPEC矛盾確認
+- **対象外**: case-close（REQ-0131）、case-open（REQ-0132）、Epic/Wave 並列実行オーケストレーション（REQ-0106）、workflow基本契約・work_type分類（REQ-0104）、intake / learning pipeline（REQ-0127 / 0128）、REQ再構成の詳細手順
+
+## Update Notes
+
+### 2026-06-16: REQ-0106 からの分割（OU-03 / Issue #831）
+
+REQ-0106（旧 "Case実行・完了"）のコマンドレベル分割により新設。以下の要件行を再採番して移行:
+
+- REQ-0106-001 → REQ-0130-001
+- REQ-0106-002 → REQ-0130-002
+- REQ-0106-005 → REQ-0130-003
+- REQ-0106-006 → REQ-0130-004
+- REQ-0106-007 → REQ-0130-005
+- REQ-0106-008 → REQ-0130-006
+- REQ-0106-031 → REQ-0130-007
+
+### 2026-06-16: REQ-0105 からの capture 責務境界移行（OU-03 / Issue #831）
+
+- REQ-0105-078 → REQ-0130-008
+- REQ-0105-079 → REQ-0130-009
+
+## 関連情報
+
+- **Split from**: REQ-0106（旧 "Case実行・完了"）、REQ-0105（capture 責務境界）
+- **Related REQs**: REQ-0131（case-close）、REQ-0106（Case実行オーケストレーション）、REQ-0104（Workflow基本契約）

--- a/docs/requirements/REQ-0131.md
+++ b/docs/requirements/REQ-0131.md
@@ -1,0 +1,73 @@
+---
+id: REQ-0131
+title: "case-close / 完了処理"
+created: "2026-06-16"
+updated: "2026-06-16"
+---
+
+## 目的
+
+case-close の完了ゲート、PR merge、Issue close、domain state 永続化、post-run capture 回収、branch / worktree cleanup を定義する。PR 本文からの intake / learning 分離回収と、ローカル変更検出時の安全な停止を含む。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0131-001 | `case-close` は未チェック項目の達成判定を実行し、達成済み項目を更新すること |
+| REQ-0131-002 | `case-close` は要件・成果物・SPEC・DOC-MAPの整合確認を行うこと |
+| REQ-0131-003 | `case-close` は ADR が必要な判断に対して ADR 作成済みかを確認すること |
+| REQ-0131-004 | `case-close` は PR merge、Issue close、domain state 永続化、branch / worktree cleanup の結果を分離して報告すること |
+| REQ-0131-005 | `case-close` は PR本文の `## Findings / Capture候補` セクションから intake / learning を分離回収し、intake 候補を `.agentdev/intake/inbox/` に、learning 候補を `.agentdev/learning/inbox.md` に保存すること |
+| REQ-0131-006 | branch / worktree 削除失敗時は警告して停止し、危険な自動削除を行わないこと |
+| REQ-0131-007 | `case-close` は `git pull --ff-only` 前にローカル変更を検出した場合、自動で `git checkout --` により変更をリセットしてはならないこと |
+| REQ-0131-008 | `case-close` は pull 前ローカル変更を検出した場合、対象ファイルと状態を表示し、構造化エラーで停止すること |
+| REQ-0131-009 | pull 前ローカル変更の自動リセット対象を「PRで削除されたファイル」に限定する旧規則は現行適用外であること |
+| REQ-0131-010 | `case-close` Step 8 乖離検出において、削除・変更対象キーワードの `docs/` 全体 grep を必須ステップとすること |
+| REQ-0131-011 | `case-close` Step 8 で Epic を検出した際、G04 自動クローズ判定を実行する前に全子 Issue の OPEN/CLOSED 状態を事前取得し、状態一覧をログ出力すること |
+| REQ-0131-012 | G04 自動クローズ判定のロジック自体は変更しないこと |
+| REQ-0131-013 | `case-close` Step 4 で squash merge が失敗した場合、5秒間隔で最大5回自動リトライすること |
+| REQ-0131-014 | リトライ全失敗後、rebase workflow（`git rebase origin/main` → force-push）へのフォールバックを提示し、ユーザー判断に委ねること |
+| REQ-0131-015 | push 操作において `--force` を禁止し、`--force-with-lease` のみを許可すること |
+| REQ-0131-016 | Issue本文の完了条件チェックボックスの評価・更新が case-close の責務であり、case-run に含まれないこと |
+| REQ-0131-017 | `case-close` は PR本文から intake / learning を分離回収し、それぞれの domain state に保存すること |
+| REQ-0131-018 | `case-close` は case-run の一時会話コンテキストを capture の入力として使用しないこと。capture 情報の入力源は PR 本文のみとする |
+| REQ-0131-019 | `case-close` はユーザーに学びの有無を問うてはならないこと。学びの検知はエージェント自律とする |
+
+## 適用範囲
+
+- **対象**: case-close、完了ゲート（要件・成果物・SPEC・DOC-MAP整合確認・ADR確認）、PR merge（squash・リトライ・フォールバック）、Issue close、capture 回収（PR本文→intake/learning domain state）、branch / worktree cleanup、ローカル変更検出時の安全停止、乖離検出（docs全体grep）、Epic G04自動クローズ判定、完了条件チェックボックス評価・更新、force-with-lease制約
+- **対象外**: case-run（REQ-0130）、case-open（REQ-0132）、Epic/Wave 並列実行オーケストレーション（REQ-0106）、workflow基本契約（REQ-0104）、intake / learning pipeline の詳細処理（REQ-0127 / 0128）
+
+## Update Notes
+
+### 2026-06-16: REQ-0106 からの分割（OU-03 / Issue #831）
+
+REQ-0106（旧 "Case実行・完了"）のコマンドレベル分割により新設。以下の要件行を再採番して移行:
+
+- REQ-0106-009 → REQ-0131-001
+- REQ-0106-010 → REQ-0131-002
+- REQ-0106-011 → REQ-0131-003
+- REQ-0106-012 → REQ-0131-004
+- REQ-0106-013 → REQ-0131-005
+- REQ-0106-014 → REQ-0131-006
+- REQ-0106-015 → REQ-0131-007
+- REQ-0106-016 → REQ-0131-008
+- REQ-0106-017 → REQ-0131-009
+- REQ-0106-021 → REQ-0131-010
+- REQ-0106-022 → REQ-0131-011
+- REQ-0106-023 → REQ-0131-012
+- REQ-0106-024 → REQ-0131-013
+- REQ-0106-025 → REQ-0131-014
+- REQ-0106-026 → REQ-0131-015
+- REQ-0106-032 → REQ-0131-016
+
+### 2026-06-16: REQ-0105 からの capture 責務境界移行（OU-03 / Issue #831）
+
+- REQ-0105-080 → REQ-0131-017
+- REQ-0105-081 → REQ-0131-018
+- REQ-0105-082 → REQ-0131-019
+
+## 関連情報
+
+- **Split from**: REQ-0106（旧 "Case実行・完了"）、REQ-0105（capture 責務境界）
+- **Related REQs**: REQ-0130（case-run）、REQ-0106（Case実行オーケストレーション）、REQ-0104（Workflow基本契約）

--- a/docs/requirements/REQ-0132.md
+++ b/docs/requirements/REQ-0132.md
@@ -1,0 +1,44 @@
+---
+id: REQ-0132
+title: "case-open / Issue作成"
+created: "2026-06-16"
+updated: "2026-06-16"
+---
+
+## 目的
+
+要件doc から GitHub Issue を生成し、REQ 番号を Issue 本文に埋め込む。Standard flow と Epic flow のルーティングを要件doc 構成に基づいて判定する。Issue 作成 + VERIFY 成功後に RU を削除する唯一のコマンドとしての責務を定義する。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0132-001 | `case-open` は要件doc から Issue 本文を生成し、対象 REQ 番号を Issue 本文に埋め込むこと |
+| REQ-0132-002 | `case-open` は入力要件doc数・scale・OU 構成に基づき Standard flow と Epic flow をルーティングすること |
+| REQ-0132-003 | `case-open` は Issue 作成 + VERIFY 成功後に RU を削除する唯一のコマンドであること |
+| REQ-0132-004 | `case-open` は RU ファイル削除を commit/push した場合、main 作業ディレクトリの HEAD と `origin/main` が一致し、`git status --porcelain` に削除済み RU ファイルが残っていないことを確認すること |
+| REQ-0132-005 | `case-open` は RU ファイル削除 commit/push 後の同期確認に失敗した場合、完了扱いにせず、対象ファイル・現在の HEAD・`origin/main` を表示して停止すること |
+| REQ-0132-006 | `case-open` は intake / learning capture を行わないこと |
+
+## 適用範囲
+
+- **対象**: case-open、Issue 本文生成（REQ番号埋め込み）、Standard / Epic flow ルーティング、RU 削除（Issue作成 + VERIFY 成功後・同期確認・失敗時停止）、capture 非関与
+- **対象外**: workflow基本契約・work_type分類・draft metadata・OU選択ゲート・upstream handoff停止条件・共通終了処理の全フロー共通化（REQ-0104）、case-run（REQ-0130）、case-close（REQ-0131）、Epic/Wave 並列実行オーケストレーション（REQ-0106）、RU lifecycle の状態定義（REQ-0105）
+
+## Update Notes
+
+### 2026-06-16: 新設（OU-03 / Issue #831）
+
+REQ-0105（旧 "Intake / Learning / Backlog"）のコマンドレベル分割により新設。case-open 固有の要件行を再採番して移行:
+
+- REQ-0105-015 → REQ-0132-003
+- REQ-0105-023 → REQ-0132-004
+- REQ-0105-024 → REQ-0132-005
+- REQ-0105-084 → REQ-0132-006
+
+REQ-0132-001・002 は case-open コマンドの基本契約を要件行として新規起票したもの（詳細なワークフロー契約は REQ-0104 が所管）。
+
+## 関連情報
+
+- **Split from**: REQ-0105（capture 責務境界・RU削除責務）
+- **Related REQs**: REQ-0104（Workflow / Command Protocol - case-open基本契約・OU選択ゲート・upstream handoff）、REQ-0105（RU lifecycle）、REQ-0130（case-run）、REQ-0131（case-close）

--- a/docs/requirements/REQ-0133.md
+++ b/docs/requirements/REQ-0133.md
@@ -1,0 +1,38 @@
+---
+id: REQ-0133
+title: "case-update / Issue更新"
+created: "2026-06-16"
+updated: "2026-06-16"
+---
+
+## 目的
+
+既存 Case の Issue 本文更新、コメント追加、REQ ファイル更新、レビュー NG 対応を実行する。主にレビューNG時の対応および Case 実行中の要件修正に使用する。case-update の責務境界と品質ゲートを定義する。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-0133-001 | `case-update` は Issue 本文更新（`--body`）、コメント追加（`--comment`）、REQ ファイル更新（`--req`）、レビュー NG 対応（`--review-ng`）のいずれかを実行すること |
+| REQ-0133-002 | `case-update` は現在のフェーズを維持し、フェーズを変更しないこと |
+| REQ-0133-003 | CI/CD修正・自律修正ループは case-update の管轄外であり、case-run の責務であること。case-update は REQ 更新・レビュー NG 時のコメント追加・Issue 本文更新のみを責務とすること |
+| REQ-0133-004 | `case-update --body` は Issue 作成時に使用されたテンプレート構造を維持し、【必須】セクションが欠落しないこと |
+| REQ-0133-005 | `case-update --review-ng` は agentdev-spec-compliance の結果を引用すること |
+| REQ-0133-006 | `case-update` は Issue番号の解決に `gh issue list` / `gh issue status` 等で open issue 一覧を取得することを禁止する。番号はユーザー入力またはセッション内会話からのみ取得すること |
+| REQ-0133-007 | `case-update --req` は直接 commit + push を行い、req-save への委譲を行わないこと |
+| REQ-0133-008 | SSoT の整合性を維持し、Issue 本文と要件doc の不整合を防ぐこと |
+
+## 適用範囲
+
+- **対象**: case-update、Issue 本文更新（テンプレート構造維持）、コメント追加、REQ ファイル更新（直接 commit + push）、レビュー NG 対応（spec-compliance 引用）、フェーズ維持、Issue番号解約制約（gh issue list 禁止）、SSoT 整合性
+- **対象外**: case-run（REQ-0130）、case-close（REQ-0131）、case-open（REQ-0132）、CI/CD修正・自律修正ループ（case-run 責務）、workflow基本契約・work_type分類（REQ-0104）、REQ ファイル管理の採番ルール・バリデーション（REQ-0101 / 0102）
+
+## Update Notes
+
+### 2026-06-16: 新設（OU-03 / Issue #831）
+
+コマンドレベル分割により新設。case-update コマンドの基本契約・Guardrail・品質ゲートを要件行として起票したもの。従来 case-update 固有の要件行は REQ-0105 / REQ-0106 に存在せず、本 REQ が初の独立要件定義である。
+
+## 関連情報
+
+- **Related REQs**: REQ-0104（Workflow / Command Protocol）、REQ-0130（case-run）、REQ-0131（case-close）、REQ-0132（case-open）、REQ-0102（要件定義・保存 - REQ管理基準）


### PR DESCRIPTION
## 概要

OU-03: REQ-0105 / REQ-0106 のコマンドレベル分割と case-open / case-update 新規 REQ 作成。

Epic #828 / Issue #831

## 変更内容

### REQ-0105 分割（旧 "Intake / Learning / Backlog" → "RU lifecycle / Requirement Unit 管理"）

REQ-0105 は 63 の要件行を持ち intake / learning / backlog / RU lifecycle / capture 境界まで網羅しており、単一 REQ として過大であった。コマンドレベルに分割し、REQ-0105 本体は RU lifecycle に特化。

| 新規 REQ | タイトル | 移行元要件行数 |
|---|---|---|
| REQ-0127 | Intake command群 (capture / from-github / promote) | 21 行 |
| REQ-0128 | Learning-promote | 7 行 |
| REQ-0129 | Backlog-review | 11 行 |
| REQ-0130 | case-run / 実装パイプライン (capture 責務境界 2 行含む) | 2 行 |
| REQ-0131 | case-close / 完了処理 (capture 責務境界 3 行含む) | 3 行 |
| REQ-0132 | case-open / Issue作成 (RU削除責務 4 行含む) | 4 行 |
| REQ-0105 残存 | RU lifecycle / Requirement Unit 管理 | 15 行 |

### REQ-0106 分割（旧 "Case実行・完了" → "Case実行オーケストレーション / Epic・Wave"）

REQ-0106 は 32 の要件行で case-run と case-close の両方を含んでいた。コマンドレベルに分割し、REQ-0106 本体は Epic/Wave オーケストレーションに特化。

| 新規 REQ | タイトル | 移行元要件行数 |
|---|---|---|
| REQ-0130 | case-run / 実装パイプライン | 7 行 |
| REQ-0131 | case-close / 完了処理 | 16 行 |
| REQ-0106 残存 | Case実行オーケストレーション / Epic・Wave | 9 行 |

### case-open / case-update 新規 REQ

| 新規 REQ | タイトル | 要件行数 | 由来 |
|---|---|---|---|
| REQ-0132 | case-open / Issue作成 | 6 行 | REQ-0105 から 4 行 + コマンド基本契約 2 行新規起票 |
| REQ-0133 | case-update / Issue更新 | 8 行 | コマンド基本契約・Guardrail・品質ゲートから新規起票 |

## 採番

- REQ-0127〜REQ-0133（7 新規 REQ）
- 各新規 REQ の要件行 ID は REQ-XXXX-001 から新規採番（元 ID は再利用せず）
- REQ-0105 / REQ-0106 の残存要件行は元の ID を維持（トレーサビリティ確保）

## 除外作業（他 OU に委譲）

- `docs/requirements/README.md` / `docs/README.md` のインデックス更新 → OU-06
- `docs/requirements/mapping-table.md` → OU-06
- `docs/DOC-MAP.md` / AGENTS.md → 別 OU

## 検証

- 全 REQ frontmatter id とファイル名の一致を確認
- 移行元要件行の合計（63 + 32 = 95）と移行先合計が一致することを確認
- 各要件行が重複なく一つの REQ にのみ配置されていることを確認
