### PR TITLE
docs: REQ-0142 の DOC-MAP 行を追加（REQ-0142〜0148 完全性補完） Refs: #1116

### DIFF
--- a/docs/DOC-MAP.md
+++ b/docs/DOC-MAP.md
@@ -51,6 +51,7 @@
 | [REQ-0139](requirements/REQ-0139.md) | 外部エージェント統合契約 | 外部エージェント統合、case-run外部実行委譲、driver adapter契約、req-define分類結果アクション |
 | [REQ-0140](requirements/REQ-0140.md) | 文書品質ゲート | 文書種別責務・要件性・文意品質・粒度の査読、IR-045、ドリフト検出、既存文書への遡及準拠修正 |
 | [REQ-0141](requirements/REQ-0141.md) | ローカル版 OpenCode 生成方式とローカルCaseファイル運用 | ローカル版生成方式、src/opencode-local/ 生成時ソース領域、ローカルCaseファイル、GitHub Issue/PR 置換、変換プロンプト、生成安全性制約 |
+| [REQ-0142](requirements/REQ-0142.md) | 配布物ID除去後の文意保持・構文健全性・責務整合 | 配布物 ID 除去後の完了条件としての文意保持・構文健全性・責務整合、Markdown 構文破損回避・主要構造重複回避・壊れた参照残骸除去、command / skill / SPEC 間責務説明整合（case-open / case-run / case-close / case-auto）、横断検査観点拡充、NG / false positive 分類明確化、docs-spec-rebuild-integrity.md |
 | [REQ-0143](requirements/REQ-0143.md) | Command 定義ファイルフォーマット標準化 | AgentDevFlow 管理 command 定義ファイル（src/opencode/commands/agentdev/*.md・.opencode/commands/repo/*.md）の command file format 準拠、適用対象限定、consumer project 独自 command 強制対象外 |
 | [REQ-0144](requirements/REQ-0144.md) | docs-check/integrity 運用是正 | 廃止REQ履歴マーク参照・workflow否定表現・RFC2119マーカー・日本語品質・skill-category-gap・コマンド一覧網羅・REQ範囲表記・fixture経年劣化・QG/case-close Step番号・Sisyphus-Junior×/ulw-loop 誤分類表記・integrity reports git除外 |
 | [REQ-0145](requirements/REQ-0145.md) | docs-check/integrity 検出設計改善 | IR-044 SPEC詳細混入解消・委譲キーワード境界ケース・catalog↔実装双方向同期・docs-check項目役割範囲・新カテゴリ追加判定フロー・IR-050/051 語彙レジストリ・閾値確定・3層検出構造責務分担・draft SPEC参照リスト・references checker偽陽性・完了条件grep設計 |


### PR DESCRIPTION
## 概要

Issue #1116（RU-0005）。`docs/DOC-MAP.md` の現行 REQ テーブルへ REQ-0142 行を追加し、REQ-0142〜0148 の完全性を補完した。

`docs/specs/req-impact-map.md` の REQ-0142〜0148 行（Impact Matrix・中影響・低影響）は spec-save（ACT-SPEC-003）で既に追加済みであり、本 PR では内容を検証のみ実施（編集なし）。

## 変更内容

- `docs/DOC-MAP.md`: REQ-0141 行と REQ-0143 行の間へ REQ-0142 行を追加。REQ-0143〜0148 と同一書式（`| [REQ-NNNN](requirements/REQ-NNNN.md) | タイトル | 概要 |`）。
  - タイトル: 配布物ID除去後の文意保持・構文健全性・責務整合（frontmatter・req-impact-map.md・README.md と一致）
  - 概要: REQ-0142 の要件（001〜007）を要約。配布物 ID 除去後の完了条件、Markdown 構文破損回避・主要構造重複回避・壊れた参照残骸除去、command / skill / SPEC 間責務説明整合（case-open / case-run / case-close / case-auto）、横断検査観点拡充、NG / false positive 分類明確化、docs-spec-rebuild-integrity.md

## 完了条件

- [x] **AG-010**: `docs/DOC-MAP.md` の現行 REQ テーブルに REQ-0142〜0148 が過不足なく揃っており、REQ-0142 の行が REQ-0143〜0148 と同一書式で記載されている
- [x] **AG-011**: `docs/specs/req-impact-map.md` の Impact Matrix および低影響リストに REQ-0142〜0148 が過不足なく揃っており、IR 列・commands 列が埋められている

## 検証

### grep による両表の REQ-0142〜0148 網羅確認

- `docs/DOC-MAP.md`: REQ-0142〜0148 の 7 行が連続して揃っている（`| [REQ-014X]` 形式で 7 件）
- `docs/specs/req-impact-map.md`:
  - Impact Matrix: REQ-0142〜0148 の 7 行（IR 列・Artifact 列ともに記載済み、spec-save 適用結果）
  - 中影響リスト: REQ-0145 / REQ-0146 / REQ-0147
  - 低影響リスト: REQ-0142 / REQ-0143 / REQ-0144 / REQ-0148

### /repo/docs-check（check_integrity.ts）実行結果

REQ カタログ完全性に関連する検出事項は **0 件**（Issue テスト戦略の条件を満たす）。

- `[ok] REQ-0142: id matches filename`
- `[ok] REQ-0142.md: all required fields present`
- `[ok] All DOC-MAP REQ references match existing files`（追加した REQ-0142 参照が有効）
- `[ok] All DOC-MAP spec references are valid`
- `[ok] All DOC-MAP guide references are valid`

サマリ: 214 ok / 2 ng / 5 warning / 3 info。2 ng（`project-docs-and-specs.md` の REQ 範囲表記・`case-close.md` の duty keyword）はいずれも本 Issue 対象外の既存検出事項。

## Findings / Capture候補

特になし。docs-check の 2 ng / 5 warning はすべて本 Issue 対象外の既存検出事項であり、別 Issue / 別 PR で扱うべきものである。

## SPEC確定候補

特になし。本変更は DOC-MAP 1 行追加のみであり、SPEC レベルの新規決定事項はない。