### PR TITLE
OU-006: case-open.md SPEC UPDATE（連結成分ベース複数 Standard/Epic 構成生成モデルへ）

### DIFF
--- a/docs/specs/system.md
+++ b/docs/specs/system.md
@@ -19,7 +19,7 @@ AgentDevFlow（`/agentdev/*` コマンド体系）は 3 つのパイプライン
 | `/agentdev/req-define` | 要件定義（壁打ち） | prometheus | [commands/req-define.md](commands/req-define.md) |
 | `/agentdev/req-save` | 要件定義の保存 | sisyphus | [commands/req-save.md](commands/req-save.md) |
 | `/agentdev/spec-save` | SPEC 候補の保存・確定 | sisyphus | [commands/spec-save.md](commands/spec-save.md) |
-| `/agentdev/case-open` | Issue 登録（Epic + 子 Issue 一括作成対応） | sisyphus | [commands/case-open.md](commands/case-open.md) |
+| `/agentdev/case-open` | Issue 登録（連結成分ベース複数 Standard/Epic 構成生成・3軸判断） | sisyphus | [commands/case-open.md](commands/case-open.md) |
 | `/agentdev/case-run` | 実装パイプライン（3 フェーズ構成） | sisyphus | [commands/case-run.md](commands/case-run.md) |
 | `/agentdev/case-update` | Issue 更新 | sisyphus | [commands/case-update.md](commands/case-update.md) |
 | `/agentdev/case-close` | 完了処理（達成判定プロトコル付き完了ゲート） | sisyphus | [commands/case-close.md](commands/case-close.md) |


### PR DESCRIPTION
## 概要

OU-006: case-open.md SPEC UPDATE（連結成分ベース複数 Standard/Epic 構成生成モデルへ）の実装・検証 PR。

Epic #1060（RU群バッチ処理と複数 execution_unit 並列実行モデル）の Wave 3 子Issue。

## 成果物検証

### 完了条件（Issue #1066）

- [x] `docs/specs/commands/case-open.md` に「連結成分ベース複数 Standard/Epic 構成生成」セクションが存在し、「独立 OU の自動 Epic 化」セクションが書き換わっていること — ✅ line 98 `### 連結成分ベース複数 Standard/Epic 構成生成（REQ-0114-088 更新・REQ-0148）`。旧「独立 OU の自動 Epic 化」参照は grep で残存なし確認済み
- [x] 3軸判断（依存強度・Epic サイズ・機能的一貫性）の判定基準が詳細化されていること — ✅ line 100 連結成分ベース説明・line 106-110 3軸判断詳細テーブル（依存強度・Epic サイズ・機能的一貫性）
- [x] 単独根（1 OU だけの連結成分）の Standard flow 扱いが明記されていること — ✅ line 102 単独根の Standard flow 扱い
- [x] See Also に REQ-0148 が追加されていること — ✅ line 137 REQ-0148 — RU群バッチ処理と複数 execution_unit 並列実行

### 検証結果

前工程（spec-save・commit 5f754465）で main にコミット済み。完了条件4項目全て充足。

## 変更内容（WARN follow-up）

本 PR は前工程で main にコミット済みの case-open.md 成果物に対応する索引ファイルの整合性更新を含む:

- `docs/specs/system.md`: コマンド一覧テーブルの case-open 説明を「Issue 登録（Epic + 子 Issue 一括作成対応）」から「Issue 登録（連結成分ベース複数 Standard/Epic 構成生成・3軸判断）」へ更新

旧説明は SPEC 更新前の挙動（独立 OU 自動 Epic 化）を反映していた。REQ-0114-088 破壊的 UPDATE 後に事実矛盾が生じていたため、本 PR で解消。

## QG-3 適用結果

| 項目 | 判定 |
|------|------|
| 実装乖離（no-deviation / impl-bug / spec-bug / scope-creep） | **no-deviation** |
| 判定根拠 | case-open.md の SPEC UPDATE 内容（4完了条件）が Issue #1066 の完了条件・提案内容と完全一致。AG-003 に基づく。追加作業（system.md 索引説明の整合性更新）は SPEC 更新に付随するスコープ内作業 |
| ADR 矛盾 | なし（REQ-0114-088 破壊的 UPDATE・CR-001 準拠） |

## Findings / Capture候補

- **task() フォールバック事象**: 本ハーネスに Sisyphus-Junior 起動用 task() ツールが公開されていないため、adapter skill「task() 起動失敗時事事後処理」Item 5（手動修正または PR 化）パスを使用した。Wave 1/2 case-run と同一制約（learning L-004）

## SPEC確定候補

（該当なし — case-open.md の SPEC 内容は spec-save で確定済み）
