### PR TITLE
docs: ローカル版 OpenCode 整合性ルール・所有権・REQ影響マップ・ガイド群の更新 (Wave 5)

### DIFF
--- a/docs/guides/consumer-project-setup.md
+++ b/docs/guides/consumer-project-setup.md
@@ -2,13 +2,16 @@
 
 AgentDevFlow を適用プロジェクトに導入する際のモデルを定義する（REQ-0103-061~065, REQ-0103-072~077）。
 
-## 4 種のリポジトリ種別（Repo Type）
+## リポジトリ種別（Repo Type）
+
+AgentDevFlow は5種のリポジトリ種別を定義する（詳細は SPEC [実行時パッケージ境界](../specs/runtime-package-boundary.md)）。本ガイドでは導入観点から各々を説明する。
 
 | 種別 | 説明 | `.opencode/` の意味 | 例 |
 |------|------|---------------------|-----|
-| **本体リポジトリ** | AgentDevFlow 本体開発リポジトリ。原本と配置先が同一リポジトリに存在 | `.opencode/` = 実行時の配置先（junction → `src/opencode/`） | agent-dev-flow |
+| **本体リポジトリ**（self-hosting） | AgentDevFlow 本体開発リポジトリ。原本と配置先が同一リポジトリに存在 | `.opencode/` = 実行時の配置先（junction → `src/opencode/`） | agent-dev-flow |
 | **consumer-with-agentdev** | AgentDevFlow を導入する製品リポジトリ。AgentDevFlow 提供 skill/command を利用 | `.opencode/` = プロジェクト独自設定の入口 + AgentDevFlow 提供 command/skill の実行時の位置 | 各種製品開発リポジトリ |
 | **consumer-local** | AgentDevFlow を利用しない OpenCode プロジェクト。独自 command/skill のみ | `.opencode/` = プロジェクト独自設定専用。`agentdev` 名前空間は使用しない | 実験的リポジトリ |
+| **consumer-generated** | ローカル版 OpenCode を導入する利用側リポジトリ。GitHub Issue/PR を使わない個人利用環境向け | `.opencode/` = 生成された AgentDevFlow 実行時の位置（実ディレクトリ・非ジャンクション）。`generated_by: local-opencode-transform` 識別子を保持 | 個人利用環境のローカルリポジトリ |
 | **plugin-future** | 将来の plugin/npm/package 配布形態（現在は未対応） | `.opencode/` = plugin が管理する実行時の位置 | （将来） |
 
 ## `.opencode/` の意味の違い
@@ -60,19 +63,72 @@ scripts/
 - AgentDevFlow の名前空間を使用しない
 - 自由に `.opencode/` を管理する
 
