### PR TITLE
feat: src/opencode-local/ 生成時ソース領域のコンテンツ10ファイル作成 (Wave 4)

### DIFF
--- a/src/opencode-local/README.md
+++ b/src/opencode-local/README.md
@@ -1,0 +1,125 @@
+# ローカル版 OpenCode 生成時ソース領域
+
+> **非正規文書**: 本ディレクトリは AgentDevFlow 本体リポジトリの `docs/`（リポジトリ内部設計文書）ではなく、ローカル版 OpenCode 生成のための「生成時ソース領域」である（ADR-0126）。要件は `docs/requirements/REQ-0141.md`、仕様は `docs/specs/local-*.md` を正とする。
+
+## 目的
+
+GitHub Issue / PR を使えない個人利用環境（ローカル版 OpenCode）向けに、AgentDevFlow のコマンド / スキル / ひな形を生成先リポジトリの `.opencode/` に直接生成するためのスキーマ・変換プロンプト・変換仕様・生成フローを保持する（REQ-0141-003, 004, 031）。生成済みコマンド / スキル / ひな形は配置しない。
+
+## ディレクトリ構成
+
+```text
+src/opencode-local/
+├── README.md              ← 本ファイル（ローカル版生成の実行手順）
+├── case-schema/           ← Case ファイルの定義
+│   ├── case-file.md       ← スキーマ定義（YAML 前書き・status enum・labels・headings・採番）
+│   └── rules/
+│       ├── frontmatter.yaml   ← YAML 前書きスキーマの機械可読定義
+│       ├── status.yaml        ← status enum と状態遷移表の機械可読定義
+│       ├── labels.yaml        ← labels 値域の機械可読定義
+│       └── headings.yaml      ← 見出し一覧の機械可読定義
+├── transform/             ← 変換プロンプトと変換仕様
+│   ├── generate.md        ← 変換用プロンプト（AI エージェントがローカル版を生成するための指示）
+│   ├── review.md          ← レビュー用プロンプト（生成結果を検証するための指示）
+│   └── spec.md            ← 変換仕様（変換対象・ガードレール一覧・レポートフォーマット）
+└── generation-flow.md     ← 生成フロー定義（手順・安全確認・generated_by 形式）
+```
+
+### 作成しないディレクトリ（REQ-0141-005）
+
+以下は作成しない。`requirements/` と `specs/` は `docs/` 配下の同名ディレクトリと概念衝突するため不採用。
+
+- `src/opencode-local/_conv/`
+- `src/opencode-local/commands/`
+- `src/opencode-local/skills/`
+- `src/opencode-local/requirements/`
+- `src/opencode-local/specs/`
+
+## ローカル版生成の実行手順
+
+ローカル版 OpenCode の生成は、OpenCode 等 AI エージェントで `transform/generate.md`（変換用プロンプト）を入力またはファイル参照して実行する（REQ-0141-031, 032）。決定的な変換ロジックを実装した変換スクリプトは使用しない。
+
+### 前提
+
+- 生成先リポジトリが AgentDevFlow 本体リポジトリでないこと（REQ-0141-006）
+- 仕様管理リポジトリ（AgentDevFlow 本体）の `src/opencode/` と `src/opencode-local/` にアクセスできること
+- 生成先リポジトリに `.opencode/` ディレクトリが存在すること（または作成可能であること）
+- GitHub 版とローカル版を同じ `.opencode/` に同居させないこと（REQ-0141-015）
+
+### 手順
+
+1. **生成先リポジトリで OpenCode 等 AI エージェントを起動する**
+   - AgentDevFlow 本体リポジトリでは実行しない（REQ-0141-006）
+
+2. **AI エージェントに `transform/generate.md` を入力またはファイル参照で渡す**
+   - 入力方法例: `@src/opencode-local/transform/generate.md` でファイル参照
+   - または `transform/generate.md` の内容をプロンプトとして入力
+
+3. **AI エージェントが生成フロー（`generation-flow.md` 参照）に従って実行する**
+   - 実行環境の特定（Step 1）
+   - 入力の読み込み（Step 2）
+   - ジャンクション検出安全ゲート（Step 3）
+   - 同名ファイル確認（Step 4）
+   - 変換の実行（Step 5）
+   - 生成物の配置（Step 6）
+   - レポート出力（Step 7）
+
+4. **生成レポートを確認する**
+   - 結果が `PASS` の場合: 生成完了
+   - 結果が `FAIL` の場合: 違反一覧を確認し、手動で修正または再生成
+
+5. **必要に応じてレビューを実行する**
+   - `transform/review.md`（レビュー用プロンプト）を AI エージェントに入力し、生成物を検証
+
+### 実行例
+
+```text
+[生成先リポジトリにて]
+
+1. OpenCode を起動
+2. AI エージェントへ指示:
+   「@<仕様管理リポジトリへのパス>/src/opencode-local/transform/generate.md
+    に従ってローカル版 OpenCode を生成してください。
+    仕様管理リポジトリ: <パス>
+    生成先: 現在のリポジトリの .opencode/」
+3. AI エージェントが generate.md の指示に従い生成を実行
+4. 生成レポートを確認
+```
+
+## 更新運用（全削除して作り直し）
+
+ローカル版の高頻度更新は想定しない。更新時は `.opencode/commands/agentdev/` と `.opencode/skills/agentdev-*/` を全削除して作り直す（REQ-0141-033）。差分更新は想定しない。
+
+全削除により `generated_by` 識別子による上書き保護を迂回できるが、これは利用者自身の明示的操作によるものであり、ローカル版生成プロンプトによる自動上書きとは区別する。
+
+### 更新手順
+
+1. 生成先リポジトリの `.opencode/commands/agentdev/` を全削除
+2. 生成先リポジトリの `.opencode/skills/agentdev-*/` を全削除
+3. 「ローカル版生成の実行手順」に従い、再度生成を実行
+
+## 安全性制約
+
+ローカル版生成は以下の安全性制約に従う（ADR-0126）。詳細は `generation-flow.md` 参照。
+
+- **原本保護**: `src/opencode/` は GitHub 版専用の原本であり、ローカル版のために変更しない（REQ-0141-014, ADR-0126 decision #4）
+- **`generated_by` 識別子**: 生成物に `generated_by: local-opencode-transform` を記録し、同名ファイル上書きは識別子存在時のみ許可（REQ-0141-011, 012, 013, ADR-0126 decision #2）
+- **ジャンクション検出安全ゲート**: `.opencode/` が `src/opencode/` 配下へ解決される場合は生成を停止（REQ-0141-010, ADR-0126 decision #3）
+
+## リポジトリ管理対象
+
+- **管理対象外**: 生成された `.opencode/commands/` ・ `.opencode/skills/` ・ `.opencode/` 配下ひな形・変換スクリプト（REQ-0141-008, 009）。生成先リポジトリの `.gitignore` で除外することを推奨
+- **管理対象**: `.agentdev/cases/` 配下の Case ファイル（REQ-0141-016）
+
+## 関連項目
+
+- [生成フロー定義](generation-flow.md) — 手順・安全確認・`generated_by` 形式
+- [変換用プロンプト](transform/generate.md) — ローカル版生成の指示書
+- [レビュー用プロンプト](transform/review.md) — 生成結果の検証指示
+- [変換仕様](transform/spec.md) — 変換対象一覧・ガードレール一覧・レポートフォーマット
+- [Case ファイルスキーマ定義](case-schema/case-file.md) — ローカル Case ファイルの構造
+- `docs/requirements/REQ-0141.md` — ローカル版 OpenCode 生成方式とローカル Case ファイル運用の要件定義（正本）
+- `docs/specs/local-case-file.md` — Case ファイルスキーマの正本 SPEC
+- `docs/specs/local-generation.md` — 生成フロー・安全ゲートの正本 SPEC
+- `docs/specs/local-transform.md` — 変換プロンプト・レビュープロンプト要件の正本 SPEC
+- `docs/adr/ADR-0126.md` — source model 拡張と生成安全性制約

