### PR TITLE
OU-007: case-auto.md SPEC UPDATE（複数 execution_unit 並列 orchestration モデルへ）

### DIFF
--- a/docs/specs/system.md
+++ b/docs/specs/system.md
@@ -23,7 +23,7 @@ AgentDevFlow（`/agentdev/*` コマンド体系）は 3 つのパイプライン
 | `/agentdev/case-run` | 実装パイプライン（3 フェーズ構成） | sisyphus | [commands/case-run.md](commands/case-run.md) |
 | `/agentdev/case-update` | Issue 更新 | sisyphus | [commands/case-update.md](commands/case-update.md) |
 | `/agentdev/case-close` | 完了処理（達成判定プロトコル付き完了ゲート） | sisyphus | [commands/case-close.md](commands/case-close.md) |
-| `/agentdev/case-auto` | 最大自走モード | sisyphus | [commands/case-auto.md](commands/case-auto.md) |
+| `/agentdev/case-auto` | 最大自走モード（複数 execution_unit 並列 orchestration・blocked 部分停止） | sisyphus | [commands/case-auto.md](commands/case-auto.md) |
 
 #### learning パイプライン
 


### PR DESCRIPTION
## 概要

OU-007: case-auto.md SPEC UPDATE（複数 execution_unit 並列 orchestration モデルへ）の実装・検証 PR。

Epic #1060（RU群バッチ処理と複数 execution_unit 並列実行モデル）の Wave 3 子Issue。

## 成果物検証

### 完了条件（Issue #1067）

- [x] `docs/specs/commands/case-auto.md` に「複数 execution_unit 並列 orchestration」セクションが存在すること — ✅ line 92 `## 複数 execution_unit 並列 orchestration（REQ-0148, ADR-0129）`
- [x] 並列実行判定（連結成分ベース・技術的依存レベル L0-L3 除外・ファイル衝突 L2 許容）が記載されていること（REQ-0148-014）— ✅ line 96-102 並列実行の判定セクション・line 102 L0-L3 除外・ファイル衝突 L2 許容
- [x] blocked 部分停止・ready 継続判定フロー（状態 enum 表）が記載されていること（REQ-0148-015/016）— ✅ line 106 blocked 部分停止・ready 継続判定フロー・line 108-116 状態 enum 表（closed/blocked/failed/running/ready）
- [x] execution_unit 群反復制御への一般化が記載されていること — ✅ line 120 execution_unit 群反復制御への一般化・line 122 単一 Epic Wave 反復は特殊ケース
- [x] グローバル並列上限なし（case-run 5件上限のみ）が明記されていること（REQ-0148-018）— ✅ line 104 グローバル並列上限は設定しない（REQ-0148-018）・case-run 単位の5件上限（REQ-0130-026 踏襲）
- [x] Step 4-1 Wave 反復制御記述が新モデルへ一般化されていること — ✅ line 49 Step 4-1 Wave 反復制御記述に execution_unit 群反復制御への一般化参照を追加
- [x] See Also に REQ-0148 と ADR-0129 が追加されていること — ✅ line 143 REQ-0148・line 147 ADR-0129

### 検証結果

前工程（spec-save・commit 5f754465）で main にコミット済み。完了条件7項目全て充足。

## 変更内容（WARN follow-up）

本 PR は前工程で main にコミット済みの case-auto.md 成果物に対応する索引ファイルの整合性更新を含む:

- `docs/specs/system.md`: コマンド一覧テーブルの case-auto 説明を「最大自走モード」から「最大自走モード（複数 execution_unit 並列 orchestration・blocked 部分停止）」へ更新

旧説明は新モデル（複数 execution_unit 並列 orchestration・blocked 部分停止・ready 継続）を反映していなかったため、SPEC 更新後に過度に抽象的になっていた。本 PR で新モデルの要点を反映。

## QG-3 適用結果

| 項目 | 判定 |
|------|------|
| 実装乖離（no-deviation / impl-bug / spec-bug / scope-creep） | **no-deviation** |
| 判定根拠 | case-auto.md の SPEC UPDATE 内容（7完了条件）が Issue #1067 の完了条件・提案内容と完全一致。AG-004/005 に基づく。追加作業（system.md 索引説明の整合性更新）は SPEC 更新に付随するスコープ内作業 |
| ADR 矛盾 | なし（ADR-0129 準拠・See Also 追加済み） |

## Findings / Capture候補

- **task() フォールバック事象**: 本ハーネスに Sisyphus-Junior 起動用 task() ツールが公開されていないため、adapter skill「task() 起動失敗時事事後処理」Item 5（手動修正または PR 化）パスを使用した。Wave 1/2 case-run と同一制約（learning L-004）

## SPEC確定候補

（該当なし — case-auto.md の SPEC 内容は spec-save で確定済み）