+### Consumer-generated（ローカル版 OpenCode 導入）
+
+GitHub Issue/PR を使わない個人利用環境向けのリポジトリ種別。AgentDevFlow 本体リポジトリの `src/opencode/` と `src/opencode-local/` を入力とし、AI エージェントが変換プロンプト（`src/opencode-local/transform/generate.md`）に従って `.opencode/commands/agentdev/` と `.opencode/skills/agentdev-*/` に直接生成する（REQ-0141, ADR-0126）。詳細な生成フロー・安全ゲートは SPEC [ローカル版 OpenCode 生成](../specs/local-generation.md) を参照。
+
+```
+.agentdev-plugin/                → agent-dev-flow の git clone 先（生成時入力の取得元）
+  src/opencode/                  → GitHub 版 AgentDevFlow の原本（生成入力その1）
+  src/opencode-local/            → ローカル版生成時ソース領域（生成入力その2）
+    README.md                    → ローカル版生成の実行手順
+    case-schema/                 → ローカル Case ファイルスキーマ定義
+    transform/                   → 変換用プロンプト・レビュー用プロンプト・変換仕様
+    generation-flow.md           → 生成フロー定義
+.opencode/
+  commands/agentdev/             → 生成されたローカル版コマンド（実ディレクトリ・非ジャンクション）
+  skills/agentdev-*/             → 生成されたローカル版スキル（実ディレクトリ・非ジャンクション）
+.agentdev/
+  cases/                         → ローカル Case ファイル（Issue / PR 相当の永続情報）
+```
+
+- **生成物の識別子**: 生成された `.opencode/commands/agentdev/**/*.md`・`.opencode/skills/agentdev-*/**/*.md` は `generated_by: local-opencode-transform` 識別子を持つ（REQ-0141-011）
+- **上書き安全性**: 同名ファイル上書きは `generated_by` 識別子が一致する場合のみ許可される（REQ-0141-012, 013）
+- **ジャンクション検出安全ゲート**: 生成前に `.opencode/` の実パスを確認し、`.opencode/` が `src/opencode/` 配下へ解決される場合は生成を停止する（REQ-0141-010）
+- **リポジトリ管理対象外**: 生成された `.opencode/commands/`, `.opencode/skills/`, `.opencode/` 配下ひな形・変換スクリプトはリポジトリ管理対象外（REQ-0141-008, 009）
+- **リポジトリ管理対象**: `.agentdev/cases/` 配下のローカル Case ファイルは Issue/PR 相当の永続情報としてリポジトリ管理対象（REQ-0141-016）
+- **更新方式**: 差分更新を想定しない。`.opencode/commands/agentdev/` と `.opencode/skills/agentdev-*/` を全削除して作り直す（REQ-0141-033）
+- **判定基準**: `.opencode/commands/agentdev/` が実ディレクトリ（非ジャンクション）で `generated_by: local-opencode-transform` を含む場合に consumer-generated と判定される（SPEC runtime-package-boundary.md）
+
+#### ローカル版セットアップ手順
+
+1. agent-dev-flow リポジトリを `.agentdev-plugin/` に clone する
+2. OpenCode 等 AI エージェントで `src/opencode-local/README.md` の実行手順に従う
+3. AI エージェントが `src/opencode-local/transform/generate.md`（変換用プロンプト）を入力またはファイル参照して実行する
+4. `.opencode/commands/agentdev/` と `.opencode/skills/agentdev-*/` に生成物が配置されることを確認する
+5. `generated_by: local-opencode-transform` 識別子が付与されていることを確認する
+6. `.agentdev/cases/` ディレクトトリが存在することを確認する（ローカル Case ファイル用）
+7. `.gitignore` に生成物（`.opencode/commands/agentdev/`, `.opencode/skills/agentdev-*/`）を追加する
+
+#### ローカル版の更新手順
+
+```powershell
+# agent-dev-flow の最新を取得
+cd .agentdev-plugin && git pull && cd ..
+
+# ローカル版の全削除と再生成（差分更新は非対応）
+# 1. .opencode/commands/agentdev/ と .opencode/skills/agentdev-*/ を削除
+# 2. 変換プロンプトを再実行（src/opencode-local/README.md の手順に従う）
+```
+
+> 詳細な実行手順・制約・安全ゲートは `src/opencode-local/README.md`（生成時ソース領域の実行エントリポイント）と SPEC [ローカル版 OpenCode 生成](../specs/local-generation.md)・[ローカル Case ファイル](../specs/local-case-file.md)・[ローカル版 OpenCode 変換プロンプト](../specs/local-transform.md) を参照。
+
 ## 予約名（Reserved Names）
 
 | 名前 | 種別 | 使用可能なリポジトリ種別 |
 |------|------|---------------------|
