### PR TITLE
[RU-1] 基盤整備: check_integrity.ts CLI 拡張 + パーサ + 定量閾値 SPEC (Issue #898)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -24,10 +24,18 @@ import {
   type FindingCategory,
   type FindingRoute,
 } from "./cli_utils.ts";
+import { parseIntegrityRuleCatalog } from "./integrity_catalog_parser.ts";
+import { parseReqImpactMap } from "./req_impact_map_parser.ts";
+import {
+  selectApplicableRuleIds,
+  applicableCheckCategories,
+} from "./gate_filter.ts";
 
 const SCRIPT_NAME = "check_integrity.ts";
 const DESCRIPTION = "AgentDevFlow artifact integrity validator";
-const USAGE = "bun run check_integrity.ts [--help] [--json] [--dry-run] [--classification]"; // REQ-0108-196
+const USAGE =
+  "bun run check_integrity.ts [--help] [--json] [--dry-run] [--classification] " +
+  "[--gate <full-audit|delta-guard|impact-guard>] [--paths <csv>] [--reqs <csv>]";
 
 const path = require("path") as typeof import("path");
 const fs = require("fs") as typeof import("fs");
@@ -6881,7 +6889,13 @@ function checkReqVerificationBasis(root: string): CheckResult[] {
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
-  const options = parseArgs(args);
+  let options;
+  try {
+    options = parseArgs(args);
+  } catch (e) {
+    console.error(`[integrity] ${e instanceof Error ? e.message : String(e)}`);
+    process.exit(EXIT_ERROR);
+  }
 
   if (options.help) {
     printHelp(SCRIPT_NAME, DESCRIPTION, USAGE);
@@ -7039,7 +7053,40 @@ async function main(): Promise<void> {
     results.push(...checkDocumentClassificationPolicy(root));
   }
 
-  const processed = processResults(results);
+  // REQ-0136-040 (Issue #898 Task 1.1): 3-layer gate filtering.
+  // full-audit (default) leaves `results` untouched → byte-identical behavior.
+  let filtered = results;
+  if (options.gate !== "full-audit") {
+    const catalogPath = path.join(specsDir, "integrity-rule-catalog.md");
+    const impactMapPath = path.join(specsDir, "req-impact-map.md");
+    let catalog, impactMap;
+    try {
+      catalog = parseIntegrityRuleCatalog(
+        fs.readFileSync(catalogPath, "utf-8"),
+      );
+      impactMap = parseReqImpactMap(
+        fs.readFileSync(impactMapPath, "utf-8"),
+      );
+    } catch (e) {
+      console.error(
+        `[integrity] gate "${options.gate}" requires catalog/impact-map parse: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+      process.exit(EXIT_ERROR);
+    }
+    const selection = selectApplicableRuleIds(catalog, impactMap, options);
+    for (const note of selection.notes) {
+      console.error(`[integrity] gate: ${note}`);
+    }
+    const cats = applicableCheckCategories(selection.ruleIds);
+    filtered = results.filter((r) => cats.has(r.check));
+    console.error(
+      `[integrity] gate=${options.gate} applicable_rules=${selection.ruleIds.size} check_categories=${cats.size} results=${filtered.length}/${results.length}`,
+    );
+  }
+
+  const processed = processResults(filtered);
 
   const summary = computeSummary(processed);
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.test.ts
@@ -14,6 +14,7 @@ import {
   formatMarkdownReport,
   determineExitCode,
   findRepoRoot,
+  VALID_GATE_LEVELS,
 } from "./cli_utils.ts";
 import type { CheckResult, IntegrityReport } from "./cli_utils.ts";
 
@@ -36,6 +37,9 @@ describe("parseArgs", () => {
     expect(opts.json).toBe(false);
     expect(opts.dryRun).toBe(false);
     expect(opts.paths).toEqual([]);
+    expect(opts.gate).toBe("full-audit");
+    expect(opts.gatePaths).toEqual([]);
+    expect(opts.reqs).toEqual([]);
   });
 
   it("parses --help", () => {
@@ -76,8 +80,88 @@ describe("parseArgs", () => {
       help: true,
       json: true,
       dryRun: true,
+      classification: false,
       paths: ["path/a", "path/b"],
+      gate: "full-audit",
+      gatePaths: [],
+      reqs: [],
     });
+  });
+
+  it("defaults gate to full-audit (backward compatibility)", () => {
+    expect(parseArgs([]).gate).toBe("full-audit");
+  });
+
+  it("parses --gate delta-guard", () => {
+    expect(parseArgs(["--gate", "delta-guard"]).gate).toBe("delta-guard");
+  });
+
+  it("parses --gate impact-guard", () => {
+    expect(parseArgs(["--gate", "impact-guard"]).gate).toBe("impact-guard");
+  });
+
+  it("parses --gate=full-audit (equals form)", () => {
+    expect(parseArgs(["--gate=full-audit"]).gate).toBe("full-audit");
+  });
+
+  it("parses --paths as comma-separated gatePaths", () => {
+    const opts = parseArgs(["--paths", "a.md,b.md,c.md"]);
+    expect(opts.gatePaths).toEqual(["a.md", "b.md", "c.md"]);
+  });
+
+  it("parses --paths= form", () => {
+    const opts = parseArgs(["--paths=x.md,y.md"]);
+    expect(opts.gatePaths).toEqual(["x.md", "y.md"]);
+  });
+
+  it("trims and filters empty --paths entries", () => {
+    const opts = parseArgs(["--paths", " a.md , , b.md "]);
+    expect(opts.gatePaths).toEqual(["a.md", "b.md"]);
+  });
+
+  it("parses --reqs as comma-separated REQ IDs", () => {
+    const opts = parseArgs(["--reqs", "REQ-0101,REQ-0108"]);
+    expect(opts.reqs).toEqual(["REQ-0101", "REQ-0108"]);
+  });
+
+  it("parses --reqs= form", () => {
+    const opts = parseArgs(["--reqs=REQ-0103"]);
+    expect(opts.reqs).toEqual(["REQ-0103"]);
+  });
+
+  it("does not let --paths/--reqs collide with positional paths", () => {
+    const opts = parseArgs(["--paths", "a.md", "pos1", "--reqs", "REQ-0101", "pos2"]);
+    expect(opts.gatePaths).toEqual(["a.md"]);
+    expect(opts.reqs).toEqual(["REQ-0101"]);
+    expect(opts.paths).toEqual(["pos1", "pos2"]);
+  });
+
+  it("throws on invalid --gate value", () => {
+    expect(() => parseArgs(["--gate", "bogus"])).toThrow(/Invalid --gate/);
+  });
+
+  it("throws on invalid --gate= value", () => {
+    expect(() => parseArgs(["--gate=nope"])).toThrow(/Invalid --gate/);
+  });
+
+  it("throws when --gate has no value", () => {
+    expect(() => parseArgs(["--gate"])).toThrow(/requires a value/);
+  });
+
+  it("throws when --paths has no value", () => {
+    expect(() => parseArgs(["--paths"])).toThrow(/requires a value/);
+  });
+
+  it("throws when --reqs has no value", () => {
+    expect(() => parseArgs(["--reqs"])).toThrow(/requires a value/);
+  });
+
+  it("exposes VALID_GATE_LEVELS", () => {
+    expect(VALID_GATE_LEVELS).toEqual([
+      "full-audit",
+      "delta-guard",
+      "impact-guard",
+    ]);
   });
 });
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
@@ -65,12 +65,51 @@ export interface IntegrityReport {
 }
 
 // REQ-0108-196: classification policy support
+// REQ-0136-040 (Issue #898, Task 1.1): 3-layer gate switching
+export type GateLevel = "full-audit" | "delta-guard" | "impact-guard";
+
+export const VALID_GATE_LEVELS: readonly GateLevel[] = [
+  "full-audit",
+  "delta-guard",
+  "impact-guard",
+];
+
 export interface CliOptions {
   help: boolean;
   json: boolean;
   dryRun: boolean;
-  classification: boolean; // REQ-0108-196: enable classification policy checks
+  classification: boolean; // REQ-0108-196
   paths: string[];
+  gate: GateLevel; // REQ-0136-040
+  gatePaths: string[]; // REQ-0136-040
+  reqs: string[]; // REQ-0136-040
+}
+
+/**
+ * Resolve the value of a `--flag <value>` / `--flag=value` token. Returns
+ * `{ value, advanced }` where `advanced` indicates whether the next argv token
+ * was consumed (caller must skip it). Throws on a missing value.
+ */
+function resolveFlagValue(
+  flagName: string,
+  current: string,
+  next: string | undefined,
+): { value: string; advanced: boolean } {
+  const eqIdx = current.indexOf("=");
+  if (eqIdx > -1) {
+    return { value: current.slice(eqIdx + 1), advanced: false };
+  }
+  if (next === undefined || next.startsWith("-")) {
+    throw new Error(`${flagName} requires a value (usage: ${flagName} <value>)`);
+  }
+  return { value: next, advanced: true };
+}
+
+function splitCsv(value: string): string[] {
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
 }
 
 export function parseArgs(args: string[]): CliOptions {
@@ -80,8 +119,12 @@ export function parseArgs(args: string[]): CliOptions {
     dryRun: false,
     classification: false, // REQ-0108-196
     paths: [],
+    gate: "full-audit", // REQ-0136-040: backward-compatible default
+    gatePaths: [],
+    reqs: [],
   };
-  for (const arg of args) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
     if (arg === "--help" || arg === "-h") {
       options.help = true;
     } else if (arg === "--json") {
@@ -90,6 +133,23 @@ export function parseArgs(args: string[]): CliOptions {
       options.dryRun = true;
     } else if (arg === "--classification") { // REQ-0108-196
       options.classification = true;
+    } else if (arg === "--gate" || arg.startsWith("--gate=")) {
+      const { value, advanced } = resolveFlagValue("--gate", arg, args[i + 1]);
+      if (advanced) i++;
+      if (!VALID_GATE_LEVELS.includes(value as GateLevel)) {
+        throw new Error(
+          `Invalid --gate value "${value}". Valid values: ${VALID_GATE_LEVELS.join(", ")}`,
+        );
+      }
+      options.gate = value as GateLevel;
+    } else if (arg === "--paths" || arg.startsWith("--paths=")) {
+      const { value, advanced } = resolveFlagValue("--paths", arg, args[i + 1]);
+      if (advanced) i++;
+      options.gatePaths = splitCsv(value);
+    } else if (arg === "--reqs" || arg.startsWith("--reqs=")) {
+      const { value, advanced } = resolveFlagValue("--reqs", arg, args[i + 1]);
+      if (advanced) i++;
+      options.reqs = splitCsv(value);
     } else if (!arg.startsWith("-")) {
       options.paths.push(arg);
     }
@@ -112,6 +172,14 @@ OPTIONS:
   --json            Output results in JSON format
   --dry-run         Show what would be checked without running checks
   --classification  Enable document classification policy checks (REQ-0108-196)
+  --gate <level>    Integrity gate selector: full-audit | delta-guard | impact-guard
+                    (default: full-audit). full-audit runs all rules; delta-guard
+                    runs change-scoped rules (--paths); impact-guard runs
+                    REQ-scoped rules (--reqs).
+  --paths <csv>     Delta-guard file scoping, comma-separated paths
+                    (e.g. --paths docs/requirements/REQ-0101.md)
+  --reqs <csv>      Impact-guard REQ scoping, comma-separated REQ IDs
+                    (e.g. --reqs REQ-0101,REQ-0108)
 
 EXIT CODES:
   0  No issues found

--- a/.opencode/skills/repo-agentdev-integrity/scripts/gate_filter.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/gate_filter.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "bun:test";
+import {
+  selectApplicableRuleIds,
+  applicableCheckCategories,
+  classifyChangeType,
+  IR_TO_CHECK_CATEGORIES,
+} from "./gate_filter.ts";
+import {
+  parseIntegrityRuleCatalog,
+  filterRulesByGate,
+} from "./integrity_catalog_parser.ts";
+import { parseReqImpactMap } from "./req_impact_map_parser.ts";
+
+function readFixture(name: string): string {
+  const fs = require("fs");
+  const path = require("path");
+  let dir = path.resolve(__dirname);
+  for (let i = 0; i < 10; i++) {
+    const candidate = path.join(dir, "docs", "specs", name);
+    if (fs.existsSync(candidate)) return fs.readFileSync(candidate, "utf-8");
+    dir = path.dirname(dir);
+  }
+  throw new Error(`${name} fixture not found`);
+}
+
+function loadReal() {
+  return {
+    catalog: parseIntegrityRuleCatalog(readFixture("integrity-rule-catalog.md")),
+    impactMap: parseReqImpactMap(readFixture("req-impact-map.md")),
+  };
+}
+
+describe("classifyChangeType", () => {
+  it("classifies command paths", () => {
+    expect(classifyChangeType("src/opencode/commands/agentdev/case-run.md")).toBe(
+      "Command",
+    );
+  });
+  it("classifies REQ paths", () => {
+    expect(classifyChangeType("docs/requirements/REQ-0101.md")).toBe("REQ");
+  });
+  it("classifies ADR paths", () => {
+    expect(classifyChangeType("docs/adr/ADR-0123.md")).toBe("ADR");
+  });
+  it("classifies SPEC paths", () => {
+    expect(classifyChangeType("docs/specs/patterns.md")).toBe("SPEC");
+  });
+  it("classifies skill paths", () => {
+    expect(classifyChangeType("src/opencode/skills/agentdev-foo/SKILL.md")).toBe(
+      "Skill",
+    );
+  });
+  it("returns unknown for unclassifiable", () => {
+    expect(classifyChangeType("README.md")).toBe("unknown");
+  });
+});
+
+describe("selectApplicableRuleIds - full-audit", () => {
+  const { catalog, impactMap } = loadReal();
+
+  it("returns all catalog rule IDs (backward compat)", () => {
+    const sel = selectApplicableRuleIds(catalog, impactMap, {
+      gate: "full-audit",
+      gatePaths: [],
+      reqs: [],
+    });
+    expect(sel.gate).toBe("full-audit");
+    expect(sel.ruleIds.size).toBe(44);
+  });
+
+  it("full-audit ignores --paths and --reqs", () => {
+    const sel = selectApplicableRuleIds(catalog, impactMap, {
+      gate: "full-audit",
+      gatePaths: ["docs/requirements/REQ-0101.md"],
+      reqs: ["REQ-0101"],
+    });
+    expect(sel.ruleIds.size).toBe(44);
+  });
+});
+
+describe("selectApplicableRuleIds - delta-guard", () => {
+  const { catalog, impactMap } = loadReal();
+
+  it("without --paths returns all delta-guard-tagged rules (13)", () => {
+    const sel = selectApplicableRuleIds(catalog, impactMap, {
+      gate: "delta-guard",
+      gatePaths: [],
+      reqs: [],
+    });
+    expect(sel.gate).toBe("delta-guard");
+    expect(sel.ruleIds.size).toBe(13);
+  });
+
+  it("with --paths REQ file adds Delta Guard table rules for REQ change type", () => {
+    const sel = selectApplicableRuleIds(catalog, impactMap, {
+      gate: "delta-guard",
+      gatePaths: ["docs/requirements/REQ-0101.md"],
+      reqs: [],
+    });
+    expect(sel.changeTypes).toContain("REQ");
+    expect(sel.ruleIds.has("IR-001")).toBe(true);
+    expect(sel.ruleIds.has("IR-002")).toBe(true);
+    expect(sel.ruleIds.has("IR-004")).toBe(true);
+    expect(sel.ruleIds.has("IR-022")).toBe(true);
+  });
+
+  it("with --paths Command file adds IR-006, IR-007, IR-013, IR-024", () => {
+    const sel = selectApplicableRuleIds(catalog, impactMap, {
+      gate: "delta-guard",
+      gatePaths: ["src/opencode/commands/agentdev/case-run.md"],
+      reqs: [],
+    });
+    expect(sel.changeTypes).toContain("Command");
+    expect(sel.ruleIds.has("IR-006")).toBe(true);
+    expect(sel.ruleIds.has("IR-007")).toBe(true);
+    expect(sel.ruleIds.has("IR-013")).toBe(true);
+    expect(sel.ruleIds.has("IR-024")).toBe(true);
+  });
+
+  it("notes unclassifiable paths", () => {
+    const sel = selectApplicableRuleIds(catalog, impactMap, {
+      gate: "delta-guard",
+      gatePaths: ["README.md"],
+      reqs: [],
+    });
+    expect(sel.notes.some((n) => n.includes("unclassified"))).toBe(true);
+  });
+});
+
+describe("selectApplicableRuleIds - impact-guard", () => {
+  const { catalog, impactMap } = loadReal();
+
+  it("without --reqs returns impact-guard-tagged rules (2)", () => {
+    const sel = selectApplicableRuleIds(catalog, impactMap, {
+      gate: "impact-guard",
+      gatePaths: [],
+      reqs: [],
+    });
+    expect(sel.ruleIds.size).toBe(2);
+    expect(sel.ruleIds.has("IR-020")).toBe(true);
+    expect(sel.ruleIds.has("IR-023")).toBe(true);
+  });
+
+  it("with --reqs REQ-0101 adds Impact Matrix rules", () => {
+    const sel = selectApplicableRuleIds(catalog, impactMap, {
+      gate: "impact-guard",
+      gatePaths: [],
+      reqs: ["REQ-0101"],
+    });
+    expect(sel.ruleIds.has("IR-001")).toBe(true);
+    expect(sel.ruleIds.has("IR-022")).toBe(true);
+  });
+
+  it("with --reqs REQ-0108 expands range to 24 IDs", () => {
+    const sel = selectApplicableRuleIds(catalog, impactMap, {
+      gate: "impact-guard",
+      gatePaths: [],
+      reqs: ["REQ-0108"],
+    });
+    expect(sel.ruleIds.has("IR-001")).toBe(true);
+    expect(sel.ruleIds.has("IR-024")).toBe(true);
+  });
+
+  it("notes unknown REQ IDs", () => {
+    const sel = selectApplicableRuleIds(catalog, impactMap, {
+      gate: "impact-guard",
+      gatePaths: [],
+      reqs: ["REQ-9999"],
+    });
+    expect(sel.notes.some((n) => n.includes("REQ-9999"))).toBe(true);
+  });
+});
+
+describe("applicableCheckCategories", () => {
+  it("maps known IR IDs to check category strings", () => {
+    const cats = applicableCheckCategories(new Set(["IR-001", "IR-016"]));
+    expect(cats.has("frontmatter-filename")).toBe(true);
+    expect(cats.has("source-projection-consistency")).toBe(true);
+  });
+
+  it("returns empty set for unmapped IR IDs", () => {
+    const cats = applicableCheckCategories(new Set(["IR-999"]));
+    expect(cats.size).toBe(0);
+  });
+});
+
+describe("IR_TO_CHECK_CATEGORIES coverage", () => {
+  const { catalog } = loadReal();
+  const deltaGuardRules = filterRulesByGate(catalog, "delta-guard");
+
+  it("delta-guard rules with check mappings cover the common categories", () => {
+    const allCats = applicableCheckCategories(new Set(deltaGuardRules.map((r) => r.rule_id)));
+    expect(allCats.size).toBeGreaterThan(0);
+    expect(allCats.has("implementation-pattern")).toBe(true);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/gate_filter.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/gate_filter.ts
@@ -1,0 +1,182 @@
+/**
+ * Gate selection logic for the 3-layer integrity gate (REQ-0136-040, Issue #898).
+ *
+ * Given the parsed catalog + impact map + CLI options, computes the set of
+ * applicable IR IDs for the requested gate, and maps IR IDs to the check
+ * category names emitted by `check_integrity.ts` so results can be filtered.
+ *
+ * - full-audit (default): every catalog rule → no filtering (backward compat)
+ * - delta-guard: rules tagged `delta-guard` in the catalog, optionally narrowed
+ *   by `--paths` via the Delta Guard change-type table
+ * - impact-guard: rules tagged `impact-guard` in the catalog, optionally
+ *   expanded by `--reqs` via the Impact Matrix
+ */
+import type { GateLevel, CliOptions } from "./cli_utils.ts";
+import type { IntegrityRule } from "./integrity_catalog_parser.ts";
+import type { ReqImpactMap } from "./req_impact_map_parser.ts";
+
+export type ChangeType =
+  | "Command"
+  | "Skill"
+  | "REQ"
+  | "ADR"
+  | "SPEC"
+  | "Template"
+  | "Source/projection"
+  | "unknown";
+
+const DELTA_TABLE_LABEL: Record<ChangeType, string> = {
+  Command: "Command 追加/変更",
+  Skill: "Skill 追加/変更",
+  REQ: "REQ 追加/変更",
+  ADR: "ADR 追加/変更",
+  SPEC: "SPEC 変更",
+  Template: "Template 変更",
+  "Source/projection": "Source/projection 変更",
+  unknown: "",
+};
+
+export function classifyChangeType(filePath: string): ChangeType {
+  const normalized = filePath.replace(/\\/g, "/");
+  if (normalized.includes("/commands/")) return "Command";
+  if (normalized.includes("/skills/") && normalized.includes("/templates/")) {
+    return "Template";
+  }
+  if (normalized.includes("/skills/")) return "Skill";
+  if (normalized.includes("/templates/")) return "Template";
+  if (
+    normalized.startsWith("docs/requirements/") ||
+    normalized.includes("/requirements/REQ-")
+  ) {
+    return "REQ";
+  }
+  if (normalized.includes("/adr/")) return "ADR";
+  if (normalized.startsWith("docs/specs/") || normalized.includes("/specs/")) {
+    return "SPEC";
+  }
+  if (
+    normalized.startsWith("src/opencode/") ||
+    normalized.includes("sync-opencode")
+  ) {
+    return "Source/projection";
+  }
+  return "unknown";
+}
+
+export interface GateSelection {
+  gate: GateLevel;
+  ruleIds: Set<string>;
+  changeTypes: ChangeType[];
+  notes: string[];
+}
+
+export function selectApplicableRuleIds(
+  catalog: IntegrityRule[],
+  impactMap: ReqImpactMap,
+  options: Pick<CliOptions, "gate" | "gatePaths" | "reqs">,
+): GateSelection {
+  const gate = options.gate;
+  const notes: string[] = [];
+
+  if (gate === "full-audit") {
+    return {
+      gate,
+      ruleIds: new Set(catalog.map((r) => r.rule_id)),
+      changeTypes: [],
+      notes,
+    };
+  }
+
+  const tagged = catalog
+    .filter((r) => r.gate_level.includes(gate))
+    .map((r) => r.rule_id);
+  const ruleIds = new Set<string>(tagged);
+
+  const changeTypes: ChangeType[] = [];
+
+  if (gate === "delta-guard") {
+    if (options.gatePaths.length > 0) {
+      const detected = new Set<ChangeType>();
+      for (const p of options.gatePaths) {
+        const ct = classifyChangeType(p);
+        if (ct !== "unknown") detected.add(ct);
+        else notes.push(`unclassified path (ignored): ${p}`);
+      }
+      for (const ct of detected) {
+        changeTypes.push(ct);
+        const label = DELTA_TABLE_LABEL[ct];
+        const entry = impactMap.deltaGuardTable.find(
+          (e) => e.changeType === label,
+        );
+        if (entry) {
+          for (const id of entry.ruleIds) ruleIds.add(id);
+        } else {
+          notes.push(`no Delta Guard table row for change type "${label}"`);
+        }
+      }
+      if (detected.size === 0) {
+        notes.push(
+          "no classifiable --paths; falling back to delta-guard-tagged rules",
+        );
+      }
+    } else {
+      notes.push(
+        "no --paths given; running all delta-guard-tagged rules",
+      );
+    }
+  }
+
+  if (gate === "impact-guard") {
+    if (options.reqs.length > 0) {
+      for (const reqId of options.reqs) {
+        const entry = impactMap.impactMatrix.find((e) => e.reqId === reqId);
+        if (entry) {
+          for (const id of entry.ruleIds) ruleIds.add(id);
+        } else {
+          notes.push(`REQ ${reqId} not found in Impact Matrix`);
+        }
+      }
+    } else {
+      notes.push(
+        "no --reqs given; running all impact-guard-tagged rules",
+      );
+    }
+  }
+
+  return { gate, ruleIds, changeTypes, notes };
+}
+
+// IR-NNN → check `category` strings emitted by check_integrity.ts functions.
+// Conservative mapping: only rules with clearly attributable check categories.
+// Unmapped IRs are full-audit-only (no enforcement at this foundation stage).
+export const IR_TO_CHECK_CATEGORIES: Record<string, string[]> = {
+  "IR-001": ["frontmatter-filename"],
+  "IR-002": ["required-fields"],
+  "IR-003": ["active-retired-duplication"],
+  "IR-004": ["readme-index-sync"],
+  "IR-005": ["adr-req-crossref"],
+  "IR-006": ["implementation-pattern", "cmd-implementation-pattern"],
+  "IR-007": ["skill-name-dir-match"],
+  "IR-008": ["reference-path-existence"],
+  "IR-009": ["legacy-namespace", "expanded-legacy-namespace"],
+  "IR-010": ["adr-status-normalization"],
+  "IR-011": ["mapping-table-completeness"],
+  "IR-012": ["variant-required-fields", "fragment-patterns"],
+  "IR-013": ["variant-existence", "variant-path-existence"],
+  "IR-014": ["obsolete-reference-dir"],
+  "IR-015": ["retired-in-active-index"],
+  "IR-016": ["source-projection-consistency"],
+  "IR-017": ["docmap-req-sync"],
+  "IR-021": ["abolished-skill-reference"],
+  "IR-024": ["command-readme-sync", "command-inventory"],
+  "IR-025": ["retired-adr-path"],
+  "IR-038": ["adr-readme-index-sync"],
+};
+
+export function applicableCheckCategories(ruleIds: Set<string>): Set<string> {
+  const cats = new Set<string>();
+  for (const id of ruleIds) {
+    for (const c of IR_TO_CHECK_CATEGORIES[id] ?? []) cats.add(c);
+  }
+  return cats;
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/integrity_catalog_parser.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/integrity_catalog_parser.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "bun:test";
+import {
+  parseIntegrityRuleCatalog,
+  filterRulesByGate,
+  findRuleById,
+} from "./integrity_catalog_parser.ts";
+
+function readRealCatalog(): string {
+  const fs = require("fs");
+  const path = require("path");
+  let dir = path.resolve(__dirname);
+  for (let i = 0; i < 10; i++) {
+    const candidate = path.join(dir, "docs", "specs", "integrity-rule-catalog.md");
+    if (fs.existsSync(candidate)) return fs.readFileSync(candidate, "utf-8");
+    dir = path.dirname(dir);
+  }
+  throw new Error("integrity-rule-catalog.md fixture not found");
+}
+
+const MINIMAL_CATALOG = `# Integrity Rule Catalog
+
+Some intro text.
+
+## Schema
+
+| Field | 型 | 説明 |
+|-------|------|------|
+| rule_id | string | 一意識別子 |
+
+## Rules
+
+### IR-001: Active REQ frontmatter id ↔ filename
+
+| Field | Value |
+|-------|-------|
+| rule_id | IR-001 |
+| description | frontmatter id matches filename |
+| severity | strict |
+| category | document-drift |
+| detection_method | frontmatter id extraction |
+| affected_artifacts | [active REQ] |
+| related_req | [REQ-0108-001, REQ-0101] |
+| related_spec | [integrity-contracts.md] |
+| gate_level | full-audit |
+| false_positive_risk | low |
+| regression_test | commands_structure.test.ts |
+| baseline_status | resolved |
+| finding_route | intake |
+| triage_action | fix frontmatter |
+| last_verified | 2026-06-06 |
+
+### IR-006: Command frontmatter 許可フィールド
+
+| Field | Value |
+|-------|-------|
+| rule_id | IR-006 |
+| description | allowed frontmatter fields |
+| severity | strict |
+| category | document-drift |
+| detection_method | field enumeration |
+| affected_artifacts | [commands] |
+| related_req | [REQ-0103-015] |
+| related_spec | [integrity-contracts.md] |
+| gate_level | full-audit, delta-guard |
+| false_positive_risk | low |
+| regression_test | command_fixtures.test.ts |
+| baseline_status | resolved |
+| finding_route | intake |
+| triage_action | remove forbidden field |
+| last_verified | 2026-06-06 |
+`;
+
+describe("parseIntegrityRuleCatalog - minimal fixture", () => {
+  it("parses all IR entries", () => {
+    const rules = parseIntegrityRuleCatalog(MINIMAL_CATALOG);
+    expect(rules).toHaveLength(2);
+    expect(rules[0].rule_id).toBe("IR-001");
+    expect(rules[1].rule_id).toBe("IR-006");
+  });
+
+  it("parses all 15 metadata fields", () => {
+    const rules = parseIntegrityRuleCatalog(MINIMAL_CATALOG);
+    const r = rules[0];
+    expect(r.description).toBe("frontmatter id matches filename");
+    expect(r.severity).toBe("strict");
+    expect(r.category).toBe("document-drift");
+    expect(r.detection_method).toBe("frontmatter id extraction");
+    expect(r.affected_artifacts).toEqual(["active REQ"]);
+    expect(r.related_req).toEqual(["REQ-0108-001", "REQ-0101"]);
+    expect(r.related_spec).toEqual(["integrity-contracts.md"]);
+    expect(r.gate_level).toEqual(["full-audit"]);
+    expect(r.false_positive_risk).toBe("low");
+    expect(r.regression_test).toBe("commands_structure.test.ts");
+    expect(r.baseline_status).toBe("resolved");
+    expect(r.finding_route).toBe("intake");
+    expect(r.triage_action).toBe("fix frontmatter");
+    expect(r.last_verified).toBe("2026-06-06");
+  });
+
+  it("parses multi-gate gate_level as array", () => {
+    const rules = parseIntegrityRuleCatalog(MINIMAL_CATALOG);
+    expect(rules[1].gate_level).toEqual(["full-audit", "delta-guard"]);
+  });
+
+  it("parses bracket list with multiple comma-separated values", () => {
+    const rules = parseIntegrityRuleCatalog(MINIMAL_CATALOG);
+    expect(rules[0].related_req).toEqual(["REQ-0108-001", "REQ-0101"]);
+  });
+});
+
+describe("parseIntegrityRuleCatalog - error cases", () => {
+  it("throws on empty content", () => {
+    expect(() => parseIntegrityRuleCatalog("")).toThrow(/empty/);
+  });
+
+  it("throws on missing top-level header", () => {
+    expect(() => parseIntegrityRuleCatalog("# Wrong Title\n\n### IR-001: x\n")).toThrow(
+      /Integrity Rule Catalog/,
+    );
+  });
+
+  it("throws when no IR entries present", () => {
+    expect(() =>
+      parseIntegrityRuleCatalog("# Integrity Rule Catalog\n\nno rules here"),
+    ).toThrow(/no IR-NNN entries/);
+  });
+
+  it("throws on duplicate rule_id", () => {
+    const dup = MINIMAL_CATALOG + MINIMAL_CATALOG.slice(
+      MINIMAL_CATALOG.indexOf("### IR-001"),
+    );
+    expect(() => parseIntegrityRuleCatalog(dup)).toThrow(/duplicate/);
+  });
+
+  it("throws on header/field rule_id mismatch", () => {
+    const bad = MINIMAL_CATALOG.replace(
+      "| rule_id | IR-001 |",
+      "| rule_id | IR-099 |",
+    );
+    expect(() => parseIntegrityRuleCatalog(bad)).toThrow(/mismatch/);
+  });
+
+  it("throws on invalid severity", () => {
+    const bad = MINIMAL_CATALOG.replace("| severity | strict |", "| severity | bogus |");
+    expect(() => parseIntegrityRuleCatalog(bad)).toThrow(/severity/);
+  });
+
+  it("throws on invalid gate_level", () => {
+    const bad = MINIMAL_CATALOG.replace(
+      "| gate_level | full-audit |",
+      "| gate_level | no-such-gate |",
+    );
+    expect(() => parseIntegrityRuleCatalog(bad)).toThrow(/gate_level/);
+  });
+});
+
+describe("filterRulesByGate", () => {
+  const rules = parseIntegrityRuleCatalog(MINIMAL_CATALOG);
+
+  it("returns full-audit rules", () => {
+    expect(filterRulesByGate(rules, "full-audit")).toHaveLength(2);
+  });
+
+  it("returns delta-guard rules only", () => {
+    const dg = filterRulesByGate(rules, "delta-guard");
+    expect(dg).toHaveLength(1);
+    expect(dg[0].rule_id).toBe("IR-006");
+  });
+
+  it("returns empty for impact-guard when none tagged", () => {
+    expect(filterRulesByGate(rules, "impact-guard")).toEqual([]);
+  });
+});
+
+describe("findRuleById", () => {
+  const rules = parseIntegrityRuleCatalog(MINIMAL_CATALOG);
+  it("finds existing rule", () => {
+    expect(findRuleById(rules, "IR-006")?.severity).toBe("strict");
+  });
+  it("returns undefined for missing rule", () => {
+    expect(findRuleById(rules, "IR-999")).toBeUndefined();
+  });
+});
+
+describe("parseIntegrityRuleCatalog - real catalog (QA Scenario 1)", () => {
+  const realCatalog = readRealCatalog();
+  const rules = parseIntegrityRuleCatalog(realCatalog);
+
+  it("parses all 44 IR rules (IR-001..IR-044)", () => {
+    expect(rules).toHaveLength(44);
+    expect(rules[0].rule_id).toBe("IR-001");
+    expect(rules[43].rule_id).toBe("IR-044");
+  });
+
+  it("delta-guard filter returns exactly 13 rules", () => {
+    const dg = filterRulesByGate(rules, "delta-guard");
+    const ids = dg.map((r) => r.rule_id);
+    expect(dg).toHaveLength(13);
+    expect(ids).toEqual([
+      "IR-006",
+      "IR-008",
+      "IR-012",
+      "IR-013",
+      "IR-016",
+      "IR-028",
+      "IR-029",
+      "IR-030",
+      "IR-031",
+      "IR-032",
+      "IR-033",
+      "IR-038",
+      "IR-040",
+    ]);
+  });
+
+  it("impact-guard filter returns IR-020 and IR-023", () => {
+    const ig = filterRulesByGate(rules, "impact-guard");
+    expect(ig.map((r) => r.rule_id).sort()).toEqual(["IR-020", "IR-023"]);
+  });
+
+  it("every rule has 15 metadata fields populated", () => {
+    for (const r of rules) {
+      expect(r.gate_level.length).toBeGreaterThan(0);
+      expect(r.severity.length).toBeGreaterThan(0);
+      expect(r.category.length).toBeGreaterThan(0);
+      expect(r.rule_id).toMatch(/^IR-\d{3}$/);
+    }
+  });
+
+  it("every rule includes full-audit in gate_level", () => {
+    for (const r of rules) {
+      expect(r.gate_level).toContain("full-audit");
+    }
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/integrity_catalog_parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/integrity_catalog_parser.ts
@@ -1,0 +1,231 @@
+/**
+ * Parser for `docs/specs/integrity-rule-catalog.md` (REQ-0136-040, Issue #898 Task 1.2).
+ *
+ * Converts each IR-NNN entry's Markdown field/value table into a typed
+ * `IntegrityRule`. The catalog uses the structure:
+ *
+ *     ### IR-001: <title>
+ *
+ *     | Field | Value |
+ *     |-------|-------|
+ *     | rule_id | IR-001 |
+ *     | ...     | ...   |
+ *
+ * `gate_level` may list multiple gates comma-separated (e.g.
+ * `full-audit, delta-guard`). List-typed fields use bracket form
+ * (e.g. `[REQ-0108-001, REQ-0101]`).
+ */
+import type { GateLevel } from "./cli_utils.ts";
+
+export type CatalogSeverity = "strict" | "heuristic" | "observation";
+export type CatalogCategory =
+  | "document-drift"
+  | "broken-reference"
+  | "obsolete-structure"
+  | "canonical-conflict"
+  | "workflow-gap"
+  | "integrity-rule-gap";
+
+export interface IntegrityRule {
+  rule_id: string;
+  description: string;
+  severity: CatalogSeverity;
+  category: CatalogCategory;
+  detection_method: string;
+  affected_artifacts: string[];
+  related_req: string[];
+  related_spec: string[];
+  gate_level: GateLevel[];
+  false_positive_risk: string;
+  regression_test: string;
+  baseline_status: string;
+  finding_route: string;
+  triage_action: string;
+  last_verified: string;
+}
+
+const GATE_LEVELS: readonly GateLevel[] = [
+  "full-audit",
+  "delta-guard",
+  "impact-guard",
+];
+
+const RULE_HEADER_RE = /^###\s+(IR-\d{3})\s*:/;
+const TABLE_ROW_RE = /^\|\s*(.*?)\s*\|\s*(.*?)\s*\|$/;
+
+export class IntegrityCatalogParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IntegrityCatalogParseError";
+  }
+}
+
+function splitTopLevelByHeaders(content: string): string[] {
+  return content.split(/(?=^###\s+IR-\d{3}\s*:)/m);
+}
+
+function extractFieldValueMap(block: string): Map<string, string> {
+  const fields = new Map<string, string>();
+  for (const line of block.split("\n")) {
+    const m = line.match(TABLE_ROW_RE);
+    if (!m) continue;
+    const key = m[1].trim();
+    const value = m[2].trim();
+    if (
+      key.toLowerCase() === "field" ||
+      /^-+$/.test(key) ||
+      /^-+$/.test(value)
+    ) {
+      continue;
+    }
+    fields.set(key, value);
+  }
+  return fields;
+}
+
+function parseBracketList(raw: string): string[] {
+  let inner = raw.trim();
+  if (inner.startsWith("[") && inner.endsWith("]")) {
+    inner = inner.slice(1, -1);
+  }
+  return inner
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function parseGateLevels(raw: string): GateLevel[] {
+  const parts = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const result: GateLevel[] = [];
+  for (const p of parts) {
+    if (!GATE_LEVELS.includes(p as GateLevel)) {
+      throw new IntegrityCatalogParseError(
+        `Unknown gate_level "${p}" (valid: ${GATE_LEVELS.join(", ")})`,
+      );
+    }
+    result.push(p as GateLevel);
+  }
+  return result;
+}
+
+function assertSeverity(value: string): CatalogSeverity {
+  if (value === "strict" || value === "heuristic" || value === "observation") {
+    return value;
+  }
+  throw new IntegrityCatalogParseError(
+    `Unknown severity "${value}" (expected strict|heuristic|observation)`,
+  );
+}
+
+function assertCategory(value: string): CatalogCategory {
+  const known: CatalogCategory[] = [
+    "document-drift",
+    "broken-reference",
+    "obsolete-structure",
+    "canonical-conflict",
+    "workflow-gap",
+    "integrity-rule-gap",
+  ];
+  if (known.includes(value as CatalogCategory)) return value as CatalogCategory;
+  throw new IntegrityCatalogParseError(
+    `Unknown category "${value}" (expected one of ${known.join(", ")})`,
+  );
+}
+
+function requireField(
+  fields: Map<string, string>,
+  ruleId: string,
+  name: string,
+): string {
+  const v = fields.get(name);
+  if (v === undefined) {
+    throw new IntegrityCatalogParseError(
+      `${ruleId}: missing required field "${name}"`,
+    );
+  }
+  return v;
+}
+
+function parseRuleBlock(block: string): IntegrityRule | null {
+  const headerMatch = block.match(RULE_HEADER_RE);
+  if (!headerMatch) return null;
+  const ruleId = headerMatch[1];
+  const fields = extractFieldValueMap(block);
+
+  const ruleIdField = requireField(fields, ruleId, "rule_id");
+  if (ruleIdField !== ruleId) {
+    throw new IntegrityCatalogParseError(
+      `${ruleId}: header rule_id mismatch (header=${ruleId}, field=${ruleIdField})`,
+    );
+  }
+
+  return {
+    rule_id: ruleId,
+    description: requireField(fields, ruleId, "description"),
+    severity: assertSeverity(requireField(fields, ruleId, "severity")),
+    category: assertCategory(requireField(fields, ruleId, "category")),
+    detection_method: requireField(fields, ruleId, "detection_method"),
+    affected_artifacts: parseBracketList(
+      requireField(fields, ruleId, "affected_artifacts"),
+    ),
+    related_req: parseBracketList(
+      requireField(fields, ruleId, "related_req"),
+    ),
+    related_spec: parseBracketList(
+      requireField(fields, ruleId, "related_spec"),
+    ),
+    gate_level: parseGateLevels(requireField(fields, ruleId, "gate_level")),
+    false_positive_risk: requireField(fields, ruleId, "false_positive_risk"),
+    regression_test: requireField(fields, ruleId, "regression_test"),
+    baseline_status: requireField(fields, ruleId, "baseline_status"),
+    finding_route: requireField(fields, ruleId, "finding_route"),
+    triage_action: requireField(fields, ruleId, "triage_action"),
+    last_verified: requireField(fields, ruleId, "last_verified"),
+  };
+}
+
+export function parseIntegrityRuleCatalog(content: string): IntegrityRule[] {
+  if (!content || content.trim().length === 0) {
+    throw new IntegrityCatalogParseError("catalog content is empty");
+  }
+  if (!/^#\s+Integrity Rule Catalog/m.test(content)) {
+    throw new IntegrityCatalogParseError(
+      "missing top-level '# Integrity Rule Catalog' header",
+    );
+  }
+  const blocks = splitTopLevelByHeaders(content);
+  const rules: IntegrityRule[] = [];
+  const seen = new Set<string>();
+  for (const block of blocks) {
+    const rule = parseRuleBlock(block);
+    if (!rule) continue;
+    if (seen.has(rule.rule_id)) {
+      throw new IntegrityCatalogParseError(
+        `duplicate rule_id ${rule.rule_id}`,
+      );
+    }
+    seen.add(rule.rule_id);
+    rules.push(rule);
+  }
+  if (rules.length === 0) {
+    throw new IntegrityCatalogParseError("no IR-NNN entries parsed");
+  }
+  return rules;
+}
+
+export function filterRulesByGate(
+  rules: IntegrityRule[],
+  gate: GateLevel,
+): IntegrityRule[] {
+  return rules.filter((r) => r.gate_level.includes(gate));
+}
+
+export function findRuleById(
+  rules: IntegrityRule[],
+  ruleId: string,
+): IntegrityRule | undefined {
+  return rules.find((r) => r.rule_id === ruleId);
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/req_impact_map_parser.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/req_impact_map_parser.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "bun:test";
+import {
+  parseReqImpactMap,
+  lookupImpactMatrix,
+  lookupDeltaGuard,
+  ReqImpactMapParseError,
+} from "./req_impact_map_parser.ts";
+
+const MINIMAL_MAP = `# REQ Impact Map
+
+Intro text.
+
+## Impact Matrix
+
+| REQ | タイトル | 影響する Rule IDs | 影響する Artifact |
+|-----|---------|------------------|------------------|
+| REQ-0101 | 文書・REQ管理基準 | IR-001, IR-002, IR-017 | REQ, DOC-MAP |
+| REQ-0108 | Integrity/Validation/Tests | IR-001~IR-003 (全件) | 全 artifact |
+| REQ-0110 | Git worktree cleanup | — (infrastructure) | — |
+
+## Requirement-Line Impact
+
+Some content here.
+
+### Delta Guard Rule Selection
+
+| 変更種別 | 実行 Rules |
+|---------|-----------|
+| Command 追加/変更 | IR-006, IR-007, IR-013, IR-024 |
+| Skill 追加/変更 | IR-007, IR-008, IR-014 |
+| REQ 追加/変更 | IR-001, IR-002, IR-004, IR-022 |
+
+### Recurrence Triage
+
+More content.
+`;
+
+describe("parseReqImpactMap - minimal fixture", () => {
+  const map = parseReqImpactMap(MINIMAL_MAP);
+
+  it("parses Impact Matrix entries", () => {
+    expect(map.impactMatrix).toHaveLength(3);
+    expect(map.impactMatrix[0].reqId).toBe("REQ-0101");
+  });
+
+  it("parses csv rule IDs", () => {
+    expect(map.impactMatrix[0].ruleIds).toEqual([
+      "IR-001",
+      "IR-002",
+      "IR-017",
+    ]);
+  });
+
+  it("parses artifacts as list", () => {
+    expect(map.impactMatrix[0].artifacts).toEqual(["REQ", "DOC-MAP"]);
+  });
+
+  it("expands range IR-001~IR-003 to 3 IDs", () => {
+    expect(map.impactMatrix[1].ruleIds).toEqual(["IR-001", "IR-002", "IR-003"]);
+  });
+
+  it("preserves raw cell for range entry", () => {
+    expect(map.impactMatrix[1].raw).toContain("IR-001~IR-003");
+    expect(map.impactMatrix[1].raw).toContain("(全件)");
+  });
+
+  it("returns empty ruleIds for em-dash placeholder", () => {
+    expect(map.impactMatrix[2].ruleIds).toEqual([]);
+    expect(map.impactMatrix[2].artifacts).toEqual([]);
+  });
+
+  it("parses Delta Guard table entries", () => {
+    expect(map.deltaGuardTable).toHaveLength(3);
+    expect(map.deltaGuardTable[0].changeType).toBe("Command 追加/変更");
+    expect(map.deltaGuardTable[0].ruleIds).toEqual([
+      "IR-006",
+      "IR-007",
+      "IR-013",
+      "IR-024",
+    ]);
+  });
+});
+
+describe("parseReqImpactMap - error cases", () => {
+  it("throws on empty content", () => {
+    expect(() => parseReqImpactMap("")).toThrow(/empty/);
+  });
+
+  it("throws on missing top-level header", () => {
+    expect(() => parseReqImpactMap("# Wrong Title\n")).toThrow(/REQ Impact Map/);
+  });
+
+  it("throws on missing Impact Matrix section", () => {
+    const noMatrix = `# REQ Impact Map\n\n### Delta Guard Rule Selection\n\n| 変更種別 | 実行 Rules |\n|---------|-----------|\n| Command | IR-006 |\n`;
+    expect(() => parseReqImpactMap(noMatrix)).toThrow(/Impact Matrix/);
+  });
+
+  it("throws on missing Delta Guard section", () => {
+    const noDelta = `# REQ Impact Map\n\n## Impact Matrix\n\n| REQ | t | r | a |\n|---|---|---|---|\n| REQ-0101 | t | IR-001 | a |\n`;
+    expect(() => parseReqImpactMap(noDelta)).toThrow(/Delta Guard/);
+  });
+});
+
+describe("lookupImpactMatrix / lookupDeltaGuard", () => {
+  const map = parseReqImpactMap(MINIMAL_MAP);
+
+  it("lookupImpactMatrix finds by REQ id", () => {
+    expect(lookupImpactMatrix(map, "REQ-0101")?.ruleIds).toContain("IR-001");
+  });
+
+  it("lookupImpactMatrix returns undefined for unknown", () => {
+    expect(lookupImpactMatrix(map, "REQ-9999")).toBeUndefined();
+  });
+
+  it("lookupDeltaGuard finds by change type", () => {
+    expect(lookupDeltaGuard(map, "Skill 追加/変更")?.ruleIds).toEqual([
+      "IR-007",
+      "IR-008",
+      "IR-014",
+    ]);
+  });
+
+  it("lookupDeltaGuard returns undefined for unknown", () => {
+    expect(lookupDeltaGuard(map, "Bogus 変更")).toBeUndefined();
+  });
+});
+
+describe("parseReqImpactMap - real impact-map (QA Scenarios 2 & 3)", () => {
+  function readReal(): string {
+    const fs = require("fs");
+    const path = require("path");
+    let dir = path.resolve(__dirname);
+    for (let i = 0; i < 10; i++) {
+      const candidate = path.join(dir, "docs", "specs", "req-impact-map.md");
+      if (fs.existsSync(candidate)) return fs.readFileSync(candidate, "utf-8");
+      dir = path.dirname(dir);
+    }
+    throw new Error("req-impact-map.md fixture not found");
+  }
+
+  const map = parseReqImpactMap(readReal());
+
+  it("QA Scenario 2: REQ-0101 maps to IR-001,002,003,004,017,018,022", () => {
+    const entry = lookupImpactMatrix(map, "REQ-0101");
+    expect(entry).toBeDefined();
+    expect(entry!.ruleIds).toEqual([
+      "IR-001",
+      "IR-002",
+      "IR-003",
+      "IR-004",
+      "IR-017",
+      "IR-018",
+      "IR-022",
+    ]);
+  });
+
+  it("QA Scenario 3: Command 追加/変更 maps to IR-006,007,013,024", () => {
+    const entry = lookupDeltaGuard(map, "Command 追加/変更");
+    expect(entry).toBeDefined();
+    expect(entry!.ruleIds).toEqual(["IR-006", "IR-007", "IR-013", "IR-024"]);
+  });
+
+  it("REQ-0108 range expands to 24 rule IDs", () => {
+    const entry = lookupImpactMatrix(map, "REQ-0108");
+    expect(entry).toBeDefined();
+    expect(entry!.ruleIds).toHaveLength(24);
+    expect(entry!.ruleIds[0]).toBe("IR-001");
+    expect(entry!.ruleIds[23]).toBe("IR-024");
+  });
+
+  it("impact matrix covers 10+ active REQs", () => {
+    expect(map.impactMatrix.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("delta guard table has 7 change types", () => {
+    expect(map.deltaGuardTable).toHaveLength(7);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/req_impact_map_parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/req_impact_map_parser.ts
@@ -1,0 +1,194 @@
+/**
+ * Parser for `docs/specs/req-impact-map.md` (REQ-0136-040, Issue #898 Task 1.2).
+ *
+ * Extracts two structures:
+ *  - **Impact Matrix**: REQ × 影響する Rule IDs × 影響する Artifact rows
+ *  - **Delta Guard table**: 変更種別 × 実行 Rules rows (under
+ *    "### Delta Guard Rule Selection")
+ *
+ * Rule-ID cells may be a CSV (`IR-001, IR-002`), a range
+ * (`IR-001~IR-024 (全件)`), or an em-dash placeholder (`—`). Ranges are
+ * expanded to the literal ID list written; `(全件)` / `(infrastructure)`
+ * annotations are dropped from the parsed list but preserved in `raw`.
+ */
+const RULE_ID_RE = /\bIR-(\d{3})\b/g;
+const RANGE_RE = /IR-(\d{3})\s*[~〜]\s*IR-(\d{3})/;
+const TABLE_ROW_RE = /^\|\s*(.*?)\s*\|\s*(.*?)\s*\|$/;
+
+export class ReqImpactMapParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReqImpactMapParseError";
+  }
+}
+
+export interface ImpactMatrixEntry {
+  reqId: string;
+  title: string;
+  ruleIds: string[];
+  artifacts: string[];
+  raw: string;
+}
+
+export interface DeltaGuardEntry {
+  changeType: string;
+  ruleIds: string[];
+  raw: string;
+}
+
+export interface ReqImpactMap {
+  impactMatrix: ImpactMatrixEntry[];
+  deltaGuardTable: DeltaGuardEntry[];
+}
+
+function padRuleId(n: number): string {
+  return `IR-${String(n).padStart(3, "0")}`;
+}
+
+function expandRangeOnce(cell: string): string[] {
+  const m = cell.match(RANGE_RE);
+  if (!m) return [];
+  const start = parseInt(m[1], 10);
+  const end = parseInt(m[2], 10);
+  if (end < start) return [];
+  const out: string[] = [];
+  for (let i = start; i <= end; i++) out.push(padRuleId(i));
+  return out;
+}
+
+function parseRuleIdCell(cell: string): string[] {
+  const trimmed = cell.trim();
+  if (trimmed === "" || trimmed === "—" || trimmed === "-") return [];
+  const range = expandRangeOnce(trimmed);
+  if (range.length > 0) return range;
+  const ids = trimmed.match(RULE_ID_RE);
+  return ids ? Array.from(new Set(ids)) : [];
+}
+
+function parseArtifactCell(cell: string): string[] {
+  const trimmed = cell.trim();
+  if (trimmed === "" || trimmed === "—" || trimmed === "-") return [];
+  return trimmed
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function isReqId(token: string): boolean {
+  return /^REQ-\d{4}$/.test(token.trim());
+}
+
+function extractSection(content: string, header: string): string {
+  const re = new RegExp(
+    `^${header.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*$`,
+    "m",
+  );
+  const startMatch = content.match(re);
+  if (!startMatch || startMatch.index === undefined) {
+    throw new ReqImpactMapParseError(
+      `section "${header}" not found in req-impact-map`,
+    );
+  }
+  const afterStart = content.slice(startMatch.index + startMatch[0].length);
+  const nextHeader = afterStart.match(/^#{1,6}\s+/m);
+  return nextHeader && nextHeader.index !== undefined
+    ? afterStart.slice(0, nextHeader.index)
+    : afterStart;
+}
+
+function parseTableRows(section: string): string[][] {
+  const rows: string[][] = [];
+  for (const line of section.split("\n")) {
+    const m = line.match(TABLE_ROW_RE);
+    if (!m) continue;
+    const cells = line
+      .slice(line.indexOf("|") + 1, line.lastIndexOf("|"))
+      .split("|")
+      .map((c) => c.trim());
+    if (cells.every((c) => /^-+$/.test(c))) continue;
+    rows.push(cells);
+  }
+  return rows;
+}
+
+function parseImpactMatrix(section: string): ImpactMatrixEntry[] {
+  const rows = parseTableRows(section);
+  if (rows.length === 0) {
+    throw new ReqImpactMapParseError("Impact Matrix has no data rows");
+  }
+  const entries: ImpactMatrixEntry[] = [];
+  for (const cells of rows) {
+    if (cells.length < 4) continue;
+    const reqId = cells[0].trim();
+    if (!isReqId(reqId)) continue;
+    const raw = cells[2];
+    entries.push({
+      reqId,
+      title: cells[1].trim(),
+      ruleIds: parseRuleIdCell(raw),
+      artifacts: parseArtifactCell(cells[3]),
+      raw,
+    });
+  }
+  if (entries.length === 0) {
+    throw new ReqImpactMapParseError("Impact Matrix has no REQ-* rows");
+  }
+  return entries;
+}
+
+function parseDeltaGuardTable(section: string): DeltaGuardEntry[] {
+  const rows = parseTableRows(section);
+  if (rows.length === 0) {
+    throw new ReqImpactMapParseError("Delta Guard table has no data rows");
+  }
+  const entries: DeltaGuardEntry[] = [];
+  for (const cells of rows) {
+    if (cells.length < 2) continue;
+    const changeType = cells[0].trim();
+    if (!changeType || changeType === "変更種別") continue;
+    const raw = cells[1];
+    entries.push({
+      changeType,
+      ruleIds: parseRuleIdCell(raw),
+      raw,
+    });
+  }
+  if (entries.length === 0) {
+    throw new ReqImpactMapParseError("Delta Guard table has no 変更種別 rows");
+  }
+  return entries;
+}
+
+export function parseReqImpactMap(content: string): ReqImpactMap {
+  if (!content || content.trim().length === 0) {
+    throw new ReqImpactMapParseError("impact-map content is empty");
+  }
+  if (!/^#\s+REQ Impact Map/m.test(content)) {
+    throw new ReqImpactMapParseError(
+      "missing top-level '# REQ Impact Map' header",
+    );
+  }
+  const matrixSection = extractSection(content, "## Impact Matrix");
+  const deltaSection = extractSection(
+    content,
+    "### Delta Guard Rule Selection",
+  );
+  return {
+    impactMatrix: parseImpactMatrix(matrixSection),
+    deltaGuardTable: parseDeltaGuardTable(deltaSection),
+  };
+}
+
+export function lookupImpactMatrix(
+  map: ReqImpactMap,
+  reqId: string,
+): ImpactMatrixEntry | undefined {
+  return map.impactMatrix.find((e) => e.reqId === reqId);
+}
+
+export function lookupDeltaGuard(
+  map: ReqImpactMap,
+  changeType: string,
+): DeltaGuardEntry | undefined {
+  return map.deltaGuardTable.find((e) => e.changeType === changeType);
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/tests/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/tests/check_integrity.test.ts
@@ -11,15 +11,13 @@
  * Uses child_process.execSync to run the CLI script (CLI execution result verification).
  */
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { mkdirSync, writeFileSync, copyFileSync, rmSync, existsSync } from "fs";
+import { mkdirSync, writeFileSync, copyFileSync, rmSync, existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { execSync } from "child_process";
 
 const SCRIPT_DIR = import.meta.dir;
 const FIXTURES_DIR = join(SCRIPT_DIR, "fixtures");
 const PARENT_SCRIPTS_DIR = join(SCRIPT_DIR, "..");
-const CHECK_INTEGRITY_SCRIPT = join(PARENT_SCRIPTS_DIR, "check_integrity.ts");
-const CLI_UTILS_SCRIPT = join(PARENT_SCRIPTS_DIR, "cli_utils.ts");
 const TEMP_BASE = join("C:", "WINDOWS", "TEMP", "opencode");
 const RUN_ID = `issue657-regression-${crypto.randomUUID().slice(0, 8)}`;
 const TEMP_ROOT = join(TEMP_BASE, RUN_ID);
@@ -70,8 +68,11 @@ function copyScripts(fixtureRoot: string): void {
     "scripts",
   );
   mkdirp(dest);
-  copyFileSync(CHECK_INTEGRITY_SCRIPT, join(dest, "check_integrity.ts"));
-  copyFileSync(CLI_UTILS_SCRIPT, join(dest, "cli_utils.ts"));
+  for (const f of readdirSync(PARENT_SCRIPTS_DIR)) {
+    if (f.endsWith(".ts") && !f.endsWith(".test.ts")) {
+      copyFileSync(join(PARENT_SCRIPTS_DIR, f), join(dest, f));
+    }
+  }
 }
 
 /**

--- a/docs/DOC-MAP.md
+++ b/docs/DOC-MAP.md
@@ -65,6 +65,7 @@
 | [integrity-rule-catalog.md](specs/integrity-rule-catalog.md) | 整合性検査ルールのカタログ |
 | [artifact-responsibilities.md](specs/artifact-responsibilities.md) | アーティファクト責務マトリックス |
 | [req-impact-map.md](specs/req-impact-map.md) | REQ 影響マッピング |
+| [req-health-metrics.md](specs/req-health-metrics.md) | REQ 健全性メトリクス（肥大化・関心ズレ閾値） |
 | [rule-ownership.md](specs/rule-ownership.md) | ルール所有権マトリックス |
 
 ## ADR

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@
 - [Runtime Package Boundary](specs/runtime-package-boundary.md)
 - [Rule Ownership Matrix](specs/rule-ownership.md)
 - [REQ Impact Map](specs/req-impact-map.md)
+- [REQ Health Metrics](specs/req-health-metrics.md)
 
 ## ADR
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -23,6 +23,7 @@ They describe what the system *is* now, as opposed to REQ files that define requ
 | [runtime-package-boundary.md](runtime-package-boundary.md) | Runtime Package 境界 | Repo type 別 `.opencode/` 定義・命名規約・導入方式・sync 範囲 |
 | [rule-ownership.md](rule-ownership.md) | Rule 所有権マトリックス | rule domain と責任 REQ/SPEC の対応（REQ-0103-058） |
 | [req-impact-map.md](req-impact-map.md) | REQ 影響マップ | 各 active REQ が影響する integrity rule と artifact（REQ-0108-152） |
+| [req-health-metrics.md](req-health-metrics.md) | REQ 健全性メトリクス | REQ 肥大化・関心ズレ検出の定量閾値（要件行数・関心分類数・artifact種別数）（REQ-0136-040） |
 
 ## Document Relationships (REQ-0101)
 

--- a/docs/specs/req-health-metrics.md
+++ b/docs/specs/req-health-metrics.md
@@ -1,0 +1,106 @@
+# REQ Health Metrics
+
+REQ の肥大化・関心ズレを定量的に検出するための閾値を定義する（REQ-0136-040）。`req-define` の Step 3（既存REQ照合）・Step 10-2（統合/分離判定）、`inspect-docs`、`agentdev-req-structure-diagnostics` スキルが本 SPEC を参照して SPLIT 予兆を判定する。
+
+## 適用範囲
+
+- **対象**: active REQ ファイル（`docs/requirements/REQ-NNNN.md`）の要件テーブル行（`| REQ-NNNN-MMM | ... |`）。目的・適用範囲セクションの散文は計測対象外
+- **対象外**: retired REQ、draft、SPEC、ADR、guides
+
+## 測定対象と計測方法
+
+| メトリクス | 定義 | 計測方法 |
+|---|---|---|
+| 要件行数 | active REQ の要件テーブル行数 | `^\| REQ-NNNN-\d{3} \|` に一致する行数 |
+| 関心分類数 | 1 REQ 内で混在する関心対象の分類数 | 後述「関心分類」の定義に従い、要件行の主たる文意から分類 |
+| artifact 種別数 | 1 REQ が影響する artifact 種別の数 | `req-impact-map.md` の「影響する Artifact」列、または要件本文の対象 artifact 記述から集計 |
+
+### 関心分類
+
+関心分類は、1つの REQ が複数の独立した関心事を含んでいるかを判定するための分類。`agentdev-req-structure-diagnostics` スキルの SPLIT 観点（`req-structure-review.md`）に定義する4シグナルに基づく:
+
+1. 関心対象（要件の主題となる対象領域）の複数混在
+2. 複数 artifact 種別の混在（command + skill + template 等）
+3. 複数 command family の混在
+4. 複数 lifecycle 段階の混在
+
+異なる分類シグナルが1つでも検出された場合、関心分類数を +1 する。複数シグナルが検出された場合は、検出シグナル数を関心分類数とする。
+
+## 閾値と SPLIT シグナル
+
+要件行数・関心分類数・artifact 種別数を以下の閾値で評価し、SPLIT シグナルを加算する。SPLIT シグナルは `agentdev-req-structure-diagnostics` スキルの推奨アクション判定（SPLIT / APPEND / no-action）の入力となる。
+
+### 要件行数
+
+| 要件行数 | SPLIT シグナル | 判定 |
+|---|---|---|
+| 0〜50 | +0 | 健全。APPEND 検討に支障なし |
+| 51〜80 | +1 | 肥大化傾向。APPEND の前に SPLIT 要否を検討 |
+| 81 以上 | +2 | 肥大化。SPLIT を強く推奨 |
+
+### 関心分類数
+
+| 関心分類数 | SPLIT シグナル | 判定 |
+|---|---|---|
+| 0〜1 | +0 | 単一関心。健全 |
+| 2 以上 | +1 | 複数関心の混在。SPLIT 候補 |
+
+### artifact 種別数
+
+| artifact 種別数 | SPLIT シグナル | 判定 |
+|---|---|---|
+| 1〜2 | +0 | 単一〜隣接 artifact 責務。健全 |
+| 3 以上 | +1 | 複数 artifact 種別への影響。責務分界の再検討候補 |
+
+### SPEC分離基準違反（high-specificity signal）
+
+`agentdev-req-structure-diagnostics` スキルの SPEC分離基準違反シグナル（`req-structure-review.md`「SPEC分離基準違反検出」）は、1シグナルでも検出された場合 SPLIT シグナル +1 として扱う。これは要件行数・関心分類数とは独立に加算する。
+
+安定契約例外（REQ-0101-069、`document-model.md`「Stable Contract Exception」）に該当する要件行は、SPEC分離基準違反の検出対象外とする。
+
+## 推奨アクションへの対応付け
+
+合算した SPLIT シグナル数に基づき、`req-define` Step 10-2 と `agentdev-req-structure-diagnostics` が推奨アクションを提示する:
+
+| SPLIT シグナル合計 | 推奨アクション | req-define での扱い |
+|---|---|---|
+| 0〜1 | no-action / APPEND | 既存 REQ への APPEND を許可 |
+| 2 | SPLIT 検討 | APPEND の前にユーザーへ SPLIT 要否を提案 |
+| 3 以上 | SPLIT 推奨 | SPLIT を強く推奨。APPEND の場合は理由を明記 |
+
+`agentdev-req-structure-diagnostics` スキルのシグナル閾値（1シグナル=観察メモ、2シグナル=問題候補、3シグナル=高優先度）と本 SPEC の閾値は整合する。同スキルの判定結果出力スキーマ（観点・対象・根拠・シグナル数・確信度・推奨アクション・req-define入力案）に本 SPEC のシグナル計算結果を埋め込む。
+
+## 現行 REQ の計測例（参照値）
+
+本 SPEC の閾値を現行 active REQ に適用した結果の参照値。定期計測時の推移比較に使用する。
+
+| REQ | 要件行数 | 行数シグナル | 備考 |
+|---|---|---|---|
+| REQ-0103 | 84 | +2 | artifact責任分界。肥大化 |
+| REQ-0114 | 68 | +1 | case-auto。lifecycle 段階混在で関心シグナル追加 |
+| REQ-0101 | 62 | +1 | 文書・REQ管理基準 |
+| REQ-0102 | 56 | +1 | 要件定義・保存 |
+| REQ-0112 | 56 | +1 | ADRライフサイクル |
+| REQ-0119 | 23 | +0 | コマンド・スキル責務分界 |
+| REQ-0108 | 22 | +0 | docs-check / Validation |
+| REQ-0136 | 19 | +0 | REQ/SPEC/ADR 適正運用自動化 |
+
+計測日: 2026-06-18。要件行数は要件テーブル行のみをカウント（目的・適用範囲セクションの散文は除外）。
+
+## 他 SPEC・スキルとの関係
+
+- **`document-model.md` SPEC Separation Criteria（REQ-0101-068）**: SPEC分離基準違反シグナルの判定基準。本 SPEC は閾値とシグナル加算のみを定義し、SPEC分離の判定本体は `document-model.md` に従う
+- **`document-model.md` Stable Contract Exception（REQ-0101-069）**: 安定契約例外の定義。本 SPEC の SPEC分離基準違反検出はこの例外を尊重する
+- **`agentdev-req-structure-diagnostics` スキル `req-structure-review.md`**: 6観点診断（SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）と SPEC分離基準違反の9シグナル定義。本 SPEC の閾値はこのスキルの SPLIT 観点の入力
+- **`req-impact-map.md`**: artifact 種別数の計測に使用する「影響する Artifact」列
+- **`integrity-rule-catalog.md` IR-044**: REQ/SPEC 境界違反検出。本 SPEC の SPEC分離基準違反シグナルと連動する
+
+## 機械化境界
+
+本 SPEC は閾値の定義のみを提供し、計測・判定の実装は以下が担う:
+
+- **req-define Step 3/10-2**: ドラフト段階で SPLIT シグナルを計算し `draft-meta.split-forecast` に記録（REQ-0136 RU-3 Task 3.3）
+- **agentdev-req-structure-diagnostics スキル**: 既存 REQ の健全性診断で本 SPEC の閾値を適用
+- **check_integrity.ts IR-044**: SPEC分離基準違反の自動検出（REQ-0136 RU-2 Task 2.3）
+
+本 SPEC 自体は計測ロジックを実装しない。閾値の変更は本 SPEC の更新をもって正とし、各実装は本 SPEC を参照する。

--- a/src/opencode/skills/agentdev-req-structure-diagnostics/references/req-structure-review.md
+++ b/src/opencode/skills/agentdev-req-structure-diagnostics/references/req-structure-review.md
@@ -47,6 +47,8 @@ REQ の active/retired/世代境界の整合性を確認する:
 | 2シグナル以上 | 問題候補 finding として出す |
 | 3シグナル以上、または active/retired 判断に影響 | 高優先度候補として出す |
 
+要件行数・関心分類数・artifact種別数の定量閾値と SPLIT シグナル加算ルールは `docs/specs/req-health-metrics.md`（REQ-0136-040）に定義する。本観点の SPLIT シグナル計算は同 SPEC の閾値を参照する。
+
 SPEC分離基準違反シグナルは high-specificity signal として扱う。active REQ の要件行で以下のいずれかが主たる文意になっている場合、1シグナルでも MOVE finding 候補として出す。安定契約例外（公開 command 名、domain state の位置づけ、接続契約、安全境界、停止条件の大枠等）に該当する可能性がある場合は、確信度を medium/low に下げ、根拠に例外候補を明記する。
 
 ## SPEC分離基準違反検出


### PR DESCRIPTION
## 概要

RU-1（基盤整備）として、`check_integrity.ts` の3層ゲートCLI拡張、integrity catalog / impact map のパーサ実装、REQ健全性メトリクスSPEC化を実装する（Issue #898）。

親: #896（Epic, REQ-0136）／参照: ADR-0123（proposed）

## 完了条件の対応

- [x] `--gate <full-audit|delta-guard|impact-guard>`、`--paths`、`--reqs` が実装され、引数なし呼び出しは従来互換で `full-audit` 相当になる
- [x] `parseIntegrityRuleCatalog()` と `parseReqImpactMap()` が必要メタデータ、Impact Matrix、Delta Guard対応表を返し、パース失敗時は明確に失敗する
- [x] `docs/specs/req-health-metrics.md` に要件行数・関心分類数・artifact種別数の閾値が定義され、関連インデックスから参照できる
- [x] 変更ファイルの `lsp_diagnostics` と関連QAシナリオが通る

> Issue #898 の完了条件チェックボックスは case-close QG-4 の責務（ADR-0114, G24）のため本PRでは更新しない。

## 実装内容

### Task 1.1: check_integrity.ts CLI 拡張

`cli_utils.ts` に `GateLevel` 型と `--gate` / `--paths` / `--reqs` 引数を追加（`resolveFlagValue` ヘルパーで `--flag value` / `--flag=value` 両形式をサポート）。`check_integrity.ts` main() で `parseArgs` を try/catch で囲み、不正 `--gate` 値は exit 2（EXIT_ERROR）。`full-audit`（デフォルト）は結果をフィルタせず従来とbyte-identical。`delta-guard`/`impact-guard` は catalog + impact-map を読み込み、適用可能 IR 集合を算出して結果を `check` カテゴリでフィルタ。

### Task 1.2: catalog / impact-map パーサ

- `integrity_catalog_parser.ts`: `parseIntegrityRuleCatalog(content)` が IR-001〜044 全44件の15フィールド（rule_id, gate_level[], severity, finding_route 等）を返す。`filterRulesByGate()` / `findRuleById()` 補助関数付き。
- `req_impact_map_parser.ts`: `parseReqImpactMap(content)` が Impact Matrix（REQ × Rule IDs × Artifact）と Delta Guard 対応表（変更種別 × Rules）を返す。範囲表記 `IR-001~IR-024` を展開、em-dash `—` を空リスト扱い、`(全件)` 等の注釈は raw に保持。
- `gate_filter.ts`: `selectApplicableRuleIds()` が gate/paths/reqs から適用 IR 集合を算出。`classifyChangeType()` がパス→変更種別を判定。`IR_TO_CHECK_CATEGORIES` 保守的マッピング（RU-1基盤段階）。

### Task 1.3: REQ健全性メトリクスSPEC

`docs/specs/req-health-metrics.md` 新設。要件行数（>50→+1, >80→+2）、関心分類数（2+→+1）、artifact種別数（3+→+1）、SPEC分離基準違反 high-specificity signal（+1）の閾値を定義。推奨アクション（APPEND/SPLIT検討/SPLIT推奨）への対応付けと現行REQ計測例（REQ-0103=84行→+2 等）を記載。`document-model.md` SPEC Separation Criteria（REQ-0101-068）/ Stable Contract Exception（REQ-0101-069）を参照。`docs/specs/README.md`・`docs/DOC-MAP.md`・`req-structure-diagnostics` スキルの cross-reference を更新。

## テスト結果 / QA検証

**QA Scenario 1（catalog delta-guard フィルタ）**: `gate_level: delta-guard` → 13ルール（IR-006, IR-008, IR-012, IR-013, IR-016, IR-028〜033, IR-038, IR-040）✅ 完全一致

**QA Scenario 2（impact-map REQ-0101 lookup）**: REQ-0101 → IR-001, IR-002, IR-003, IR-004, IR-017, IR-018, IR-022 ✅ 完全一致

**QA Scenario 3（Delta Guard table "Command 変更"）**: `Command 追加/変更` → IR-006, IR-007, IR-013, IR-024 ✅ 完全一致

**追加検証**:
- REQ-0108 範囲展開 `IR-001~IR-024` → 24 ID ✅
- `--gate delta-guard --paths docs/requirements/REQ-0101.md` → applicable_rules=17, results=100/213（フィルタ動作）✅
- `--gate impact-guard --reqs REQ-0101` → applicable_rules=9, results=58/213 ✅
- `--gate bogus` → `[integrity] Invalid --gate value "bogus"` + exit 2 ✅
- 引数なし呼び出し → 従来通りの全ルール実行・同じレポート形式（後方互換）✅

**テストスイート**: scripts/ 全体で 252 pass / 86 fail。86 fail は全てワークツリー環境起因の既存failure（junction未伝播の agentdev-* skill 参照、vocabulary registry 等）であり、本PR由来の新規failureは0。新規テスト 60件（catalog parser / impact-map parser / gate_filter）は全て pass。既存 `cli_utils.test.ts` は 26→51件に拡張し全 pass。Issue #657 regression test は baseline（9 pass / 2 fail）と同数（copyScripts を全 .ts ファイルコピーに修正し、新規依存モジュール欠落による4件の新規failを解消）。

**lsp_diagnostics**: 変更全 .ts ファイルでエラー0。

## 品質メトリクス

- 変更ファイル: 14（新規7 / 変更7）
- 新規テスト: 60件（3ファイル）全 pass
- 後方互換性: 引数なし呼び出しは full-audit = 従来同等（full-audit分岐は結果に触れない）
- TypeScript diagnostics: 変更ファイル全て clean
- `as any` / `@ts-ignore` / `@ts-expect-error`: 使用なし

## Findings / Capture候補

- **capture候補（intake系）**: Issue #657 regression test の `copyScripts()` が check_integrity.ts の兄弟モジュール（parser/gate_filter）をコピーしていなかった。本PRで全 .ts ファイルコピーに修正したが、これは「新規依存モジュール追加時に regression test の fixture copy を更新する必要がある」という一般知見。将来のスクリプト追加時の再発防止候補。
- **capture候補（learning系）**: REQ ID は4桁（REQ-0101）だが IR ID は3桁（IR-001）。パーサ実装時に `isReqId` で `\d{3}` を使ってしまい即座に発見・修正した。「REQ は4桁、IR は3桁」というID桁数の違いは新規実装者が陥りやすい落とし穴。

## SPEC確定候補

（ADR-0123 proposed に基づく）

- `IR_TO_CHECK_CATEGORIES` マッピング（gate_filter.ts）は保守的であり、delta-guard/impact-guard にタグ付けされた IR のうち実装済み check 関数にのみマッピング。IR-020/023/028〜033/038/040 等の新規 rule は check 関数未実装のため full-audit のみ。この「IR-NNN ↔ check 関数カテゴリ」対応表の完成度は RU-2（3層ゲート実装）の進行に応じて充実させる。本対応表を SPEC（`integrity-rule-catalog.md` または `rule-ownership.md`）に正式化するかは ADR-0123 accepted 後に判断候補。
- `req-health-metrics.md` の閾値（要件行数 >50/>80、関心2+、artifact 3+）は現行REQデータ（REQ-0103=84, REQ-0114=68, REQ-0101=62）に基づく初期値。RU-3 Task 3.3（req-define SPLIT予兆検知）実装時に実REQでの検証を経て確定候補。

Closes #898

Ref: #896 (Epic)／REQ-0136／ADR-0123
