### PR TITLE
[Wave 2][OU-003] case-auto 簡素化 (Epic orchestration 移管・REQ-0114)

### DIFF
--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -36,53 +36,43 @@ agent: sisyphus
      - `artifact: spec` entry が空の場合 → spec-save をスキップし case-open へ進む
      - `artifact_actions` フィールドが存在しない（旧形式 draft）場合 → **後方互換**: spec-save をスキップし従来ワークフロー（req-save → case-open → …）で実行
    - **auto_gate preflight**: `draft-data` の `auto_gate.auto_ready` を確認し、false の場合または未解決 item（unresolved_questions / unresolved_conflicts / out_of_repo_operations / stop_reasons）が残る場合は停止する（REQ-0138-013）
-4. **各工程の実行**: case-auto は各工程（req-save / spec-save / case-open / case-run / case-close）を task() で起動し、オーケストレーションに専念する（ADR-0127, REQ-0114-006/084/085）。case-run は Sisyphus-Junior(ulw-loop) への task() 委譲モデル（ADR-0114/0128）を使用する。各工程の task() は対応するコマンド定義（`.opencode/commands/agentdev/{step}.md`）を authoritative source として読み込み実行する。case-auto は各工程の完了結果（保存済みファイル・Issue/PR番号・pass/warn/fail）のみを受領し、次工程への入力として渡す。**インライン実行は禁止する**（REQ-0114-073・コンテキスト枯渇防止）
+4. **各工程の実行**: case-auto は全工程（req-save / spec-save / case-open / case-run / case-close）を各コマンドの委譲契約に従って task() で起動し、オーケストレーションに専念する（ADR-0127, REQ-0114-006/084/085）。case-run は Sisyphus-Junior(ulw-loop) への task() 委譲モデル（ADR-0114/0128）を使用する。各工程の task() は対応するコマンド定義（`.opencode/commands/agentdev/{step}.md`）を authoritative source として読み込み実行する。case-auto は各工程の完了結果（保存済みファイル・Issue/PR番号・pass/warn/fail）のみを受領し、次工程への入力として渡す。**インライン実行は禁止する**（REQ-0114-073・コンテキスト枯渇防止）
 
    ### 工程別委譲契約（ADR-0112 §5・ADR-0127）
 
    case-auto は各工程を以下の委譲契約で起動する:
 
-   | 工程 | 起動方式 | inputs | output_contract |
-   |------|---------|--------|-----------------|
-   | req-save | task() | draft path, OU ID | 保存済みREQ/ADRリスト, draft status=saved, pass/warn/fail |
-   | spec-save | task() | draft path | 保存済みSPECリスト, SPEC消費済みフラグ, pass/warn/fail |
-   | case-open | task() | draft path, OU ID | Issue番号(Epic含む), pass/warn/fail |
-    | case-run | task()（ADR-0114/0128） | Issue番号, worktree root | completed(pr)/blocked/failed |
-   | case-close | task() | Issue番号, PR番号 | マージ結果, Capture保存結果, 削除済みブランチ, pass/warn/fail |
+    | 工程 | 起動方式 | inputs | output_contract |
+    |------|---------|--------|-----------------|
+    | req-save | task() | draft path, OU ID | 保存済みREQ/ADRリスト, draft status=saved, pass/warn/fail |
+    | spec-save | task() | draft path | 保存済みSPECリスト, SPEC消費済みフラグ, pass/warn/fail |
+    | case-open | task() | draft path, OU ID | Issue番号(Epic含む), pass/warn/fail |
+    | case-run | task()（ADR-0114/0128） | 単一 Issue番号 または Epic Issue番号（`#epic`・現在 Wave の子Issue を case-run が並列委譲） | completed(pr)/blocked/failed（Epic Wave 実行時は子Issue ごとの結果集合） |
+    | case-close | task() | 単一 Issue番号 または Epic Issue番号（`#epic`・現在 Wave の一括クローズ） | マージ結果, Capture保存結果, 削除済みブランチ, pass/warn/fail, Epic 最終 Wave 判定結果 |
 
    各 task() の side_effect_boundary は対応するコマンド定義のガードレール（ファイル操作制約）に従う。case-auto は各 task() の結果に基づいて次工程へ進むか停止条件（Step 7）を判定する。各工程の後段処理（case-open の RU 削除、case-close の learning/intake capture・.agentdev/ commit/push 等）は各 task() が対応するコマンド定義に従って実行する
    - **品質ゲート（QG-1〜QG-4）の継承**: case-auto は QG を独自実装しない。構成コマンド（req-save: QG-1, case-open: QG-2, case-run: QG-3, case-close: QG-4）がそれぞれ `agentdev-quality-gates` スキルを参照して Gate を適用する。各 task() が対応する Gate を実行する。case-auto は工程間制御のみを担い、Gate 判定を再評価・差し替えしない（G07, G09）
    - **case-run の実行担当サブエージェント委譲モデル**: case-run は実装実行を実行担当サブエージェント（`agentdev-case-run-execution-adapter`）経由で外部実行バックエンドへ委譲し、自身は orchestration に専念する（ADR-0114）。case-auto は case-run の実行担当サブエージェント委譲モデルを変更せず、実装実行・PR作成を自ら行わない。実行担当サブエージェント result（completed(pr)/blocked/failed）の処理は case-run 定義に従う
    - case-auto は req-save / case-open の task() に draft path と OU ID のみを渡すこと（REQ-0114-052）。OU 本文の切り出しは行わない
    - case-auto は OU の統合・分割、REQ 操作分類、Issue 階層判定を再評価しないこと（REQ-0114-054）。各 task() が対応するコマンド定義（req-save / case-open）の判定結果に従う
