### PR TITLE
[RU-2] 3層ゲート実装: Delta Guard + Impact Guard + Full Audit + IR-044 (Issue #899)

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,112 @@
+# AgentDevFlow Git Hooks
+
+3層ゲート（事前予防）のうち、commit / push 時に自動実行される Delta Guard と Impact Guard を提供する (REQ-0136-004, REQ-0136-005, REQ-0136-008)。
+
+## Hooks
+
+| Hook | Gate | 起動タイミング | ブロック条件 |
+|------|------|---------------|-------------|
+| `pre-commit` | Delta Guard | `git commit` 実行時 | staged files に対する strict 違反 |
+| `pre-push` | Impact Guard | `git push` 実行時 | 未push範囲の変更 REQ/ADR に関連する strict 違反 |
+
+いずれの hook も `--strict-only` 付きで `check_integrity.ts` を起動する。heuristic / observation finding は警告表示のみで commit / push をブロックしない。
+
+## Setup
+
+### Windows (PowerShell 7+)
+
+```powershell
+./.githooks/setup-hooks.ps1
+```
+
+### Unix / macOS / Linux / Git Bash
+
+```sh
+./.githooks/setup-hooks.sh
+```
+
+両スクリプトとも `git config core.hooksPath .githooks` を設定するだけで、hook 本体は変更しない。冪等であり、何度実行しても安全。
+
+## Enable / Disable / Status
+
+```powershell
+# Windows
+./.githooks/setup-hooks.ps1 -Action status
+./.githooks/setup-hooks.ps1 -Action disable
+./.githooks/setup-hooks.ps1 -Action enable
+```
+
+```sh
+# Unix
+./.githooks/setup-hooks.sh status
+./.githooks/setup-hooks.sh disable
+./.githooks/setup-hooks.sh enable
+```
+
+## Bypass (一時的)
+
+環境変数 `DEVFLOW_SKIP_HOOKS` を設定すると、その1回の commit / push で hook をスキップできる。
+
+```sh
+DEVFLOW_SKIP_HOOKS=1 git commit -m "..."
+DEVFLOW_SKIP_HOOKS=1 git push
+```
+
+> 日常的な回避ではなく、merge や automated commit など例外的な場面でのみ使用すること。
+
+## Prerequisites
+
+- **bun**: 両 hook は `bun run check_integrity.ts` を起動する。bun が PATH にない場合、hook は警告を出してスキップする（ブロックしない）。
+- **Git 2.9+**: `core.hooksPath` のサポートに必要。
+
+## 動作の詳細
+
+### Delta Guard (pre-commit)
+
+1. `git diff --cached --name-only --diff-filter=ACM` で staged files を取得
+2. カンマ区切り CSV に変換
+3. `bun run check_integrity.ts --gate delta-guard --paths <csv> --strict-only` を実行
+4. exit code 1 (strict 違反) → commit block。exit code 0 → 許可。
+
+### Impact Guard (pre-push)
+
+1. pre-push 引数 (`local_ref local_sha remote_ref remote_sha`) から未push範囲を算出
+2. `git diff --name-only <range>` で変更ファイルを取得
+3. 変更 REQ/ADR ファイルから REQ ID を抽出 (例: `docs/requirements/REQ-0101.md` → `REQ-0101`)
+4. `bun run check_integrity.ts --gate impact-guard --reqs <req_csv> --strict-only` を実行
+5. exit code 1 (strict 違反) → push block。exit code 0 → 許可。
+
+## Troubleshooting
+
+### hook が実行されない
+
+1. `setup-hooks.ps1` / `setup-hooks.sh` を実行して `core.hooksPath` が `.githooks` に設定されているか確認:
+   ```sh
+   git config core.hooksPath
+   ```
+2. `.githooks/pre-commit` / `.githooks/pre-push` に実行権限があるか確認 (Unix):
+   ```sh
+   chmod +x .githooks/pre-commit .githooks/pre-push
+   ```
+
+### bun not found
+
+bun がインストールされていない場合、hook は警告を出してスキップする。bun をインストールすること:
+   ```sh
+   curl -fsSL https://bun.sh/install | bash   # Unix
+   powershell -c "irm bun.sh/install.ps1|iex"  # Windows
+   ```
+
+### strict 違反で commit / push がブロックされる
+
+該当 finding を修正することが推奨される。どうしても回避が必要な場合は `DEVFLOW_SKIP_HOOKS=1` を使用する。ただし、strict 違反は「即時修正が必要」な機械検証可能な不整合であるため (gate-levels.md)、放置しないこと。
+
+### hook 実行エラー (exit code 2)
+
+`check_integrity.ts` が入力エラーや実行エラーで終了した場合、hook は非ブロックでスキップする。エラーの詳細は stderr を確認すること。
+
+## Related
+
+- REQ-0136: REQ/SPEC/ADR 適正運用の自動化（3層ゲート + 新ワークフロー）
+- [gate-levels.md](../.opencode/skills/repo-agentdev-integrity/references/gate-levels.md): strict / heuristic / observation 水準定義
+- [integrity-rule-catalog.md](../docs/specs/integrity-rule-catalog.md): 全 integrity rule 定義

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Delta Guard — change-scoped integrity check on staged files (REQ-0136-004).
+#
+# Runs the delta-guard gate against the staged file set. STRICT violations
+# block the commit (exit 1); heuristic/observation findings are printed as
+# warnings but do not block (--strict-only).
+#
+# Bypass:  DEVFLOW_SKIP_HOOKS=1 git commit ...
+# Disable: run setup-hooks.sh with the disable flag (see .githooks/README.md).
+
+# Git invokes hooks with the repo root as CWD, but resolve explicitly for safety.
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo_root" || exit 0
+
+if [ -n "$DEVFLOW_SKIP_HOOKS" ]; then
+  echo "[delta-guard] skipped (DEVFLOW_SKIP_HOOKS set)"
+  exit 0
+fi
+
+script="$repo_root/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts"
+if [ ! -f "$script" ]; then
+  echo "[delta-guard] check_integrity.ts not found; skipping"
+  exit 0
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "[delta-guard] bun not found on PATH; skipping delta guard" >&2
+  exit 0
+fi
+
+# Staged additions/modifications (drop deletions — they have no content to check).
+staged=$(git diff --cached --name-only --diff-filter=ACM)
+if [ -z "$staged" ]; then
+  echo "[delta-guard] no staged files; skipping"
+  exit 0
+fi
+
+# Build a comma-separated CSV (newline → comma, trim trailing comma).
+csv=$(printf '%s\n' "$staged" | grep -v '^[[:space:]]*$' | tr '\n' ',' | sed 's/,$//')
+if [ -z "$csv" ]; then
+  echo "[delta-guard] no classifiable staged files; skipping"
+  exit 0
+fi
+
+echo "[delta-guard] running delta guard on staged files..."
+bun run "$script" --gate delta-guard --paths "$csv" --strict-only
+status=$?
+
+if [ "$status" -eq 0 ]; then
+  echo "[delta-guard] passed"
+  exit 0
+fi
+
+# status 1 = strict violation → block. status 2 = input/execution error.
+if [ "$status" -eq 2 ]; then
+  echo "[delta-guard] check execution error; skipping (non-blocking)" >&2
+  exit 0
+fi
+
+echo "[delta-guard] STRICT violations detected — commit blocked." >&2
+echo "[delta-guard] Fix the violations, or bypass with:" >&2
+echo "[delta-guard]   DEVFLOW_SKIP_HOOKS=1 git commit ..." >&2
+exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Impact Guard — REQ/ADR-scoped integrity check before push (REQ-0136-005).
+#
+# Identifies changed REQ/ADR files in the unpushed commit range, extracts the
+# affected REQ IDs, and runs the impact-guard gate. STRICT violations block the
+# push (exit 1); heuristic/observation findings are warnings only (--strict-only).
+#
+# Git passes 4 line-delimited args on stdin:
+#   <local ref> <local sha> <remote ref> <remote sha>
+# We use local/remote sha to compute the changed-file range when possible.
+#
+# Bypass:  DEVFLOW_SKIP_HOOKS=1 git push ...
+# Disable: run setup-hooks.sh with the disable flag (see .githooks/README.md).
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo_root" || exit 0
+
+if [ -n "$DEVFLOW_SKIP_HOOKS" ]; then
+  echo "[impact-guard] skipped (DEVFLOW_SKIP_HOOKS set)"
+  exit 0
+fi
+
+script="$repo_root/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts"
+if [ ! -f "$script" ]; then
+  echo "[impact-guard] check_integrity.ts not found; skipping"
+  exit 0
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "[impact-guard] bun not found on PATH; skipping impact guard" >&2
+  exit 0
+fi
+
+# Read the first line of push arguments: local_ref local_sha remote_ref remote_sha
+read -r local_ref local_sha remote_ref remote_sha <<EOF
+$(cat)
+EOF
+
+# Determine the diff range. New branch (remote_sha all zeros) → diff against the
+# upstream tracking branch or origin/main; otherwise local_sha..remote_sha range.
+zero=$(git hash-object --stdin </dev/null 2>/dev/null | sed 's/[0-9a-f]/0/g')
+range=""
+if [ "$remote_sha" = "$zero" ] || [ -z "$remote_sha" ]; then
+  # New branch: compare against origin/main if it exists, else HEAD's first parent
+  if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    range="origin/main...$local_sha"
+  elif [ "$local_sha" != "$zero" ]; then
+    range="${local_sha}^..$local_sha"
+  fi
+else
+  range="${remote_sha}..${local_sha}"
+fi
+
+if [ -z "$range" ]; then
+  echo "[impact-guard] no push range determined; skipping"
+  exit 0
+fi
+
+# Changed files in the unpushed range.
+changed=$(git diff --name-only --diff-filter=ACM "$range" 2>/dev/null)
+if [ -z "$changed" ]; then
+  echo "[impact-guard] no changed files in push range; skipping"
+  exit 0
+fi
+
+# Extract REQ IDs from changed REQ/ADR files (e.g. docs/.../REQ-0101.md → REQ-0101).
+req_ids=$(printf '%s\n' "$changed" \
+  | grep -E 'docs/(requirements|adr)/' \
+  | grep -oE 'REQ-[0-9]{4}' \
+  | sort -u \
+  | tr '\n' ',' \
+  | sed 's/,$//')
+
+if [ -z "$req_ids" ]; then
+  echo "[impact-guard] no changed REQ/ADR files in push range; skipping"
+  exit 0
+fi
+
+echo "[impact-guard] running impact guard for: $req_ids"
+bun run "$script" --gate impact-guard --reqs "$req_ids" --strict-only
+status=$?
+
+if [ "$status" -eq 0 ]; then
+  echo "[impact-guard] passed"
+  exit 0
+fi
+
+if [ "$status" -eq 2 ]; then
+  echo "[impact-guard] check execution error; skipping (non-blocking)" >&2
+  exit 0
+fi
+
+echo "[impact-guard] STRICT violations detected — push blocked." >&2
+echo "[impact-guard] Fix the violations, or bypass with:" >&2
+echo "[impact-guard]   DEVFLOW_SKIP_HOOKS=1 git push ..." >&2
+exit 1

--- a/.githooks/setup-hooks.ps1
+++ b/.githooks/setup-hooks.ps1
@@ -1,0 +1,56 @@
+#!/usr/bin/env pwsh
+# AgentDevFlow git hooks setup (Windows / PowerShell 7+) — REQ-0136-008.
+#
+# Enables Delta Guard (pre-commit) and Impact Guard (pre-push) by pointing
+# git's core.hooksPath at the repo-local .githooks directory. Idempotent.
+#
+# Usage:
+#   ./setup-hooks.ps1              # enable (default)
+#   ./setup-hooks.ps1 -Action disable
+#   ./setup-hooks.ps1 -Action status
+#
+# This script only touches core.hooksPath; it does not modify hook contents.
+
+[CmdletBinding()]
+param(
+    [ValidateSet('enable', 'disable', 'status')]
+    [string]$Action = 'enable'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Resolve-Path (git rev-parse --show-toplevel 2>$null)
+if (-not $repoRoot) {
+    throw "Could not determine git repo root. Run from inside a git repository."
+}
+$hooksDir = Join-Path $repoRoot '.githooks'
+
+function Get-HooksPath { (git config core.hooksPath 2>$null) -as [string] }
+function Set-HooksPath([string]$value) { git config core.hooksPath $value }
+function Clear-HooksPath { git config --unset core.hooksPath 2>$null; $global:LASTEXITCODE = 0 }
+
+switch ($Action) {
+    'status' {
+        $current = Get-HooksPath
+        if ($current -eq '.githooks') {
+            Write-Output "hooks: ENABLED (core.hooksPath=.githooks)"
+        } elseif ($current) {
+            Write-Output "hooks: custom core.hooksPath='$current' (not the default .githooks)"
+        } else {
+            Write-Output "hooks: DISABLED (using git default .git/hooks)"
+        }
+    }
+    'disable' {
+        Clear-HooksPath
+        Write-Output "hooks: DISABLED (core.hooksPath unset; git will use .git/hooks)"
+    }
+    'enable' {
+        if (-not (Test-Path -LiteralPath (Join-Path $hooksDir 'pre-commit'))) {
+            throw "pre-commit hook not found at $hooksDir. Ensure .githooks/ is checked out."
+        }
+        Set-HooksPath '.githooks'
+        Write-Output "hooks: ENABLED (core.hooksPath=.githooks)"
+        Write-Output "  - pre-commit  : Delta Guard (REQ-0136-004)"
+        Write-Output "  - pre-push    : Impact Guard (REQ-0136-005)"
+        Write-Output "Bypass a single commit/push with: DEVFLOW_SKIP_HOOKS=1"
+    }
+}

--- a/.githooks/setup-hooks.sh
+++ b/.githooks/setup-hooks.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# AgentDevFlow git hooks setup (Unix / macOS / Linux / Git Bash) — REQ-0136-008.
+#
+# Enables Delta Guard (pre-commit) and Impact Guard (pre-push) by pointing
+# git's core.hooksPath at the repo-local .githooks directory. Idempotent.
+#
+# Usage:
+#   ./setup-hooks.sh               # enable (default)
+#   ./setup-hooks.sh disable
+#   ./setup-hooks.sh status
+#
+# This script only touches core.hooksPath; it does not modify hook contents.
+
+set -u
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$repo_root" ]; then
+  echo "setup-hooks: could not determine git repo root" >&2
+  exit 1
+fi
+
+action=${1:-enable}
+
+case "$action" in
+  status)
+    current=$(git config core.hooksPath 2>/dev/null | tr -d '[:space:]')
+    if [ "$current" = ".githooks" ]; then
+      echo "hooks: ENABLED (core.hooksPath=.githooks)"
+    elif [ -n "$current" ]; then
+      echo "hooks: custom core.hooksPath='$current' (not the default .githooks)"
+    else
+      echo "hooks: DISABLED (using git default .git/hooks)"
+    fi
+    ;;
+  disable)
+    git config --unset core.hooksPath 2>/dev/null || true
+    echo "hooks: DISABLED (core.hooksPath unset; git will use .git/hooks)"
+    ;;
+  enable)
+    if [ ! -f "$repo_root/.githooks/pre-commit" ]; then
+      echo "setup-hooks: pre-commit hook not found at $repo_root/.githooks" >&2
+      exit 1
+    fi
+    git config core.hooksPath .githooks
+    echo "hooks: ENABLED (core.hooksPath=.githooks)"
+    echo "  - pre-commit  : Delta Guard (REQ-0136-004)"
+    echo "  - pre-push    : Impact Guard (REQ-0136-005)"
+    echo "Bypass a single commit/push with: DEVFLOW_SKIP_HOOKS=1"
+    ;;
+  *)
+    echo "usage: $0 [enable|disable|status]" >&2
+    exit 2
+    ;;
+esac