-| `agentdev` | コマンド名前空間 | `self-hosting`, `consumer-with-agentdev` |
-| `agentdev-*` | スキルプレフィックス | `self-hosting`, `consumer-with-agentdev` |
-| `.agentdev/` | ドメイン状態ディレクトリ | `self-hosting`, `consumer-with-agentdev` |
-| `.agentdev-plugin/` | 適用プロジェクトの clone 先 | consumer-with-agentdev |
+| `agentdev` | コマンド名前空間 | `self-hosting`, `consumer-with-agentdev`, `consumer-generated` |
+| `agentdev-*` | スキルプレフィックス | `self-hosting`, `consumer-with-agentdev`, `consumer-generated` |
+| `.agentdev/` | ドメイン状態ディレクトリ | `self-hosting`, `consumer-with-agentdev`, `consumer-generated` |
+| `.agentdev-plugin/` | 適用プロジェクトの clone 先 | `consumer-with-agentdev`, `consumer-generated` |
+| `generated_by: local-opencode-transform` | 生成物識別子 | `consumer-generated` のみ付与（REQ-0141-011） |
 
 **禁止事項**:
 - consumer-local での `agentdev` 名前空間の使用（REQ-0103-056）
 - consumer-with-agentdev での AgentDevFlow 提供ファイルの直接編集（上書きされる可能性）
 - `.agentdev-plugin/` を `.agentdev/` として使用すること（ドメイン状態と競合）
+- consumer-generated での `generated_by` 識別子を持たないファイル・異なる識別子を持つファイルの上書き（REQ-0141-012, 013）
+- consumer-generated での `.opencode/` が `src/opencode/` 配下へ解決される環境での生成実行（REQ-0141-010）
 
 > **注意**: `agentdev-integrity`（旧 integrity skill）は AgentDevFlow 配布対象外となった（ADR-0106）。docs-check は `repo-agentdev-integrity`（配布対象外スキル）として AgentDevFlow 本体リポジトリでのみ実行される。適用プロジェクトには配布されない。
 
@@ -121,7 +177,8 @@ cd .agentdev-plugin && git pull && cd ..
 |--------|---------------|------|
 | `scripts/sync-self-opencode.ps1` | `self-hosting` | `src/opencode/` ↔ `.opencode/` の同期 |
 | `scripts/install-consumer-opencode.ps1` | `consumer-with-agentdev` | `.agentdev-plugin/` clone + ジャンクション 作成 |
-| `scripts/check-consumer-opencode.ps1` | consumer-with-agentdev | インストール状態の検証 |
+| `scripts/check-consumer-opencode.ps1` | `consumer-with-agentdev` | インストール状態の検証 |
+| （決定的変換スクリプトなし） | `consumer-generated` | 決定的な変換ロジックを実装したスクリプトは使用しない（REQ-0141-032）。AI エージェントが `src/opencode-local/transform/generate.md` 変換プロンプトに従って生成する |
 
 ### Self-hosting での同期
 

--- a/docs/guides/glossary.md
+++ b/docs/guides/glossary.md
@@ -34,6 +34,7 @@ AgentDevFlow で使う用語の定義。
 | promoted artifact（採用済み成果物） | backlog-review の入力となる整形済み成果物。Intake/Learning それぞれの `promoted/` に配置 |
 | セッション由来 RU | チャット内で合意形成済みの内容を直接保存した RU |
 | evaluation-report | learning-promote 内部で生成される分析レポート。同コマンドの昇華判定フェーズの入力として使用される |
+| ローカル Case ファイル（Local Case File） | GitHub Issue/PR を使わない個人利用環境（ローカル版 OpenCode）で Issue/PR 相当の永続情報を保持するファイル。`.agentdev/cases/case-{NNNN}.md` に配置（REQ-0141-016）。詳細なスキーマは SPEC `local-case-file.md` 参照 |
 
 ## パイプライン
 
@@ -75,3 +76,22 @@ AgentDevFlow で使う用語の定義。
 | Script | ガードレール・検査・補助処理の実行可能ロジック。Skill 配下 `scripts/` に配置 |
 | 原本（source） | `src/opencode/` 配下の正規の定義ファイル。AgentDevFlow 本体の command/skill/template はここに配置される |
 | 配置先（projection） | `.opencode/` 配下の実行時の配布先。AgentDevFlow 本体リポジトリでは ジャンクション/symlink による投影先、適用プロジェクトでは install script による配置先 |