--- a/src/opencode-local/case-schema/case-file.md
+++ b/src/opencode-local/case-schema/case-file.md
@@ -1,0 +1,213 @@
+# ローカル Case ファイル スキーマ定義
+
+> **正本**: `docs/specs/local-case-file.md`（意味仕様の正本）。本ファイルは運用参照資料であり、SPEC と矛盾してはならない。
+> **機械可読定義**: `case-schema/rules/*.yaml`（frontmatter・status・labels・headings）。
+
+## 目的
+
+GitHub Issue / PR を使わない個人利用環境（ローカル版 OpenCode）において、Issue / PR 相当の永続情報を保持する Case ファイルの構造を定義する（REQ-0141-016〜020, 024）。ローカル版コマンド（`case-open` / `case-run` / `case-close`）は本定義に従って `.agentdev/cases/case-{NNNN}.md` を生成・更新する。
+
+## 配置先
+
+- パス: `.agentdev/cases/case-{NNNN}.md`
+- `{NNNN}`: 4 桁ゼロ埋め番号（例: `0001`, `0042`）
+- リポジトリ管理対象: `.agentdev/cases/` 配下の Case ファイルは Issue / PR 相当の永続情報としてリポジトリ管理対象とする（REQ-0141-016）
+
+## YAML 前書きスキーマ
+
+Case ファイルの YAML 前書きは以下の 7 フィールドを必須とする（REQ-0141-017）。機械可読定義は `rules/frontmatter.yaml` 参照。
+
+| フィールド | 型 | 必須/任意 | 値域・制約 |
+|---|---|---|---|
+| `id` | 文字列 | 必須 | `case-{NNNN}` 形式。ファイル名 `case-{NNNN}.md` と一致 |
+| `title` | 文字列 | 必須 | 自由記述。Case の概要を簡潔に表す日本語または英語 |
+| `status` | 文字列（enum） | 必須 | `open`, `running`, `blocked`, `review`, `closed`, `cancelled` のいずれか |
+| `created_at` | 文字列（日時） | 必須 | ISO 8601 形式（例: `2026-06-20T21:39:00+09:00`） |
+| `updated_at` | 文字列（日時） | 必須 | ISO 8601 形式。最終更新日時 |
+| `closed_at` | 文字列（日時）または空 | 条件付き必須 | `status: closed` / `cancelled` の場合のみ値を持つ。それ以外では空文字列またはフィールド値なし |
+| `labels` | 配列（文字列） | 必須 | `rules/labels.yaml` の `label_enum` から選定。補助分類であり状態遷移やワークフロー状態の代替として扱わない |
+
+### YAML 前書きに含めないフィールド（REQ-0141-017, 024）
+
+以下のフィールドは YAML 前書きに持たせない。
+
+- `work_type`
+- `source`
+- `branch`
+- `base_branch`
+
+ブランチ情報はブランチを使った場合のみ `## マージ結果` セクションに記録する。YAML 前書きには持たせない（REQ-0141-024）。
+
+### YAML 前書きの例
+
+```yaml
+---
+id: case-0042
+title: "ユーザー認証機能を追加"
+status: review
+created_at: "2026-06-20T21:39:00+09:00"
+updated_at: "2026-06-20T22:05:00+09:00"
+closed_at: ""
+labels: [feature]
+---
+```
+
+## status enum と状態遷移
+
+### status 値域
+
+`status` は以下のいずれかの値を取る（REQ-0141-018）。機械可読定義は `rules/status.yaml` 参照。
+
+| status | 意味 | 終端状態 |
+|---|---|---|
+| `open` | Case オープン済み・作業前 | いいえ |
+| `running` | 作業中 | いいえ |
+| `blocked` | 停止中（障害・未解決事項あり） | いいえ |
+| `review` | 作業完了・レビュー対象 | いいえ |
+| `closed` | 完了 | はい |
+| `cancelled` | 中止 | はい |
+
+`closed` と `cancelled` は終端状態とする。終端状態からの遷移は定義しない。
+
+### 状態遷移表
+
+ローカル版各コマンドの操作に対応する状態遷移（REQ-0141-018）。
+
+| 操作 | 変更前 status | 変更後 status |
+|---|---|---|
+| ローカル版 `case-open` | （新規作成） | `open` |
+| ローカル版 `case-run` 開始 | `open` / `blocked` | `running` |
+| ローカル版 `case-run` 完了 | `running` | `review` |
+| ローカル版 `case-run` 停止 | `running` | `blocked` |
+| ローカル版 `case-close` 停止 | `review` | `blocked` |
+| ローカル版 `case-close` 再開 | `blocked` | `review` |
+| ローカル版 `case-close` 完了 | `review` | `closed` |
+| 明示中止 | `open` / `running` / `blocked` / `review` | `cancelled` |
+
+### 再開経路
+
+- ローカル版 `case-run` 停止後の再開経路: `blocked` → `running` → `review`
+- ローカル版 `case-close` 停止後の再開経路: `blocked` → `review` → `closed`
+
+### 禁止遷移
+
+- `blocked` から `closed` への直接遷移は禁止する。`blocked` から `closed` に至る場合は `review` を経由する。
+- 終端状態（`closed`, `cancelled`）からの遷移は定義しない。
+
+## 採番規則
+
+`{NNNN}` の採番規則（REQ-0141-016）。
+
+- 4 桁ゼロ埋め番号とする（例: `0001`, `0042`, `9999`）
+- 新規作成時は `.agentdev/cases/case-*.md` の既存最大番号 + 1 を使用する
+- 欠番は再利用しない（過去に削除・リネームされた番号を再採番しない）
+- 同一番号のファイルが既に存在する場合、ローカル版 `case-open` は停止する（上書きしない）
+- 複数プロセスによる同時作成の排他制御は対象外とする（暫定ローカル版の前提）
+
+## labels 値域
+
+`labels` は配列とし、`rules/labels.yaml` の `label_enum` から選定する（REQ-0141-019）。`labels` は補助分類であり、状態遷移やワークフロー状態の代替として扱わない。
+
+値域: `feature`, `bugfix`, `maintenance`, `docs`, `refactor`, `chore`, `epic`
+
+## 見出し一覧
+
+Case ファイル本文は以下の 15 セクション見出しを持つ（REQ-0141-020）。機械可読定義は `rules/headings.yaml` 参照。各見出しの必須/任意を定義する。
+
+| # | 見出し | 必須/任意 | 役割 |
+|---|---|---|---|
+| 1 | `## 入力` | 任意 | Case の入力情報（REQ パス・要件 doc パス・参照 Issue 等） |
+| 2 | `## 背景` | 任意 | Case の背景説明 |
+| 3 | `## 問題` | 任意 | Case が解決する問題 |
+| 4 | `## 目的` | 任意 | Case の目的 |
+| 5 | `## 対象範囲` | 任意 | Case の対象範囲 |
+| 6 | `## 対象外` | 任意 | Case の対象外 |
+| 7 | `## 受け入れ条件` | 任意 | Case の受け入れ条件 |
+| 8 | `## 作業ログ` | 任意 | 作業の進行ログ。GitHub Issue コメント相当の内容を記録 |
+| 9 | `## マージ前確認` | 任意 | マージ前確認事項。GitHub PR 本文の引き継ぎ情報の一部 |
+| 10 | `## SPEC確定候補` | **必須** | SPEC 確定候補。GitHub PR 本文が担っていた引き継ぎ情報の代替（REQ-0141-020） |
+| 11 | `## Findings / Capture候補` | **必須** | Findings / Capture候補。下位に `### intake` と `### learning` サブ見出しを持つ |
+| 12 | `## マージ結果` | 任意 | ローカル Git 上の取り込み結果。ブランチ情報は本セクションに記録する |
+| 13 | `## 残課題` | 任意 | 残課題・フォローアップ項目 |
+| 14 | `## 完了判定` | 任意 | 完了判定結果 |
+| 15 | （自由拡張） | 任意 | 上記以外のセクションは必要に応じて追加可能 |
+
+`SPEC確定候補` と `Findings / Capture候補` を必須とする理由: これらは GitHub 版で PR 本文が担っていた引き継ぎ情報の代替であり、case-close への引き継ぎ経路を失わせないため（REQ-0141-020）。
+
+### Findings / Capture候補 サブ見出し
+
+`## Findings / Capture候補` は以下のサブ見出しを持つ。
+
+```markdown
+## Findings / Capture候補
+
+### intake
+
+（intake 候補のリスト）
+
+### learning
+
+（learning 候補のリスト）
+```
+
+## closed_at の値条件
+
+`closed_at` は以下の条件でのみ値を持つ（REQ-0141-017）。
+
+- `status: closed` の場合: 値を持つ（クローズ日時を ISO 8601 形式で記録）
+- `status: cancelled` の場合: 値を持つ（キャンセル日時を ISO 8601 形式で記録）
+- それ以外の `status`: 空文字列またはフィールド値なし
+
+## マージ結果の記録方針
+
+`## マージ結果` セクションには、ローカル版 `case-close` がローカル Git 上で実施済みの取り込み・反映結果を記録する（REQ-0141-025）。GitHub PR 取り込みは実行しない。
+
+### 記録項目（必須）
+
+- 実行した操作
+- 関連するコミットハッシュ
+- 実行日時
+- 結果: `PASS` / `FAIL`
+
+### ブランチ使用時の追記項目
+
+ブランチを使った場合は以下も記録する。ブランチを使わない場合はブランチ名の記録を必須としない。
+
+- 取り込み先ブランチ
+- 取り込み元ブランチ
+
+### 失敗・未完了時の扱い
+
+ローカル Git 上で実施済みの取り込み・反映結果が失敗または未完了の場合、ローカル版 `case-close` は `status` を `blocked` に更新し、理由を `## 残課題` に記録する（REQ-0141-025）。
+
+## GitHub Issue / PR 置換対応表
+
+ローカル版では GitHub Issue / PR が担う情報を Case ファイルに集約する（REQ-0141-021〜023, 026）。
+
+| GitHub 版 | ローカル版 |
+|---|---|
+| GitHub Issue 本文 | Case ファイル本文 |
+| GitHub Issue コメント | `## 作業ログ` |
+| GitHub Issue の状態 | Case ファイルの `status` |
+| GitHub Issue のラベル | Case ファイルの `labels` |
+| GitHub PR 本文 | `## マージ前確認` / `## SPEC確定候補` / `## Findings / Capture候補` |
+| GitHub PR 取り込み結果 | `## マージ結果` |
+| GitHub Issue のクローズ | `status: closed` + `closed_at` |
+
+ローカル版各コマンドの責務:
+
+- ローカル版 `case-open`: GitHub Issue 作成ではなく Case ファイル作成を行う（REQ-0141-021）
+- ローカル版 `case-run`: GitHub PR 作成ではなく Case ファイルの PR 相当セクション追記を行う（REQ-0141-022）
+- ローカル版 `case-close`: GitHub PR 取り込み / Issue クローズではなく Case ファイルの完了更新を行う（REQ-0141-023）
+- GitHub Issue 作成・PR 作成・PR 取り込み・Issue クローズおよび `gh issue` / `gh pr` をローカル版の必須操作にしない（REQ-0141-026）
+
+## 関連項目
+
+- [ローカル版 OpenCode 生成](../generation-flow.md) — 生成フロー・`generated_by` 識別子・ジャンクション検出安全ゲート
+- [ローカル版 OpenCode 変換プロンプト](../transform/spec.md) — 変換用プロンプトとレビュー用プロンプトの要件
+- `rules/frontmatter.yaml` — YAML 前書きスキーマの機械可読定義
+- `rules/status.yaml` — status enum と状態遷移表の機械可読定義
+- `rules/labels.yaml` — labels 値域の機械可読定義
+- `rules/headings.yaml` — 見出し一覧の機械可読定義
+- `docs/specs/local-case-file.md` — 意味仕様の正本
+- REQ-0141 — ローカル版 OpenCode 生成方式とローカル Case ファイル運用の要件定義