--- a/.github/workflows/full-audit.yml
+++ b/.github/workflows/full-audit.yml
@@ -1,0 +1,87 @@
+name: Full Audit
+
+# Full Audit (REQ-0136-007): runs all integrity rules periodically and on
+# trigger events that warrant a repository-wide re-audit:
+#   - monthly schedule
+#   - integrity-rule-catalog.md changes
+#   - ADR additions / changes
+#   - REQ retire events (docs/requirements/retired/)
+# Reports are written to .agentdev/integrity/reports/ and uploaded as artifacts.
+
+on:
+  schedule:
+    # 1st of each month at 03:00 UTC
+    - cron: "0 3 1 * *"
+  pull_request:
+    paths:
+      - "docs/specs/integrity-rule-catalog.md"
+      - "docs/adr/ADR-*.md"
+      - "docs/adr/README.md"
+      - "docs/requirements/retired/**"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: full-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+
+      - name: Run Full Audit
+        run: |
+          bun run .opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts \
+            --gate full-audit --json > full-audit-report.json
+          # Print human-readable summary to the workflow log
+          bun run .opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts \
+            --gate full-audit
+        continue-on-error: true
+
+      - name: Summarize result
+        id: result
+        run: |
+          # Extract counts from the JSON report (tolerant of missing fields).
+          NG=$(bun -e 'const d=JSON.parse(require("fs").readFileSync("full-audit-report.json","utf-8"));console.log(d.summary?.ng ?? 0)')
+          WARN=$(bun -e 'const d=JSON.parse(require("fs").readFileSync("full-audit-report.json","utf-8"));console.log(d.summary?.warning ?? 0)')
+          echo "ng=$NG" >> "$GITHUB_OUTPUT"
+          echo "warning=$WARN" >> "$GITHUB_OUTPUT"
+          echo "::notice::Full Audit summary — NG: $NG, Warning: $WARN"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: full-audit-report
+          path: |
+            full-audit-report.json
+            .agentdev/integrity/reports/
+
+      - name: Commit report (scheduled / manual only)
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .agentdev/integrity/reports/
+          if git diff --cached --quiet; then
+            echo "No report changes to commit."
+          else
+            git commit -m "chore(integrity): full audit report [skip ci]"
+            git push
+          fi
+
+      - name: Fail on strict violations (pull requests)
+        if: github.event_name == 'pull_request' && steps.result.outputs.ng != '0'
+        run: |
+          echo "::error::Full Audit found ${{ steps.result.outputs.ng }} strict violation(s)."
+          exit 1

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -12,6 +12,7 @@ import {
   formatJsonReport,
   formatMarkdownReport,
   determineExitCode,
+  determineExitCodeStrict,
   findRepoRoot,
   determineRoute,
   writeReportFile,
@@ -35,7 +36,7 @@ const SCRIPT_NAME = "check_integrity.ts";
 const DESCRIPTION = "AgentDevFlow artifact integrity validator";
 const USAGE =
   "bun run check_integrity.ts [--help] [--json] [--dry-run] [--classification] " +
-  "[--gate <full-audit|delta-guard|impact-guard>] [--paths <csv>] [--reqs <csv>]";
+  "[--gate <full-audit|delta-guard|impact-guard>] [--paths <csv>] [--reqs <csv>] [--strict-only]";
 
 const path = require("path") as typeof import("path");
 const fs = require("fs") as typeof import("fs");
@@ -6887,6 +6888,145 @@ function checkReqVerificationBasis(root: string): CheckResult[] {
   return results;
 }
 
+// ─── IR-044: REQ/SPEC boundary violation detection (REQ-0136-006) ──────────
+// Detects SPEC detail contamination in active REQ requirement lines.
+// 9 SPEC separation criteria violation signals (REQ-0101-068, REQ-0136-006):
+//   1. schema field   2. enum value list      3. fixture detail
+//   4. checker individual rule   5. false positive suppression
+//   6. Step number    7. Phase number         8. internal algorithm
+//   9. specific work history
+// Stable contract exception (REQ-0101-069) is exempt from detection.
+
+// 9 SPEC separation criteria violation signals with conservative keyword patterns.
+// Patterns target the *primary intent* of a requirement line; heuristic severity.
+const IR044_SIGNAL_PATTERNS: ReadonlyArray<{ signal: string; pattern: RegExp }> = [
+  // 1. schema field — detailed schema/field type definitions belong in SPEC
+  {
+    signal: "schema field",
+    pattern:
+      /schema\s*field|スキーマ\s*フィールド|frontmatter\s*フィールド\s*の\s*型|field\s*の\s*型\s*は\s*["'`]|必須\s*フィールド\s*.*型\s*[=:]/i,
+  },
+  // 2. enum value list — enumerated value inventories belong in SPEC
+  {
+    signal: "enum value list",
+    pattern: /\benum\s*(値|リスト|一覧)?|\b列挙値?\s*(一覧|リスト)?|値\s*一覧\s*[:：]/i,
+  },
+  // 3. fixture detail — test fixture content belongs in SPEC/test docs
+  { signal: "fixture detail", pattern: /\bfixtures?\b|フィクスチャ|テスト\s*データ\s*詳細/i },
+  // 4. checker individual rule — detection logic detail belongs in rule catalog
+  {
+    signal: "checker individual rule",
+    pattern:
+      /checker\s*(個別\s*)?ルール|検出\s*(ルール|パターン)\s*[:：]|detection\s*pattern\s*[:：]/i,
+  },
+  // 5. false positive suppression — FP handling detail belongs in rule catalog
+  {
+    signal: "false positive suppression",
+    pattern:
+      /false\s*positive\s*(抑制|除外)|偽陽性\s*(抑制|除外)|\bFP\s*抑制|除外\s*(パス|ルール)\s*[:：]|\bexempt\s*(path|file)/i,
+  },
+  // 6. Step number — workflow step references belong in command/skill reference
+  {
+    signal: "Step number",
+    pattern: /\bStep\s*\d+(?:\s*[-‐-]\s*\d+)?\b|ステップ\s*\d+(?:\s*[-‐-]\s*\d+)?/,
+  },
+  // 7. Phase number — phase numbering belongs in command/skill reference
+  {
+    signal: "Phase number",
+    pattern: /\bPhase\s*\d+\b|フェーズ\s*\d+/,
+  },
+  // 8. internal algorithm — implementation algorithm belongs in SPEC
+  {
+    signal: "internal algorithm",
+    pattern: /内部\s*アルゴリズム|internal\s*algorithm|実装\s*アルゴリズム/i,
+  },
+  // 9. specific work history — past work records belong in PR/Issue history
+  {
+    signal: "work history",
+    pattern:
+      /作業履歴\s*[:：]|PR\s*#\d+|commit\s+[0-9a-f]{7,40}|\bINC-\d{4,}\b|Issue\s*#\d+\s*で\s*(実装|追加|修正)/i,
+  },
+];
+
+// REQ-0101-069 stable contract exception — these topics may be summarized in REQ
+// even when phrased as parameters/classifications. Lines matching these are exempt.
+const IR044_STABLE_CONTRACT_PATTERN =
+  /公開\s*command\s*名|公開入口|domain\s*state\s*の\s*位置づけ|接続\s*契約|利用者.*分類\s*体系|安全\s*境界|停止条件\s*の\s*大枠|安定した\s*外部\s*契約|安定する\s*外部\s*契約/;
+
+function checkReqSpecBoundaryViolation(root: string): CheckResult[] {
+  const results: CheckResult[] = [];
+  const reqDir = path.join(root, "docs", "requirements");
+  if (!fs.existsSync(reqDir)) return results;
+  let foundViolation = false;
+
+  for (const file of listFiles(reqDir)) {
+    // listFiles only returns top-level .md files; retired/ subdirectory excluded.
+    if (!file.startsWith("REQ-") || !file.endsWith(".md")) continue;
+    const fullPath = path.join(reqDir, file);
+    const content = readText(fullPath);
+    if (!content) continue;
+    const relPath = resolveRelative(fullPath, root);
+
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Only inspect requirement table rows: | REQ-NNNN-NNN | description |
+      const rowMatch = line.match(
+        /^\|\s*(REQ-\d{4}-\d{3})\s*\|\s*([\s\S]*?)\s*\|\s*$/,
+      );
+      if (!rowMatch) continue;
+      const reqItemId = rowMatch[1];
+      const description = rowMatch[2];
+
+      // Skip header / separator artifacts
+      if (/^-+$/.test(description) || /^要\s*件$/.test(description.trim())) {
+        continue;
+      }
+
+      // Strip inline code spans so code-only tokens don't trigger keyword match
+      const stripped = stripInlineCode(description);
+
+      // Exempt stable contract exception (REQ-0101-069)
+      if (IR044_STABLE_CONTRACT_PATTERN.test(stripped)) continue;
+      // Exempt negation context (e.g. "must not contain schema field")
+      if (isNegationContext(line)) continue;
+
+      for (const { signal, pattern } of IR044_SIGNAL_PATTERNS) {
+        if (pattern.test(stripped)) {
+          foundViolation = true;
+          results.push(
+            warn(
+              "CanonicalConflict",
+              "req-spec-boundary-violation",
+              `REQ requirement line may contain SPEC detail ("${signal}") — consider moving to SPEC/rule catalog/command reference (IR-044, REQ-0136-006)`,
+              relPath,
+              i + 1,
+              {
+                evidence: `${reqItemId}: ${description.trim()}`,
+                expected:
+                  "REQ should describe external contract / state / behavior; SPEC detail belongs in SPEC docs",
+                route: "req-define",
+              },
+            ),
+          );
+          break; // one finding per requirement line
+        }
+      }
+    }
+  }
+
+  if (!foundViolation) {
+    results.push(
+      ok(
+        "CanonicalConflict",
+        "req-spec-boundary-violation",
+        "No REQ/SPEC boundary violations detected in active REQs (IR-044, REQ-0136-006)",
+      ),
+    );
+  }
+  return results;
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   let options;
@@ -7046,6 +7186,7 @@ async function main(): Promise<void> {
     ...checkCrossReqVocabularyConsistency(root),
     ...checkMappingTableHistoryLabels(root),
     ...checkReqVerificationBasis(root),
+    ...checkReqSpecBoundaryViolation(root), // IR-044 (REQ-0136-006)
   ];
 
   // REQ-0108-196: classification policy checks (enabled by --classification flag)
@@ -7107,7 +7248,11 @@ async function main(): Promise<void> {
   const reportPath = writeReportFile(root, report);
   console.error(`Report written to: ${reportPath}`);
 
-  process.exit(determineExitCode(summary));
+  // REQ-0136-004/005: git hooks fail only on strict findings.
+  const exitCode = options.strictOnly
+    ? determineExitCodeStrict(processed)
+    : determineExitCode(summary);
+  process.exit(exitCode);
 }
 
 main();

--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.test.ts
@@ -85,6 +85,7 @@ describe("parseArgs", () => {
       gate: "full-audit",
       gatePaths: [],
       reqs: [],
+      strictOnly: false,
     });
   });
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
@@ -83,6 +83,7 @@ export interface CliOptions {
   gate: GateLevel; // REQ-0136-040
   gatePaths: string[]; // REQ-0136-040
   reqs: string[]; // REQ-0136-040
+  strictOnly: boolean; // REQ-0136-004/005: hooks fail only on strict findings
 }
 
 /**
@@ -122,6 +123,7 @@ export function parseArgs(args: string[]): CliOptions {
     gate: "full-audit", // REQ-0136-040: backward-compatible default
     gatePaths: [],
     reqs: [],
+    strictOnly: false, // REQ-0136-004/005
   };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -133,6 +135,8 @@ export function parseArgs(args: string[]): CliOptions {
       options.dryRun = true;
     } else if (arg === "--classification") { // REQ-0108-196
       options.classification = true;
+    } else if (arg === "--strict-only") { // REQ-0136-004/005
+      options.strictOnly = true;
     } else if (arg === "--gate" || arg.startsWith("--gate=")) {
       const { value, advanced } = resolveFlagValue("--gate", arg, args[i + 1]);
       if (advanced) i++;
@@ -180,6 +184,8 @@ OPTIONS:
                     (e.g. --paths docs/requirements/REQ-0101.md)
   --reqs <csv>      Impact-guard REQ scoping, comma-separated REQ IDs
                     (e.g. --reqs REQ-0101,REQ-0108)
+  --strict-only     Exit non-zero only on strict findings; heuristic/observation
+                    findings do not cause failure (used by git hooks)
 
 EXIT CODES:
   0  No issues found
@@ -421,6 +427,16 @@ export function determineExitCode(summary: ScanSummary): number {
   return EXIT_OK;
 }
 
+export function determineExitCodeStrict(
+  results: CheckResult[],
+): number {
+  const hasStrict = results.some(
+    (r) =>
+      r.finding_level === "strict" && r.level !== "ok" && r.level !== "info",
+  );
+  return hasStrict ? EXIT_NG : EXIT_OK;
+}
+
 export function determineRoute(
   category: FindingCategory,
   occurrences: number,
@@ -461,6 +477,7 @@ const CHECK_TO_FINDING_CATEGORY: Record<string, FindingCategory> = {
   "adr-status-normalization": "canonical-conflict",
   "workflow-status-prohibition": "canonical-conflict",
   "lifecycle-boundary": "canonical-conflict",
+  "req-spec-boundary-violation": "canonical-conflict",
   "readme-index-sync": "broken-reference",
   "adr-readme-index-sync": "broken-reference",
   "spec-readme-index-sync": "broken-reference",
@@ -545,6 +562,9 @@ export function classifyResult(r: CheckResult): CheckResult {
   }
   if (!r.finding_category && r.level !== "ok" && r.level !== "info") {
     r.finding_category = classifyFindingCategory(r.check);
+  }
+  if (!r.finding_level) {
+    r.finding_level = classifyFindingLevel(r.level, r.check);
   }
   if (!r.route && r.finding_category) {
     r.route = determineRoute(r.finding_category, 1);

--- a/.opencode/skills/repo-agentdev-integrity/scripts/hooks_integration.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/hooks_integration.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdirSync, writeFileSync, copyFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+
+const SCRIPT_DIR = import.meta.dir;
+const SCRIPT_FILE = join(SCRIPT_DIR, "check_integrity.ts");
+const CLI_UTILS_FILE = join(SCRIPT_DIR, "cli_utils.ts");
+const GATE_FILTER_FILE = join(SCRIPT_DIR, "gate_filter.ts");
+const CATALOG_PARSER_FILE = join(SCRIPT_DIR, "integrity_catalog_parser.ts");
+const IMPACT_MAP_PARSER_FILE = join(SCRIPT_DIR, "req_impact_map_parser.ts");
+const REPO_ROOT = (function () {
+  const path = require("path");
+  let dir = path.resolve(SCRIPT_DIR);
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(join(dir, ".githooks"))) return dir;
+    dir = path.dirname(dir);
+  }
+  return path.dirname(path.dirname(path.dirname(SCRIPT_DIR)));
+})();
+const PRE_COMMIT_HOOK = join(REPO_ROOT, ".githooks", "pre-commit");
+const CATALOG_SPEC = join(REPO_ROOT, "docs", "specs", "integrity-rule-catalog.md");
+const IMPACT_MAP_SPEC = join(REPO_ROOT, "docs", "specs", "req-impact-map.md");
+const TEMP_BASE = join("C:", "WINDOWS", "TEMP", "opencode");
+const RUN_ID = `hooks-test-${crypto.randomUUID().slice(0, 8)}`;
+const TEMP_ROOT = join(TEMP_BASE, RUN_ID);
+
+function mkdirp(p: string): void {
+  mkdirSync(p, { recursive: true });
+}
+
+function sh(cwd: string, script: string): { code: number; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync(["sh", "-c", script], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    code: proc.exitCode ?? -1,
+    stdout: proc.stdout?.toString("utf-8") ?? "",
+    stderr: proc.stderr?.toString("utf-8") ?? "",
+  };
+}
+
+function copyScripts(fixtureRoot: string): void {
+  const dest = join(
+    fixtureRoot,
+    ".opencode",
+    "skills",
+    "repo-agentdev-integrity",
+    "scripts",
+  );
+  mkdirp(dest);
+  copyFileSync(SCRIPT_FILE, join(dest, "check_integrity.ts"));
+  copyFileSync(CLI_UTILS_FILE, join(dest, "cli_utils.ts"));
+  copyFileSync(GATE_FILTER_FILE, join(dest, "gate_filter.ts"));
+  copyFileSync(CATALOG_PARSER_FILE, join(dest, "integrity_catalog_parser.ts"));
+  copyFileSync(IMPACT_MAP_PARSER_FILE, join(dest, "req_impact_map_parser.ts"));
+  const hooksDest = join(fixtureRoot, ".githooks");
+  mkdirp(hooksDest);
+  copyFileSync(PRE_COMMIT_HOOK, join(hooksDest, "pre-commit"));
+  // Delta/Impact gates parse the catalog + impact-map SPEC files at runtime.
+  const specsDest = join(fixtureRoot, "docs", "specs");
+  mkdirp(specsDest);
+  copyFileSync(CATALOG_SPEC, join(specsDest, "integrity-rule-catalog.md"));
+  copyFileSync(IMPACT_MAP_SPEC, join(specsDest, "req-impact-map.md"));
+}
+
+function initGitRepo(root: string): void {
+  sh(root, 'git init -q && git config user.email t@t.t && git config user.name t');
+}
+
+function buildBase(root: string): void {
+  const reqDir = join(root, "docs", "requirements");
+  mkdirp(reqDir);
+  writeFileSync(
+    join(reqDir, "REQ-0001.md"),
+    [
+      "---",
+      "id: REQ-0001",
+      "title: Test REQ",
+      "created: 2025-01-01",
+      "updated: 2025-01-02",
+      "---",
+      "",
+      "## 目的",
+      "",
+      "Valid requirement.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  writeFileSync(
+    join(reqDir, "README.md"),
+    [
+      "# Requirements",
+      "",
+      "| ID | Title |",
+      "|----|-------|",
+      "| REQ-0001 | Test REQ |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  const adrDir = join(root, "docs", "adr");
+  mkdirp(adrDir);
+  writeFileSync(
+    join(adrDir, "ADR-0001.md"),
+    [
+      "---",
+      "id: ADR-0001",
+      "title: Test ADR",
+      "status: accepted",
+      "---",
+      "",
+      "REQ-0001.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  writeFileSync(
+    join(adrDir, "README.md"),
+    [
+      "# ADR Index",
+      "",
+      "| ADR | Title | Status |",
+      "|-----|-------|--------|",
+      "| ADR-0001 | Test ADR | accepted |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  const specsDir = join(root, "docs", "specs");
+  mkdirp(specsDir);
+  writeFileSync(join(specsDir, "system.md"), "# System\n", "utf-8");
+  writeFileSync(join(specsDir, "patterns.md"), "# Patterns\n", "utf-8");
+  mkdirp(join(root, ".opencode", "skills"));
+  mkdirp(join(root, ".opencode", "commands", "agentdev"));
+  writeFileSync(join(root, "README.md"), "# Test Repo\n", "utf-8");
+}
+
+describe("pre-commit Delta Guard hook (REQ-0136-004)", () => {
+  beforeAll(() => mkdirp(TEMP_ROOT));
+  afterAll(() => {
+    if (existsSync(TEMP_ROOT)) rmSync(TEMP_ROOT, { recursive: true, force: true });
+  });
+
+  it("blocks commit on a STRICT violation (frontmatter id ≠ filename)", () => {
+    const fx = join(TEMP_ROOT, "block-strict");
+    mkdirp(fx);
+    copyScripts(fx);
+    initGitRepo(fx);
+    buildBase(fx);
+    // REQ file whose frontmatter id does NOT match its filename (IR-001 strict).
+    writeFileSync(
+      join(fx, "docs", "requirements", "REQ-0002.md"),
+      [
+        "---",
+        "id: REQ-9999",
+        "title: Mismatched id",
+        "created: 2025-01-01",
+        "updated: 2025-01-02",
+        "---",
+        "",
+        "Bad frontmatter.",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    sh(fx, "git add -A && git commit -q -m init --no-gpg-sign >/dev/null 2>&1 || true");
+    // Stage a change to trigger the hook, then run pre-commit directly.
+    writeFileSync(
+      join(fx, "docs", "requirements", "REQ-0002.md"),
+      [
+        "---",
+        "id: REQ-9999",
+        "title: Mismatched id v2",
+        "created: 2025-01-01",
+        "updated: 2025-01-02",
+        "---",
+        "",
+        "Bad frontmatter staged.",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    sh(fx, "git add -A");
+    const res = sh(fx, "DEVFLOW_SKIP_HOOKS= ./.githooks/pre-commit");
+    expect(res.code).toBe(1);
+  });
+
+  it("allows commit when only heuristic (non-strict) findings exist", () => {
+    const fx = join(TEMP_ROOT, "allow-heuristic");
+    mkdirp(fx);
+    copyScripts(fx);
+    initGitRepo(fx);
+    buildBase(fx);
+    // IR-044 heuristic finding only (Step number in requirement row).
+    writeFileSync(
+      join(fx, "docs", "requirements", "REQ-0001.md"),
+      [
+        "---",
+        "id: REQ-0001",
+        "title: Test REQ",
+        "created: 2025-01-01",
+        "updated: 2025-01-02",
+        "---",
+        "",
+        "## 要件",
+        "",
+        "| ID | 要件 |",
+        "|---|---|",
+        "| REQ-0001-001 | Step 4-2 で判定すること |",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    sh(fx, "git add -A");
+    const res = sh(fx, "DEVFLOW_SKIP_HOOKS= ./.githooks/pre-commit");
+    expect(res.code).toBe(0);
+  });
+
+  it("allows commit for clean staged files", () => {
+    const fx = join(TEMP_ROOT, "clean");
+    mkdirp(fx);
+    copyScripts(fx);
+    initGitRepo(fx);
+    buildBase(fx);
+    sh(fx, "git add -A");
+    const res = sh(fx, "DEVFLOW_SKIP_HOOKS= ./.githooks/pre-commit");
+    expect(res.code).toBe(0);
+  });
+
+  it("skips (exit 0) when DEVFLOW_SKIP_HOOKS is set", () => {
+    const fx = join(TEMP_ROOT, "skip");
+    mkdirp(fx);
+    copyScripts(fx);
+    initGitRepo(fx);
+    buildBase(fx);
+    writeFileSync(
+      join(fx, "docs", "requirements", "REQ-0002.md"),
+      [
+        "---",
+        "id: REQ-9999",
+        "title: Mismatched",
+        "created: 2025-01-01",
+        "updated: 2025-01-02",
+        "---",
+        "",
+        "Bad.",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    sh(fx, "git add -A");
+    const res = sh(fx, "DEVFLOW_SKIP_HOOKS=1 ./.githooks/pre-commit");
+    expect(res.code).toBe(0);
+    expect(res.stdout).toContain("skipped");
+  });
+
+  it("skips (exit 0) when there are no staged files", () => {
+    const fx = join(TEMP_ROOT, "no-staged");
+    mkdirp(fx);
+    copyScripts(fx);
+    initGitRepo(fx);
+    buildBase(fx);
+    sh(fx, "git add -A && git commit -q -m init --no-gpg-sign >/dev/null 2>&1 || true");
+    const res = sh(fx, "DEVFLOW_SKIP_HOOKS= ./.githooks/pre-commit");
+    expect(res.code).toBe(0);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/ir044_boundary.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/ir044_boundary.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdirSync, writeFileSync, copyFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+
+const SCRIPT_DIR = import.meta.dir;
+const SCRIPT_FILE = join(SCRIPT_DIR, "check_integrity.ts");
+const CLI_UTILS_FILE = join(SCRIPT_DIR, "cli_utils.ts");
+const GATE_FILTER_FILE = join(SCRIPT_DIR, "gate_filter.ts");
+const CATALOG_PARSER_FILE = join(SCRIPT_DIR, "integrity_catalog_parser.ts");
+const IMPACT_MAP_PARSER_FILE = join(SCRIPT_DIR, "req_impact_map_parser.ts");
+const TEMP_BASE = join("C:", "WINDOWS", "TEMP", "opencode");
+const RUN_ID = `ir044-test-${crypto.randomUUID().slice(0, 8)}`;
+const TEMP_ROOT = join(TEMP_BASE, RUN_ID);
+
+interface RunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runScript(cwd: string, args: string[]): RunResult {
+  const scriptPath = join(
+    cwd,
+    ".opencode",
+    "skills",
+    "repo-agentdev-integrity",
+    "scripts",
+    "check_integrity.ts",
+  );
+  const proc = Bun.spawnSync(["bun", "run", scriptPath, ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stdout: proc.stdout?.toString("utf-8") ?? "",
+    stderr: proc.stderr?.toString("utf-8") ?? "",
+  };
+}
+
+function mkdirp(p: string): void {
+  mkdirSync(p, { recursive: true });
+}
+
+function copyScripts(fixtureRoot: string): void {
+  const dest = join(
+    fixtureRoot,
+    ".opencode",
+    "skills",
+    "repo-agentdev-integrity",
+    "scripts",
+  );
+  mkdirp(dest);
+  copyFileSync(SCRIPT_FILE, join(dest, "check_integrity.ts"));
+  copyFileSync(CLI_UTILS_FILE, join(dest, "cli_utils.ts"));
+  copyFileSync(GATE_FILTER_FILE, join(dest, "gate_filter.ts"));
+  copyFileSync(CATALOG_PARSER_FILE, join(dest, "integrity_catalog_parser.ts"));
+  copyFileSync(IMPACT_MAP_PARSER_FILE, join(dest, "req_impact_map_parser.ts"));
+}
+
+// Minimal valid fixture. `extraReqRows` is appended to the REQ requirements
+// table so tests can inject IR-044 target lines.
+function buildFixture(root: string, extraReqRows: string[] = []): void {
+  const reqDir = join(root, "docs", "requirements");
+  mkdirp(reqDir);
+
+  const reqRows = extraReqRows.length > 0
+    ? "\n## 要件\n\n| ID | 要件 |\n|---|---|\n" + extraReqRows.join("\n") + "\n"
+    : "";
+
+  writeFileSync(
+    join(reqDir, "REQ-0001.md"),
+    [
+      "---",
+      "id: REQ-0001",
+      "title: Test REQ",
+      "created: 2025-01-01",
+      "updated: 2025-01-02",
+      "---",
+      "",
+      "## 目的",
+      "",
+      "Test requirement.",
+      "",
+      reqRows,
+    ].join("\n"),
+    "utf-8",
+  );
+  writeFileSync(
+    join(reqDir, "README.md"),
+    [
+      "# Requirements",
+      "",
+      "| ID | Title |",
+      "|----|-------|",
+      "| REQ-0001 | Test REQ |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const adrDir = join(root, "docs", "adr");
+  mkdirp(adrDir);
+  writeFileSync(
+    join(adrDir, "ADR-0001.md"),
+    [
+      "---",
+      "id: ADR-0001",
+      "title: Test ADR",
+      "status: accepted",
+      "---",
+      "",
+      "Relates to REQ-0001.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  writeFileSync(
+    join(adrDir, "README.md"),
+    [
+      "# ADR Index",
+      "",
+      "| ADR | Title | Status |",
+      "|-----|-------|--------|",
+      "| ADR-0001 | Test ADR | accepted |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const specsDir = join(root, "docs", "specs");
+  mkdirp(specsDir);
+  writeFileSync(join(specsDir, "system.md"), "# System\n", "utf-8");
+  writeFileSync(join(specsDir, "patterns.md"), "# Patterns\n", "utf-8");
+
+  mkdirp(join(root, ".opencode", "skills"));
+  const cmdDir = join(root, ".opencode", "commands", "agentdev");
+  mkdirp(cmdDir);
+  writeFileSync(
+    join(cmdDir, "README.md"),
+    [
+      "# Commands",
+      "",
+      "| Command | Description |",
+      "|---------|-------------|",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  writeFileSync(join(root, "README.md"), "# Test Repo\n", "utf-8");
+}
+
+function findingsOf(stdout: string, check: string): any[] {
+  let report: any;
+  try {
+    report = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  return (report.results || []).filter(
+    (r: any) => r.check === check && r.level !== "ok" && r.level !== "info",
+  );
+}
+
+describe("IR-044: REQ/SPEC boundary violation detection (REQ-0136-006)", () => {
+  beforeAll(() => mkdirp(TEMP_ROOT));
+  afterAll(() => {
+    if (existsSync(TEMP_ROOT)) rmSync(TEMP_ROOT, { recursive: true, force: true });
+  });
+
+  it("detects schema field signal", () => {
+    const fx = join(TEMP_ROOT, "schema-field");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | frontmatter フィールドの型は string とすること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBeGreaterThan(0);
+    expect(f[0].message).toContain("schema field");
+  });
+
+  it("detects enum value list signal", () => {
+    const fx = join(TEMP_ROOT, "enum-list");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | 対象の enum 値一覧を定義すること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBeGreaterThan(0);
+    expect(f[0].message).toContain("enum value list");
+  });
+
+  it("detects fixture detail signal", () => {
+    const fx = join(TEMP_ROOT, "fixture");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | テスト用 fixture を提供すること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBeGreaterThan(0);
+    expect(f[0].message).toContain("fixture detail");
+  });
+
+  it("detects checker individual rule signal", () => {
+    const fx = join(TEMP_ROOT, "checker-rule");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | checker 個別ルールとして正規表現を定義すること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBeGreaterThan(0);
+    expect(f[0].message).toContain("checker individual rule");
+  });
+
+  it("detects false positive suppression signal", () => {
+    const fx = join(TEMP_ROOT, "fp-suppression");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | false positive 抑制の除外パスを定義すること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBeGreaterThan(0);
+    expect(f[0].message).toContain("false positive suppression");
+  });
+
+  it("detects Step number signal", () => {
+    const fx = join(TEMP_ROOT, "step-number");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | Step 4-2 で判定結果を記録すること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBeGreaterThan(0);
+    expect(f[0].message).toContain("Step number");
+  });
+
+  it("detects Phase number signal", () => {
+    const fx = join(TEMP_ROOT, "phase-number");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | Phase 2 で検証を実施すること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBeGreaterThan(0);
+    expect(f[0].message).toContain("Phase number");
+  });
+
+  it("detects internal algorithm signal", () => {
+    const fx = join(TEMP_ROOT, "algorithm");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | 内部アルゴリズムはトポロジカルソートを使用すること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBeGreaterThan(0);
+    expect(f[0].message).toContain("internal algorithm");
+  });
+
+  it("detects work history signal", () => {
+    const fx = join(TEMP_ROOT, "work-history");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | 作業履歴: PR #123 で実装済みの機能であること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBeGreaterThan(0);
+    expect(f[0].message).toContain("work history");
+  });
+
+  it("exempts stable contract exception (REQ-0101-069)", () => {
+    const fx = join(TEMP_ROOT, "stable-contract");
+    mkdirp(fx);
+    copyScripts(fx);
+    // Mentions a SPEC-ish keyword but is a stable external contract summary.
+    buildFixture(fx, [
+      "| REQ-0001-001 | 公開 command 名として /agentdev/case-run を定義すること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBe(0);
+  });
+
+  it("exempts negation context", () => {
+    const fx = join(TEMP_ROOT, "negation");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | REQ は schema field を含まないこと |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBe(0);
+  });
+
+  it("reports ok when active REQs have no SPEC detail", () => {
+    const fx = join(TEMP_ROOT, "clean-req");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | システムは利用者に完了報告を提示すること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const okFindings = (() => {
+      let report: any;
+      try {
+        report = JSON.parse(res.stdout);
+      } catch {
+        return [];
+      }
+      return (report.results || []).filter(
+        (r: any) =>
+          r.check === "req-spec-boundary-violation" && r.level === "ok",
+      );
+    })();
+    expect(okFindings.length).toBe(1);
+  });
+
+  it("does not scan retired REQ files", () => {
+    const fx = join(TEMP_ROOT, "retired-excluded");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx);
+    const retiredDir = join(fx, "docs", "requirements", "retired");
+    mkdirp(retiredDir);
+    writeFileSync(
+      join(retiredDir, "REQ-0050.md"),
+      [
+        "---",
+        "id: REQ-0050",
+        "title: Retired",
+        "created: 2025-01-01",
+        "updated: 2025-01-02",
+        "---",
+        "",
+        "## 要件",
+        "",
+        "| ID | 要件 |",
+        "|---|---|",
+        "| REQ-0050-001 | internal algorithm は廃止済み |",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBe(0);
+  });
+
+  it("sets route to req-define and category canonical-conflict", () => {
+    const fx = join(TEMP_ROOT, "route-meta");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | Step 1 で処理すること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBeGreaterThan(0);
+    expect(f[0].route).toBe("req-define");
+    expect(f[0].finding_category).toBe("canonical-conflict");
+  });
+});
+
+describe("--strict-only exit code (REQ-0136-004/005)", () => {
+  beforeAll(() => mkdirp(TEMP_ROOT));
+  afterAll(() => {
+    if (existsSync(TEMP_ROOT)) rmSync(TEMP_ROOT, { recursive: true, force: true });
+  });
+
+  it("does NOT fail (exit 0) when only heuristic findings exist", () => {
+    const fx = join(TEMP_ROOT, "heuristic-only");
+    mkdirp(fx);
+    copyScripts(fx);
+    // IR-044 findings are heuristic (warning level). With --strict-only, exit 0.
+    buildFixture(fx, [
+      "| REQ-0001-001 | Step 4-2 で処理すること |",
+    ]);
+    const res = runScript(fx, ["--json", "--strict-only"]);
+    expect(res.exitCode).toBe(0);
+    // But heuristic findings should still be present in the report.
+    const f = findingsOf(res.stdout, "req-spec-boundary-violation");
+    expect(f.length).toBeGreaterThan(0);
+  });
+
+  it("DOES fail (exit 1) without --strict-only when heuristic findings exist", () => {
+    const fx = join(TEMP_ROOT, "heuristic-no-strict-flag");
+    mkdirp(fx);
+    copyScripts(fx);
+    buildFixture(fx, [
+      "| REQ-0001-001 | Step 4-2 で処理すること |",
+    ]);
+    const res = runScript(fx, ["--json"]);
+    expect(res.exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements Issue #899 (RU-2): the 3-layer integrity gate for REQ/SPEC/ADR 適正運用 — Delta Guard (pre-commit), Impact Guard (pre-push), Full Audit automation, IR-044 (REQ/SPEC boundary violation detection), and git hook setup tooling.

### Changes

**Task 2.1 — Delta Guard (`.githooks/pre-commit`)** [REQ-0136-004]
- POSIX `sh` hook that gathers staged files (`git diff --cached --name-only --diff-filter=ACM`), builds a CSV, and runs `check_integrity.ts --gate delta-guard --paths <csv> --strict-only`.
- STRICT violations block the commit (exit 1); heuristic/observation findings are warnings only.
- `DEVFLOW_SKIP_HOOKS=1` bypass; missing bun → non-blocking skip.

**Task 2.2 — Impact Guard (`.githooks/pre-push`)** [REQ-0136-005]
- POSIX `sh` hook that derives the unpushed range from pre-push args, extracts changed REQ IDs from REQ/ADR files, and runs `check_integrity.ts --gate impact-guard --reqs <req_csv> --strict-only`.
- STRICT violations block the push (exit 1).

**Task 2.3 — IR-044 REQ/SPEC boundary violation detection** [REQ-0136-006]
- New `checkReqSpecBoundaryViolation()` in `check_integrity.ts` detects the 9 SPEC separation criteria violation signals (schema field, enum value list, fixture detail, checker individual rule, FP suppression, Step number, Phase number, internal algorithm, work history) in active REQ requirement lines.
- Stable contract exception (REQ-0101-069) and negation contexts are exempt.
- Heuristic severity (warning); routes to `req-define`.

**Task 2.4 — Full Audit automation (`.github/workflows/full-audit.yml`)** [REQ-0136-007]
- Monthly cron schedule + trigger on `integrity-rule-catalog.md` / ADR / retired-REQ changes + `workflow_dispatch`.
- Runs `--gate full-audit`, uploads report artifact, commits report on scheduled runs, fails PRs with strict violations.

**Task 2.5 — Hook setup + README** [REQ-0136-008]
- `setup-hooks.ps1` (Windows) and `setup-hooks.sh` (Unix/Git Bash): idempotent enable/disable/status via `core.hooksPath`.
- `.githooks/README.md` with usage, enable/disable, bypass, troubleshooting.

**Supporting changes**
- `cli_utils.ts`: added `--strict-only` flag + `determineExitCodeStrict()` (hooks fail only on strict findings); `classifyResult()` now populates `finding_level` (root-cause fix so strict/heuristic/observation is consistently classified); `req-spec-boundary-violation` → `canonical-conflict` category mapping.
- `cli_utils.test.ts`: updated `parseArgs` combination test for the new `strictOnly` field.
- `check_integrity.ts`: registered IR-044 check; wires `--strict-only` into exit-code logic.

### Tests
- `ir044_boundary.test.ts` (16 tests): each of the 9 signals, stable-contract exemption, negation exemption, retired exclusion, route/category metadata, `--strict-only` exit-code semantics.
- `hooks_integration.test.ts` (5 tests): pre-commit blocks on strict violation, allows heuristic-only/clean, `DEVFLOW_SKIP_HOOKS` bypass, no-staged-files skip.
- Full suite: **273 pass / 86 fail** (86 failures are pre-existing baseline; 21 new tests all pass; 0 regressions).

## Findings / Capture候補

- IR-044 稼働確認で既存 active REQ（REQ-0101, REQ-0104, REQ-0108, REQ-0114, REQ-0124, REQ-0126, REQ-0131, REQ-0136）に SPEC 混入シグナル（Step 番号・fixture・enum 等）が検出された。これは REQ-0136-017（既存REQ の SPEC 混入洗い出し）の想定内成果物。heuristic warning のみで block 対象外。別 Issue で段階的な SPEC 移行を推奨。
- `classifyResult()` が `finding_level` を未設定のまま残す既存不具合を修正。`--strict-only` 動作の前提となるため root-cause fix として実施。既存テストへの影響なし（full suite 86 fail はすべて事前 baseline と同一）。

Closes #899

Related: Parent #896, REQ-0136, ADR-0123