+
+## ローカル版 OpenCode
+
+GitHub Issue/PR を使わない個人利用環境向けの AgentDevFlow 利用形態（REQ-0141, ADR-0126）に関連する用語。
+
+| 用語 | 定義 |
+|------|------|
+| ローカル版 OpenCode | GitHub Issue/PR を使わない個人利用環境向けの AgentDevFlow 利用形態（REQ-0141-001）。GitHub 版 AgentDevFlow の原本を変換プロンプト経由でローカル運用向けに生成して利用する |
+| 仕様管理リポジトリ | AgentDevFlow 本体リポジトリ（agent-dev-flow）。ローカル版生成の入力元として扱われる（REQ-0141-002） |
+| 生成先リポジトリ | ローカル版 OpenCode を導入する利用側リポジトリ。`consumer-generated` リポジトリ種別に対応（REQ-0141-002） |
+| consumer-generated | ローカル版 OpenCode を導入するリポジトリ種別。`.opencode/commands/agentdev/` が実ディレクトリ（非ジャンクション）かつ `generated_by: local-opencode-transform` 識別子を含むことで判定される（SPEC `runtime-package-boundary.md`） |
+| `generated_by` 識別子 | ローカル版生成物に付与される識別情報。値は `local-opencode-transform`（REQ-0141-011）。同名ファイル上書きは本識別子が一致する場合のみ許可される（REQ-0141-012, 013）。IR-048 で整合性を検証 |
+| `src/opencode-local/` | ローカル版生成時ソース領域。AgentDevFlow 本体リポジトリに配置され、`README.md`・`case-schema/`・`transform/`・`generation-flow.md` のみを保持する（REQ-0141-004, 005）。IR-047 でディレクトリ構成を検証 |
+| 生成時ソース（generation-time source） | `src/opencode-local/` の役割。生成済みコマンド/スキル/ひな形を配置せず、生成プロセスへの入力のみを保持する。IR-047 で監視される |
+| Local backend | ローカル版 OpenCode のバックエンド区分。GitHub backend（GitHub Issue/PR を使う通常運用）との差分として SPEC `workflow-contracts.md` で定義される。SSoT は GitHub Issue/PR ではなくローカル Case ファイル（`.agentdev/cases/case-{NNNN}.md`）となる |
+| 変換用プロンプト | `src/opencode-local/transform/generate.md`。AI エージェントが GitHub 版原本をローカル版に変換する際に従うプロンプト（REQ-0141-028, 032） |
+| レビュー用プロンプト | `src/opencode-local/transform/review.md`。ローカル版生成物の変換品質を検証するプロンプト（REQ-0141-028） |
+| 変換仕様 | `src/opencode-local/transform/spec.md`。変換対象・ガードレール・レポートフォーマットを定義する（REQ-0141-029） |
+| ジャンクション検出安全ゲート | ローカル版生成前に `.opencode/` の実パスを確認し、`src/opencode/` 配下へ解決される場合は生成を停止する安全機構（REQ-0141-010）。原本保護を担保する |

--- a/docs/specs/integrity-rule-catalog.md
+++ b/docs/specs/integrity-rule-catalog.md
@@ -1,5 +1,5 @@
 ---
-updated: 2026-06-19
+updated: 2026-06-20
 ---
 
 # Integrity Rule Catalog
@@ -929,6 +929,66 @@ updated: 2026-06-19
 | finding_route | intake |
 | triage_action | 分類に基づき修正。NG（英字混じり抽象用語に日本語説明不在／`read-only` 宣言に反して出力生成・commit・push が許可されている）は許可/禁止操作を明示化・日本語説明を併記。WARNING（識別子は保持するが日本語説明が不十分）は説明を補強。OK（日本語名と識別子が両立し許可/禁止操作が明確）は対応不要。default severity は warning、accepted SPEC または 現行 REQ で NG 分類の場合は error に昇格 |
 | last_verified | 2026-06-19 |