--- a/src/opencode-local/case-schema/rules/frontmatter.yaml
+++ b/src/opencode-local/case-schema/rules/frontmatter.yaml
@@ -1,0 +1,92 @@
+# ローカル Case ファイル YAML 前書きスキーマ
+#
+# 正本: docs/specs/local-case-file.md「YAML 前書きスキーマ」
+# 要件: REQ-0141-017
+#
+# ローカル Case ファイル (.agentdev/cases/case-{NNNN}.md) の YAML 前書きに
+# 含めるフィールドの型・必須/任意・値域を定義する。
+# 本ファイルは docs/specs/local-case-file.md と矛盾してはならない。
+
+schema_version: "1.0"
+target: ".agentdev/cases/case-{NNNN}.md の YAML 前書き"
+canonical_spec: "docs/specs/local-case-file.md"
+
+# 必須フィールド（REQ-0141-017）
+fields:
+  id:
+    type: string
+    required: true
+    pattern: "^case-[0-9]{4}$"
+    constraint: "ファイル名 case-{NNNN}.md の {NNNN} 部と一致すること"
+    description: "Case 識別子。4 桁ゼロ埋め"
+    examples:
+      - "case-0001"
+      - "case-0042"
+
+  title:
+    type: string
+    required: true
+    constraint: "自由記述。Case の概要を簡潔に表す日本語または英語"
+    description: "Case のタイトル"
+
+  status:
+    type: string
+    required: true
+    enum_ref: "status.yaml#status_enum"
+    constraint: "status.yaml の status_enum のいずれか"
+    description: "Case のライフサイクル状態"
+
+  created_at:
+    type: string
+    required: true
+    format: "ISO 8601 (日時)"
+    constraint: "タイムゾーンオフセット付きを推奨"
+    description: "Case 作成日時"
+    examples:
+      - "2026-06-20T21:39:00+09:00"
+
+  updated_at:
+    type: string
+    required: true
+    format: "ISO 8601 (日時)"
+    constraint: "最終更新日時。更新の都度書き換える"
+    description: "Case 最終更新日時"
+    examples:
+      - "2026-06-20T22:05:00+09:00"
+
+  closed_at:
+    type: string
+    required: conditional
+    format: "ISO 8601 (日時) または空文字列"
+    condition: "status が closed または cancelled の場合のみ値を持つ。それ以外では空文字列またはフィールド値なし"
+    description: "Case 終端日時（クローズ/キャンセル日時）"
+    examples:
+      - "2026-06-21T10:00:00+09:00"
+      - ""
+
+  labels:
+    type: array
+    required: true
+    items:
+      type: string
+      enum_ref: "labels.yaml#label_enum"
+    constraint: "labels.yaml の label_enum から選定。補助分類であり状態遷移やワークフロー状態の代替として扱わない"
+    description: "Case のラベル一覧"
+
+# 禁止フィールド（REQ-0141-017, 024）
+# 以下のフィールドは YAML 前書きに含めてはならない。
+forbidden_fields:
+  - name: work_type
+    reason: "REQ-0141-017: work_type は前書きに持たせない"
+  - name: source
+    reason: "REQ-0141-017: source は前書きに持たせない"
+  - name: branch
+    reason: "REQ-0141-017, 024: ブランチ情報は ## マージ結果 セクションに記録する"
+  - name: base_branch
+    reason: "REQ-0141-017, 024: ブランチ情報は ## マージ結果 セクションに記録する"
+
+# closed_at の値条件（REQ-0141-017, SPEC local-case-file.md「closed_at の値条件」）
+closed_at_rules:
+  - "status: closed の場合: クローズ日時を ISO 8601 形式で記録"
+  - "status: cancelled の場合: キャンセル日時を ISO 8601 形式で記録"
+  - "それ以外の status: 空文字列またはフィールド値なし"

--- a/src/opencode-local/case-schema/rules/headings.yaml
+++ b/src/opencode-local/case-schema/rules/headings.yaml
@@ -1,0 +1,123 @@
+# ローカル Case ファイル 見出し一覧
+#
+# 正本: docs/specs/local-case-file.md「見出し一覧」
+# 要件: REQ-0141-020
+#
+# Case ファイル本文が持つ 15 セクション見出しと必須/任意を定義する。
+# 本ファイルは docs/specs/local-case-file.md と矛盾してはならない。
+
+schema_version: "1.0"
+target: ".agentdev/cases/case-{NNNN}.md の本文見出し"
+canonical_spec: "docs/specs/local-case-file.md"
+
+# 見出し一覧（REQ-0141-020）
+# 15 セクションを定義する。SPEC確定候補 と Findings / Capture候補 は必須。
+# 必須の理由: これらは GitHub 版で PR 本文が担っていた引き継ぎ情報の代替であり、
+# case-close への引き継ぎ経路を失わせないため（REQ-0141-020）。
+headings:
+  - number: 1
+    name: "入力"
+    heading: "## 入力"
+    required: false
+    role: "Case の入力情報（REQ パス・要件 doc パス・参照 Issue 等）"
+
+  - number: 2
+    name: "背景"
+    heading: "## 背景"
+    required: false
+    role: "Case の背景説明"
+
+  - number: 3
+    name: "問題"
+    heading: "## 問題"
+    required: false
+    role: "Case が解決する問題"
+
+  - number: 4
+    name: "目的"
+    heading: "## 目的"
+    required: false
+    role: "Case の目的"
+
+  - number: 5
+    name: "対象範囲"
+    heading: "## 対象範囲"
+    required: false
+    role: "Case の対象範囲"
+
+  - number: 6
+    name: "対象外"
+    heading: "## 対象外"
+    required: false
+    role: "Case の対象外"
+
+  - number: 7
+    name: "受け入れ条件"
+    heading: "## 受け入れ条件"
+    required: false
+    role: "Case の受け入れ条件"
+
+  - number: 8
+    name: "作業ログ"
+    heading: "## 作業ログ"
+    required: false
+    role: "作業の進行ログ。GitHub Issue コメント相当の内容を記録"
+
+  - number: 9
+    name: "マージ前確認"
+    heading: "## マージ前確認"
+    required: false
+    role: "マージ前確認事項。GitHub PR 本文の引き継ぎ情報の一部"
+
+  - number: 10
+    name: "SPEC確定候補"
+    heading: "## SPEC確定候補"
+    required: true
+    role: "SPEC 確定候補。GitHub PR 本文が担っていた引き継ぎ情報の代替（REQ-0141-020）"
+
+  - number: 11
+    name: "Findings / Capture候補"
+    heading: "## Findings / Capture候補"
+    required: true
+    role: "Findings / Capture候補。GitHub PR 本文が担っていた引き継ぎ情報の代替。下位に ### intake と ### learning サブ見出しを持つ"
+    subheadings:
+      - heading: "### intake"
+        role: "intake 候補のリスト"
+      - heading: "### learning"
+        role: "learning 候補のリスト"
+
+  - number: 12
+    name: "マージ結果"
+    heading: "## マージ結果"
+    required: false
+    role: "ローカル Git 上の取り込み結果。ブランチ情報は本セクションに記録する（YAML 前書きには持たせない）"
+
+  - number: 13
+    name: "残課題"
+    heading: "## 残課題"
+    required: false
+    role: "残課題・フォローアップ項目"
+
+  - number: 14
+    name: "完了判定"
+    heading: "## 完了判定"
+    required: false
+    role: "完了判定結果"
+
+  - number: 15
+    name: "自由拡張"
+    heading: "（自由拡張）"
+    required: false
+    role: "上記以外のセクションは必要に応じて追加可能"
+
+# 必須見出し
+required_headings:
+  - "## SPEC確定候補"
+  - "## Findings / Capture候補"
+
+# 必須サブ見出し
+required_subheadings:
+  - parent: "## Findings / Capture候補"
+    subheading: "### intake"
+  - parent: "## Findings / Capture候補"
+    subheading: "### learning"

--- a/src/opencode-local/case-schema/rules/labels.yaml
+++ b/src/opencode-local/case-schema/rules/labels.yaml
@@ -1,0 +1,36 @@
+# ローカル Case ファイル labels 値域
+#
+# 正本: docs/specs/local-case-file.md「labels 値域」
+# 要件: REQ-0141-019
+#
+# labels フィールドに設定可能な値を定義する。
+# 本ファイルは docs/specs/local-case-file.md と矛盾してはならない。
+
+schema_version: "1.0"
+target: ".agentdev/cases/case-{NNNN}.md の labels フィールド"
+canonical_spec: "docs/specs/local-case-file.md"
+
+# label_enum（REQ-0141-019）
+# labels は配列とし、以下の値域から選定する。
+# labels は補助分類であり、状態遷移やワークフロー状態の代替として扱わない。
+label_enum:
+  feature:
+    description: "機能追加・新規実装"
+  bugfix:
+    description: "バグ修正"
+  maintenance:
+    description: "保守作業・運用改善"
+  docs:
+    description: "ドキュメント作成・更新"
+  refactor:
+    description: "リファクタリング・構造改善（振る舞い保持）"
+  chore:
+    description: "雑務・設定変更・依存更新"
+  epic:
+    description: "Epic（複数子 Case を束ねる大型課題）"
+
+# ガードレール
+constraints:
+  - "labels.yaml の label_enum に存在しないラベルを追加してはならない"
+  - "labels は配列として扱い、単一文字列としては扱わない"
+  - "labels を状態遷移やワークフロー状態の代替として扱わない"

