### PR TITLE
OU-003: REQ-0132 APPEND REQ-0132-015/016/017（複数 Standard/Epic 構成生成）

### DIFF
--- a/docs/DOC-MAP.md
+++ b/docs/DOC-MAP.md
@@ -41,7 +41,7 @@
 | [REQ-0129](requirements/REQ-0129.md) | Backlog-review | backlog-review コマンド定義 |
 | [REQ-0130](requirements/REQ-0130.md) | case-run / 実装パイプライン | case-run 3フェーズ構成・自律修正ループ |
 | [REQ-0131](requirements/REQ-0131.md) | case-close / 完了処理 | case-close 完了ゲート・QG-4・達成判定 |
-| [REQ-0132](requirements/REQ-0132.md) | case-open / Issue作成 | case-open Epic・子Issue作成 |
+| [REQ-0132](requirements/REQ-0132.md) | case-open / Issue作成 | case-open Epic・子Issue作成、連結成分ベース複数Standard/Epic構成生成・3軸判断・単独根Standard flow |
 | [REQ-0133](requirements/REQ-0133.md) | case-update / Issue更新 | case-update Issue本文更新・コメント追加 |
 | [REQ-0134](requirements/REQ-0134.md) | 配布基盤: source/projection・sync・repo type・consumer install | source/projection layout、sync/migration script、repo type、consumer install |
 | [REQ-0135](requirements/REQ-0135.md) | Drafts配置・Draft Type Registry | `.agentdev/drafts/` 配置ルール、draft type registry、`.sisyphus/` 除外 |

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -29,7 +29,7 @@
 | [REQ-0129](REQ-0129.md) | Backlog-review | backlog-review、RU 直接生成、採用済み成果物の読込・統合・矛盾検出、depends_on（RU-ID限定・循環依存検証）、REQ再構成intake ルーティング分離 |
 | [REQ-0130](REQ-0130.md) | case-run / 実装パイプライン | case-run、作業用 worktree 実装、PR 作成、QG-3（PR作成直前ゲート）、本筋外 検出事項のPR本文記録、capture 責務境界（inbox 非変更・PR本文経由引き継ぎ） |
 | [REQ-0131](REQ-0131.md) | case-close / 完了処理 | case-close、完了ゲート、PR merge（squash・リトライ・フォールバック）、Issue close、capture 回収（PR本文→ドメイン状態）、branch/worktree cleanup、ローカル変更検出時の安全停止、force-with-lease制約 |
-| [REQ-0132](REQ-0132.md) | case-open / Issue作成 | case-open、Issue本文生成（REQ番号埋め込み）、Standard/Epic flow ルーティング、RU削除責務（Issue作成+VERIFY成功後）、capture 非関与 |
+| [REQ-0132](REQ-0132.md) | case-open / Issue作成 | case-open、Issue本文生成（REQ番号埋め込み）、Standard/Epic flow ルーティング、連結成分ベース複数Standard/Epic構成生成・3軸判断・単独根Standard flow、RU削除責務（Issue作成+VERIFY成功後）、capture 非関与 |
 | [REQ-0133](REQ-0133.md) | case-update / Issue更新 | case-update、Issue本文更新（テンプレート構造維持）、コメント追加、REQ ファイル更新（直接commit+push）、レビューNG対応、フェーズ維持 |
 | [REQ-0134](REQ-0134.md) | 配布基盤: source/projection・sync・repo type・consumer install | source/projection layout、sync/migration script、repo type、consumer install |
 | [REQ-0135](REQ-0135.md) | Drafts配置・Draft Type Registry | `.agentdev/drafts/` 配置ルール、draft type registry、`.sisyphus/` 除外 |


### PR DESCRIPTION
## 概要

OU-003: REQ-0132 APPEND REQ-0132-015/016/017（複数 Standard/Epic 構成生成）の実装PR。

## 成果物検証

### 完了条件（Issue #1063）

- [x] `docs/requirements/REQ-0132.md` に REQ-0132-015（複数 Standard/Epic 混在生成）が追記されていること
- [x] `docs/requirements/REQ-0132.md` に REQ-0132-016（連結成分ベース3軸判断）が追記されていること
- [x] `docs/requirements/REQ-0132.md` に REQ-0132-017（単独根 Standard flow）が追記されていること

### 検証結果

REQ-0132-015: case-open は OU 群から複数 Standard Issue / 複数 Epic Issue / 両者の混在を作成できること（単一 Epic 集約に限定しない）

REQ-0132-016: case-open は依存グラフの連結成分（必須依存のみをエッジとする）を Epic 候補の出発点とし、依存強度・Epic サイズ・機能的一貫性の3軸で最終構成を自律生成すること

REQ-0132-017: case-open は単独根（1 OU だけの連結成分）を Epic 化せず Standard flow として扱うこと

3要件行とも AG-003 と整合し、REQ-0148-005/006/007/008/010 と重複・矛盾しない。前工程（req-save・commit e78c081a）で main にコミット済み。

## 変更内容

本PRは前工程で main にコミット済みの REQ-0132.md 成果物に対応する索引ファイルの整合性更新を含む:

- `docs/requirements/README.md`: REQ-0132 関心対象に「連結成分ベース複数Standard/Epic構成生成・3軸判断・単独根Standard flow」を追加
- `docs/DOC-MAP.md`: REQ-0132 説明に同上を追加

## QG-3 適用結果

| 項目 | 判定 |
|------|------|
| 実装乖離（no-deviation / impl-bug / spec-bug / scope-creep） | **no-deviation** |
| 判定根拠 | REQ-0132-015/016/017 の内容が Issue #1063 の完了条件・提案内容と完全一致。追加作業（README/DOC-MAP 索引更新）は整合性維持が目的でスコープ逸脱なし |
| ADR 矛盾 | なし（AG-003 準拠） |

## Findings / Capture候補

- **task() フォールバック事象**: 本ハーネスに Sisyphus-Junior 起動用 task() ツールが公開されていないため、adapter skill「task() 起動失敗時事事後処理」Item 5（手動修正または PR 化）パスを使用した。Wave 1 case-run と同一制約（learning L-004）