+
+### IR-046: consumer-generated リポジトリ種別誤検知防止
+
+| Field | Value |
+|-------|-------|
+| rule_id | IR-046 |
+| description | `.opencode/commands/agentdev/` が実ディレクトリ（非ジャンクション）かつ `generated_by: local-opencode-transform` 識別子を含む場合、当該リポジトリを consumer-generated として扱い、IR-016（Source/projection 整合性）の source/projection divergence 対象から除外すること（REQ-0141-007, 011）。ローカル版生成物はジャンクションではなく実ファイル配置であるため、IR-016 の「ジャンクション破損」判定が誤検知となるのを防ぐ |
+| severity | heuristic |
+| category | canonical-conflict |
+| detection_method | `.opencode/commands/agentdev/` がジャンクション・シンボリックリンクでないことを確認後、配下のファイルから `generated_by: local-opencode-transform` 識別子を検出。識別子検出時は consumer-generated と判定し IR-016 を適用除外とする |
+| affected_artifacts | [.opencode/commands/agentdev/, .opencode/skills/agentdev-*/] |
+| related_req | [REQ-0141-007, REQ-0141-011, REQ-0141-014] |
+| related_spec | [runtime-package-boundary.md, local-generation.md] |
+| gate_level | full-audit |
+| false_positive_risk | 低。ジャンクション検出と `generated_by` 識別子検出の組合せで確実に判定可能 |
+| regression_test | (追加予定) |
+| baseline_status | new |
+| finding_route | intake |
+| triage_action | IR-016 を consumer-generated リポジトリでは適用除外とする。識別子不在の場合は IR-016 を通常適用する |
+| last_verified | 2026-06-20 |
+
+### IR-047: src/opencode-local/ 生成時ソース領域ディレクトリ構成
+
+| Field | Value |
+|-------|-------|
+| rule_id | IR-047 |
+| description | `src/opencode-local/` はローカル版生成時ソース領域であり、許容されたディレクトリ構成（`README.md`, `case-schema/`, `transform/`, `generation-flow.md`）のみを保持すること（REQ-0141-004）。禁止パス（`requirements/`, `specs/`, `_conv/`, `commands/`, `skills/`）を作成しないこと（REQ-0141-005） |
+| severity | strict |
+| category | obsolete-structure |
+| detection_method | `src/opencode-local/` 配下のディレクトリ・ファイル一覧を取得し、許容リスト（`README.md`, `case-schema/`, `transform/`, `generation-flow.md`）外のパスを検出 |
+| affected_artifacts | [src/opencode-local/] |
+| related_req | [REQ-0141-003, REQ-0141-004, REQ-0141-005] |
+| related_spec | [local-generation.md] |
+| gate_level | full-audit, delta-guard |
+| false_positive_risk | なし。パスの直接比較による機械的検出 |
+| regression_test | (追加予定) |
+| baseline_status | new |
+| finding_route | intake |
+| triage_action | 許容リスト外のディレクトリ・ファイルを削除し、`src/opencode-local/` を生成時ソース領域の構成に復元 |
+| last_verified | 2026-06-20 |
+
+### IR-048: generated_by 識別子整合性
+
+| Field | Value |
+|-------|-------|
+| rule_id | IR-048 |
+| description | ローカル版生成物に `generated_by: local-opencode-transform` 識別情報が付与されていること（REQ-0141-011）。同名ファイル上書きは識別子が一致する場合のみ許可され、識別子不在・異なる識別子のファイルを上書きしてはならないこと（REQ-0141-012, 013） |
+| severity | strict |
+| category | canonical-conflict |
+| detection_method | `.opencode/commands/agentdev/**/*.md` と `.opencode/skills/agentdev-*/**/*.md` から frontmatter またはメタ識別子中の `generated_by` を抽出し、`local-opencode-transform` と一致することを確認。同名ファイル上書き時の識別子整合性はローカル版生成プロセスが `## 変換仕様` ガードレールで検証 |
+| affected_artifacts | [.opencode/commands/agentdev/, .opencode/skills/agentdev-*/] |
+| related_req | [REQ-0141-011, REQ-0141-012, REQ-0141-013] |
+| related_spec | [local-generation.md, local-transform.md] |
+| gate_level | full-audit, delta-guard |
+| false_positive_risk | 中。生成物への識別子付与方式（frontmatter vs ヘッダコメント）の揺れ・AgentDevFlow 本体原本（識別子なし）との混同に注意 |
+| regression_test | (追加予定) |
+| baseline_status | new |
+| finding_route | intake |
+| triage_action | 識別子付与方式を `local-generation.md` の定義に統一。競合ファイルは手動マージまたは識別子付与後に再生成 |
+| last_verified | 2026-06-20 |
 
 ## ゲートレベル
 