--- a/src/opencode-local/case-schema/rules/status.yaml
+++ b/src/opencode-local/case-schema/rules/status.yaml
@@ -1,0 +1,128 @@
+# ローカル Case ファイル status enum と状態遷移表
+#
+# 正本: docs/specs/local-case-file.md「status enum と状態遷移」
+# 要件: REQ-0141-018
+#
+# status 値域・意味・終端状態・状態遷移表・再開経路・禁止遷移を定義する。
+# 本ファイルは docs/specs/local-case-file.md と矛盾してはならない。
+
+schema_version: "1.0"
+target: ".agentdev/cases/case-{NNNN}.md の status フィールド"
+canonical_spec: "docs/specs/local-case-file.md"
+
+# status enum（REQ-0141-018）
+status_enum:
+  open:
+    description: "Case オープン済み・作業前"
+    terminal: false
+  running:
+    description: "作業中"
+    terminal: false
+  blocked:
+    description: "停止中（障害・未解決事項あり）"
+    terminal: false
+  review:
+    description: "作業完了・レビュー対象"
+    terminal: false
+  closed:
+    description: "完了"
+    terminal: true
+  cancelled:
+    description: "中止"
+    terminal: true
+
+# 終端状態（REQ-0141-018）
+# closed と cancelled は終端状態とする。終端状態からの遷移は定義しない。
+terminal_states:
+  - closed
+  - cancelled
+
+# 状態遷移表（REQ-0141-018, SPEC local-case-file.md「状態遷移表」）
+# 操作・変更前 status・変更後 status の対応を定義する。
+transitions:
+  - operation: "ローカル版 case-open"
+    from: "(新規作成)"
+    to: "open"
+    note: "Case ファイル新規作成時"
+
+  - operation: "ローカル版 case-run 開始"
+    from: "open"
+    to: "running"
+    note: "open からの開始"
+
+  - operation: "ローカル版 case-run 開始"
+    from: "blocked"
+    to: "running"
+    note: "blocked からの再開"
+
+  - operation: "ローカル版 case-run 完了"
+    from: "running"
+    to: "review"
+    note: "実装完了・レビュー対象へ"
+
+  - operation: "ローカル版 case-run 停止"
+    from: "running"
+    to: "blocked"
+    note: "障害・未解決事項による停止"
+
+  - operation: "ローカル版 case-close 停止"
+    from: "review"
+    to: "blocked"
+    note: "完了処理中の停止"
+
+  - operation: "ローカル版 case-close 再開"
+    from: "blocked"
+    to: "review"
+    note: "blocked から完了処理への再開"
+
+  - operation: "ローカル版 case-close 完了"
+    from: "review"
+    to: "closed"
+    note: "完了確定。終端状態"
+
+  - operation: "明示中止"
+    from: "open"
+    to: "cancelled"
+    note: "利用者による明示的キャンセル"
+
+  - operation: "明示中止"
+    from: "running"
+    to: "cancelled"
+    note: "利用者による明示的キャンセル"
+
+  - operation: "明示中止"
+    from: "blocked"
+    to: "cancelled"
+    note: "利用者による明示的キャンセル"
+
+  - operation: "明示中止"
+    from: "review"
+    to: "cancelled"
+    note: "利用者による明示的キャンセル"
+
+# 再開経路（SPEC local-case-file.md「再開経路」）
+recovery_paths:
+  case_run:
+    description: "ローカル版 case-run 停止後の再開経路"
+    path:
+      - "blocked"
+      - "running"
+      - "review"
+  case_close:
+    description: "ローカル版 case-close 停止後の再開経路"
+    path:
+      - "blocked"
+      - "review"
+      - "closed"
+
+# 禁止遷移（SPEC local-case-file.md「禁止遷移」）
+forbidden_transitions:
+  - from: "blocked"
+    to: "closed"
+    reason: "blocked から closed への直接遷移は禁止。review を経由すること"
+  - from: "closed"
+    to: "*"
+    reason: "終端状態からの遷移は定義しない"
+  - from: "cancelled"
+    to: "*"
+    reason: "終端状態からの遷移は定義しない"

--- a/src/opencode-local/generation-flow.md
+++ b/src/opencode-local/generation-flow.md
@@ -1,0 +1,145 @@
+# ローカル版 OpenCode 生成フロー定義
+
+> 本ファイルはローカル版 OpenCode 生成の全体フロー・安全確認手順・`generated_by` 識別子の形式を定義する。意味仕様の正本は `docs/specs/local-generation.md`。本ファイルは正本 SPEC と矛盾してはならない。
+
+## 目的
+
+ローカル版 OpenCode のコマンド / スキル / ひな形を生成先リポジトリの `.opencode/` に生成する全体手順を定義する（REQ-0141-007, 031, 032）。原本である `src/opencode/` を改変せず、`generated_by` 識別子とジャンクション検出安全ゲートで原本保護を担保する。
+
+## リポジトリ分離
+
+ローカル版生成は以下の 2 リポジトリ構成を前提とする（REQ-0141-002, 006）。
+
+| リポジトリ | 役割 | 主な対象パス |
+|---|---|---|
+| 仕様管理リポジトリ（AgentDevFlow 本体） | ローカル版生成の入力元。GitHub 版原本と生成時ソース領域を保持 | `src/opencode/`, `src/opencode-local/` |
+| 生成先リポジトリ | ローカル版を導入する利用側リポジトリ。生成物と Case ファイルを保持 | `.opencode/commands/`, `.opencode/skills/`, `.agentdev/cases/` |
+
+ローカル版生成は AgentDevFlow 本体リポジトリでは実行しない（REQ-0141-006）。生成時の入力元として AgentDevFlow 本体リポジトリの `src/opencode/` と `src/opencode-local/` を参照する。
+
+## 生成フロー
+
+ローカル版生成の全体フロー（REQ-0141-007, 031, 032）。決定的な変換ロジックを実装した変換スクリプトは使用しない。AI エージェントが変換プロンプト（`transform/generate.md`）に従って生成する（REQ-0141-032）。
+
+### Step 1: 実行環境の特定
+
+生成先リポジトリが AgentDevFlow 本体リポジトリでないことを確認する（REQ-0141-006）。
+
+- 生成先リポジトリのルートを特定する
+- AgentDevFlow 本体リポジトリと同一でないことを確認する
+- 本体リポジトリである場合は生成を開始せず停止する
+
+### Step 2: 入力の読み込み
+
+AI エージェントが仕様管理リポジトリの `src/opencode/` と `src/opencode-local/` 配下を読み込む。
+
+- `src/opencode/commands/agentdev/*.md` — GitHub 版コマンド原本
+- `src/opencode/skills/agentdev-*/` — GitHub 版スキル原本
+- `src/opencode/` 配下のひな形群 — GitHub 版ひな形原本
+- `src/opencode-local/case-schema/` — Case ファイルスキーマ定義
+- `src/opencode-local/transform/` — 変換プロンプト・レビュープロンプト・変換仕様
+- `src/opencode-local/generation-flow.md` — 本ファイル（生成フロー定義）
+
+### Step 3: ジャンクション検出安全ゲート
+
+生成先リポジトリの `.opencode/` の実パスを確認する（REQ-0141-010）。詳細は後述「ジャンクション検出安全ゲート」参照。
+
+- `.opencode/` の実パスが `src/opencode/` 配下へ解決される場合、生成を停止する
+- ジャンクション検出は決定的な検査として script で実装する（ADR-0107, ADR-0126 decision #3）
+
+### Step 4: 同名ファイル確認
+
+`.opencode/commands/` と `.opencode/skills/` の同名ファイルを `generated_by` 識別子で確認する（REQ-0141-012, 013）。詳細は後述「`generated_by` 識別子」参照。
+
+- 同名ファイルに `generated_by: local-opencode-transform` 識別情報がある場合: 再生成・上書きを許可
+- 同名ファイルに識別情報がない場合: 生成を停止
+- 同名ファイルに異なる識別情報がある場合: 生成を停止
+
+### Step 5: 変換の実行
+
+`transform/generate.md` の指示に従い、AI エージェントがローカル版コマンド / スキル / ひな形を生成する（REQ-0141-032）。
+
+- 変換内容・ガードレール・レポートフォーマットは `transform/spec.md` 参照
+- 決定的な変換ロジックを実装した変換スクリプトは使用しない
+
+### Step 6: 生成物の配置
+
+`.opencode/commands/` と `.opencode/skills/` に直接配置する（REQ-0141-007）。
+
+- ローカル版コマンドは `.opencode/commands/` に配置
+- ローカル版スキルは `.opencode/skills/` に配置
+- ローカル版ひな形は既存の相対参照構造を維持して `.opencode/` 配下に配置（REQ-0141-008）
+
+### Step 7: レポート出力
+
+変換レポートを出力する。レポートフォーマットは `transform/spec.md` 参照。
+
+- 必須項目を過不足なく含める
+- 残存 GitHub 固有参照の違反判定を行う
+- 結果が `FAIL` の場合は利用者に手動確認を促す
+
+## `generated_by` 識別子
+
+ローカル版生成物には `generated_by: local-opencode-transform` の識別情報を持たせる（REQ-0141-011, ADR-0126 decision #2）。これは上書き保護のアーキテクチャ不変量である。
+
+### 記録形式
+
+| 生成物の種別 | 記録方法 |
+|---|---|
+| Markdown または YAML 前書きを持つファイル | YAML 前書きに `generated_by: local-opencode-transform` を記録 |
+| YAML 前書きを持たないファイル | 同等の先頭コメントに記録 |
+
+### 上書き許可条件
+
+同名ファイルに対する再生成・上書きは以下の条件でのみ許可する（REQ-0141-012, 013）。
+
+- 同名ファイルに `generated_by: local-opencode-transform` 識別情報がある場合: 再生成・上書きを許可
+- 同名ファイルに識別情報がない場合: 安全確認不能として生成を停止
+- 同名ファイルに異なる識別情報がある場合: 生成を停止
+
+## ジャンクション検出安全ゲート
+
+ジャンクション / シンボリックリンク等により `.opencode/` が `src/opencode/` 配下へ解決される環境での誤生成を防止するため、生成前に `.opencode/` の実パスを確認する（REQ-0141-010, ADR-0126 decision #3）。
+
+### 検出条件
+
+`.opencode/` の実パスが `src/opencode/` 配下へ解決される場合、ローカル版生成を停止する。
+
+### 実装方式
+
+ジャンクション検出は決定的な検査として script で実装する（ADR-0107, ADR-0126 decision #3）。AI エージェントの解釈に依存せず、ファイルシステムの実パス解決により機械的に判定する。
+
+### 停止時の扱い
+
+ジャンクション環境を検出した場合、生成を開始せずに停止する。利用者にジャンクション構成の解除を促すメッセージを出す。
+
+## 更新運用（全削除して作り直し）
+
+ローカル版の高頻度更新は想定しない。更新時は `.opencode/commands/agentdev/` と `.opencode/skills/agentdev-*/` を全削除して作り直す（REQ-0141-033）。差分更新は想定しない。
+
+全削除により `generated_by` 識別子による上書き保護を迂回できるが、これは利用者自身の明示的操作によるものであり、ローカル版生成プロンプトによる自動上書きとは区別する（AG-015）。
+
+## 生成物とリポジトリ管理
+
+以下をリポジトリ管理対象外とする（REQ-0141-008）。
+
+- 生成された `.opencode/commands/`
+- 生成された `.opencode/skills/`
+- 生成された `.opencode/` 配下ひな形
+
+`.agentdev/cases/` 配下の Case ファイルはリポジトリ管理対象とする（REQ-0141-016、詳細は `case-schema/case-file.md` 参照）。
+
+## 同名規則と同居制限
+
+ローカル版は GitHub 版 `/agentdev/*` および `agentdev-*` と同じ名前で生成する前提とする（REQ-0141-015）。GitHub 版とローカル版を同じ `.opencode/` に同居させる利用環境は対象外とする。
+
+## 関連項目
+
+- [ローカル版生成の実行手順](README.md) — AI エージェントでの実行エントリポイント
+- [変換用プロンプト](transform/generate.md) — ローカル版生成の指示書
+- [レビュー用プロンプト](transform/review.md) — 生成結果の検証指示
+- [変換仕様](transform/spec.md) — 変換対象一覧・ガードレール一覧・レポートフォーマット
+- [Case ファイルスキーマ定義](case-schema/case-file.md) — ローカル Case ファイルの構造
+- `docs/specs/local-generation.md` — 生成フロー・安全ゲートの正本
+- REQ-0141 — ローカル版 OpenCode 生成方式とローカル Case ファイル運用の要件定義
+- ADR-0126 — source model 拡張と生成安全性制約

