### PR TITLE
fix(agentdev): Wave 3 横断検出・修正・再発防止 (#1021)

### DIFF
--- a/docs/specs/skills/agentdev-doc-writing.md
+++ b/docs/specs/skills/agentdev-doc-writing.md
@@ -35,6 +35,7 @@ docs 配下の REQ/ADR/SPEC/guides/DOC-MAP/README および関連する command/
 - `references/ai-slop-detection.md` — AI-slop 検出
 - `references/rewrite-patterns.md` — 検出→書き換え
 - `references/review-output.md` — 査読出力形式
+- `references/execution-subject-classification.md` — 実行主体分類（command / skill / subagent / harness）の査読
 
 原本は `docs/specs/writing-style.md`。内容が重複する場合は原本を優先（REQ-0140-023）。
 

--- a/docs/specs/skills/agentdev-inspect-skills.md
+++ b/docs/specs/skills/agentdev-inspect-skills.md
@@ -25,7 +25,7 @@ Command→Skill 参照妥当性と Skill 構造を、ファイル修正なしで
 
 ## 参照する references
 
-- なし（SKILL.md 本文に集約）
+- `references/execution-subject-misclassification.md` — 実行主体分類誤認の判定基準（REQ-0125-010）
 
 ## 現在の動作
 

--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -42,7 +42,7 @@ agent: sisyphus
  - **auto_gate preflight**: `draft-data` の `auto_gate.auto_ready` を確認し、false の場合または未解決 item（unresolved_questions/ unresolved_conflicts/ out_of_repo_operations/ stop_reasons）が残る場合は停止する
 ### Step 4: 各工程の実行
 
-case-auto は全工程（req-save/ spec-save/ case-open/ case-run/ case-close）を各コマンドの委譲契約に従って task で起動し、オーケストレーションに専念する。case-run は Sisyphus-Junior(ulw-loop) への task 委譲モデルを使用する。各工程の task は対応するコマンド定義（`.opencode/commands/agentdev/{step}.md`）を authoritative source として読み込み実行する。case-auto は各工程の完了結果（保存済みファイル・Issue/PR番号・pass/warn/fail）のみを受領し、次工程への入力として渡す。**インライン実行は禁止する**（コンテキスト枯渇防止）
+case-auto は全工程（req-save/ spec-save/ case-open/ case-run/ case-close）を各コマンドの委譲契約に従って task で起動し、オーケストレーションに専念する。case-run は Sisyphus-Junior・ulw-loop への task 委譲モデル（`task(subagent_type="Sisyphus-Junior", load_skills=["agentdev-case-run-execution-adapter"])` + 委譲 prompt 内 `/ulw-loop` command）を使用する。各工程の task は対応するコマンド定義（`.opencode/commands/agentdev/{step}.md`）を authoritative source として読み込み実行する。case-auto は各工程の完了結果（保存済みファイル・Issue/PR番号・pass/warn/fail）のみを受領し、次工程への入力として渡す。**インライン実行は禁止する**（コンテキスト枯渇防止）
 
 **工程別委譲契約**:
 
@@ -71,7 +71,7 @@ case-auto は全工程（req-save/ spec-save/ case-open/ case-run/ case-close）
  2. **クリーンアップ検証ゲート**を実行し、ドラフトファイル・RUファイルの残存がないことを確認すること。残存時は停止すること
  3. Step 4-1（Wave 反復制御）に進む
  - **Step 4-1 Wave 反復制御（case-run #epic → case-close #epic の反復）**: Epic Issue 番号を記録する。Epic Issue 本文（SSoT）から Wave 構成・各子Issue ステータスを読み取る（**読み取りのみ・Epic Issue 本文の書き込みは case-close の単一書き手責務・**）。Epic/Wave orchestration（子Issue 選択・task 並列起動・Epic Issue 本文ステータス追跡テーブルの更新）は case-run/ case-close が担い、case-auto は Wave 反復制御に専念する。以下の Wave 反復ループを実行する:
- 1. **task→case-run(#epic)**: Epic Issue 番号を case-run task に渡す。case-run は現在 Wave の ready 子Issue を Sisyphus-Junior(ulw-loop) に並列委譲（最大5件）し、1 Wave の実行（PR作成まで）で return する
+ 1. **task→case-run(#epic)**: Epic Issue 番号を case-run task に渡す。case-run は現在 Wave の ready 子Issue を Sisyphus-Junior・ulw-loop（adapter skill + 委譲 prompt 内 `/ulw-loop` command）に並列委譲（最大5件）し、1 Wave の実行（PR作成まで）で return する
  2. **task→case-close(#epic)**: case-run task の結果（子Issue ごとの completed(pr)/ blocked/ failed）を確認する。completed(pr) の子Issue がある場合、Epic Issue 番号を case-close task に渡す。case-close は現在 Wave の PR作成済み子Issue を一括マージ・クローズし、Epic status table を更新する（単一書き手）。case-close は最終 Wave 判定を行い、Epic クローズ または 残 Wave 通知を返す
  3. **次 Wave 判定**: case-close task() の結果から Epic 全 Wave 完了可否を判定する:
  - **全 Wave 完了（Epic クローズ済み）**: Epic 完了報告（Step 8）へ進む

--- a/src/opencode/skills/agentdev-workflow-orchestration/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-orchestration/SKILL.md
@@ -5,7 +5,7 @@ description: case-run の状態機械・サブエージェント protocol・self
 
 # case-run オーケストレーションナレッジベース
 
-case-run コマンドのオーケストレーション知識ベース。状態機械・サブエージェントプロトコル・自律修正ループ・CI 対応ループ・エラー回復の判定基準と詳細構造を提供する。case-run は単一 Issue または単一 Wave（`#epic` 指定時: 現在 ready な Wave の子Issue を Sisyphus-Junior(ulw-loop) に並列委譲・最大5件）を処理し、Epic 全体（複数 Wave）の一括実行・Wave 境界（PR マージ）は扱わない（Wave 構成生成は case-open、Wave 境界クローズは case-close の責務）。
+case-run コマンドのオーケストレーション知識ベース。状態機械・サブエージェントプロトコル・自律修正ループ・CI 対応ループ・エラー回復の判定基準と詳細構造を提供する。case-run は単一 Issue または単一 Wave（`#epic` 指定時: 現在 ready な Wave の子Issue を Sisyphus-Junior・ulw-loop（adapter skill + 委譲 prompt 内 `/ulw-loop` command）に並列委譲・最大5件）を処理し、Epic 全体（複数 Wave）の一括実行・Wave 境界（PR マージ）は扱わない（Wave 構成生成は case-open、Wave 境界クローズは case-close の責務）。
 
 ## 状態機械
 


### PR DESCRIPTION
<!-- 【必須】 -->
## 対象 Issue

Closes #1021

Epic: #1018 (Wave 3 — final Wave)

## 概要

OU-002 Wave 3: Wave 1（doc-writing 実行主体分類査読）と Wave 2（inspect-skills / integrity-rule-catalog 境界違反検出）で確立した検出能力をリポジトリ全体に適用し、文書種別責務境界の同型違反を横断的に検出・修正する。

## 変更内容

### Part A: 既知の ulw-loop 委譲契約違反（3件）

`Sisyphus-Junior(ulw-loop)` という ulw-loop を Sisyphus-Junior のパラメータのように扱う表記を、正しい委譲モデル（`Sisyphus-Junior` subagent + `agentdev-case-run-execution-adapter` skill + 委譲 prompt 内 `/ulw-loop` command）へ是正。

| ファイル | 行 | 変更 |
|---|---|---|
| `src/opencode/commands/agentdev/case-auto.md` | L45 | `Sisyphus-Junior(ulw-loop)` → `Sisyphus-Junior・ulw-loop（task(subagent_type="Sisyphus-Junior", load_skills=["agentdev-case-run-execution-adapter"]) + 委譲 prompt 内 /ulw-loop command）` |
| `src/opencode/commands/agentdev/case-auto.md` | L74 | `Sisyphus-Junior(ulw-loop)` → `Sisyphus-Junior・ulw-loop（adapter skill + 委譲 prompt 内 /ulw-loop command）` |
| `src/opencode/skills/agentdev-workflow-orchestration/SKILL.md` | L8 | `Sisyphus-Junior(ulw-loop)` → `Sisyphus-Junior・ulw-loop（adapter skill + 委譲 prompt 内 /ulw-loop command）` |

正規化スタイルは `case-run.md` L2/L8（OU-001 で修正済み）の precedent（`Sisyphus-Junior・ulw-loop` を `・` で区切る shorthand）に準拠。

### Part B: SPEC ドリフト修正（2件）

Wave 1 (PR #1023) と Wave 2 (PR #1024) で追加された新規 references ファイルが各 SPEC の references リストに反映されていなかった不整合を是正。

| ファイル | 変更 |
|---|---|
| `docs/specs/skills/agentdev-doc-writing.md` | references リスト 7件→8件。`execution-subject-classification.md`（実行主体分類の査読）を追加 |
| `docs/specs/skills/agentdev-inspect-skills.md` | 「参照する references: なし（SKILL.md 本文に集約）」を削除し、`execution-subject-misclassification.md`（実行主体分類誤認の判定基準・REQ-0125-010）を追加 |

### Part C: 横断検出結果

対象パターン（`load_skills=["ulw-loop"]` / `ulw-loop` skill 誤称 / `Sisyphus-Junior(ulw-loop)` ペアリング / ADR Decision セクション主題違反）でリポジトリ全体を grep 検出。

| パターン | 検出結果 | 対応 |
|---|---|---|
| `Sisyphus-Junior(ulw-loop)` | 3件（Part A で既修正） | Part A で修正済み |
| `load_skills=["ulw-loop"]` | 4件 | 全て説明文（「旧仕様は誤り」「true positive」「検出パターン例示」）。除外対象 |
| `/ulw-loop` skill 誤称 | 0件 | — |
| ADR Decision 主題違反（廃止/削除/移行） | 1件（ADR-0113 deprecated） | 後述「Findings」参照 |

編集可能範囲（command/skill/SPEC/AGENTS.md）での新規違反は **0件**。

### Part D: 修正

Part C で編集可能範囲における新規違反が検出されなかったため、Part D での追加修正はなし。Part A の3件が全て。

## 検証結果

### 静的 grep 検証

- `Sisyphus[\-\.]Junior[\(（]\s*ulw[\-\.]loop` パターン: **0件**（Part A 修正前は3件）
- `load_skills\s*=\s*\[\s*["']ulw[\-\.]loop["']\s*\]` パターン: 4件（全て説明文・除外対象）
- `/ulw-loop skill|スキル` 誤称: **0件**

### /repo/docs-check 実行

`bun run .opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts` を実行。本 PR に起因する新規 NG/WARNING なし。検出される findings は全て事前存在するもので Wave 3 scope 外（REQ/ADR/guide 内容の静的検査結果）。

### QG-3 verdict: **pass**

| 観点 | 結果 |
|---|---|
| Issue Part A-D 要件合致 | ✓ pass |
| スコープクリープなし（G14） | ✓ pass — ユーザタスク範囲内のみ編集 |
| impl-bug なし | ✓ pass — テキスト正規化のみ・既存 precedent 準拠 |
| spec-bug なし | ✓ pass — SPEC 更新は実在する新規ファイルに基づく |
| REQ/ADR 編集なし（constraint） | ✓ pass |
| 除外リストファイル再編集なし | ✓ pass |

## Findings / Capture候補

### ADR-0113 Decision 主題違反（Wave 3 scope 外・constraint により未修正）

- **ファイル**: `docs/adr/ADR-0113.md`
- **違反**: title「診断ワークフロー導入とレビュー系コマンド完全削除」と Decision セクション `### 2. docs-review / skill-review の完全削除` で「完全削除」という作業手段を主題にしている（REQ-0101-043/044 準拠）
- **理由**: ADR-0113 は `status: deprecated`（2026-06-16, OU-07）。diagnostics → inspect 改名により現行根拠として非適合。deprecated ADR のため現行基盤への影響なし
- **対応**: 本 PR の constraint「Do NOT edit REQ/ADR files」により未修正。別途 ADR 整理ケースで扱うべき

### 事前存在する docs-check findings（本 PR 由来ではない）

`/repo/docs-check` 実行で検出される下記 findings は本 PR 由来ではなく Wave 3 scope 外:

- retired-in-active-index (REQ-0115/0117/0118/0120/0121 in docs/requirements/README.md)
- workflow-status-prohibition (REQ-0141, local-case-file.md, patterns.md)
- reference-path-existence (worktree-operations.md in case-run.md / case-run-execution-adapter)
- req-range-staleness (project-docs-and-specs.md: REQ-0141 → 実際は REQ-0143)
- legacy-normative-marker (workflow-orchestration/SKILL.md L29「（MUST）」— 本 PR の L8 編集箇所とは別)
- doc-language-quality warnings (advisor/advisory 英語混じり)
- req-spec-boundary-violation warnings

これらは本 PR の編集ファイル（case-auto.md, workflow-orchestration/SKILL.md L8, doc-writing.md SPEC, inspect-skills.md SPEC）とは無関係。

## SPEC確定候補

なし。本 PR は既存 SPEC（`docs/specs/skills/agentdev-doc-writing.md`, `docs/specs/skills/agentdev-inspect-skills.md`）の references リスト追従のみで、SPEC レベルの新規記述（schema/enum/判定表/内部アルゴリズム）は発見されなかった。

## テスト戦略 達成状況

- [x] 静的検証: `Sisyphus-Junior(ulw-loop)` パターン grep で 0 件
- [x] 静的検証: `load_skills=["ulw-loop"]` の実委譲指定 grep で 0 件（説明文のみ残存・除外対象）
- [x] 静的検証: `/ulw-loop skill|スキル` 誤称 grep で 0 件
- [x] 静的検証: ADR Decision セクション主題違反 grep で該当 ADR（ADR-0113 deprecated）を検出
- [x] E2E 検証: `/repo/docs-check`（`check_integrity.ts`）実行 — 本 PR 起因の新規 NG なし
- [x] E2E 検証: agentdev-doc-writing skill（Wave 1 成果）の査読観点を本 PR で適用（Part C で実行）
- [x] E2E 検証: agentdev-inspect-skills skill（Wave 2 成果）の診断観点を本 PR で適用（Part C で実行）

## 完了条件 達成状況

- [x] `docs/requirements/REQ-*.md` において要件行に実装詳細が混入していないこと — 本 PR は REQ を編集していない（constraint）。事前状態を維持
- [x] `docs/adr/ADR-*.md` において Decision セクションが廃止・削除・移行を主題にしていないこと — ADR-0113 は deprecated かつ constraint により本 PR では未修正（Findings 記載）
- [x] `docs/specs/*.md` において実行主体分類の誤認が存在しないこと — 本 PR で part B 修正済み
- [x] `src/opencode/commands/agentdev/*.md` において SPEC 未定義の実行契約が存在しないこと — case-auto.md L45/L74 修正済み
- [x] `src/opencode/skills/agentdev-*/SKILL.md` において command/harness/subagent の skill 誤称が存在しないこと — workflow-orchestration/SKILL.md L8 修正済み
- [x] `AGENTS.md` が SPEC/command/skill と矛盾する実行契約を含まないこと — AGENTS.md は OU-001 で修正済み・本 PR では追加違反なし
- [x] OU-001 で既に修正済みの ulw-loop 委譲契約バグが再修正対象に含まれていないこと（AG-006 除外条件） — case-run.md, AGENTS.md, adapter skill, oh-my-openagent.md は除外リスト通り未編集
- [ ] `/repo/docs-check` で整合性エラーが 0 件であること — 本 PR 起因の新規 NG は 0 件だが、事前存在する NG（REQ/ADR/guide 内容）は Wave 3 scope 外のため残存
- [x] Wave 1 / Wave 2 が本 Wave の検出に使用されていること — Part C で適用済み

<!-- 【必須】 -->
## レビューポイント

1. **Part A の正規化スタイル**: `case-auto.md` L45/L74 と `workflow-orchestration/SKILL.md` L8 で `Sisyphus-Junior・ulw-loop`（`・` 区切り shorthand）+ 括弧内に詳細モデル記述とした。`case-run.md` L2/L8（OU-001 precedent）と整合するか
2. **Part B の references 記述**: `execution-subject-classification.md` と `execution-subject-misclassification.md` の各 SPEC での説明文が適切か
3. **ADR-0113 の扱い**: deprecated ADR の Decision 主題違反を本 PR で修正せず Findings に記録する判断（constraint 準拠）が妥当か
4. **docs-check findings の扱い**: 事前存在する NG findings を本 PR scope 外として扱う判断
