### PR TITLE
feat(scripts): install-consumer-opencode.ps1 -LocalMode 追加 (#1110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,24 @@ AgentDevFlow を外部プロジェクトに導入する手順。
 
 ### インストール
 
+通常版（GitHub 版 OpenCode を利用する環境）のインストール。
+
 ```powershell
 # 1. scripts/ を適用先リポジトリにコピー
 # 2. インストールを実行（clone + ジャンクション 作成）
 ./scripts/install-consumer-opencode.ps1 -Mode apply
 ```
 
+ローカル版（ローカル版 OpenCode を利用する環境）のインストール。`-LocalMode` を付けると `agentdev-gh-cli` だけが `src/opencode-local/agentdev-gh-cli/` へ接続され、それ以外の command/skill は通常版と同じ `src/opencode/` 配下へ接続される（REQ-0103-158、ADR-0131）。
+
+```powershell
+./scripts/install-consumer-opencode.ps1 -Mode apply -LocalMode
+```
+
 ### 状態確認
 
 ```powershell
-# インストール状態を確認
+# インストール状態を確認（リンクモードを自動検出して報告）
 ./scripts/check-consumer-opencode.ps1
 ```
 
@@ -93,9 +101,13 @@ AgentDevFlow を外部プロジェクトに導入する手順。
 # agent-dev-flow の最新を取得して再同期
 cd .agentdev-plugin && git pull && cd ..
 ./scripts/install-consumer-opencode.ps1 -Mode apply
+# ローカル版環境の場合は -LocalMode を付けて再実行
+# ./scripts/install-consumer-opencode.ps1 -Mode apply -LocalMode
 ```
 
 ### 推奨 .gitignore 設定
+
+通常版・ローカル版ともに同一。`agentdev-gh-cli` はリンク先が異なるだけなので `.opencode/skills/agentdev-*/` パターンで網羅される。
 
 ```gitignore
 .agentdev-plugin/

--- a/scripts/check-consumer-opencode.ps1
+++ b/scripts/check-consumer-opencode.ps1
@@ -9,6 +9,10 @@
     - All expected junctions exist and point to correct targets
     - Reports divergences
 
+    Auto-detects link mode from the agentdev-gh-cli junction target:
+    - Normal mode: agentdev-gh-cli -> src/opencode/skills/agentdev-gh-cli/
+    - Local mode:  agentdev-gh-cli -> src/opencode-local/agentdev-gh-cli/ (consumer-generated)
+
     No apply mode is provided. Use install-consumer-opencode.ps1 -Mode apply to fix issues.
 
 .PARAMETER PluginDir
@@ -27,9 +31,13 @@ $ErrorActionPreference = 'Stop'
 $RepoRoot = $PWD.Path
 $PluginPath = Join-Path $RepoRoot $PluginDir
 $SourceDir = Join-Path $PluginPath 'src\opencode'
+$LocalSourceDir = Join-Path $PluginPath 'src\opencode-local'
 $ProjectionDir = Join-Path $RepoRoot '.opencode'
 $CommandsDir = Join-Path $ProjectionDir 'commands'
 $SkillsDir = Join-Path $ProjectionDir 'skills'
+
+# Skill redirected to src/opencode-local/ in local mode (REQ-0103-158, ADR-0131 decision #3)
+$LocalModeRedirectSkill = 'agentdev-gh-cli'
 
 # --- Helper Functions ---
 
@@ -46,6 +54,20 @@ function Get-JunctionTarget {
     if (-not $item) { return $null }
     if (-not ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) { return $null }
     return $item.Target
+}
+
+function Get-TargetSourcePath {
+    <#
+    .SYNOPSIS
+        Resolve the absolute source path backing a projection relative path.
+        When $DetectedLocalMode is true, skills\<LocalModeRedirectSkill> is redirected
+        to src/opencode-local/<LocalModeRedirectSkill>/ (REQ-0103-158, ADR-0131 decision #3).
+    #>
+    param([string]$RelPath, [bool]$LocalMode)
+    if ($LocalMode -and $RelPath -eq "skills\$LocalModeRedirectSkill") {
+        return Join-Path $LocalSourceDir $LocalModeRedirectSkill
+    }
+    return Join-Path $SourceDir $RelPath
 }
 
 # --- Main ---
@@ -82,7 +104,36 @@ if (-not (Test-Path -LiteralPath $SourceDir)) {
     Write-Host "[OK] Source directory exists: $PluginDir/src/opencode/"
 }
 
-# 3. .opencode/ status
+# 3. Link mode detection (agentdev-gh-cli junction target)
+# Local mode: agentdev-gh-cli -> src/opencode-local/agentdev-gh-cli/ (consumer-generated)
+# Normal mode: agentdev-gh-cli -> src/opencode/skills/agentdev-gh-cli/ (consumer-with-agentdev)
+$DetectedLocalMode = $false
+$ghCliProjection = Join-Path $SkillsDir $LocalModeRedirectSkill
+$ghCliLocalSource = Join-Path $LocalSourceDir $LocalModeRedirectSkill
+if (Test-Junction -Path $ghCliProjection) {
+    $ghCliTarget = Get-JunctionTarget -Path $ghCliProjection
+    if ($ghCliTarget -and (Test-Path -LiteralPath $ghCliTarget) -and
+        ((Resolve-Path -LiteralPath $ghCliTarget).Path -eq (Resolve-Path -LiteralPath $ghCliLocalSource).Path)) {
+        $DetectedLocalMode = $true
+    }
+}
+if ($DetectedLocalMode) {
+    Write-Host '[INFO] Link mode: local (consumer-generated) — agentdev-gh-cli -> src/opencode-local/'
+} else {
+    Write-Host '[INFO] Link mode: normal (consumer-with-agentdev) — agentdev-gh-cli -> src/opencode/'
+}
+
+# 3b. Local redirect source (local mode only)
+if ($DetectedLocalMode) {
+    if (-not (Test-Path -LiteralPath $ghCliLocalSource)) {
+        Write-Host "[DIVERGENCE] Local redirect source not found: $PluginDir/src/opencode-local/$LocalModeRedirectSkill/"
+        $divergences++
+    } else {
+        Write-Host "[OK] Local redirect source exists: $PluginDir/src/opencode-local/$LocalModeRedirectSkill/"
+    }
+}
+
+# 4. .opencode/ status
 if (-not (Test-Path -LiteralPath $ProjectionDir)) {
     Write-Host '[DIVERGENCE] .opencode/ does not exist'
     $divergences++
@@ -93,7 +144,7 @@ if (-not (Test-Path -LiteralPath $ProjectionDir)) {
     Write-Host '[OK] .opencode/ is a real directory'
 }
 
-# 4. Parent directories
+# 5. Parent directories
 if (Test-Path -LiteralPath $ProjectionDir) {
     foreach ($parentRel in @('commands', 'skills')) {
         $parentPath = Join-Path $ProjectionDir $parentRel
@@ -109,7 +160,7 @@ if (Test-Path -LiteralPath $ProjectionDir) {
     }
 }
 
-# 5. Junction checks
+# 6. Junction checks
 if (Test-Path -LiteralPath $SourceDir) {
     # Enumerate expected targets from source
     $targets = [System.Collections.Generic.List[string]]::new()
@@ -130,7 +181,7 @@ if (Test-Path -LiteralPath $SourceDir) {
 
     foreach ($relPath in ($targets | Sort-Object)) {
         $targetPath = Join-Path $ProjectionDir $relPath
-        $expectedSource = Join-Path $SourceDir $relPath
+        $expectedSource = Get-TargetSourcePath -RelPath $relPath -LocalMode $DetectedLocalMode
 
         if (-not (Test-Path -LiteralPath $targetPath)) {
             Write-Host "[DIVERGENCE] Missing junction: $relPath"
@@ -149,7 +200,7 @@ if (Test-Path -LiteralPath $SourceDir) {
         }
     }
 
-    # 6. Orphan detection (agentdev-* junctions that don't match source)
+    # 7. Orphan detection (agentdev-* junctions that don't match source)
     Write-Host ''
     Write-Host '--- Orphan junctions ---'
     $orphansFound = $false

--- a/scripts/install-consumer-opencode.ps1
+++ b/scripts/install-consumer-opencode.ps1
@@ -17,8 +17,17 @@
     - .opencode/commands/repo/      = real directory (repo-local only)
     - .opencode/skills/repo-*/      = real directories (repo-local only)
 
+    -LocalMode redirects agentdev-gh-cli to the local OpenCode source:
+    - skills/agentdev-gh-cli/       = junction -> .agentdev-plugin/src/opencode-local/agentdev-gh-cli/
+    All other agentdev-* artifacts still link to src/opencode/ as normal.
+
 .PARAMETER Mode
     One of: dry-run, check, apply
+
+.PARAMETER LocalMode
+    Switch. When set, agentdev-gh-cli is junctioned to src/opencode-local/agentdev-gh-cli/
+    instead of src/opencode/skills/agentdev-gh-cli/. All other agentdev-* command/skill
+    junctions target src/opencode/ as normal (REQ-0103-158, ADR-0131 decision #3).
 
 .PARAMETER PluginDir
     Directory name for the agent-dev-flow checkout (default: .agentdev-plugin).
@@ -35,12 +44,15 @@
     ./scripts/install-consumer-opencode.ps1 -Mode check
     ./scripts/install-consumer-opencode.ps1 -Mode apply
     ./scripts/install-consumer-opencode.ps1 -Mode apply -PluginDir .agentdev-plugin
+    ./scripts/install-consumer-opencode.ps1 -Mode apply -LocalMode
 #>
 
 param(
     [Parameter(Mandatory)]
     [ValidateSet('dry-run', 'check', 'apply')]
     [string]$Mode,
+
+    [switch]$LocalMode,
 
     [string]$PluginDir = '.agentdev-plugin',
 
@@ -53,6 +65,7 @@ $ErrorActionPreference = 'Stop'
 $RepoRoot = $PWD.Path
 $PluginPath = Join-Path $RepoRoot $PluginDir
 $SourceDir = Join-Path $PluginPath 'src\opencode'
+$LocalSourceDir = Join-Path $PluginPath 'src\opencode-local'
 $ProjectionDir = Join-Path $RepoRoot '.opencode'
 $CommandsDir = Join-Path $ProjectionDir 'commands'
 $SkillsDir = Join-Path $ProjectionDir 'skills'
@@ -60,6 +73,9 @@ $SkillsDir = Join-Path $ProjectionDir 'skills'
 # Repo-local patterns excluded from junction management
 $RepoLocalCommandNames = @('repo')
 $RepoLocalSkillPrefix = 'repo-'
+
+# In LocalMode this skill is redirected from src/opencode-local/ (REQ-0103-158, ADR-0131 decision #3)
+$LocalModeRedirectSkill = 'agentdev-gh-cli'
 
 # --- Helper Functions ---
 
@@ -100,6 +116,21 @@ function Get-ConsumerJunctionTargets {
     }
 
     return ($targets | Sort-Object)
+}
+
+function Get-TargetSourcePath {
+    <#
+    .SYNOPSIS
+        Resolve the absolute source path backing a projection relative path.
+        In LocalMode, skills\<LocalModeRedirectSkill> is redirected to
+        src/opencode-local/<LocalModeRedirectSkill>/ (REQ-0103-158, ADR-0131 decision #3).
+        All other targets back to src/opencode/ as normal.
+    #>
+    param([string]$RelPath)
+    if ($LocalMode -and $RelPath -eq "skills\$LocalModeRedirectSkill") {
+        return Join-Path $LocalSourceDir $LocalModeRedirectSkill
+    }
+    return Join-Path $SourceDir $RelPath
 }
 
 # --- Clone / Update ---
@@ -146,6 +177,15 @@ if (-not (Test-Path -LiteralPath $SourceDir)) {
     exit 1
 }
 
+# LocalMode requires the local source redirect target to exist
+if ($LocalMode) {
+    $localRedirectSource = Join-Path $LocalSourceDir $LocalModeRedirectSkill
+    if (-not (Test-Path -LiteralPath $localRedirectSource)) {
+        Write-Error "[ERROR] LocalMode redirect source not found: $localRedirectSource. Ensure $PluginDir contains agent-dev-flow checkout with src/opencode-local/."
+        exit 1
+    }
+}
+
 $targets = Get-ConsumerJunctionTargets
 
 # ============================================================
@@ -154,6 +194,9 @@ $targets = Get-ConsumerJunctionTargets
 
 if ($Mode -eq 'check') {
     Write-Host '=== Consumer Install Check ==='
+    if ($LocalMode) {
+        Write-Host '[INFO] LocalMode: agentdev-gh-cli redirects to src/opencode-local/agentdev-gh-cli/'
+    }
     $divergences = 0
 
     # 1. Plugin checkout
@@ -170,6 +213,16 @@ if ($Mode -eq 'check') {
         $divergences++
     } else {
         Write-Host "[OK] Source directory exists: $PluginDir/src/opencode/"
+    }
+
+    # 2b. Local redirect source (LocalMode only)
+    if ($LocalMode) {
+        if (-not (Test-Path -LiteralPath $localRedirectSource)) {
+            Write-Host "[DIVERGENCE] LocalMode redirect source not found: $PluginDir/src/opencode-local/$LocalModeRedirectSkill/"
+            $divergences++
+        } else {
+            Write-Host "[OK] LocalMode redirect source exists: $PluginDir/src/opencode-local/$LocalModeRedirectSkill/"
+        }
     }
 
     # 3. .opencode/ must be a real directory
@@ -204,7 +257,7 @@ if ($Mode -eq 'check') {
             Write-Host "[DIVERGENCE] Missing junction: $relPath"
             $divergences++
         } elseif (Test-Junction -Path $targetPath) {
-            $expectedSource = Join-Path $SourceDir $relPath
+            $expectedSource = Get-TargetSourcePath -RelPath $relPath
             $actualTarget = Get-JunctionTarget -Path $targetPath
             if ($actualTarget -and (Test-Path -LiteralPath $actualTarget) -and ((Resolve-Path -LiteralPath $actualTarget).Path -eq (Resolve-Path -LiteralPath $expectedSource).Path)) {
                 Write-Host "[OK] Junction: $relPath"
@@ -248,6 +301,9 @@ if ($Mode -eq 'check') {
 
 if ($Mode -eq 'dry-run') {
     Write-Host '=== Consumer Install Dry Run ==='
+    if ($LocalMode) {
+        Write-Host '[INFO] LocalMode: agentdev-gh-cli redirects to src/opencode-local/agentdev-gh-cli/'
+    }
 
     # .opencode/ status
     if (Test-Junction -Path $ProjectionDir) {
@@ -275,9 +331,9 @@ if ($Mode -eq 'dry-run') {
 
     foreach ($relPath in $targets) {
         $targetPath = Join-Path $ProjectionDir $relPath
+        $expectedSource = Get-TargetSourcePath -RelPath $relPath
         if (Test-Junction -Path $targetPath) {
             $actualTarget = Get-JunctionTarget -Path $targetPath
-            $expectedSource = Join-Path $SourceDir $relPath
             if ($actualTarget -and (Test-Path -LiteralPath $actualTarget)) {
                 Write-Host "[OK] Already junctioned: $relPath"
             } else {
@@ -287,7 +343,7 @@ if ($Mode -eq 'dry-run') {
         } elseif (Test-Path -LiteralPath $targetPath) {
             Write-Host "[ERROR] Path exists and is not a junction: $relPath"
         } else {
-            Write-Host "[WOULD ADD] Create junction: $relPath"
+            Write-Host "[WOULD ADD] Create junction: $relPath -> $expectedSource"
         }
     }
 
@@ -302,6 +358,9 @@ if ($Mode -eq 'dry-run') {
 
 if ($Mode -eq 'apply') {
     Write-Host '=== Consumer Install: applying junctions ==='
+    if ($LocalMode) {
+        Write-Host '[INFO] LocalMode: agentdev-gh-cli redirects to src/opencode-local/agentdev-gh-cli/'
+    }
 
     # Step 1: Ensure .opencode/ is a real directory
     if (Test-Junction -Path $ProjectionDir) {
@@ -338,18 +397,19 @@ if ($Mode -eq 'apply') {
     Write-Host '--- Junctions ---'
     foreach ($relPath in $targets) {
         $targetPath = Join-Path $ProjectionDir $relPath
-        $sourcePath = Join-Path $SourceDir $relPath
+        $sourcePath = Get-TargetSourcePath -RelPath $relPath
 
         if (Test-Junction -Path $targetPath) {
             $actualTarget = Get-JunctionTarget -Path $targetPath
-            if ($actualTarget -and (Test-Path -LiteralPath $actualTarget)) {
+            $expectedSource = $sourcePath
+            if ($actualTarget -and (Test-Path -LiteralPath $actualTarget) -and ((Resolve-Path -LiteralPath $actualTarget).Path -eq (Resolve-Path -LiteralPath $expectedSource).Path)) {
                 Write-Host "[OK] Already junctioned: $relPath"
                 continue
             } else {
-                Write-Host "[ACTION] Removing broken junction: $relPath"
+                Write-Host "[ACTION] Removing junction (wrong target): $relPath"
                 cmd /c "rmdir `"$targetPath`"" 2>&1
                 if ($LASTEXITCODE -ne 0) {
-                    Write-Error "[ERROR] Failed to remove broken junction: $relPath"
+                    Write-Error "[ERROR] Failed to remove junction: $relPath"
                     exit 1
                 }
             }
@@ -364,7 +424,7 @@ if ($Mode -eq 'apply') {
             New-Item -ItemType Directory -Path $parentPath -Force | Out-Null
         }
 
-        Write-Host "[ACTION] Creating junction: $relPath"
+        Write-Host "[ACTION] Creating junction: $relPath -> $sourcePath"
         $result = cmd /c "mklink /J `"$targetPath`" `"$sourcePath`" 2>&1"
         if ($LASTEXITCODE -ne 0) {
             Write-Error "[ERROR] Failed to create junction ${relPath}: $result"


### PR DESCRIPTION
## 概要

`install-consumer-opencode.ps1` に `-LocalMode` スイッチを追加し、local mode（`consumer-generated`）向けの agentdev-gh-cli 差し替えリンク設定を実装した（REQ-0103-158、ADR-0131 decision #3）。

## 変更内容

### `scripts/install-consumer-opencode.ps1`
- `-LocalMode` スイッチパラメータ追加
- `Get-TargetSourcePath` ヘルパー追加: LocalMode 時、`skills\agentdev-gh-cli` のソースを `src/opencode-local/agentdev-gh-cli/` へリマップ（それ以外は `src/opencode/` のまま）
- LocalMode リダイレクトソース存在検証（apply/check/dry-run 各モード）
- apply モードのジャンクション再作成ロジックを改良: リンク先が意図した target と異なる場合に再作成（モード切替をサポート）

### `scripts/check-consumer-opencode.ps1`
- リンクモード自動検出: `agentdev-gh-cli` ジャンクションの解決先から local mode（`consumer-generated`）と normal mode（`consumer-with-agentdev`）を識別
- `Get-TargetSourcePath` ヘルパーによる検出モードに応じた期待ソースパス計算
- local mode 時のリダイレクトソース存在チェック

### `README.md`
- 導入手順に local mode（`-LocalMode`）のインストール例を追加
- 状態確認コマンドにリンクモード自動検出の注記
- 更新手順に local mode 再実行の注記
- 推奨 `.gitignore` が通常版・ローカル版で同一である旨を明記

## 完了条件の達証

| AG | 内容 | 状態 | 証拠 |
|----|------|------|------|
| AG-001 | `-LocalMode` スイッチが local mode リンク構成を実現 | 達成 | apply `-LocalMode` で `agentdev-gh-cli -> src/opencode-local/agentdev-gh-cli/`、他は `src/opencode/` へ接続（E2E 検証済み） |
| AG-002 | REQ-0103-158 source 要件追記 | 既達成（req-save） | `docs/requirements/REQ-0103.md` line 100 に REQ-0103-158 存在を確認 |
| AG-003 | runtime-package-boundary.md link mode 技術詳細領域 | 既達成（spec-save） | `docs/specs/runtime-package-boundary.md` に「## link mode 接続手順技術詳細」セクション存在を確認 |
| AG-004-a | ローカル版導入がスクリプト1実行で完結 | 達成 | `install-consumer-opencode.ps1 -Mode apply -LocalMode` の1実行で完結 |
| AG-004-b | README 導入手順と推奨 .gitignore が local mode に対応 | 達成 | README 更新済み、.gitignore パターンは両モード同一 |
| AG-004-c | check-consumer-opencode.ps1 が local mode を検出 | 達成 | `[INFO] Link mode: local (consumer-generated)` を出力、全ジャンクション OK |

## 検証

- **PowerShell 構文解析**: 両スクリプト parse OK（`[System.Management.Automation.Language.Parser]`）
- **PSScriptAnalyzer**: Warning のみ（`PSAvoidUsingWriteHost` は既存コードと同一パターン、`PSReviewUnusedParameter` はスコープ変数の誤検知）。新規エラー・新規警告カテゴリなし
- **E2E テスト**（テンポラリ consumer リポジトリで実施）:
  - `dry-run -LocalMode`: `agentdev-gh-cli -> src/opencode-local/`、他は `src/opencode/` を WOULD ADD として表示 ✓
  - `apply -LocalMode`: 全ジャンクション作成成功、exit 0 ✓
  - `check-consumer-opencode.ps1`: local mode 自動検出、全ジャンクション OK、exit 0 ✓
  - `check -LocalMode`: 0 divergence ✓
  - **モード切替**（local → normal）: apply（-LocalMode なし）が `agentdev-gh-cli` の wrong target を検出・再作成、check が normal mode を検出 ✓

Closes #1110

## Findings / Capture候補

- 本 Issue のスコープ外だが、`install-consumer-opencode.ps1` apply モードのジャンクション再作成ロジックを「broken（解決不能）」から「wrong target（意図した target と異なる）」へ拡張した。これは LocalMode 切替を正しく処理するために必要な変更であり、normal mode でも自己修復性が向上する。既存の broken junction に対する挙動は後方互換（再作成される）。

## SPEC確定候補

（本実装で新たに判明した SPEC レベルの詳細はなく、既存 SPEC `runtime-package-boundary.md` の「install-consumer-opencode.ps1 -LocalMode の入出力契約」セクション通りに実装したため、SPEC 確定候補なし）