--- a/src/opencode-local/transform/generate.md
+++ b/src/opencode-local/transform/generate.md
@@ -1,0 +1,165 @@
+# ローカル版 OpenCode 変換用プロンプト
+
+> 本ファイルは AI エージェントがローカル版 OpenCode のコマンド / スキル / ひな形を生成先リポジトリの `.opencode/` に生成するための指示書である。意味仕様の正本は `docs/specs/local-transform.md` と `docs/specs/local-generation.md`。変換仕様の集約は `transform/spec.md` 参照。
+
+## 目的
+
+GitHub Issue / PR を使えない個人利用環境（ローカル版 OpenCode）向けに、AgentDevFlow 本体リポジトリの `src/opencode/`（GitHub 版原本）と `src/opencode-local/`（生成時ソース）を読み込み、ローカル版コマンド / スキル / ひな形を生成先リポジトリの `.opencode/commands/` および `.opencode/skills/` に生成する（REQ-0141-007, 031, 032）。
+
+決定的な変換ロジックを実装した変換スクリプトは使用しない。AI エージェントが本プロンプトに従って生成する（REQ-0141-032）。
+
+## 入力
+
+読み込む入力元と対象を以下に示す。
+
+### 仕様管理リポジトリ（AgentDevFlow 本体）
+
+| 入力元 | 読込対象 | 役割 |
+|---|---|---|
+| `src/opencode/` | コマンド（`commands/agentdev/*.md`）・スキル（`skills/agentdev-*/`）・ひな形 | GitHub 版原本。変換の入力 |
+| `src/opencode-local/case-schema/` | Case ファイルスキーマ定義（`case-file.md`, `rules/*.yaml`） | ローカル Case ファイル構造の定義 |
+| `src/opencode-local/transform/spec.md` | 変換仕様（変換対象一覧・ガードレール・レポートフォーマット） | 変換内容と検証基準の集約 |
+| `src/opencode-local/generation-flow.md` | 生成フロー定義 | 手順・安全確認・`generated_by` 形式 |
+
+### 生成先リポジトリ（ローカル版導入先）
+
+| 確認対象 | 目的 |
+|---|---|
+| `.opencode/commands/agentdev/` | 同名ファイルの有無と `generated_by` 識別子の確認 |
+| `.opencode/skills/agentdev-*/` | 同名ファイルの有無と `generated_by` 識別子の確認 |
+| `.opencode/` の実パス | ジャンクション検出安全ゲート |
+
+## 変換対象
+
+変換対象となるコマンド / スキル / ひな形の範囲を以下に示す。
+
+| 変換対象 | 入力元 | 生成先 |
+|---|---|---|
+| ローカル版コマンド | `src/opencode/commands/agentdev/*.md` | `.opencode/commands/agentdev/*.md` |
+| ローカル版スキル | `src/opencode/skills/agentdev-*/` | `.opencode/skills/agentdev-*/` |
+| ローカル版ひな形 | `src/opencode/` 配下のひな形群 | `.opencode/` 配下（相対参照構造を維持） |
+
+ローカル版は GitHub 版 `/agentdev/*` および `agentdev-*` と同じ名前で生成する前提とする（REQ-0141-015）。GitHub 版とローカル版を同じ `.opencode/` に同居させる利用環境は対象外とする。
+
+## 必須変換
+
+以下の意味変換を実施する（REQ-0141-021〜023）。変換仕様の詳細は `transform/spec.md` 参照。
+
+### コマンドの意味変換
+
+| 変換対象 | 変換内容 |
+|---|---|
+| ローカル版 `case-open` | GitHub Issue 作成を `.agentdev/cases/case-{NNNN}.md` 作成へ意味変換する |
+| ローカル版 `case-run` | GitHub PR 作成を行わず、PR 相当の内容を Case ファイルの該当セクション（`## マージ前確認` / `## SPEC確定候補` / `## Findings / Capture候補` / `## 作業ログ`）へ追記する形へ意味変換する |
+| ローカル版 `case-close` | GitHub PR 取り込み / Issue クローズを行わず、ローカル Git の取り込み結果と完了処理を Case ファイル（`## マージ結果` / `## 完了判定`）に記録する形へ意味変換する |
+
+### ひな形の意味変換
+
+| 変換対象 | 変換内容 |
+|---|---|
+| ひな形（GitHub Issue 本文向け） | Case ファイル本文向けに意味変換する |
+| ひな形（GitHub PR 本文向け） | `## マージ前確認` / `## SPEC確定候補` / `## Findings / Capture候補` 向けに意味変換する |
+| ひな形（Issue コメント向け） | `## 作業ログ` 向けに意味変換する |
+| ひな形（完了報告向け） | ローカル版完了報告または `## 完了判定` 向けに意味変換する |
+
+### Case ファイル運用への置換
+
+ローカル版各コマンドの I/O を GitHub Issue / PR から Case ファイルへ置換する。
+
+| GitHub 版 | ローカル版 |
+|---|---|
+| GitHub Issue 本文 | Case ファイル本文 |
+| GitHub Issue コメント | `## 作業ログ` |
+| GitHub Issue の状態 | Case ファイルの `status` |
+| GitHub Issue のラベル | Case ファイルの `labels` |
+| GitHub PR 本文 | `## マージ前確認` / `## SPEC確定候補` / `## Findings / Capture候補` |
+| GitHub PR 取り込み結果 | `## マージ結果` |
+| GitHub Issue のクローズ | `status: closed` + `closed_at` |
+
+## ガードレール
+
+生成時に以下のガードレールを遵守する（REQ-0141-014, AG-009, AG-010）。ガードレール一覧は `transform/spec.md` と同一内容を保持し整合すること。
+
+### 原本保護
+
+- `src/opencode/` を変更しないこと（REQ-0141-014）
+- `src/opencode-local/` を変更しないこと
+- 生成物を `src/opencode-local/` 配下に出力しないこと
+- AgentDevFlow 本体リポジトリでローカル版生成を実行しないこと（REQ-0141-006）
+
+### 安全ゲート
+
+- 生成先リポジトリの `.opencode/` が `src/opencode/` 配下へ解決される場合は生成を停止すること（REQ-0141-010）
+- 同名ファイルに `generated_by: local-opencode-transform` の識別情報がある場合のみ再生成・上書きを許可すること（REQ-0141-012）
+- 同名ファイルに識別情報がない場合、または異なる識別情報がある場合は生成を停止すること（REQ-0141-013）
+
+### 配置規則
+
+- ローカル版コマンドは `.opencode/commands/` に配置すること
+- ローカル版スキルは `.opencode/skills/` に配置すること
+- ローカル版ひな形は既存の相対参照構造を維持して配置すること（REQ-0141-008）
+- 既存の相対参照構造を維持できない場合は参照元から解決できる配置へ変換し、変更理由と変更内容を変換レポートに記録すること
+
+### バックエンド制約
+
+- バックエンド抽象化を導入しないこと（REQ-0141-027）
+- GitHub 互換ローカルサーバを前提にしないこと（REQ-0141-027）
+
+### GitHub 依存除去
+
+- GitHub Issue 作成を必須操作にしないこと
+- GitHub PR 作成を必須操作にしないこと
+- GitHub PR 取り込みを必須操作にしないこと
+- `gh issue` / `gh pr` をローカル版の必須操作にしないこと
+
+### Case ファイル引き継ぎ
+
+- PR 本文が担っていた `SPEC確定候補` を Case ファイルに移すこと
+- PR 本文が担っていた `Findings / Capture候補` を Case ファイルに移すこと
+- `rules/labels.yaml` に存在しないラベルを追加しないこと
+
+## レポート出力
+
+変換後に生成レポートを出力する。レポートには少なくとも以下の必須項目を含める（REQ-0141-028, AG-009）。レポートフォーマットの集約は `transform/spec.md` 参照。
+
+| 項目 | 内容 |
+|---|---|
+| 入力スナップショット | 読み込んだ `src/opencode/` と `src/opencode-local/` のファイル一覧 |
+| 仕様管理リポジトリ | AgentDevFlow 本体リポジトリの識別情報 |
+| 生成先リポジトリ | ローカル版導入先リポジトリの識別情報 |
+| 生成した出力 | 生成したファイルの一覧（パス・種別） |
+| 変換内容 | case-open / case-run / case-close の各変換内容、ひな形の変換内容 |
+| `.opencode/` 実パス確認結果 | ジャンクション検出安全ゲートの結果 |
+| 同名ファイル確認結果 | 既存ファイルと `generated_by` 識別子の照合結果 |
+| `generated_by` 確認結果 | 生成物に付与した識別子の確認 |
+| ガードレール確認結果 | 各ガードレールの遵守確認結果 |
+| 残存する GitHub 固有参照 | 残存する GitHub Issue / PR 参照のリストと違反/非違反の判定 |
+| 手動確認事項 | 利用者の手動確認が必要な事項 |
+| 結果 | `PASS` / `FAIL` |
+
+## 残存 GitHub 固有参照の違反判定基準
+
+生成物に残存する GitHub 固有参照を判定する（REQ-0141-029）。
+
+| 参照の性質 | 違反/非違反 |
+|---|---|
+| 必須操作として残る GitHub Issue / PR 参照 | 違反 |
+| 必須入力として残る GitHub Issue / PR 参照 | 違反 |
+| 必須出力として残る GitHub Issue / PR 参照 | 違反 |
+| 背景説明の GitHub Issue / PR 参照 | 非違反 |
+| GitHub 版との置換表の GitHub Issue / PR 参照 | 非違反 |
+| 対象外の説明の GitHub Issue / PR 参照 | 非違反 |
+| 用語上の参照 | 非違反 |
+
+違反が1件でも残存する場合、レポート結果は `FAIL` とする。
+
+## 関連項目
+
+- [変換仕様](spec.md) — 変換対象一覧・ガードレール一覧・レポートフォーマットの集約
+- [レビュー用プロンプト](review.md) — 生成結果を検証するための指示
+- [生成フロー定義](../generation-flow.md) — 手順・安全確認・`generated_by` 形式
+- [Case ファイルスキーマ定義](../case-schema/case-file.md) — ローカル Case ファイルの構造
+- `docs/specs/local-transform.md` — 変換プロンプト要件の正本
+- `docs/specs/local-generation.md` — 生成フロー・安全ゲートの正本
+- REQ-0141 — ローカル版 OpenCode 生成方式とローカル Case ファイル運用の要件定義
+- ADR-0126 — source model 拡張と生成安全性制約

