### PR TITLE
OU-002: REQ-0138 APPEND REQ-0138-019/020（depends_on 意義拡張・case_open_hints）

### DIFF
--- a/docs/DOC-MAP.md
+++ b/docs/DOC-MAP.md
@@ -47,7 +47,7 @@
 | [REQ-0135](requirements/REQ-0135.md) | Drafts配置・Draft Type Registry | `.agentdev/drafts/` 配置ルール、draft type registry、`.sisyphus/` 除外 |
 | [REQ-0136](requirements/REQ-0136.md) | REQ/SPEC 責務分離の徹底と新ワークフロー（spec-save 新設・req-define 強化） | spec-save 新設、req-define SPEC分離強化、case-* SPEC確定フロー、inspect-promote 自動promote、REQ健全性メトリクス、SPEC lifecycle（draft/accepted） |
 | [REQ-0137](requirements/REQ-0137.md) | 並列実行安全 git 操作規律（共有作業ツリーでの case-auto 並行実行支援） | 並列実行安全 git 操作規律、スイープ操作禁止、明示パスステージ&コミット、消費アーティファクト(draft/RU)削除信頼性・Form Zero解消・削除検証 Standard/Epic 全flow適用 |
-| [REQ-0138](requirements/REQ-0138.md) | 構造化req_draft契約 | コマンド間引き継ぎ draft 契約、soft-contract原則、artifact_actions構造、LLM推論消費 |
+| [REQ-0138](requirements/REQ-0138.md) | 構造化req_draft契約 | コマンド間引き継ぎ draft 契約、soft-contract原則、artifact_actions構造、LLM推論消費、depends_on意義拡張（技術的+機能的依存ヒント）・case_open_hints記録 |
 | [REQ-0139](requirements/REQ-0139.md) | 外部エージェント統合契約 | 外部エージェント統合、case-run外部実行委譲、driver adapter契約、req-define分類結果アクション |
 | [REQ-0140](requirements/REQ-0140.md) | 文書品質ゲート | 文書種別責務・要件性・文意品質・粒度の査読、IR-045、ドリフト検出、既存文書への遡及準拠修正 |
 | [REQ-0141](requirements/REQ-0141.md) | ローカル版 OpenCode 生成方式とローカルCaseファイル運用 | ローカル版生成方式、src/opencode-local/ 生成時ソース領域、ローカルCaseファイル、GitHub Issue/PR 置換、変換プロンプト、生成安全性制約 |

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -35,7 +35,7 @@
 | [REQ-0135](REQ-0135.md) | Drafts配置・Draft Type Registry | `.agentdev/drafts/` 配置ルール、draft type registry、`.sisyphus/` 除外 |
 | [REQ-0136](REQ-0136.md) | REQ/SPEC 責務分離の徹底と新ワークフロー（spec-save 新設・req-define 強化） | spec-save 新設、req-define SPEC分離強化、case-* SPEC確定フロー、inspect-promote 自動promote、REQ健全性メトリクス |
 | [REQ-0137](REQ-0137.md) | 並列実行安全 git 操作規律 | 並列実行安全 git 操作規律、スイープ操作禁止、明示パスステージ&コミット、消費アーティファクト(draft/RU)削除信頼性・Form Zero解消・削除検証 Standard/Epic 全flow適用 |
-| [REQ-0138](REQ-0138.md) | 構造化req_draft契約 | コマンド間引き継ぎ draft 契約、soft-contract原則、artifact_actions構造、LLM推論消費 |
+| [REQ-0138](REQ-0138.md) | 構造化req_draft契約 | コマンド間引き継ぎ draft 契約、soft-contract原則、artifact_actions構造、LLM推論消費、depends_on意義拡張（技術的+機能的依存ヒント）・case_open_hints記録 |
 | [REQ-0139](REQ-0139.md) | 外部エージェント統合契約 | 外部エージェント統合、case-run外部実行委譲、driver adapter契約、req-define分類結果アクション |
 | [REQ-0140](REQ-0140.md) | 文書品質ゲート | 文書種別責務・要件性・文意品質・粒度の査読、執筆規範（japanese-tech-writing）・配置基準（document-type-responsibilities.md）のSSoT分割、IR-045、ドリフト検出、既存文書への遡及準拠修正 |
 | [REQ-0141](REQ-0141.md) | ローカル版 OpenCode 生成方式とローカルCaseファイル運用 | ローカル版生成方式、src/opencode-local/ 生成時ソース領域、ローカルCaseファイル、GitHub Issue/PR 置換、変換プロンプト、生成安全性制約 |


### PR DESCRIPTION
## 概要

OU-002: REQ-0138 APPEND REQ-0138-019/020（depends_on 意義拡張・case_open_hints）の実装PR。

## 成果物検証

### 完了条件（Issue #1062）

- [x] `docs/requirements/REQ-0138.md` に REQ-0138-019（depends_on 意義拡張・ヒント扱い）が追記されていること
- [x] `docs/requirements/REQ-0138.md` に REQ-0138-020（case_open_hints 記録）が追記されていること

### 検証結果

REQ-0138-019: req-define は OU の depends_on に技術的依存と機能的依存を含めて case-open 向けヒントとして記録すること（確定DAGではなくヒント）

REQ-0138-020: case_open_hints には Epic 構成推論の参考情報（3軸判断のヒント・連結成分候補・Wave 構成候補）を記録できること

両要件行とも AG-001（depends_on は case-open 向けヒント・case-auto への必須出力ではない）と整合する。前工程（req-save・commit e78c081a）で main にコミット済み。

## 変更内容

本PRは前工程で main にコミット済みの REQ-0138.md 成果物に対応する索引ファイルの整合性更新を含む:

- `docs/requirements/README.md`: REQ-0138 関心対象に「depends_on意義拡張（技術的+機能的依存ヒント）・case_open_hints記録」を追加
- `docs/DOC-MAP.md`: REQ-0138 説明に同上を追加

## QG-3 適用結果

| 項目 | 判定 |
|------|------|
| 実装乖離（no-deviation / impl-bug / spec-bug / scope-creep） | **no-deviation** |
| 判定根拠 | REQ-0138-019/020 の内容が Issue #1062 の完了条件・提案内容と完全一致。追加作業（README/DOC-MAP 索引更新）は整合性維持が目的でスコープ逸脱なし |
| ADR 矛盾 | なし（AG-001 準拠） |

## Findings / Capture候補

- **task() フォールバック事象**: 本ハーネスに Sisyphus-Junior 起動用 task() ツールが公開されていないため、adapter skill「task() 起動失敗時事事後処理」Item 5（手動修正または PR 化）パスを使用した。Wave 1 case-run と同一制約（learning L-004）
