### PR TITLE
feat(integrity): docs-check/integrity 運用是正（REQ-0144・#1029）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -5141,6 +5141,7 @@ function checkSkillCategoryGap(
     ["Mapping table history", ["MappingTableHistoryLabels"]],
     ["REQ verification basis", ["ReqVerificationBasis"]],
     ["Skill-internal section ref", ["SkillInternalSectionRef"]],
+    ["docs 日本語表現・文意整合", ["DocLanguageQuality"]],
   ]);
 
   let foundGap = false;
@@ -6738,6 +6739,72 @@ function checkLegacyNormativeMarkers(root: string): CheckResult[] {
   return results;
 }
 
+const SJ_ULWLOOP_PATTERN = /Sisyphus-Junior[\s]*[(（]\s*ulw-loop\s*[)）]/;
+const SJ_ULWLOOP_EXEMPT_PATHS: RegExp[] = [
+  /retired\/REQ-/,
+  /docs[\\/]+requirements[\\/]+REQ-/,
+  /mapping-table\.md$/,
+  /integrity-rule-catalog\.md$/,
+  /\.test\.ts$/,
+  /check_integrity\.ts$/,
+];
+
+function checkSisyphusJuniorUlwLoopMisclassification(root: string): CheckResult[] {
+  const results: CheckResult[] = [];
+  const scanDirs = [
+    path.join(root, "docs"),
+    path.join(root, ".opencode", "skills"),
+    path.join(root, ".opencode", "commands"),
+    path.join(root, "src", "opencode", "skills"),
+    path.join(root, "src", "opencode", "commands"),
+  ];
+
+  const mdFiles: string[] = [];
+  for (const dir of scanDirs) {
+    if (!fs.existsSync(dir)) continue;
+    if (fs.statSync(dir).isDirectory()) {
+      const entries = fs.readdirSync(dir, { recursive: true }) as string[];
+      for (const entry of entries) {
+        if (typeof entry === "string" && entry.endsWith(".md")) {
+          mdFiles.push(path.join(dir, entry));
+        }
+      }
+    }
+  }
+
+  let found = false;
+  for (const filePath of mdFiles) {
+    const content = readText(filePath);
+    if (!content) continue;
+    const relPath = resolveRelative(filePath, root);
+    if (SJ_ULWLOOP_EXEMPT_PATHS.some((re) => re.test(relPath))) continue;
+    const inCodeBlock = content.split("```");
+    const nonCodeParts = inCodeBlock.filter((_, i) => i % 2 === 0).join(" ");
+    if (SJ_ULWLOOP_PATTERN.test(nonCodeParts)) {
+      found = true;
+      results.push(
+        ng(
+          "ExecutionSubject",
+          "sisyphus-junior-ulw-loop-misclassification",
+          "'Sisyphus-Junior(ulw-loop)' misclassification found: /ulw-loop is a command, not a skill (REQ-0144-012/013)",
+          relPath,
+        ),
+      );
+    }
+  }
+
+  if (!found) {
+    results.push(
+      ok(
+        "ExecutionSubject",
+        "sisyphus-junior-ulw-loop-misclassification",
+        "No 'Sisyphus-Junior(ulw-loop)' misclassification detected (REQ-0144-013)",
+      ),
+    );
+  }
+  return results;
+}
+
 const CROSS_REQ_VOCAB_PATTERNS: Array<{
   current: string;
   deprecated: string[];
@@ -7376,6 +7443,7 @@ async function main(): Promise<void> {
     ...checkReqVerificationBasis(root),
     ...checkDocLanguageQuality(root), // IR-045 (REQ-0140)
     ...checkReqSpecBoundaryViolation(root), // IR-044 (REQ-0108-259)
+    ...checkSisyphusJuniorUlwLoopMisclassification(root), // REQ-0144-013
   ];
 
   // REQ-0108-196: classification policy checks (enabled by --classification flag)

--- a/.opencode/skills/repo-agentdev-integrity/scripts/tests/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/tests/check_integrity.test.ts
@@ -145,6 +145,11 @@ function buildValidFixture(root: string): void {
       "| Command | Description |",
       "|---------|-------------|",
       "| `/agentdev/test-cmd` | Test command |",
+      "| `/agentdev/case-run` | Run |",
+      "| `/agentdev/case-close` | Close |",
+      "| `/agentdev/case-open` | Open |",
+      "| `/agentdev/case-auto` | Auto |",
+      "| `/agentdev/req-save` | Save |",
       "",
     ].join("\n"),
     "utf-8",
@@ -187,10 +192,26 @@ function buildValidFixture(root: string): void {
     writeFileSync(join(guidesDir, `${name}.md`), `# ${name}\n`, "utf-8");
   }
 
-  // Skills: agentdev-test-skill (valid prefix)
+  // Skills: agentdev-test-skill (valid prefix) — both source and projection
   const skillDir = join(root, ".opencode", "skills", "agentdev-test-skill");
   mkdirp(skillDir);
   writeFileSync(join(skillDir, "SKILL.md"), "# agentdev-test-skill\n", "utf-8");
+  const skillSrcDir = join(root, "src", "opencode", "skills", "agentdev-test-skill");
+  mkdirp(skillSrcDir);
+  writeFileSync(join(skillSrcDir, "SKILL.md"), "# agentdev-test-skill\n", "utf-8");
+
+  // Skills: agentdev-workflow-orchestration — both source and projection
+  const wfOrchProjDir = join(root, ".opencode", "skills", "agentdev-workflow-orchestration");
+  mkdirp(wfOrchProjDir);
+  writeFileSync(join(wfOrchProjDir, "SKILL.md"), "# agentdev-workflow-orchestration\n", "utf-8");
+
+  // Skills: agentdev-workflow-templates — both source and projection
+  const wfTemplatesProjDir = join(root, ".opencode", "skills", "agentdev-workflow-templates");
+  mkdirp(wfTemplatesProjDir);
+  writeFileSync(join(wfTemplatesProjDir, "SKILL.md"), "# agentdev-workflow-templates\n", "utf-8");
+  const wfTemplatesSrcDir = join(root, "src", "opencode", "skills", "agentdev-workflow-templates");
+  mkdirp(wfTemplatesSrcDir);
+  writeFileSync(join(wfTemplatesSrcDir, "SKILL.md"), "# agentdev-workflow-templates\n", "utf-8");
 
   // Skills: repo-agentdev-integrity (required by the script)
   const integritySkillDir = join(
@@ -218,6 +239,20 @@ function buildValidFixture(root: string): void {
     ].join("\n"),
     "utf-8",
   );
+  const integrityRefsDir = join(integritySkillDir, "references");
+  mkdirp(integrityRefsDir);
+  writeFileSync(
+    join(integrityRefsDir, "vocabulary-registry.md"),
+    [
+      "# Vocabulary Registry",
+      "",
+      "| コマンド名 | コマンドパス | スキル名 | 廃止済み概念 |",
+      "|---|---|---|---|",
+      "| test-cmd | .opencode/commands/agentdev/test-cmd.md | agentdev-test-skill | (none) |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
 
   // Commands
   const cmdDir = join(root, ".opencode", "commands", "agentdev");
@@ -235,6 +270,31 @@ function buildValidFixture(root: string): void {
     ].join("\n"),
     "utf-8",
   );
+
+  // Capture-boundary duty commands (required by check_integrity.ts checkCommandCaptureDuties)
+  const captureDutyCommands: Record<string, string> = {
+    "case-run.md": "記録のみ（capture-boundaries 参照）",
+    "case-close.md": "回収・保存（capture-boundaries 参照）",
+    "req-save.md": "原則非関与（capture-boundaries 参照）",
+    "case-open.md": "非関与（capture-boundaries 参照）",
+    "case-auto.md": "委譲（capture-boundaries 参照）",
+  };
+  for (const [filename, body] of Object.entries(captureDutyCommands)) {
+    writeFileSync(
+      join(cmdDir, filename),
+      [
+        "---",
+        `description: ${filename} capture duty stub`,
+        "agent: sisyphus",
+        "---",
+        "",
+        `capture-boundaries 参照。duty: ${body}`,
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+  }
+
   writeFileSync(
     join(cmdDir, "README.md"),
     [
@@ -243,6 +303,55 @@ function buildValidFixture(root: string): void {
       "| Command | Description | Agent |",
       "|---------|-------------|-------|",
       "| `agentdev/test-cmd` | Test command | test-agent |",
+      "| `agentdev/case-run` | Run | sisyphus |",
+      "| `agentdev/case-close` | Close | sisyphus |",
+      "| `agentdev/case-open` | Open | sisyphus |",
+      "| `agentdev/case-auto` | Auto | sisyphus |",
+      "| `agentdev/req-save` | Save | sisyphus |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // capture-boundaries.md at canonical location (src/opencode/skills/agentdev-workflow-orchestration/references/)
+  const captureBoundariesDir = join(
+    root,
+    "src",
+    "opencode",
+    "skills",
+    "agentdev-workflow-orchestration",
+    "references",
+  );
+  mkdirp(captureBoundariesDir);
+  writeFileSync(
+    join(captureBoundariesDir, "capture-boundaries.md"),
+    "# Capture Boundaries\n",
+    "utf-8",
+  );
+
+  // pr_desc.md template with required capture section structure
+  const templatesDir = join(
+    root,
+    ".opencode",
+    "skills",
+    "agentdev-workflow-templates",
+    "templates",
+  );
+  mkdirp(templatesDir);
+  writeFileSync(
+    join(templatesDir, "pr_desc.md"),
+    [
+      "# PR Description",
+      "",
+      "## Findings / Capture候補",
+      "",
+      "### intake",
+      "",
+      "（intake 候補）",
+      "",
+      "### learning",
+      "",
+      "（learning 候補）",
       "",
     ].join("\n"),
     "utf-8",
@@ -254,7 +363,7 @@ function buildValidFixture(root: string): void {
     [
       "# Test Repo",
       "",
-      "test-cmd",
+      "test-cmd case-run case-close case-open case-auto req-save",
       "",
     ].join("\n"),
     "utf-8",
@@ -480,6 +589,35 @@ describe("Issue #657 regression: CLI execution verification", () => {
       const content = require("fs").readFileSync(fixturePath, "utf-8") as string;
       expect(content).toContain("10 ガイド");
       expect(content).not.toContain("9 ガイド");
+    });
+  });
+
+  describe("fixture drift detection (REQ-0144-009)", () => {
+    it("valid fixture produces zero NG (drift detection smoke test)", () => {
+      const r = runCli(VALID_ROOT, ["--json"]);
+      const parsed = JSON.parse(r.stdout);
+      expect(parsed.summary.ng).toBe(0);
+    });
+
+    it("valid fixture produces zero warnings (drift detection for warning-level rules)", () => {
+      const r = runCli(VALID_ROOT, ["--json"]);
+      const parsed = JSON.parse(r.stdout);
+      expect(parsed.summary.warning).toBe(0);
+    });
+
+    it("copied script matches source script (copyScripts sync verification)", () => {
+      const sourceScript = join(PARENT_SCRIPTS_DIR, "check_integrity.ts");
+      const copiedScript = join(
+        VALID_ROOT,
+        ".opencode",
+        "skills",
+        "repo-agentdev-integrity",
+        "scripts",
+        "check_integrity.ts",
+      );
+      const sourceContent = require("fs").readFileSync(sourceScript, "utf-8") as string;
+      const copiedContent = require("fs").readFileSync(copiedScript, "utf-8") as string;
+      expect(copiedContent).toBe(sourceContent);
     });
   });
 });

--- a/docs/DOC-MAP.md
+++ b/docs/DOC-MAP.md
@@ -52,7 +52,7 @@
 | [REQ-0140](requirements/REQ-0140.md) | 文書品質ゲート | 文書種別責務・要件性・文意品質・粒度の査読、AI-slop検出、IR-045、ドリフト検出、既存文書への遡及準拠修正 |
 | [REQ-0141](requirements/REQ-0141.md) | ローカル版 OpenCode 生成方式とローカルCaseファイル運用 | ローカル版生成方式、src/opencode-local/ 生成時ソース領域、ローカルCaseファイル、GitHub Issue/PR 置換、変換プロンプト、生成安全性制約 |
 | [REQ-0143](requirements/REQ-0143.md) | Command 定義ファイルフォーマット標準化 | AgentDevFlow 管理 command 定義ファイル（src/opencode/commands/agentdev/*.md・.opencode/commands/repo/*.md）の command file format 準拠、適用対象限定、consumer project 独自 command 強制対象外 |
-| [REQ-0144](requirements/REQ-0144.md) | docs-check/integrity 運用是正 | 廃止REQ履歴マーク参照・workflow否定表現・RFC2119マーカー・日本語品質・skill-category-gap・コマンド一覧網羅・REQ範囲表記・fixture経年劣化・QG/case-close Step番号・Sisyphus-Junior(ulw-loop)誤分類・integrity reports git除外 |
+| [REQ-0144](requirements/REQ-0144.md) | docs-check/integrity 運用是正 | 廃止REQ履歴マーク参照・workflow否定表現・RFC2119マーカー・日本語品質・skill-category-gap・コマンド一覧網羅・REQ範囲表記・fixture経年劣化・QG/case-close Step番号・Sisyphus-Junior×/ulw-loop 誤分類表記・integrity reports git除外 |
 | [REQ-0145](requirements/REQ-0145.md) | docs-check/integrity 検出設計改善 | IR-044 SPEC詳細混入解消・委譲キーワード境界ケース・catalog↔実装双方向同期・docs-check項目役割範囲・新カテゴリ追加判定フロー・IR-050/051 語彙レジストリ・閾値確定・3層検出構造責務分担・draft SPEC参照リスト・references checker偽陽性・完了条件grep設計 |
 | [REQ-0146](requirements/REQ-0146.md) | 実行契約・委譲・プロセス設計 | oh-my-openagent CLI引数正規化・委譲プロンプト雛形・case-open即時push・case-auto委譲契約MUST NOT DO・case-close squash merge後reset・git-common-procedures・実行主体分類表・3層検出構造SPEC化・doc-writing査読観点・前工程完了度3段階・subagent-protocol・command-authoring判断基準・バッチIssue完了判定追跡性 |
 | [REQ-0147](requirements/REQ-0147.md) | 文書化規律・HITL境界 | SKILL↔command同一ルール重複許容基準・新旧REQ適用運用ルール・promote/review系HITL限定・判断確定後自動実行・破壊的変更承認維持・learning-promote prune・intake-promote自動実行・backlog-review矛盾検出時追加判断 |

--- a/docs/guides/project-docs-and-specs.md
+++ b/docs/guides/project-docs-and-specs.md
@@ -22,7 +22,7 @@ DOC-MAP（文書探索入口：索引）
 
 要件定義の永続基準。システムが満たすべき要件を記述する。
 
-- 現行 REQ は REQ-0101 から REQ-0141 までの 33 件（REQ-0111, REQ-0115, REQ-0116, REQ-0117, REQ-0118, REQ-0120, REQ-0121, REQ-0122 は廃止）
+- 現行 REQ は REQ-0101 から REQ-0147 までの 39 件（REQ-0111, REQ-0115, REQ-0116, REQ-0117, REQ-0118, REQ-0120, REQ-0121, REQ-0122 は廃止・履歴参照のみ）
 - 旧 REQ（REQ-0001〜REQ-0050 [全て廃止]）は `docs/requirements/retired/` に移動済み。履歴参照に限定する
 - 旧 REQ と新 REQ の対応関係は `docs/requirements/mapping-table.md` に記録
 

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -41,7 +41,7 @@
 | [REQ-0141](REQ-0141.md) | ローカル版 OpenCode 生成方式とローカルCaseファイル運用 | ローカル版生成方式、src/opencode-local/ 生成時ソース領域、ローカルCaseファイル、GitHub Issue/PR 置換、変換プロンプト、生成安全性制約 |
 | [REQ-0142](REQ-0142.md) | 配布物ID除去後の文意保持・構文健全性・責務整合 | 配布物 ID 除去後の完了条件（構文健全性・文意保持・責務整合）、command/skill/SPEC 間の責務説明整合（case-open/run/close/auto）、横断検査の観点拡充、NG 分類明確化 |
 | [REQ-0143](REQ-0143.md) | Command 定義ファイルフォーマット標準化 | AgentDevFlow 管理 command 定義ファイル（src/opencode/commands/agentdev/*.md・.opencode/commands/repo/*.md）の command file format 準拠要件、適用対象限定、consumer project 独自 command の強制対象外 |
-| [REQ-0144](REQ-0144.md) | docs-check/integrity 運用是正 | 廃止REQ履歴マーク参照・workflow否定表現・RFC2119マーカー・日本語品質・skill-category-gap・コマンド一覧網羅・REQ範囲表記・fixture経年劣化・QG/case-close Step番号・Sisyphus-Junior(ulw-loop)誤分類・integrity reports git除外 |
+| [REQ-0144](REQ-0144.md) | docs-check/integrity 運用是正 | 廃止REQ履歴マーク参照・workflow否定表現・RFC2119マーカー・日本語品質・skill-category-gap・コマンド一覧網羅・REQ範囲表記・fixture経年劣化・QG/case-close Step番号・Sisyphus-Junior×/ulw-loop 誤分類表記・integrity reports git除外 |
 | [REQ-0145](REQ-0145.md) | docs-check/integrity 検出設計改善 | IR-044 SPEC詳細混入解消・委譲キーワード境界ケース・catalog↔実装双方向同期・docs-check項目役割範囲・新カテゴリ追加判定フロー・IR-050/051 語彙レジストリ・閾値確定・3層検出構造責務分担・draft SPEC参照リスト・references checker偽陽性・完了条件grep設計 |
 | [REQ-0146](REQ-0146.md) | 実行契約・委譲・プロセス設計 | oh-my-openagent CLI引数正規化・委譲プロンプト雛形・case-open即時push・case-auto委譲契約MUST NOT DO・case-close squash merge後reset・git-common-procedures・実行主体分類表・3層検出構造SPEC化・doc-writing査読観点・前工程完了度3段階・subagent-protocol・command-authoring判断基準・バッチIssue完了判定追跡性 |
 | [REQ-0147](REQ-0147.md) | 文書化規律・HITL境界 | SKILL↔command同一ルール重複許容基準・新旧REQ適用運用ルール・promote/review系HITL限定・判断確定後自動実行・破壊的変更承認維持・learning-promote prune・intake-promote自動実行・backlog-review矛盾検出時追加判断 |

--- a/docs/specs/system.md
+++ b/docs/specs/system.md
@@ -31,6 +31,7 @@ AgentDevFlow（`/agentdev/*` コマンド体系）は 3 つのパイプライン
 |---|---|---|---|
 | `agentdev-learning-capture`（スキル） | エージェント主体で学びを検知・抽出・自律蓄積 | キャプチャ層 | [skills/agentdev-learning-capture.md](skills/agentdev-learning-capture.md) |
 | `/agentdev/learning-promote` | learning entry を分析・分類・昇華判定 | 昇華層 | [commands/learning-promote.md](commands/learning-promote.md) |
+| `/agentdev/backlog-review` | 採用済み成果物を分析・統合し RU を生成 | backlog 層 | [commands/backlog-review.md](commands/backlog-review.md) |
 
 #### intake ワークフロー
 

--- a/src/opencode/skills/agentdev-quality-gates/references/qg-3-implementation-deviation.md
+++ b/src/opencode/skills/agentdev-quality-gates/references/qg-3-implementation-deviation.md
@@ -6,7 +6,7 @@ case-run で PR 作成前に、実装が Issue/ REQ/ ADR/ SPEC/ work plan から
 
 | コマンド | 配置ステップ | 対象成果物 |
 |---------|-------------|-----------|
-| case-run | Step 8（提出フェーズ・乖離検出） | git diff（実装差分）・変更ファイル一覧 |
+| case-run | Step 6-7（実行担当サブエージェント委譲・result 処理） | Sisyphus-Junior が実装と乖離検出を実行。case-run は result として受領 |
 
 ## 乖離の定義
 


### PR DESCRIPTION
## 対応 Issue

Closes #1029

Parent: #1028 (Epic Wave 1)

## 概要

REQ-0144（docs-check/integrity 運用是正）の実装。check_integrity.test.ts fixture 経年劣化の解消、check_integrity.ts category map の網羅、Sisyphus-Junior(ulw-loop) 誤分類検出パターン追加、各種運用是正（コマンド一覧・REQ 範囲・QG Step 参照・表記）を行う。

## 変更内容

### check_integrity.test.ts（REQ-0144-008/009）
- REQ-0144-008: valid fixture に以下を追加し、7件の既知 NG を解消
  - 5つの capture-boundary duty command（case-run/close/open/auto, req-save）
  - capture-boundaries.md（canonical location）
  - pr_desc.md template（## Findings / Capture候補 + ### intake + ### learning セクション）
  - vocabulary-registry.md（コマンド名・コマンドパス・スキル名・廃止済み概念 セクション含む）
  - source/projection skill ペア（agentdev-test-skill, agentdev-workflow-orchestration, agentdev-workflow-templates）
  - system.md と README.md のコマンド一覧・言及の拡充
- REQ-0144-009: fixture drift detection テスト 3件追加
  - valid fixture produces zero NG（drift detection smoke test）
  - valid fixture produces zero warnings（warning-level rules のドリフト検出）
  - copied script matches source script（copyScripts sync verification）

### check_integrity.ts（REQ-0144-005/013）
- REQ-0144-005: categoryToCheckPattern map に "docs 日本語表現・文意整合" → ["DocLanguageQuality"] を追加し、skill-category-gap を解消
- REQ-0144-013: checkSisyphusJuniorUlwLoopMisclassification 関数追加。"Sisyphus-Junior(ulw-loop)" パターンを検出（/ulw-loop は command であり skill ではない）。REQ files・retired・test files・check_integrity.ts 自身を exempt 対象

### system.md（REQ-0144-006）
- learning パイプライン表に `/agentdev/backlog-review` を追加

### docs/guides/project-docs-and-specs.md（REQ-0144-007）
- REQ 範囲表記を「REQ-0101 から REQ-0141 までの 33 件」から「REQ-0101 から REQ-0147 までの 39 件」に更新。廃止 REQ に「履歴参照のみ」マーク追加

### qg-3-implementation-deviation.md（REQ-0144-010）
- 配置ステップ参照を「Step 8（提出フェーズ・乖離検出）」から「Step 6-7（実行担当サブエージェント委譲・result 処理）」に更新。現在の case-run.md Step 構成に適合

### DOC-MAP.md / requirements/README.md（REQ-0144-012）
- REQ-0144 index entry の "Sisyphus-Junior(ulw-loop)誤分類" を "Sisyphus-Junior×/ulw-loop 誤分類表記" に変更し、誤分類パターンに一致しない形式に

## 完了条件

- [x] REQ-0144-001: 現行文書は廃止 REQ を履歴マーキングなしに参照しない（REQ-0101-016 準拠の徹底） — 既存の "（...は廃止）" "retired archive" 等のマーキングで既に満たされている
- [ ] REQ-0144-002: 現行文書に workflow 否定表現（"not X" 形式）を含めない — 広範囲の日本語表現問題。本 PR では未対応（REQ-0145 または別 Issue で対応）
- [ ] REQ-0144-003: 現行文書に RFC2119 マーカー（MUST/SHOULD 等）を含めない — 広範囲。本 PR では未対応
- [ ] REQ-0144-004: docs 配下の日本語品質は REQ-0101-061・REQ-0140-003 に準拠する — 広範囲。本 PR では未対応
- [x] REQ-0144-005: check_integrity.ts の category-to-check-pattern map は定義済み category を全て網羅する（skill-category-gap の解消）
- [x] REQ-0144-006: docs/specs/system.md のコマンド一覧は全 agentdev コマンドを網羅する（backlog-review 含む）
- [x] REQ-0144-007: docs/guides/*.md の REQ 範囲表記は実 REQ 最大番号に追従する（REQ-0143 時点まで反映）
- [x] REQ-0144-008: scripts/tests/check_integrity.test.ts の fixture は最新 check_integrity.ts ルールに追従する（既存5件赤 + valid fixture 7件 NG の解消）
- [x] REQ-0144-009: copyScripts 本採用環境下で fixture drift を自動検出する仕組みが存在する
- [x] REQ-0144-010: QG-3/QG-4 references は現行 case-run Step 番号を参照する
- [x] REQ-0144-011: case-close.md ガードレール（G17/G19/G23）は現行 Step 番号を参照する — 既に Step 11/12/3-2 で整合済み
- [x] REQ-0144-012: 文書に "Sisyphus-Junior(ulw-loop)" 形式の誤分類表記を含めない（/ulw-loop は command であり skill ではない） — index entries のみ修正。REQ-0144.md 自身の記述は task 制約により改変不可
- [x] REQ-0144-013: SPEC↔source 同期検査は "Sisyphus-Junior\(ulw-loop\)" パターンを恒久的に検出する
- [ ] REQ-0144-014: .agentdev/integrity/reports/ は git 管理対象外である（.gitignore で除外） — task 制約（.gitignore は既存の unstaged 変更のため commit 対象外）により blocked。別途 commit 必要

## 検証

- `bun test "./.opencode/skills/repo-agentdev-integrity/scripts/tests/check_integrity.test.ts"` → 14 pass / 0 fail（11 existing + 3 new drift detection tests）
- `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts --json` → skill-category-gap: ok / REQ range: ok / Sisyphus-Junior check: 正常検出

## Findings / Capture候補

### intake
- REQ-0144-002/003/004（workflow 否定表現・RFC2119 marker・日本語品質）は広範囲な文書是正が必要。個別 Issue または REQ-0145（検出設計改善）で対応すべき
- REQ-0144-014（.agentdev/integrity/reports/ git除外）は本 PR では blocked。.gitignore の既存 unstaged 変更（当該エントリ追加を含む）を別途 commit する必要がある

### learning
- check_integrity.ts の新規検出ルール追加時は、テスト fixture の更新と categoryToCheckPattern map の更新をペアで行う必要がある。copyScripts + drift detection テストがこの乖離を自動検出する

## SPEC確定候補

- check_integrity.ts の SJ_ULWLOOP_PATTERN・checkSisyphusJuniorUlwLoopMisclassification は検出ルールの実装詳細。integrity-rule-catalog.md にカタログ化should be considered（REQ-0145 または別途）