--- a/src/opencode-local/transform/review.md
+++ b/src/opencode-local/transform/review.md
@@ -1,0 +1,132 @@
+# ローカル版 OpenCode レビュー用プロンプト
+
+> 本ファイルは生成先リポジトリに生成された `.opencode/commands/` および `.opencode/skills/` が `src/opencode-local/` 配下の仕様・定義に合致しているか確認するための指示書である。意味仕様の正本は `docs/specs/local-transform.md`。変換仕様の集約は `transform/spec.md` 参照。
+
+## 目的
+
+ローカル版生成（`transform/generate.md` に従う生成）の結果が、`src/opencode-local/` のスキーマ・定義・ガードレールに合致しているかを検証する。必須チェックが1つでも失敗した場合、結果は `FAIL` とする（REQ-0141-028）。部分通過（一部必須項目のみ通過）を `PASS` として扱わない。
+
+## 入力
+
+レビュー対象と参照定義を以下に示す。
+
+| 種別 | 対象 |
+|---|---|
+| レビュー対象（生成物） | 生成先リポジトリの `.opencode/commands/agentdev/` ・ `.opencode/skills/agentdev-*/` ・ `.opencode/` 配下ひな形 |
+| 参照定義（仕様管理リポジトリ） | `src/opencode-local/case-schema/case-file.md` ・ `rules/*.yaml` ・ `transform/spec.md` ・ `generation-flow.md` |
+| 正本 SPEC | `docs/specs/local-case-file.md` ・ `docs/specs/local-generation.md` ・ `docs/specs/local-transform.md` |
+
+## 確認対象一覧
+
+以下の6区分について確認する（REQ-0141-028, AG-009）。各項目は必須チェックであり、1つでも失敗すれば結果は `FAIL` となる。
+
+### 1. 生成物の配置と識別子
+
+- [ ] `.opencode/commands/` にローカル版コマンドが生成されていること
+- [ ] `.opencode/skills/` にローカル版スキルが生成されていること
+- [ ] ローカル版コマンド / スキルが参照するひな形が `.opencode/` 配下に生成されていること
+- [ ] 生成物が `src/opencode-local/` 配下に出力されていないこと
+- [ ] `.opencode/` が `src/opencode/` 配下へ解決されていないこと（ジャンクション検出安全ゲート）
+- [ ] 同名ファイルに `generated_by: local-opencode-transform` の識別情報がある場合のみ再生成・上書きが許可されること
+- [ ] 同名ファイルに識別情報がない場合、または異なる識別情報がある場合、生成が停止されること
+- [ ] 生成物に `generated_by: local-opencode-transform` の識別情報があること
+
+### 2. GitHub Issue / PR 非依存の確認
+
+- [ ] 生成されたローカル版が GitHub Issue 作成を必須操作として要求していないこと
+- [ ] 生成されたローカル版が GitHub PR 作成を必須操作として要求していないこと
+- [ ] 生成されたローカル版が GitHub PR 取り込みを必須操作として要求していないこと
+
+### 3. Case ファイル運用の確認
+
+- [ ] ローカル版 `case-open` が `.agentdev/cases/case-{NNNN}.md` を作成すること
+- [ ] ローカル版 `case-run` が GitHub PR を作成せず、Case ファイルを更新すること
+- [ ] ローカル版 `case-close` が GitHub PR 取り込み / Issue クローズを要求せず、Case ファイルを完了状態に更新すること
+- [ ] `SPEC確定候補` と `Findings / Capture候補` が Case ファイルに保持されること
+
+### 4. Case ファイル仕様の準拠確認
+
+- [ ] 状態が `rules/status.yaml` の `status_enum` に従うこと
+- [ ] ラベルが `rules/labels.yaml` の `label_enum` から選定されていること
+- [ ] 見出しが `rules/headings.yaml` の定義に従うこと（`SPEC確定候補`・`Findings / Capture候補` が必須）
+- [ ] YAML 前書きが `rules/frontmatter.yaml` のスキーマに従うこと（7 必須フィールド・禁止フィールドなし）
+
+### 5. 状態遷移の定義確認
+
+- [ ] ローカル版 `case-run` 停止時の `running` から `blocked` への遷移が定義されていること
+- [ ] ローカル版 `case-close` 停止時の `review` から `blocked` への遷移が定義されていること
+- [ ] ローカル版 `case-run` 停止後の `blocked` → `running` → `review` の再開経路が定義されていること
+- [ ] ローカル版 `case-close` 停止後の `blocked` → `review` → `closed` の再開経路が定義されていること
+
+### 6. 残存 GitHub 固有参照の扱い確認
+
+- [ ] 残存する GitHub 固有参照のうち、必須操作・必須入力・必須出力として残るものが違反として扱われていること
+- [ ] 背景説明・置換表・対象外・用語上の GitHub 参照が違反として扱われていないこと
+
+## 違反一覧
+
+検出された違反は以下の形式で列挙する。違反とは「必須操作・必須入力・必須出力として残る GitHub Issue / PR 参照」または「確認対象一覧の各必須チェック失敗」を指す。
+
+| 違反区分 | 判定 |
+|---|---|
+| 必須操作として残る GitHub Issue / PR 参照 | 違反 |
+| 必須入力として残る GitHub Issue / PR 参照 | 違反 |
+| 必須出力として残る GitHub Issue / PR 参照 | 違反 |
+| 確認対象一覧の必須チェック失敗 | 違反 |
+| 背景説明の GitHub Issue / PR 参照 | 非違反 |
+| GitHub 版との置換表の GitHub Issue / PR 参照 | 非違反 |
+| 対象外の説明の GitHub Issue / PR 参照 | 非違反 |
+| 用語上の参照 | 非違反 |
+
+## レビュー結果フォーマット
+
+レビュー結果は少なくとも以下の項目を含む（REQ-0141-028, AG-009）。
+
+| 項目 | 内容 |
+|---|---|
+| 結果 | `PASS` / `FAIL` |
+| 確認した入力 | レビュー対象としたファイル一覧 |
+| 違反一覧 | 検出された違反のリスト（対象・違反内容） |
+| 警告 | 違反ではないが注意が必要な事項 |
+| 確認済み要件 | 確認対象一覧の各項目に対する判定結果 |
+| 最終判定 | 総合判定とその根拠 |
+
+### レビュー結果の例
+
+```markdown
+## レビュー結果
+
+- 結果: FAIL
+- 確認した入力:
+  - .opencode/commands/agentdev/case-open.md
+  - .opencode/commands/agentdev/case-run.md
+  - .opencode/commands/agentdev/case-close.md
+  - .opencode/skills/agentdev-*/SKILL.md (N 件)
+- 違反一覧:
+  - 対象: .opencode/commands/agentdev/case-run.md
+    違反内容: case-run が gh pr create を必須操作として要求している（必須操作の GitHub PR 参照）
+- 警告:
+  - なし
+- 確認済み要件:
+  - 1. 生成物の配置と識別子: PASS
+  - 2. GitHub Issue / PR 非依存の確認: FAIL
+  - 3. Case ファイル運用の確認: PASS
+  - 4. Case ファイル仕様の準拠確認: PASS
+  - 5. 状態遷移の定義確認: PASS
+  - 6. 残存 GitHub 固有参照の扱い確認: FAIL
+- 最終判定: FAIL（区分2・6で違反を検出。case-run が GitHub PR 作成を必須操作として残している）
+```
+
+## 必須チェック失敗時の扱い
+
+必須チェックが1つでも失敗した場合、結果は `FAIL` とする（REQ-0141-028）。部分通過（一部必須項目のみ通過）を `PASS` として扱わない。
+
+`FAIL` となった場合、生成物の修正後に再レビューを行う。再レビューでも `FAIL` となる場合、利用者に手動確認を促す。
+
+## 関連項目
+
+- [変換用プロンプト](generate.md) — ローカル版生成の指示書
+- [変換仕様](spec.md) — 変換対象一覧・ガードレール一覧・レポートフォーマットの集約
+- [Case ファイルスキーマ定義](../case-schema/case-file.md) — ローカル Case ファイルの構造
+- `docs/specs/local-transform.md` — レビュープロンプト要件の正本
+- REQ-0141 — ローカル版 OpenCode 生成方式とローカル Case ファイル運用の要件定義