--- a/docs/specs/req-impact-map.md
+++ b/docs/specs/req-impact-map.md
@@ -31,13 +31,14 @@
 | REQ-0133 | case-update / Issue更新 | IR-006 | commands |
 | REQ-0110 | Git worktree cleanup 信頼性 | — (infrastructure) | — |
 | REQ-0102 | 要件定義・保存 | IR-001, IR-002 | REQ |
-| REQ-0134 | 配布基盤: source/projection・sync・repo type・consumer install | IR-006, IR-016 | commands, skills, ドメイン状態 |
+| REQ-0134 | 配布基盤: source/projection・sync・repo type・consumer install | IR-006, IR-016, IR-046 | commands, skills, ドメイン状態 |
 | REQ-0135 | Drafts配置・Draft Type Registry | IR-016 | ドメイン状態 |
 | REQ-0136 | REQ/SPEC 責務分離の徹底と新ワークフロー（spec-save 新設・req-define 強化） | IR-008, IR-044 | REQ, SPEC, commands |
 | REQ-0137 | 並列実行安全 git 操作規律 | — (infrastructure) | — |
 | REQ-0138 | 構造化req_draft契約 | IR-016 | ドメイン状態 |
 | REQ-0139 | 外部エージェント統合契約 | IR-006, IR-024 | commands, skills |
 | REQ-0140 | 文書品質ゲート | IR-013, IR-045 | docs, SPEC, writing-style.md |
+| REQ-0141 | ローカル版 OpenCode 生成方式とローカルCaseファイル運用 | IR-016, IR-046, IR-047, IR-048 | src/opencode-local/, .opencode/commands/agentdev/, .opencode/skills/agentdev-*/, .agentdev/cases/, SPEC, guides |
 
 ## 要件行影響（Requirement-Line Impact）
 
@@ -63,6 +64,7 @@
 - **REQ-0104**: Command protocol (2 ルール)
 - **REQ-0106**: Case 実行オーケストレーション (3 ルール)
 - **REQ-0107**: Reporting (2 ルール)
+- **REQ-0141**: ローカル版 OpenCode 生成方式とローカルCaseファイル運用 (4 ルール: IR-016, IR-046, IR-047, IR-048)
 
 ### 低影響（1-2 ルール）
 - **REQ-0102**, **REQ-0105**, **REQ-0112**, **REQ-0113**, **REQ-0114**, **REQ-0123**, **REQ-0124**, **REQ-0125**, **REQ-0126**, **REQ-0127**, **REQ-0128**, **REQ-0129**, **REQ-0130**, **REQ-0131**, **REQ-0132**, **REQ-0133**, **REQ-0134**, **REQ-0135**, **REQ-0136**, **REQ-0138**, **REQ-0139**, **REQ-0140**

--- a/docs/specs/rule-ownership.md
+++ b/docs/specs/rule-ownership.md
@@ -38,6 +38,9 @@
 | 30 | REQ 検証基準（必達要件） | REQ-0108 | integrity-contracts.md | 規範語ではなく必達要件判定に基づく検証（REQ-0115-044 から REQ-0108 に移管） |
 | 31 | Quality Gates | REQ-0108 | quality-gates.md | QG-1〜QG-4 定義・機械化境界・実装マッピング（REQ-0115 から REQ-0108 に移管） |
 | 32 | docs 日本語表現・文意整合 | REQ-0140, REQ-0108 (255-257) | integrity-rule-catalog.md (IR-045) | 英字混じり抽象用語・読取専用セマンティクスの検出。文書表記・文意品質ゲート（付帯品質ゲート）の機械検査担当 |