-     - case-open task() の完了後、出力を確認して以下のいずれかに分岐する:
-       - **Standard flow（単一 Issue）**:
-         1. case-open task() が共通終了処理（Step 17〜18-2: コメント追加・ドラフト削除・RU削除・完了報告）を完了していることを確認すること（REQ-0104-045〜047）
-         2. **クリーンアップ検証ゲート**（後述）を実行し、ドラフトファイル・RUファイルの残存がないことを確認すること（REQ-0137-007）。残存時は停止すること
-         3. 既存の直列フロー（case-run → case-close）を実行
-       - **Epic Issue（マルチREQ または 単一REQ Epic flow）**:
-        1. case-open task() が共通終了処理（Step 17〜18-2: コメント追加・ドラフト削除・RU削除・完了報告）を完了していることを確認すること（REQ-0104-045〜047）
-        2. **クリーンアップ検証ゲート**を実行し、ドラフトファイル・RUファイルの残存がないことを確認すること（REQ-0114-060〜062）。残存時は停止すること
-        3. Step 4-1〜4-3 のキュー処理に進む
-       - **Step 4-1 キュー開始（子Issue単位オーケストレーション）**: Epic Issue 番号を記録する。Epic Issue 本文から子Issue一覧・Wave 構成・ステータス追跡テーブルを読み取る（永続状態を SSoT とする）。以下の子Issue単位ループを実行する（SPEC `docs/specs/workflow-contracts.md` 子Issue単位オーケストレーションモデル SC-007, REQ-0114-045〜048）:
-         1. **子Issue選択**: Wave table の「実行方法」列を確認し、status が `ready` の子Issue を選択する。「並列」指定は最大5件まで同時選択。「直列」指定は1件。`ready` がない場合、依存が満たされた `pending` Issue を `ready` に遷移させて選択する。ただし前提Issue が blocked/failed の場合は `pending` のまま選択対象外。
-         2. **running 遷移**: 選択した全子Issue を `running` に遷移させる（Epic Issue ステータス追跡テーブルを case-auto が更新）。
-          3. **case-run 並行委譲**: 選択した各子Issue 番号 + 要件docパスを case-run（task()・ADR-0114/0128）に渡す。「並列」指定は同時に起動。「直列」指定は1件完了後に次を起動。case-run は単一 Issue または単一 Wave を処理する（REQ-0130-010）。
-         4. **全完了待機**: 全 case-run の完了を待つ。
-         5. **結果確認**: 永続状態を再読込し各子Issue の結果（completed(pr) / blocked / failed）を確認する。
-         6. **case-close task()（子Issue単位・逐次）**: 完了した子Issue を Issue番号昇順で case-close task() に渡す。blocked/failed の子Issue は case-close 対象外。
-         7. **次Wave判定**: 同一Waveの全子Issue の結果が出揃ったら、次Waveの ready 判定に進む。Step 1 に戻る。
-       - **Step 4-2 case-close（子Issue単位）**: case-run 完了後、Step 4-1-4 で確認した結果に基づき当該1子Issue の case-close task() 起動を決定する（SC-009）:
-        - 正常完了（completed(pr)）: 該当子Issue を `completed` に遷移させ case-close task() を起動する
-        - blocked: 該当子Issue を `blocked` に遷移させ、停止理由・再開可能コマンドを報告する
-        - failed: 該当子Issue を `failed` に遷移させる。正常完了した他の子Issue のみ case-close 対象とする
-        - 各子Issue の case-close task() は既存の case-close.md 定義に従う（learning/intake capture、`.agentdev/` commit/push を含む）。子Issue ごとに独立して起動し、キュー全体での一括 capture は行わない
-        - case-auto は 1 OU（Epic の場合は全子Issue 処理完了）を close まで完了した後に次の OU へ進むこと（REQ-0114-053）
-     - **Step 4-3 全体完了判定**: 全子Issue の case-close 処理完了後:
-     - Epic Issue の子Issue全ステータスが CLOSED の場合 → Epic 自動クローズ確認（case-close Step 8 相当） → 全体完了報告
-      - 未クローズの子Issue が残る場合（blocked / failed） → 部分完了報告
-     - 停止時は完了済み OU、進行中 OU、未実行 OU、再開可能な次コマンドを報告すること（REQ-0114-056）
-    - **クリーンアップ検証ゲート**: Standard flow の case-run 移行前・Epic Issue の Step 4-1 キュー処理開始前の双方で、以下を検証する（REQ-0114-060〜063, REQ-0137-007）:
+      - case-open task() の完了後、出力を確認して以下のいずれかに分岐する:
+        - **Standard flow（単一 Issue）**:
+          1. case-open task() が共通終了処理（Step 17〜18-2: コメント追加・ドラフト削除・RU削除・完了報告）を完了していることを確認すること（REQ-0104-045〜047）
+          2. **クリーンアップ検証ゲート**（後述）を実行し、ドラフトファイル・RUファイルの残存がないことを確認すること（REQ-0137-007）。残存時は停止すること
+          3. 既存の直列フロー（case-run → case-close）を実行
+        - **Epic Issue flow（マルチREQ または 単一REQ Epic flow）**:
+          1. case-open task() が共通終了処理（Step 17〜18-2: コメント追加・ドラフト削除・RU削除・完了報告）を完了していることを確認すること（REQ-0104-045〜047）
+          2. **クリーンアップ検証ゲート**を実行し、ドラフトファイル・RUファイルの残存がないことを確認すること（REQ-0114-060〜062）。残存時は停止すること
+          3. Step 4-1（Wave 反復制御）に進む
+        - **Step 4-1 Wave 反復制御（case-run #epic → case-close #epic の反復・ADR-0128 Decision #5, REQ-0114-084）**: Epic Issue 番号を記録する。Epic Issue 本文（ADR-0109 SSoT）から Wave 構成・各子Issue ステータスを読み取る（**読み取りのみ・Epic Issue 本文の書き込みは case-close の単一書き手責務・ADR-0125**）。Epic/Wave orchestration（子Issue 選択・task() 並列起動・Epic Issue 本文ステータス追跡テーブルの更新）は case-run / case-close が担い、case-auto は Wave 反復制御に専念する。以下の Wave 反復ループを実行する:
+          1. **task()→case-run(#epic)**: Epic Issue 番号を case-run task() に渡す。case-run は現在 Wave の ready 子Issue を Sisyphus-Junior(ulw-loop) に並列委譲（最大5件・REQ-0130-010）し、1 Wave の実行（PR作成まで）で return する
+          2. **task()→case-close(#epic)**: case-run task() の結果（子Issue ごとの completed(pr) / blocked / failed）を確認する。completed(pr) の子Issue がある場合、Epic Issue 番号を case-close task() に渡す。case-close は現在 Wave の PR作成済み子Issue を一括マージ・クローズし、Epic status table を更新する（単一書き手・ADR-0125）。case-close は最終 Wave 判定を行い、Epic クローズ または 残 Wave 通知を返す
+          3. **次 Wave 判定**: case-close task() の結果から Epic 全 Wave 完了可否を判定する:
+             - **全 Wave 完了（Epic クローズ済み）**: Epic 完了報告（Step 8）へ進む
+             - **残 Wave あり**: Step 1（task()→case-run(#epic)）に戻り次 Wave を実行する（べき等・Epic Issue 本文から進行状況判定）
+          4. **blocked / failed の扱い**: case-run task() が blocked / failed を返した子Issue は case-close 対象外となる。一部 completed(pr) がある場合は case-close(#epic) で completed(pr) のみ処理し、その後停止条件（Step 7）の判定へ進む。全子Issue が blocked / failed の場合は Wave 反復を停止し部分完了報告（Step 8）へ進む。停止時は完了済み OU・進行中 OU・未実行 OU・再開可能な次コマンドを報告すること（REQ-0114-056）
+          5. **OU 逐次処理**: 1 OU（Epic 全 Wave 完了）を close まで完了した後に次の OU へ進むこと（REQ-0114-053）。Epic Issue flow でも Step 8-1（逐次OU処理ループ）相当の処理を適用する
+    - **クリーンアップ検証ゲート**: Standard flow の case-run 移行前・Epic Issue flow の Step 4-1（Wave 反復制御）開始前の双方で、以下を検証する（REQ-0114-060〜063, REQ-0137-007）:
       - ドラフトファイル（`.agentdev/drafts/req-draft-*.md`）が削除されていること。残存する場合は停止し手動削除を依頼すること
       - 当該ケースで消費した RU ファイル（`.agentdev/backlog/req-units/RU-*.md`）が削除されていること。残存する場合は停止し手動削除を依頼すること
       - 検証結果（成功・残存ファイル一覧）を case-auto 完了報告（Step 8）に含めること
@@ -100,7 +90,7 @@ agent: sisyphus
    - (8) merge conflict / remote hash不一致
    - (9) 作成元不明branch / user-owned branch / 他作業branchの削除検出
    - (10) 未コミット変更の帰属不明
-8. **完了報告**: 最終工程（case-close task()）の完了報告をそのまま出力する。Epic Issue を伴うキュー実行時は、完了・blocked・failed 子Issue一覧を含める。停止時は完了済み OU、進行中 OU、未実行 OU、再開可能な次コマンドを報告する（REQ-0114-056）
+8. **完了報告**: 最終工程（case-close task()）の完了報告をそのまま出力する。Epic Issue を伴う Wave 反復実行時は、完了・blocked・failed 子Issue 一覧を含める（Epic Issue 本文ステータス追跡テーブルから読み取り・case-auto は書き込まない・ADR-0125）。停止時は完了済み OU、進行中 OU、未実行 OU、再開可能な次コマンドを報告する（REQ-0114-056）
     - **タイミング情報の追記（REQ-0114-083）**: 完了報告生成時刻（Step 8 開始時点）を JST・人間が読みやすい形式（例: `2026-06-21 15:30:00 JST`）で記録する。case-close task() の完了報告（テンプレート）は変更せず、case-auto が以下を追記すること:
       - 開始時刻: Step 1 で記録した `case_auto_started_at`
       - 終了時刻: 完了報告生成時刻
@@ -131,13 +121,12 @@ agent: sisyphus
 - G28: case-auto は各 task() の完了結果（Issue/PR番号・pass/warn/fail）のみを親コンテキストに保持し、工程内部の調査過程・中間ログ・読解メモを親コンテキストに累積しないこと（REQ-0114-073/085・ADR-0127）
 - G13: case-auto は Issue 階層決定ロジックを持ってはならない。複数 REQ doc または scale:large の場合は case-open の Issue 構造ルールに委譲する
 - G14: case-auto は req-save task() から case-open task() への状態引き継ぎ時、複数 REQ doc の保存結果をフィルタリングまたは再評価してはならない。保存結果をそのまま渡す
-- G15: case-auto は Wave table の「実行方法」列に基づき子Issue を選択し case-run に委譲する。「並列」指定の ready 子Issue は最大5件まで同時に委譲する。「直列」指定は1件ずつ委譲する。Wave全体の一括実行を case-run に委譲しない（REQ-0114-045, REQ-0130-010）
-- G16: case-auto は独自の操作単位ステータス追跡を持ってはならない。Epic Issue のステータス追跡テーブルを使用する
+- G15: case-auto は子Issue 選択ロジック・子Issue 単位の task() 並列起動を行わない。Wave 全体の実行を case-run(#epic) に委譲し、Wave 境界のクローズを case-close(#epic) に委譲する（ADR-0128 Decision #5, REQ-0114-084, REQ-0130-010）
+- G16: case-auto は独自の操作単位ステータス追跡を持ってはならない。Epic Issue のステータス追跡テーブルを使用する。**Epic Issue 本文の書き込みは case-close の単一書き手責務（ADR-0125）。case-auto は読み取るのみで書き込まない**
 - G18: case-auto は操作単位キューの管理・制御のみを担い、OU 本文の抽出・変換・REQ 操作解釈を行わないこと（REQ-0114-051）
 - G19: case-auto は req-save 段階（case-open 完了前）のみ draft を OU 情報の SSoT として扱うこと。case-open 完了後は子Issue（Epic Issue のステータス追跡テーブル含む）が SSoT となること。クリーンアップ検証ゲート（ドラフト削除検証）は case-open 完了後に実行すること。独自の OU 状態管理を持たないこと（REQ-0114-058）
 - G20: OU 間依存は queue dependency として扱い、依存関係があるだけでは Epic Issue 化しないこと（REQ-0114-055）
 - G21: case-auto は Epic Issue 化の判定に関与しないこと。case-open の判定結果に従うこと（REQ-0114-057）
-- G26: 並列実行の最大同時委譲数（5件）は運用環境の外部実行バックエンド並行負荷に応じて調整可能とする。外部実行バックエンドの同時実行能力が5未満の場合、実行環境の制約に合わせて並列数を減らすこと
 
 ### 出力制約
 - G10: 成果物本文（Issue本文・PR本文・commit message・保存対象ファイル本文・テンプレート成果物）はverbatimで返す。判定結果・調査過程・中間ログ・読解メモは要約・成果物パス・根拠・親判断事項・capture候補へ圧縮して返す


### PR DESCRIPTION
Closes #984

## 概要

case-auto から case-run / case-close へ Epic/Wave orchestration を移管し、case-auto を pipeline 制御 + Wave 反復に簡素化する（OU-003・REQ-0114・Wave 2）。

REQ-0114-084（req-save で保存済み）の要件行更新（ACT-REQ-003・AG-004）を case-auto コマンド定義へ反映する。Wave 1 で case-run（task()/ulw-loop 委譲・Epic Wave 実行）・case-close（Epic Wave クローズ）が更新済みのため、本 PR は Wave 2 として case-auto の Epic orchestration ロジック削除・Wave 反復制御への置換を完結する。

## 変更内容

### `src/opencode/commands/agentdev/c-auto.md`

#### 削除した Step（Epic orchestration 移管）

- **Step 4-1 キュー開始（子Issue単位オーケストレーション）**: 子Issue選択・running遷移（case-auto が Epic Issue 本文を更新）・case-run 並行委譲・全完了待機・結果確認・case-close task()（子Issue単位・逐次）・次Wave判定
- **Step 4-2 case-close（子Issue単位）**: case-run 完了後の子Issue単位 case-close 起動判定
- **Step 4-3 全体完了判定**: 全子Issue case-close 処理完了後の Epic 自動クローズ確認

#### 新設した Step

- **Step 4-1 Wave 反復制御（case-run #epic → case-close #epic の反復・ADR-0128 Decision #5, REQ-0114-084）**:
  1. `task()→case-run(#epic)`: Epic Issue 番号を case-run task() に渡し、現在 Wave の ready 子Issue を case-run が Sisyphus-Junior(ulw-loop) に並列委譲（最大5件・REQ-0130-010）。1 Wave の実行（PR作成まで）で return
  2. `task()→case-close(#epic)`: completed(pr) の子Issue がある場合、Epic Issue 番号を case-close task() に渡し、現在 Wave の一括マージ・クローズ・Epic status table 更新（単一書き手・ADR-0125）・最終 Wave 判定を委譲
  3. 次 Wave 判定: 全 Wave 完了で Epic 完了報告、残 Wave ありで Step 1 へ戻る（べき等）
  4. blocked / failed 扱い: completed(pr) のみ case-close(#epic) 対象。全 blocked/failed で部分完了報告
  5. OU 逐次処理（REQ-0114-053）は Epic Issue flow でも適用

#### 削除したガードレール

- **G26**: 並列実行の最大同時委譲数（5件）調整 — case-run 内部責務に移管

#### 更新したガードレール

- **G15**: 「Wave table の『実行方法』列に基づき子Issue を選択し case-run に委譲」→「case-auto は子Issue 選択ロジック・子Issue 単位の task() 並列起動を行わない。Wave 全体の実行を case-run(#epic) に委譲、Wave 境界のクローズを case-close(#epic) に委譲」（ADR-0128 Decision #5, REQ-0114-084, REQ-0130-010）
- **G16**: ADR-0125 単一書き手制約明記（「case-auto は読み取るのみで書き込まない」）

#### その他の更新

- **委譲契約表**: case-run / case-close 行を `#epic` 入力（Epic Wave 実行 / Epic Wave クローズ）に対応。case-close output_contract に「Epic 最終 Wave 判定結果」を追加
- **Step 4 冒頭**: 「各工程」→「全工程（REQ-0114-084 traceability 明確化）」・「各コマンドの委譲契約に従って task() で起動」に調整
- **Step 8 完了報告**: 「Epic Issue を伴うキュー実行時」→「Epic Issue を伴う Wave 反復実行時」・ADR-0125 読み取りのみ明記
- **クリーンアップ検証ゲート**: 「Step 4-1 キュー処理開始前」→「Step 4-1（Wave 反復制御）開始前」

### case-auto 残存責務（維持）

- pipeline 制御（req-save→spec-save→case-open→case-run→case-close）の全工程 task() 起動（REQ-0114-084）
- Wave 反復制御（case-run #epic → case-close #epic の反復）
- OU 逐次処理（REQ-0114-053/065〜067）
- 停止条件検出・完了報告（Step 7・Step 8）

### 編集していないファイル（スコープ外）

- `AGENTS.md`: ハーネス選定セクションは Wave 1 で ADR-0128 Decision #1 に整合済み。case-auto workflow 記述は AGENTS.md に存在しないため更新不要
- `case-run.md` / `case-close.md`: Wave 1 で更新済み（PR #988 / #987 でマージ）
- REQ / ADR / SPEC: req-save / spec-save 完了済み（REQ-0114-084 は docs/requirements/REQ-0114.md へ反映済み）

## 検証

- Issue #984 テスト戦略に基づく grep 検証を実施:
  - 旧記述（子Issue選択 / 子Issue単位の task() 並列起動 / 子Issue単位オーケストレーション / Epic status table 更新 / CLI subprocess 委譲を維持 / Step 4-2 case-close（子Issue単位） / Step 4-3 全体完了判定 / case-run 並行委譲 / Wave全体の一括実行を case-run に委譲しない / 最大同時委譲数 / running 遷移）: 全て残存 0 件
  - 新記述（Wave 反復制御 / case-run(#epic) / case-close(#epic) / 全工程 / ADR-0128 Decision #5 / ADR-0125 / task() で起動）: 全て存在
  - ADR-0125 単一書き手制約（Epic Issue 本文読み取りのみ）: 記述あり
- REQ-0101-071（active REQ の Update Notes セクション禁止）・REQ-0101-073（変更履歴セクション禁止）: 本 PR は REQ ファイルを編集していないため非違反