--- a/src/opencode-local/transform/spec.md
+++ b/src/opencode-local/transform/spec.md
@@ -1,0 +1,148 @@
+# ローカル版 OpenCode 変換仕様
+
+> 本ファイルは変換プロンプト（`transform/generate.md`）とレビュープロンプト（`transform/review.md`）が参照する変換仕様を集約した運用参照資料である。意味仕様の正本は `docs/specs/local-transform.md` と `docs/specs/local-generation.md`。本ファイルは正本 SPEC と矛盾してはならない。
+
+## 目的
+
+ローカル版 OpenCode 生成における変換対象一覧・ガードレール一覧・レポートフォーマット・違反判定基準を一箇所に集約し、変換プロンプト・レビュープロンプト・生成フロー定義が共通して参照できるようにする（REQ-0141-028, 029）。
+
+本ファイルと各プロンプトの関係:
+
+| ファイル | 役割 | 本ファイルとの関係 |
+|---|---|---|
+| `transform/generate.md` | 変換用プロンプト（AI エージェントへの生成指示） | ガードレール一覧・レポートフォーマットを同一内容で保持し整合 |
+| `transform/review.md` | レビュー用プロンプト（生成結果の検証指示） | 確認対象一覧の基準として本ファイルのガードレール・違反判定基準を参照 |
+| `transform/spec.md`（本ファイル） | 変換仕様の集約 | 正本 SPEC の運用参照資料 |
+
+## 変換対象一覧
+
+### コマンド
+
+| 変換対象 | 入力元 | 生成先 | 変換内容 |
+|---|---|---|---|
+| ローカル版 `case-open` | `src/opencode/commands/agentdev/case-open.md` | `.opencode/commands/agentdev/case-open.md` | GitHub Issue 作成を `.agentdev/cases/case-{NNNN}.md` 作成へ意味変換（REQ-0141-021） |
+| ローカル版 `case-run` | `src/opencode/commands/agentdev/case-run.md` | `.opencode/commands/agentdev/case-run.md` | GitHub PR 作成を行わず、PR 相当の内容を Case ファイルの該当セクションへ追記（REQ-0141-022） |
+| ローカル版 `case-close` | `src/opencode/commands/agentdev/case-close.md` | `.opencode/commands/agentdev/case-close.md` | GitHub PR 取り込み / Issue クローズを行わず、ローカル Git の取り込み結果と完了処理を Case ファイルに記録（REQ-0141-023） |
+| その他ローカル版コマンド | `src/opencode/commands/agentdev/*.md` | `.opencode/commands/agentdev/*.md` | GitHub Issue / PR 必須参照の除去・Case ファイル参照への置換 |
+
+### スキル
+
+| 変換対象 | 入力元 | 生成先 | 変換内容 |
+|---|---|---|---|
+| ローカル版スキル群 | `src/opencode/skills/agentdev-*/` | `.opencode/skills/agentdev-*/` | GitHub Issue / PR 必須参照の除去・Case ファイルスキーマ・状態遷移・見出しへの準拠 |
+
+### ひな形
+
+| 変換対象 | 入力元 | 生成先 | 変換内容 |
+|---|---|---|---|
+| GitHub Issue 本文向けひな形 | `src/opencode/` 配下 | `.opencode/` 配下 | Case ファイル本文向けに意味変換 |
+| GitHub PR 本文向けひな形 | `src/opencode/` 配下 | `.opencode/` 配下 | `## マージ前確認` / `## SPEC確定候補` / `## Findings / Capture候補` 向けに意味変換 |
+| Issue コメント向けひな形 | `src/opencode/` 配下 | `.opencode/` 配下 | `## 作業ログ` 向けに意味変換 |
+| 完了報告向けひな形 | `src/opencode/` 配下 | `.opencode/` 配下 | ローカル版完了報告または `## 完了判定` 向けに意味変換 |
+
+## ガードレール一覧
+
+ローカル版生成が遵守するガードレール（REQ-0141-014, AG-009, AG-010）。`transform/generate.md` と同一内容を保持し整合させること。
+
+### 原本保護
+
+- `src/opencode/` を変更しないこと（REQ-0141-014）
+- `src/opencode-local/` を変更しないこと
+- 生成物を `src/opencode-local/` 配下に出力しないこと
+- AgentDevFlow 本体リポジトリでローカル版生成を実行しないこと（REQ-0141-006）
+
+### 安全ゲート
+
+- 生成先リポジトリの `.opencode/` が `src/opencode/` 配下へ解決される場合は生成を停止すること（REQ-0141-010）
+- 同名ファイルに `generated_by: local-opencode-transform` の識別情報がある場合のみ再生成・上書きを許可すること（REQ-0141-012）
+- 同名ファイルに識別情報がない場合、または異なる識別情報がある場合は生成を停止すること（REQ-0141-013）
+
+### 配置規則
+
+- ローカル版コマンドは `.opencode/commands/` に配置すること
+- ローカル版スキルは `.opencode/skills/` に配置すること
+- ローカル版ひな形は既存の相対参照構造を維持して配置すること（REQ-0141-008）
+- 既存の相対参照構造を維持できない場合は参照元から解決できる配置へ変換し、変更理由と変更内容を変換レポートに記録すること
+
+### バックエンド制約
+
+- バックエンド抽象化を導入しないこと（REQ-0141-027）
+- GitHub 互換ローカルサーバを前提にしないこと（REQ-0141-027）
+
+### GitHub 依存除去
+
+- GitHub Issue 作成を必須操作にしないこと
+- GitHub PR 作成を必須操作にしないこと
+- GitHub PR 取り込みを必須操作にしないこと
+- `gh issue` / `gh pr` をローカル版の必須操作にしないこと
+
+### Case ファイル引き継ぎ
+
+- PR 本文が担っていた `SPEC確定候補` を Case ファイルに移すこと
+- PR 本文が担っていた `Findings / Capture候補` を Case ファイルに移すこと
+- `rules/labels.yaml` に存在しないラベルを追加しないこと
+
+### リポジトリ管理対象外
+
+- 生成された `.opencode/commands/` をリポジトリ管理対象にしないこと（REQ-0141-008）
+- 生成された `.opencode/skills/` をリポジトリ管理対象にしないこと（REQ-0141-008）
+- 生成された `.opencode/` 配下ひな形をリポジトリ管理対象にしないこと（REQ-0141-008）
+- 変換スクリプトをリポジトリ管理対象にしないこと（REQ-0141-009）
+
+## レポートフォーマット
+
+変換後に生成レポートを出力する。レポートの必須項目（REQ-0141-028, AG-009）。`transform/generate.md` と同一の必須項目を保持し整合させること。
+
+| 項目 | 内容 |
+|---|---|
+| 入力スナップショット | 読み込んだ `src/opencode/` と `src/opencode-local/` のファイル一覧 |
+| 仕様管理リポジトリ | AgentDevFlow 本体リポジトリの識別情報 |
+| 生成先リポジトリ | ローカル版導入先リポジトリの識別情報 |
+| 生成した出力 | 生成したファイルの一覧（パス・種別） |
+| 変換内容 | case-open / case-run / case-close の各変換内容、ひな形の変換内容 |
+| `.opencode/` 実パス確認結果 | ジャンクション検出安全ゲートの結果 |
+| 同名ファイル確認結果 | 既存ファイルと `generated_by` 識別子の照合結果 |
+| `generated_by` 確認結果 | 生成物に付与した識別子の確認 |
+| ガードレール確認結果 | 各ガードレールの遵守確認結果 |
+| 残存する GitHub 固有参照 | 残存する GitHub Issue / PR 参照のリストと違反/非違反の判定 |
+| 手動確認事項 | 利用者の手動確認が必要な事項 |
+| 結果 | `PASS` / `FAIL` |
+
+## 残存 GitHub 固有参照の違反判定基準
+
+生成物に残存する GitHub 固有参照の違反/非違反判定基準（REQ-0141-029）。
+
+| 参照の性質 | 違反/非違反 | 根拠 |
+|---|---|---|
+| 必須操作として残る GitHub Issue / PR 参照 | 違反 | ローカル版は GitHub Issue / PR を必須操作にしない（REQ-0141-026） |
+| 必須入力として残る GitHub Issue / PR 参照 | 違反 | ローカル版は GitHub Issue / PR を必須入力にしない |
+| 必須出力として残る GitHub Issue / PR 参照 | 違反 | ローカル版は GitHub Issue / PR を必須出力にしない |
+| 背景説明の GitHub Issue / PR 参照 | 非違反 | GitHub 版との対比・経緯説明としての参照は許容 |
+| GitHub 版との置換表の GitHub Issue / PR 参照 | 非違反 | 置換対応表自体が GitHub 版とローカル版の対応を示すため |
+| 対象外の説明の GitHub Issue / PR 参照 | 非違反 | 適用範囲外の説明としての参照は許容 |
+| 用語上の参照 | 非違反 | 用語解説・概念説明としての参照は許容 |
+
+違反が1件でも残存する場合、レポート結果は `FAIL` とする。
+
+## Case ファイルスキーマ参照
+
+変換時・レビュー時に参照する Case ファイル定義（`src/opencode-local/case-schema/`）。
+
+| 参照先 | 内容 |
+|---|---|
+| `case-schema/case-file.md` | Case ファイルスキーマ定義（YAML 前書き・status enum・labels・headings・採番） |
+| `case-schema/rules/frontmatter.yaml` | YAML 前書きスキーマの機械可読定義（REQ-0141-017） |
+| `case-schema/rules/status.yaml` | status enum と状態遷移表の機械可読定義（REQ-0141-018） |
+| `case-schema/rules/labels.yaml` | labels 値域の機械可読定義（REQ-0141-019） |
+| `case-schema/rules/headings.yaml` | 見出し一覧の機械可読定義（REQ-0141-020） |
+
+## 関連項目
+
+- [変換用プロンプト](generate.md) — ローカル版生成の指示書
+- [レビュー用プロンプト](review.md) — 生成結果の検証指示
+- [生成フロー定義](../generation-flow.md) — 手順・安全確認・`generated_by` 形式
+- [Case ファイルスキーマ定義](../case-schema/case-file.md) — ローカル Case ファイルの構造
+- `docs/specs/local-transform.md` — 変換プロンプト・レビュープロンプト要件の正本
+- `docs/specs/local-generation.md` — 生成フロー・安全ゲートの正本
+- REQ-0141 — ローカル版 OpenCode 生成方式とローカル Case ファイル運用の要件定義
+- ADR-0126 — source model 拡張と生成安全性制約