+| 33 | local-case-file（ローカル Case ファイルスキーマ） | REQ-0141 (016-020, 024, 025) | local-case-file.md | ローカル版 OpenCode の Case ファイル YAML 前書き・status enum・labels 値域・見出し一覧・マージ結果記録 |
+| 34 | local-generation（ローカル版生成フロー・安全ゲート） | REQ-0141 (001-015) | local-generation.md | ローカル版生成フロー Step・`generated_by: local-opencode-transform` 識別子・ジャンクション検出安全ゲート・上書き許可条件 |
+| 35 | local-transform（ローカル版変換プロンプト） | REQ-0141 (028, 029, 032) | local-transform.md | 変換用プロンプト（`transform/generate.md`）・レビュー用プロンプト（`transform/review.md`）・変換仕様（`transform/spec.md`）の要件 |
 
 ## 重複ルールの解消状況
 


### PR DESCRIPTION
Closes #959

## 概要

REQ-0141 Wave 5（直列フェーズ）として、整合性ルールカタログ・ルール所有権マトリックス・REQ影響マップ・ガイド群の5ファイルを更新した。設定済みの `src/opencode-local/` 生成時ソース領域・`consumer-generated` リポジトリ種別・`generated_by` 識別子を、整合性ルール体系・所有権・影響マップ・導入ガイド・用語集の各方面に統合した。

## 変更ファイル

| # | ファイル | 変更種別 | 内容 |
|---|---------|---------|------|
| 1 | `docs/specs/integrity-rule-catalog.md` | UPDATE | IR-046（consumer-generated 誤検知防止）・IR-047（`src/opencode-local/` ディレクトリ構成）・IR-048（`generated_by` 識別子整合性）の3ルールを追加。`updated` 日付を 2026-06-20 に更新 |
| 2 | `docs/specs/rule-ownership.md` | UPDATE | ルールドメイン33-35 として `local-case-file`・`local-generation`・`local-transform` を追加。いずれも正規 REQ = REQ-0141、正規 SPEC = `local-*.md` |
| 3 | `docs/specs/req-impact-map.md` | UPDATE | REQ-0141 行を影響マトリックスに追加（IR-016/046/047/048 の4ルール）。REQ-0134 行を consumer-generated 対応により IR-046 追加で更新。中影響カテゴリに REQ-0141 を追加 |
| 4 | `docs/guides/consumer-project-setup.md` | UPDATE | リポジトリ種別表を5種化（consumer-generated 追加）。Consumer-generated 詳細セクション・ローカル版セットアップ手順・ローカル版更新手順を追加。予約名表・スクリプト適用範囲表を consumer-generated 対応で更新 |
| 5 | `docs/guides/glossary.md` | UPDATE | 成果物セクションに「ローカル Case ファイル」を追加。新規「ローカル版 OpenCode」セクションを設け、ローカル版 OpenCode・consumer-generated・`generated_by`・`src/opencode-local/`・生成時ソース・Local backend・変換用/レビュー用プロンプト・変換仕様・ジャンクション検出安全ゲートの各用語を定義 |

## 完了条件の確認

Issue #959 の完了条件7項目をすべて充足:

