### PR TITLE
feat(case-open): 自律構成生成・execution_groups廃止・skipped除外 (#918)

### DIFF
--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -43,14 +43,14 @@ agent: sisyphus
        2. **クリーンアップ検証ゲート**を実行し、ドラフトファイル・RUファイルの残存がないことを確認すること（REQ-0114-060〜062）。残存時は停止すること
        3. Step 4-1〜4-3 のキュー処理に進む
      - **Step 4-1 キュー開始**: ドラフトの `operation_units` セクションから OU 構造を読み取り、処理順序を決定する（`recommended_order`, `depends_on` に基づく）。Epic Issue 番号を記録する。Epic Issue の子Issue一覧（Wave 構成含む）を読み取る。case-run 相当処理に Epic Issue 番号を渡す。case-run の Epic Orchestrator モードが全 Wave の子Issue実行を処理する。case-auto は Wave 実行プロトコルを実装しない（`agentdev-workflow-orchestration` を参照）
-     - **Step 4-2 case-close ループ**: case-run 相当処理の完了後、その出力（成功/失敗/スキップされた子Issue一覧）から case-close 対象を決定する:
-      - 正常完了した子Issue: case-close 相当処理を実行
-      - 失敗・スキップされた子Issue: case-close を試みない
+     - **Step 4-2 case-close ループ**: case-run 相当処理の完了後、その出力（completed / blocked / failed の子Issue一覧）から case-close 対象を決定する:
+      - 正常完了した子Issue（completed）: case-close 相当処理を実行
+      - blocked / failed の子Issue: case-close を試みない（`⏭スキップ` 状態は採用しない。前提未達の Issue は pending のまま選択対象外となる）
       - 各子Issue の case-close は既存の case-close.md 定義に従う（learning/intake capture、`.agentdev/` commit/push を含む）。各子Issue ごとに独立して実行し、キュー全体での一括 capture は行わない
       - case-auto は 1 OU を close まで完了した後に次の OU へ進むこと（REQ-0114-053）
      - **Step 4-3 全体完了判定**: 全子Issue の case-close 処理完了後:
      - Epic Issue の子Issue全ステータスが CLOSED の場合 → Epic 自動クローズ確認（case-close Step 8 相当） → 全体完了報告
-      - 未クローズの子Issue が残る場合（失敗/スキップ） → 部分完了報告
+      - 未クローズの子Issue が残る場合（blocked / failed） → 部分完了報告
      - 停止時は完了済み OU、進行中 OU、未実行 OU、再開可能な次コマンドを報告すること（REQ-0114-056）
    - **クリーンアップ検証ゲート**: Epic Issue の Step 4-1 キュー処理開始前に、以下を検証する（REQ-0114-060〜063）:
      - ドラフトファイル（`.agentdev/drafts/req-draft-*.md`）が削除されていること。残存する場合は停止し手動削除を依頼すること
@@ -69,7 +69,7 @@ agent: sisyphus
    - (8) merge conflict / remote hash不一致
    - (9) 作成元不明branch / user-owned branch / 他作業branchの削除検出
    - (10) 未コミット変更の帰属不明
-8. **完了報告**: 最終工程（case-close）の完了報告をそのまま出力する。Epic Issue を伴うキュー実行時は、完了・失敗・スキップ子Issue一覧を含める。停止時は完了済み OU、進行中 OU、未実行 OU、再開可能な次コマンドを報告する（REQ-0114-056）
+8. **完了報告**: 最終工程（case-close）の完了報告をそのまま出力する。Epic Issue を伴うキュー実行時は、完了・blocked・failed 子Issue一覧を含める。停止時は完了済み OU、進行中 OU、未実行 OU、再開可能な次コマンドを報告する（REQ-0114-056）
 8-1. **Standard flow 逐次OU処理ループ**: Standard flow の case-close 完了後、未処理 OU が残存する場合は次 OU の処理を自動的に開始する（REQ-0114-065〜067）:
    - 処理対象の全 OU から次の未処理 OU を特定する（`recommended_order`, `depends_on` に基づく）
     - 次 OU が存在する場合: 当該 OU の work_type に応じた工程分岐で Step 2 に戻る（feature: req-save → spec-save → case-open → …、bugfix/maintenance/docs_chore: case-open → …）。feature の場合の spec-save 実行判定は Step 3 に従う

--- a/src/opencode/commands/agentdev/case-open.md
+++ b/src/opencode/commands/agentdev/case-open.md
@@ -32,17 +32,16 @@ agent: sisyphus
 2. **マルチREQ入力判定**: 入力要件doc数を確認
    - 単一REQ → Step 3
    - 複数REQ または draft-meta `scale: large` → **マルチREQ Epic flow**（Step 4〜）
-   - **OU モード時**: Step 0-1 で選択した OU が複数または `scale: large` を含む場合 → `execution_groups` 検証（Step 2-1）を経て Epic flow に分岐
+   - **OU モード時**: Step 0-1 で選択した OU が複数または `scale: large` を含む場合 → Epic flow に分岐（Step 2-1 で自律的に構成を生成）
 
 3. **規模判定**（Step 2で単一REQの場合）:
    - `scale: large` → **単一REQ Epic flow**（Step 4〜）
    - `scale: standard` / フィールドなし → **Standard flow**（Step 14〜）
 
-2-1. **execution_groups 検証**（OU モード・複数REQ時）: ドラフトの `execution_groups` セクションを読み取り、Epic 候補の根拠を検証する（REQ-0104-039）:
-   - 各 execution_group の `rationale` が明示されている場合 → Epic / child Issue を作成
-   - `rationale` が空・矛盾している場合 → Epic 化せず、停止または単体 Issue 化
-   - **独自推論禁止**: `execution_groups` の提案に基づかない独自推論で Epic Issue を作成しない（REQ-0104-040）
-   - 複数 OU であることだけを理由に Epic Issue を作成しない（REQ-0104-041）
+2-1. **自律構成生成**（OU モード・複数REQ時）: ドラフトの `operation_units` セクションを読み取り、要件分析に基づいて Epic / Wave / Issue 構造を自律生成する（REQ-0104-039, REQ-0132-007）。req-define の出力（operation_units の `depends_on`, `recommended_order` 等）は参考情報とし、case-open が最終構造を決定する:
+   - 複数 OU が存在する場合、要件分析に基づいて Epic Issue および子 Issue 構造を生成する（REQ-0104-041）
+   - **停止条件**: 要件が曖昧で Issue 構造を生成できない場合、または operation_units の要件に矛盾が含まれる場合は停止し、要件の明確化を求める（REQ-0132-010）
+   - **禁止事項**: 機能要件・非機能要件・制約・対象外・受け入れ条件を新規に作成しない（REQ-0132-009, REQ-0104-040）。実装順序・Issue分解についてユーザー確認を求めない（REQ-0132-008）
 
 **共通ルール**（全Step適用）:
 - **VERIFY**: gh CLI書込後は毎回 `agentdev-gh-cli` の VERIFY操作に従い検証
@@ -62,7 +61,7 @@ Epic flow は Step 2 または Step 3 のルーティングにより開始。マ
 
 4. `agentdev-workflow-templates` の選定ルールに従いテンプレートを読み込む。詳細は `agentdev-issue-management` を参照
 
-5. Epic Issue本文を生成。`execution_groups` セクションから Epic 候補グループの根拠を読み取る（REQ-0104-039）。詳細は `agentdev-issue-management` を参照。委譲接続点: サブエージェントは分解候補・依存候補・子Issue数検査を pass/warn/fail/partial で返し、親エージェントがEpic本文と停止判断を確定する
+5. Epic Issue本文を生成。Step 2-1 の自律構成分析結果（Epic / Wave / Issue 構造・依存関係）に基づいて Epic 本文を構築する（REQ-0104-039, REQ-0132-007）。詳細は `agentdev-issue-management` を参照。委譲接続点: サブエージェントは分解候補・依存候補・子Issue数検査を pass/warn/fail/partial で返し、親エージェントがEpic本文と停止判断を確定する
 
 6. Epic Issueを作成:
    - ラベル: `enhancement`, `feature`, `epic`
@@ -132,7 +131,7 @@ Epic flow は Step 2 または Step 3 のルーティングにより開始。マ
 - G18: case-open は intake / learning capture を行わない。capture 境界の詳細は `agentdev-workflow-orchestration` を参照
 
 ### OU 処理制約
-- G19: case-open は `execution_groups` の提案に基づかない独自推論で Epic Issue を作成しないこと（REQ-0104-040）
-- G20: case-open は複数 OU であることだけを理由に Epic Issue を作成しないこと（REQ-0104-041）。REQ-0104-029（複数REQ doc → Epic）は本要件により狭義化される
+- G19: case-open は自律的な要件分析に基づいて Epic Issue を作成すること（REQ-0104-040）。ただし機能要件・非機能要件・対象外・受け入れ条件を新規に作成しないこと（REQ-0132-009）
+- G20: case-open は複数 OU が存在する場合、要件分析に基づいて Epic Issue および子 Issue 構造を生成すること（REQ-0104-041）。単一 Issue で完結する場合は Epic を作成しないこと
 - G21: case-open の Issue 化単位は REQ doc 単位ではなく OU 単位とすること（REQ-0104-042）
 - G22: case-open の capture 責務は非関与。intake / learning capture を行わない。境界の詳細は `agentdev-workflow-orchestration/references/capture-boundaries.md` 参照

--- a/src/opencode/commands/agentdev/req-define.md
+++ b/src/opencode/commands/agentdev/req-define.md
@@ -59,9 +59,8 @@ agent: sisyphus
 6. **要件doc生成** → テンプレート: `.opencode/skills/agentdev-req-file-manager/templates/doc_requirement.md` を Read → 目的/要件/適用範囲の【必須】構造に従って生成。【必須】セクションの欠落禁止。Step 4-2/4-3 で分離した SPEC 候補がある場合、テンプレートの補助セクション `## SPEC候補` を生成し、`draft-meta.spec-candidates` の内容（SC-ID・想定配置先SPEC・分離根拠・元候補）を人間可読な一覧として記載すること（REQ-0136-009, 010）。SPEC 候補がない場合は同セクションを省略する
    - **6-0. 定義完全性ゲート（QG-1）**: 要件doc生成後、`agentdev-quality-gates` の QG-1（Definition Integrity Gate）に従い、REQ/SPEC 分類・ADR ゲート・チェックボックス測可能性・必須セクション完全性・SPEC 候補分離の妥当性を検証する。判定基準・検査観点は同スキルの `.opencode/skills/agentdev-quality-gates/references/qg-1-definition-integrity.md` を参照。fail 時は壁打ち（Step 2）へ差し戻し
    - **6-1. operation_units セクション生成**: 複数RU入力時の統合/分離結果（Step 10-2）を基に `operation_units` セクションを生成する。各 OU は `ou_id`, `source_ru`, `target_req`, `target_spec`, `operation`, `scale`, `depends_on`, `recommended_order`, `issue_policy`, `result` フィールドを持つ（REQ-0102-033〜035, REQ-0136-013）。単一REQ操作の場合も 1 件の OU として出力する
-     - `operation` の値は対象 artifact により2系統（REQ-0136-013）: REQ 操作は `create` / `append` / `update`、SPEC 操作は `spec-create` / `spec-update`。後方互換性のため既存の `create` / `append` / `update` は維持する
-     - `target_req` は REQ 操作（create/append/update）の対象 REQ、`target_spec` は SPEC 操作（spec-create/spec-update）の対象 SPEC パス（例: `docs/specs/patterns.md`、新規は `new:{topic-slug}`）。両フィールドは操作種別に応じて使い分け、未使用時は省略可能とする
-   - **6-2. execution_groups セクション生成**: OU 群を分析し、Epic 候補グループを `execution_groups` セクションに記録する。各 execution_group は `id`, `type`, `purpose`, `included_ou`, `rationale` を持つ（REQ-0102-036）。記録は提案であり、Issue 発行は行わない（REQ-0102-038）
+      - `operation` の値は対象 artifact により2系統（REQ-0136-013）: REQ 操作は `create` / `append` / `update`、SPEC 操作は `spec-create` / `spec-update`。後方互換性のため既存の `create` / `append` / `update` は維持する
+      - `target_req` は REQ 操作（create/append/update）の対象 REQ、`target_spec` は SPEC 操作（spec-create/spec-update）の対象 SPEC パス（例: `docs/specs/patterns.md`、新規は `new:{topic-slug}`）。両フィールドは操作種別に応じて使い分け、未使用時は省略可能とする
 
 7. **work_type 判定**: ラベルに基づき4値分類（bugfix/feature/maintenance/docs_chore）。bugfix + ADR必要時は feature に昇格
 
@@ -69,7 +68,7 @@ agent: sisyphus
    - **8-1. 実装スコープシグナル確認**（REQ-0102-056）: ドラフト内に実装詳細セクション（修正候補リスト・findings catalog・影響ファイル一覧等）が存在する場合、`agentdev-workflow-lifecycle` の実装スコープシグナル基準に基づき scale: large への昇格を判定すること。昇格時は昇格理由をユーザーに提示し、Step 8 の分解計画協議を実施すること
 
 9. **ドラフト保存**:
-   全 work_type（feature / bugfix / maintenance / docs_chore）で `.agentdev/drafts/req-draft-{topic-slug}.md` に保存。draft-meta セクション（work_type/req-operation/target-req/adr-required/topic-slug/scale/status 等）を追加。Step 6-1 で生成した `operation_units` セクションと Step 6-2 で生成した `execution_groups` セクションを含める。Step 4-2/4-3 で分離した SPEC 候補は `draft-meta.spec-candidates`（SC-ID・content・intended_spec・classification・source）に、Step 3-2/10-2 で計測した SPLIT 予兆は `draft-meta.split-forecast`（target・metrics・signals・total・recommended_action・thresholds_ref）に記録すること（REQ-0136-010, 011）。draft-meta の work_type が後続コマンドの消費パターンを決定する（feature: req-save が消費、bugfix/maintenance/docs_chore: req-save をスキップして case-open が消費）。`spec-candidates` / `split-forecast` は省略可能だが、spec-save・case-auto はこれらの有無で spec-save スキップ判定を行う（ADR-0123）
+   全 work_type（feature / bugfix / maintenance / docs_chore）で `.agentdev/drafts/req-draft-{topic-slug}.md` に保存。draft-meta セクション（work_type/req-operation/target-req/adr-required/topic-slug/scale/status 等）を追加。Step 6-1 で生成した `operation_units` セクションを含める。`execution_groups` セクションは出力しない（REQ-0102-038）。Step 4-2/4-3 で分離した SPEC 候補は `draft-meta.spec-candidates`（SC-ID・content・intended_spec・classification・source）に、Step 3-2/10-2 で計測した SPLIT 予兆は `draft-meta.split-forecast`（target・metrics・signals・total・recommended_action・thresholds_ref）に記録すること（REQ-0136-010, 011）。draft-meta の work_type が後続コマンドの消費パターンを決定する（feature: req-save が消費、bugfix/maintenance/docs_chore: req-save をスキップして case-open が消費）。`spec-candidates` / `split-forecast` は省略可能だが、spec-save・case-auto はこれらの有無で spec-save スキップ判定を行う（ADR-0123）
    - **9-1. 実装詳細の分離**（REQ-0102-057）: ドラフトに実装詳細（個別ファイルの編集指示・修正候補リスト・findings catalog 等）が含まれる場合、当該内容を要件定義部分（要件行・acceptance criteria・適用範囲）とは分離されたセクションに配置し、要件定義部分の判読性を確保すること。実装詳細がドラフト全体の過半を占める場合は、完了条件チェックボックスへの要約をユーザーに提案すること
 
 10. **要件doc確認**: 生成した要件docをユーザーに提示（承認は求めず提示のみ）。差し戻し時は壁打ち継続（Step 1 へ）。次コマンド実行を確定の意思表示として扱う
@@ -84,7 +83,7 @@ agent: sisyphus
 
     **10-5. Wave 候補・依存関係の記録**: 詳細は `agentdev-req-analysis` を参照。委譲接続点: サブエージェントは依存候補のみを返し、親エージェントが順序依存を確定する
 
-    **10-6. OU 構造検証**: 生成した `operation_units` セクションについて以下を確認する: (a) 各 OU に `ou_id`, `operation` が設定されている (b) REQ 操作（create/append/update）の OU に `target_req` が、SPEC 操作（spec-create/spec-update）の OU に `target_spec` が設定されている (c) `execution_groups` の `included_ou` が実在する `ou_id` を参照している (d) `depends_on` が実在する `ou_id` を参照している (e) `result` セクションが空である（req-save/spec-save/case-open が書き戻すため）（REQ-0136-013）
+    **10-6. OU 構造検証**: 生成した `operation_units` セクションについて以下を確認する: (a) 各 OU に `ou_id`, `operation` が設定されている (b) REQ 操作（create/append/update）の OU に `target_req` が、SPEC 操作（spec-create/spec-update）の OU に `target_spec` が設定されている (c) `depends_on` が実在する `ou_id` を参照している (d) `result` セクションが空である（req-save/spec-save/case-open が書き戻すため）（REQ-0136-013）
 
 11. **完了報告**: 完了報告templateに従って出力。work_type に応じたvariantを選択:
     - feature standard → .opencode/commands/agentdev/templates/req-define/feature.md
@@ -106,5 +105,5 @@ agent: sisyphus
 - G11: ADR閾値以上の判断は `agentdev-adr-guidelines` へ
 - G12: work_type 判定基準は `agentdev-workflow-lifecycle` を参照
 - G13: req-define は Issue 階層を決定しない。Issue 階層の決定は case-open の責務範囲
-- G14: req-define は draft に `operation_units` と `execution_groups` セクションを出力すること（REQ-0102-033, 036）。単一REQ操作の場合も 1 件の OU として出力する
+- G14: req-define は draft に `operation_units` セクションを出力し、`execution_groups` セクションは出力しないこと（REQ-0102-033, 038）。単一REQ操作の場合も 1 件の OU として出力する。Epic / Wave / Issue 構成の生成は case-open の責務である
 - G15: SPEC 分離基準（REQ-0101-068）に該当する要件行候補は REQ 要件行に残留させず、`draft-meta.spec-candidates` と `## SPEC候補` 補助セクションへ分離すること（REQ-0136-010）。安定契約例外（REQ-0101-069）は分離対象外。最終 REQ ファイルに SPEC候補セクションは残さない（spec-save が消費）

--- a/src/opencode/skills/agentdev-epic-tracker/SKILL.md
+++ b/src/opencode/skills/agentdev-epic-tracker/SKILL.md
@@ -5,20 +5,26 @@ description: Updates parent Epic Issue status tracking tables across case-run an
 
 # Epic Status Tracker
 
-親Epic Issueのステータス追跡テーブル（☐ 未着手 / 🔄 進行中 / ✅ 完了 / ❌ 対処不要 / ⏭ スキップ）を更新する知識ベース。
+親Epic Issueのステータス追跡テーブル（`pending` / `ready` / `running` / `completed` / `blocked` / `failed`）を更新する知識ベース。
 
-- **参照元**: `case-run`（進行中更新）、`case-close`（完了更新）
+- **参照元**: `case-auto`（子Issue選択・running 更新）、`case-close`（completed 更新）
 - **特性**: 宣言的定義のみ提供。手順・手続きは各コマンド定義に委ねる
+- **`⏭スキップ` は採用しない**（REQ-0106-030）。前提未達の Issue は `pending` のまま選択対象外となる。Wave status は保存せず、Wave 内 Issue 状態から導出する
 
 ## ステータス値定義
 
-| 値 | 意味 | 設定タイミング | 終了状態 |
+子Issue 実行状態 enum（REQ-0106-030、workflow-contracts.md「子Issue実行状態 enum」参照）:
+
+| 値 | 意味 | 設定主体 | 終了状態 |
 |---|---|---|---|
-| `☐ 未着手` | 子Issue未着手 | Epic作成時（初期値） | いいえ |
-| `🔄 進行中` | 子Issue作業中 | `case-run` 実行中 | いいえ |
-| `✅ 完了 ([PR#N](URL))` | 子Issue完了 | `case-close` 完了時 | はい |
-| `❌ 対処不要` | 対処不要（手動設定） | ユーザー手動 | はい |
-| `⏭ スキップ` | 前提条件未達・依存関係未充足等で Orchestrator がスキップした子Issue。手動操作では使用不可（Orchestratorのみ設定可能） | Epic Orchestrator（Wave完了時） | はい |
+| `pending` | 依存 Issue または前 Wave の完了待ち。異常ではない | case-open（初期値） | いいえ |
+| `ready` | 依存が満たされ、case-auto が次に case-run へ渡せる状態 | case-auto | いいえ |
+| `running` | case-auto が選択し、case-run が実行中の状態 | case-auto | いいえ |
+| `completed` | Issue の実装・検証・必要な case-close が完了した状態 | case-close | はい |
+| `blocked` | 要件曖昧性・外部副作用・権限不足・矛盾等により自動継続できない状態 | case-run / case-auto | はい |
+| `failed` | 実装・検証・CI・PR 作成などの実行結果として失敗した状態 | case-run | はい |
+
+Epic自動クローズ判定では `completed` を終了状態として扱う（`blocked` / `failed` は終了状態だが自動クローズ完了とはみなさない）。
 
 ## 親Epic検出
 
@@ -29,58 +35,48 @@ description: Updates parent Epic Issue status tracking tables across case-run an
 
 ## ステータス更新プロトコル
 
-### case-run: 進行中更新
+### case-auto: running 更新（子Issue選択時）
 
-**単一Issueモード**:
+`case-auto` が子Issue を選択して `case-run` に渡す際、当該子Issue を `ready`/`pending` → `running` に更新する:
 1. 子Issue本文から `Parent: #{N}` を検出
 2. 親Epicが存在しない → スキップ
 3. `gh issue view {N}` でEpic本文を取得（`agentdev-gh-cli` 準拠）
 4. 正規表現で該当子Issue行を特定・置換（後述「正規表現パターン」の新4列/旧4列形式に対応）:
-   - 新4列: `(\| \d+-\d+ \| #{child_issue} \| )☐ 未着手 (\|)` → `$1🔄 進行中 $2`
-   - 旧4列: `(\| \d+ \| #{child_issue} \| [^|]* \| )☐ 未着手 (\|)` → `$1🔄 進行中 $2`
-5. 既に `🔄 進行中`、`✅ 完了`、`❌ 対処不要`、または `⏭ スキップ` の場合 → スキップ（べき等性）
+   - 新4列: `(\| \d+-\d+ \| #{child_issue} \| )(pending|ready) (\|)` → `$1running $2`
+   - 旧4列: `(\| \d+ \| #{child_issue} \| [^|]* \| )(pending|ready) (\|)` → `$1running $2`
+5. 既に `running`、`completed`、`blocked`、または `failed` の場合 → スキップ（べき等性）
 6. `gh issue edit {N} --body-file {temp}` でEpic本文を更新
-7. 更新失敗時 → 警告表示して `case-run` 自体は継続（フォールバック）
+7. 更新失敗時 → 警告表示して継続（フォールバック）
 
-**Epic Orchestratorモード（Wave一括更新）**:
+### case-close: completed 更新
 
-Epic Orchestrator は各 Wave 開始時に対象子 Issue の Epic ステータスを一括更新する。サブエージェントによる同時更新の競合を回避するため、親エージェントが一括処理を担う。
+`case-close` 完了時に子Issue を `running` → `completed` に更新する:
+1. 子Issue本文から `Parent: #{N}` を検出
+2. 親Epicが存在しない → スキップ
+3. `gh issue view {N}` でEpic本文を取得（`agentdev-gh-cli` 準拠）
+4. 正規表現で該当子Issue行を特定・置換:
+   - 新4列: `(\| \d+-\d+ \| #{child_issue} \| )running (\|)` → `$1completed ([PR#{pr_number}]({pr_url})) $2`
+   - 旧4列: `(\| \d+ \| #{child_issue} \| [^|]* \| )running (\|)` → `$1completed ([PR#{pr_number}]({pr_url})) $2`
+5. 既に `completed` の場合 → スキップ（べき等性）
+6. `gh issue edit {N} --body-file {temp}` でEpic本文を更新
 
-Wave開始時一括更新（`☐ 未着手` → `🔄 進行中`）:
-1. Wave テーブルから該当 Wave の子 Issue 番号を抽出
-2. 親Epic本文を取得（`gh issue view {epic_N}`）
-3. 子Issue番号の昇順で、各子Issue行を一括置換:
-   - 新4列: `(\| \d+-\d+ \| #{child_issue} \| )☐ 未着手 (\|)` → `$1🔄 進行中 $2`
-   - 旧4列: `(\| \d+ \| #{child_issue} \| [^|]* \| )☐ 未着手 (\|)` → `$1🔄 進行中 $2`
-4. 既に `🔄 進行中`、`✅ 完了`、`❌ 対処不要`、または `⏭ スキップ` の場合 → スキップ（べき等性）
-5. `gh issue edit {epic_N} --body-file {temp}` でEpic本文を一括更新
+`blocked` / `failed` は case-run / case-auto が設定する終了状態。case-close はこれらを `completed` に上書きしない。
 
-Wave完了時ステータス更新:
-- 成功した子Issue: `🔄 進行中` → `✅ 完了 ([PR#{pr_number}]({pr_url}))` （`case-close` で実行）
-- 失敗した子Issue: `🔄 進行中` を維持（再実行可能にするため）
-- スキップされた子Issue: `🔄 進行中` → `⏭ スキップ` （Orchestratorのみ設定、手動操作では使用不可）
-
-一括更新順序: 子Issue番号の昇順
-
-### case-close: 完了更新
-
-`case-close` の既存実装を変更しない:
-- `✅ 完了` への更新・Epic自動クローズ判定は既存手順のまま
-- 本スキルは知識ベースとして参照されるのみ
+一括更新順序（Epic Orchestrator 等の複数子Issue一括更新時）: 子Issue番号の昇順
 
 ## 正規表現パターン
 
-Epic本文のステータス追跡テーブルは以下の2形式をサポートする:
+Epic本文のステータス追跡テーブルは以下の2形式をサポートする。ステータス値は子Issue 実行状態 enum（`pending` / `ready` / `running` / `completed` / `blocked` / `failed`）を使用する。
 
 ### 新4列形式（# / Issue / ステータス / 内容）
 
 ```markdown
 | # | Issue | ステータス | 内容 |
 |---|-------|-----------|------|
-| 1-1 | #42 | ☐ 未着手 | 子Issueの概要 |
-| 1-2 | #43 | 🔄 進行中 | 子Issueの概要 |
-| 1-3 | #44 | ✅ 完了 ([PR#100](https://...)) | 子Issueの概要 |
-| 1-4 | #45 | ❌ 対処不要 | 子Issueの概要 |
+| 1-1 | #42 | pending | 子Issueの概要 |
+| 1-2 | #43 | running | 子Issueの概要 |
+| 1-3 | #44 | completed ([PR#100](https://...)) | 子Issueの概要 |
+| 1-4 | #45 | blocked | 子Issueの概要 |
 ```
 
 ### 旧4列形式（# / Issue / タイトル / ステータス）
@@ -88,51 +84,51 @@ Epic本文のステータス追跡テーブルは以下の2形式をサポート
 ```markdown
 | # | Issue | タイトル | ステータス |
 |---|-------|----------|-----------|
-| 1 | #42 | 子Issueの概要 | ☐ 未着手 |
-| 2 | #43 | 子Issueの概要 | 🔄 進行中 |
-| 3 | #44 | 子Issueの概要 | ✅ 完了 ([PR#99](https://github.com/...)) |
-| 4 | #45 | 子Issueの概要 | ❌ 対処不要 |
+| 1 | #42 | 子Issueの概要 | pending |
+| 2 | #43 | 子Issueの概要 | running |
+| 3 | #44 | 子Issueの概要 | completed ([PR#99](https://github.com/...)) |
+| 4 | #45 | 子Issueの概要 | failed |
 ```
 
-### 新4列形式: 未着手 → 進行中
+### 新4列形式: pending/ready → running
 
 ```
-検索: (\| \d+-\d+ \| #{child_issue} \| )☐ 未着手 (\|)
-置換: $1🔄 進行中 $2
+検索: (\| \d+-\d+ \| #{child_issue} \| )(pending|ready) (\|)
+置換: $1running $2
 ```
 
-### 新4列形式: 進行中/未着手 → 完了
+### 新4列形式: running → completed
 
 ```
-検索: (\| \d+-\d+ \| #{child_issue} \| )(☐ 未着手|🔄 進行中) (\|)
-置換: $1✅ 完了 ([PR#{pr_number}]({pr_url})) $3
+検索: (\| \d+-\d+ \| #{child_issue} \| )running (\|)
+置換: $1completed ([PR#{pr_number}]({pr_url})) $2
 ```
 
-### 旧4列形式: 未着手 → 進行中
+### 旧4列形式: pending/ready → running
 
 ```
-検索: (\| \d+ \| #{child_issue} \| [^|]* \| )☐ 未着手 (\|)
-置換: $1🔄 進行中 $2
+検索: (\| \d+ \| #{child_issue} \| [^|]* \| )(pending|ready) (\|)
+置換: $1running $2
 ```
 
-### 旧4列形式: 進行中/未着手 → 完了
+### 旧4列形式: running → completed
 
 ```
-検索: (\| \d+ \| #{child_issue} \| [^|]* \| )(☐ 未着手|🔄 進行中) (\|)
-置換: $1✅ 完了 ([PR#{pr_number}]({pr_url})) $3
+検索: (\| \d+ \| #{child_issue} \| [^|]* \| )running (\|)
+置換: $1completed ([PR#{pr_number}]({pr_url})) $2
 ```
 
 ### 完了状態のべき等性確認
 
-`✅ 完了` はPRリンク付き `✅ 完了 ([PR#N](...))` の場合もあるため、
-べき等性確認時は `✅ 完了` で前方一致させる:
+`completed` はPRリンク付き `completed ([PR#N](...))` の場合もあるため、
+べき等性確認時は `completed` で前方一致させる:
 
 ```
 旧4列形式:
-検索: \| \d+ \| #{child_issue} \|[^|]*\| ✅ 完了
+検索: \| \d+ \| #{child_issue} \|[^|]*\| completed
 
 新4列形式:
-検索: \| \d+-\d+ \| #{child_issue} \| ✅ 完了
+検索: \| \d+-\d+ \| #{child_issue} \| completed
 ```
 
 ### べき等性確認
@@ -140,8 +136,8 @@ Epic本文のステータス追跡テーブルは以下の2形式をサポート
 更新前に現在のステータス値を確認:
 - 対象行が既に目標ステータス → スキップ
 - 対象行が不存在 → 警告表示してスキップ
-- `❌ 対処不要` の行 → 更新対象外（スキップ）
-- `⏭ スキップ` の行 → 更新対象外（スキップ）
+- `completed` の行 → 更新対象外（スキップ）
+- `blocked` / `failed` の行 → case-close による `completed` 上書きの対象外（スキップ）
 
 ## See Also
 
@@ -156,12 +152,12 @@ Epic本文のステータス追跡テーブルは以下の2形式をサポート
 
 Epicステータス更新はPRのmerge前後で一貫性を保つ必要がある:
 
-**merge前（case-run 実行中）**:
-- 子Issueを `☐ 未着手` → `🔄 進行中` に更新
+**merge前（case-auto が case-run に子Issue を渡す時）**:
+- 子Issueを `pending`/`ready` → `running` に更新
 - 親Epic本文を取得し、該当子Issue行を更新
 
 **merge後（case-close 完了時）**:
-- 子Issueを `🔄 進行中` → `✅ 完了 ([PR#N](URL))` に更新
+- 子Issueを `running` → `completed ([PR#N](URL))` に更新
 - PR番号とURLを含める
 
 **状態遷移の一貫性チェック**:
@@ -185,11 +181,11 @@ PR mergeに失敗した場合、Epicステータスの整合性を保つ:
 | 失敗タイミング | Epicステータス | 対応 |
 |--------------|----------------|------|
 | PR作成前（conflict検出） | 変更なし | PR作成を停止 |
-| PR作成後、merge前 | `🔄 進行中` | status維持（完了しない） |
-| merge時（conflict発生） | `🔄 進行中` | status維持、解決後に再試行 |
-| merge時（CI失敗等） | `🔄 進行中` | status維持、問題修正後に再試行 |
+| PR作成後、merge前 | `running` | status維持（完了しない） |
+| merge時（conflict発生） | `running` | status維持、解決後に再試行 |
+| merge時（CI失敗等） | `running` | status維持、問題修正後に再試行 |
 
-**重要**: merge失敗時はステータスを `✅ 完了` にしない。`🔄 進行中` を維持し、再実行可能にする。
+**重要**: merge失敗時はステータスを `completed` にしない。`running` を維持し、再実行可能にする。実行結果として失敗が確定した場合は `failed` に遷移する。
 
 **失敗報告フォーマット**:
 ```markdown
@@ -198,9 +194,9 @@ PR mergeに失敗した場合、Epicステータスの整合性を保つ:
 **PR番号**: #{pr_number}
 **Epic番号**: #{epic_number}
 **子Issue**: #{child_issue}
-**現在ステータス**: 🔄 進行中
+**現在ステータス**: running
 **失敗理由**: {failure_reason}
-**対応**: ステータスを維持（🔄 進行中）、問題解決後に再実行
+**対応**: ステータスを維持（running）、問題解決後に再実行
 ```
 
 #### 3. Epic本文のconflictリスク

--- a/src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_epic.md
+++ b/src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_epic.md
@@ -29,8 +29,8 @@ REQ-{req_number}
 
 | # | Issue | ステータス | 内容 |
 |---|-------|-----------|------|
-| {seq} | #{child_issue} | ☐ 未着手 | {child_1_title} |
-| {seq} | #{child_issue} | ☐ 未着手 | {child_2_title} |
+| {seq} | #{child_issue} | pending | {child_1_title} |
+| {seq} | #{child_issue} | pending | {child_2_title} |
 
 ## 実行順序
 <!-- 【必須】 -->
@@ -45,12 +45,15 @@ REQ-{req_number}
 ## ステータス追跡
 <!-- 【必須】 -->
 
+子Issue 実行状態 enum（`pending` / `ready` / `running` / `completed` / `blocked` / `failed`）。`⏭スキップ` は採用しない（REQ-0106-030）。
+
 | 状態 | 件数 |
 |------|------|
-| ☐ 未着手 | {total} |
-| 🔄 進行中 | 0 |
-| ✅ 完了 | 0 |
-| ❌ 対処不要 | 0 |
+| pending | {total} |
+| running | 0 |
+| completed | 0 |
+| blocked | 0 |
+| failed | 0 |
 
 ## 完了条件
 <!-- 【必須】 -->


### PR DESCRIPTION
## 概要

case-open が要件doc から自律的に Epic/Wave/Issue 構造を生成する責務を確立。req-define は execution_groups を出力しない。⏭スキップを全ドキュメントから廃止。

## REQ 参照

- REQ-0132-007〜010: case-open 自律構成生成
- REQ-0104-029/039-041: execution_groups → 自律生成
- REQ-0102-038: execution_groups 出力停止
- REQ-0106-030: skipped廃止・Wave status導出

## 完了条件

- [x] case-open.md が execution_groups に依存せず自律的に構成を生成する
- [x] req-define.md が execution_groups セクションを出力しない
- [x] ⏭スキップ が対象ドキュメントから廃止されている
- [x] 子Issue 実行状態ライフサイクル（pending/ready/running/completed/blocked/failed）が定義されている

## テスト結果

- check_integrity.ts: NG=0（新規エラー・警告なし）

## Findings / Capture候補

### intake
（該当なし）

### learning
（該当なし）

## SPEC確定候補

workflow-contracts.md「子Issue単位オーケストレーションモデル」セクション（status: draft → accepted 確定候補）
system.md Epicステータス追跡セクション（既存 accepted）