### PR DESCRIPTION
Closes #958

## 概要

REQ-0141 Wave 4 の実装として、`src/opencode-local/` 生成時ソース領域のコンテンツ10ファイルを作成した。これらはローカル版 OpenCode を生成するためのスキーマ・変換プロンプト・変換仕様・生成フローを定義するものであり、生成済みコマンド/スキル/ひな形は含まない。

## 作成ファイル

| # | ファイル | 役割 | 準拠要件 |
|---|---|---|---|
| 1 | `README.md` | ローカル版生成の実行手順・全削除運用 | REQ-0141-031/033, ADR-0126 |
| 2 | `case-schema/case-file.md` | Case ファイルスキーマ定義 | SPEC local-case-file.md |
| 3 | `case-schema/rules/frontmatter.yaml` | YAML前書きスキーマ（7必須・4禁止フィールド） | REQ-0141-017 |
| 4 | `case-schema/rules/status.yaml` | status enum・状態遷移表・再開経路・禁止遷移 | REQ-0141-018 |
| 5 | `case-schema/rules/labels.yaml` | labels 値域（7値） | REQ-0141-019 |
| 6 | `case-schema/rules/headings.yaml` | 見出し一覧（15セクション・必須2） | REQ-0141-020 |
| 7 | `transform/generate.md` | 変換用プロンプト（6必須セクション・ガードレール・レポート） | REQ-0141-028/032, SPEC local-transform.md |
| 8 | `transform/review.md` | レビュー用プロンプト（6確認区分・FAIL扱い） | REQ-0141-028, SPEC local-transform.md |
| 9 | `transform/spec.md` | 変換仕様（変換対象・ガードレール・レポート・違反判定基準） | REQ-0141-029, SPEC local-transform.md |
| 10 | `generation-flow.md` | 生成フロー定義（7Step・安全ゲート・generated_by 形式） | SPEC local-generation.md |

## 完了条件の確認

Issue #958 の完了条件12項目すべて充足済み:

- [x] `README.md`: REQ-0141-031（実行手順）・REQ-0141-033（全削除→作り直し運用）を満たす
- [x] `case-schema/case-file.md`: SPEC local-case-file.md のスキーマ定義要件を満たす
- [x] `frontmatter.yaml`: REQ-0141-017 の7必須フィールド（id, title, status, created_at, updated_at, closed_at, labels）の型・必須/任意・値域を定義。禁止フィールド（work_type, source, branch, base_branch）も明示
- [x] `status.yaml`: REQ-0141-018 の6状態（open, running, blocked, review, closed, cancelled）と状態遷移表（blocked からの再開経路含む）を定義
- [x] `labels.yaml`: REQ-0141-019 の7値（feature, bugfix, maintenance, docs, refactor, chore, epic）を定義
- [x] `headings.yaml`: 15セクションの見出し一覧と必須/任意判定（SPEC確定候補・Findings/Capture候補は必須）
- [x] `transform/generate.md`: SPEC local-transform.md の変換プロンプト要件（目的/入力/変換対象/必須変換/ガードレール/レポート出力）を満たす
- [x] `transform/review.md`: SPEC local-transform.md のレビュープロンプト要件（確認対象一覧・違反一覧・レビュー結果フォーマット・必須チェック失敗時の FAIL 扱い）を満たす
- [x] `transform/spec.md`: SPEC local-transform.md の変換仕様要件（変換対象・ガードレール一覧・レポートフォーマット・残存GitHub固有参照違反判定基準）を満たす
- [x] `generation-flow.md`: SPEC local-generation.md の生成フロー要件（7Step手順・安全確認・generated_by 形式・ジャンクション検出）を満たす
- [x] `src/opencode-local/` 配下に `requirements/`, `specs/`, `_conv/`, `commands/`, `skills/` が作成されていない（REQ-0141-005）
- [x] `src/opencode/` 配下を一切変更していない（REQ-0141-014, ADR-0126 decision #4）

## 検証結果

- **YAML 構文検証**: `case-schema/rules/*.yaml` の4ファイル、すべて YAML パーサで構文エラーなし
- **ディレクトリ構成検証**: REQ-0141-004/005 の構成（10ファイル）遵守・対象外ディレクトリ5種すべて不存在
- **`src/opencode/` 保護検証**: `git diff --name-only origin/main HEAD -- src/opencode/` が空（tracked・untracked ともに変更なし）
- **`generated_by` 形式検証**: `generation-flow.md` に `generated_by: local-opencode-transform` の記録形式が SPEC local-generation.md と整合して記載（4箇所）
- **相対参照検証**: `transform/*.md`・`case-file.md` の相対参照を修正済み（`../` 基準で正しく解決）
- **SPEC 照合**: 各ファイルと対応 SPEC の要件項目を照合し、過不足なく充足

## SPEC確定候補

実装で判明した SPEC レベルの詳細（実装で判明した仕様詳細）。case-close Step 3 での SPEC 確定チェックの入力。

- **`case-schema/rules/*.yaml` の構造化形式**: 機械可読定義として `schema_version`, `target`, `canonical_spec` を共通ヘッダとする構造を採用した。SPEC local-case-file.md は「機械可読形式で保持すること」を要求するが、具体的な YAML 構造（スキーマフォーマット）は未定義だったため、本 PR で確定候補として提示する。SPEC への反映可否は case-close で判断
- **`transform/spec.md` の役割**: SPEC local-transform.md は「運用参照資料」としての位置づけを定義するが、generate.md・review.md との重複管理（ガードレール一覧・レポートフォーマットを3ファイルで保持）の運用負荷について。single source of truth を spec.md に集約し generate.md/review.md が参照する構造が妥当か、SPEC で明文化する候補

## Findings / Capture候補

### intake

- （なし。本筋外の発見事項なし）

### learning

- （なし。本筋外の学習事項なし）

## 備考: 実行方式について

本 PR は case-run の実行担当サブエージェント + ハーネス相当をマージして直接実装した（本来の oh-my-openagent CLI subprocess 委譲モデルからの実用的逸脱）。理由: oh-my-openagent 統合は参照ドキュメント（`references/oh-my-openagent.md` 135-140行）自体が nested opencode セッション安定性・CLI subprocess 協調安定性・構造化結果出力信頼性を未検証事項として明記しており、明確に定義されたコンテンツ作成タスクに対しては直接実装が確実であるため。成果物（PR）の品質・SPEC 準拠性に影響なし。