- [x] `docs/specs/integrity-rule-catalog.md` が更新され、consumer-generated リポジトリ種別・`src/opencode-local/` 生成時ソース領域・`generated_by` 識別子に関連する整合性ルールが追加されていること → IR-046/047/048 の3ルール追加
- [x] `docs/specs/rule-ownership.md` が更新され、REQ-0141 と SPEC local-*.md（新規3 + 更新2）がルールドメイン対応表に記載されていること → 行33-35 追加
- [x] `docs/specs/req-impact-map.md` が更新され、REQ-0141・新規設定（3新規 SPEC）・REQ-0134（consumer リポジトリ種別更新）の影響アーティファクトが過不足なく記載されていること → REQ-0141 行追加・REQ-0134 行更新・中影響カテゴリへ REQ-0141 追加
- [x] `docs/guides/consumer-project-setup.md` が更新され、consumer-generated リポジトリ種別の検証条件（`.opencode/commands/agentdev/` のみ実ディレクトリ・ジャンクション・`generated_by: local-opencode-transform` を持つ）と主前提が記載されていること → consumer-generated セクション・セットアップ手順追加
- [x] `docs/guides/glossary.md` が更新され、ローカル版 OpenCode・`src/opencode-local/`・ローカルCaseファイル・consumer-generated・`generated_by` 識別子の用語が定義されていること → 「ローカル版 OpenCode」セクション新設、10用語追加
- [x] `src/opencode/` 配下を一切変更していないこと → `git status` で空であることを確認済み（REQ-0141-014）
- [x] 関連インデックス（`docs/specs/README.md`, `docs/DOC-MAP.md`, `docs/guides/README.md`）の相互整合に齟齬がないこと → 5 SPEC は既に spec-save で `docs/specs/README.md` に記載済み、`docs/guides/README.md` のリンク先は変更なし、`docs/DOC-MAP.md` は SPEC/guides 一覧へのパス参照のみで本PRの変更が新規文書追加を伴わないため齟齬なし

## 検証結果

- **`src/opencode/` 永続検証**: `git status -- src/opencode/` で空であることを確認（REQ-0141-014, ADR-0126 decision #4 準拠）
- **5ファイル変更範囲確認**: `git diff --stat` で5ファイルのみ変更、151行追加・9行削除
- **SPEC 整合性確認**: IR-046/047/048 の各フィールド15個以上保持（rule_id, description, severity, category, detection_method, affected_artifacts, related_req, related_spec, gate_level, false_positive_risk, regression_test, baseline_status, finding_route, triage_action, last_verified）
- **正となる情報源の確認**: AGENTS.md記載の情報源優先順位に従い、REQ-0141 > ADR-0126 > 5 SPEC > ガイド > インデックス の順で照合。整合性ルールカタログの新規3ルールは REQ-0141 の各要件項目（REQ-0141-003〜005, 007, 011〜013）に裏付けられる
- **docs-check スキャン対象外確認**: `src/opencode-local/` は docs-check のスキャン対象外（IR-004 解釈: src/opencode-local/ は Command/Skill/Template/Script のいずれにも該当しない生成時ソース領域）

## SPEC確定候補

本PRでSPEC確定候補として記録する事項:

- **`integrity-rule-catalog.md` の IR-046/047/48 検出メソッド詳細化候補**: 新規3ルールの `detection_method` フィールドは検出アプローチの概要レベル（ジャンクション検出 + 識別子検出、パス直接比較、frontmatter/メタ識別子からの `generated_by` 抽出等）。実装フェーズで具体化する際、検出器実装（`repo-agentdev-integrity` skill 配下）と整合する詳細アルゴリズム・検出対象ファイルパス粒度・例外パターン（IR-016 との適用除外ロジック等）を SPEC 側で確定させる候補。現在はカタログでの概要記載レベルで十分だが、実装時に `integrity-contracts.md` への追記が必要になりうる

## Findings / Capture候補

### intake

- なし（本筋外の発見事項なし）

### learning

- なし（本筋外の再発防止知見なし）

## 備考: マージ前実装方式について

本PRは case-run の実装フェーズ簡易ベージョン + ハーネス直接マージで実施した（Wave 4 #958 と同様）。理由: oh-my-openagent 側の文書（`references/oh-my-openagent.md` 135-140行）が nested opencode セッション安定性・CLI subprocess 安定性・構造化結果出力信頼性を未検証として位置づけており、確実に定義されたコンテンツ実装タスクに対しては直接実装が確度高いため。変更範囲は Issue #959 の対象5ファイルのみに限定し、`src/opencode/` 配下は一切変更していない（REQ-0141-014, ADR-0126 decision #4 準拠）。
