### PR TITLE
fix(skills): case-run-execution-adapter SKILL.md 参照パス明示化 (#1115)

### DIFF
--- a/src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md
+++ b/src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md
@@ -84,7 +84,7 @@ case-run から引き渡された worktree root（相対パス）配下でのみ
 | worktree root 以外のパス（メインリポジトリルート直下、他 worktree 等）でのファイル編集 | メインリポジトリでの作業を検知した場合は直ちに作業を停止し、`failed` として result を返却する。詳細本文は Issue コメントに SSoT として構造化して記録する |
 | メインリポジトリパスを引き渡し、使用すること | case-run は worktree root（相対パス）のみを引き渡す。Sisyphus-Junior は受け取った worktree root 配下でのみ作業する |
 
-**自己検証**: 実装作業開始前に `agentdev-git-worktree` の検証ヘルパー（`references/worktree-operations.md`「worktree 内判定ヘルパー」参照）で現在 worktree 内にいることを自己検証する。メインリポジトリにいると判定された場合は実装を開始せず `failed` として result を返却する。
+**自己検証**: 実装作業開始前に `agentdev-git-worktree` の検証ヘルパー（`.opencode/skills/agentdev-git-worktree/references/worktree-operations.md`「worktree 内判定ヘルパー」参照）で現在 worktree 内にいることを自己検証する。メインリポジトリにいると判定された場合は実装を開始せず `failed` として result を返却する。
 
 ## Findings/ Capture 配置
 


### PR DESCRIPTION
Closes #1115

## 概要

`agentdev-case-run-execution-adapter/SKILL.md` 1行の参照パス明示化。

相対参照 `` `references/worktree-operations.md` ``（line 87）は、参照元 skill（`agentdev-case-run-execution-adapter`）内に存在しないファイルを指しており、cross-skill 解決で `agentdev-git-worktree` にのみ存在するファイルとして ReferencePath NG になっていた。明示パス `` `.opencode/skills/agentdev-git-worktree/references/worktree-operations.md` `` に変更して解決した。

## 変更点

- `src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md`（1行）
  - `references/worktree-operations.md`
    → `.opencode/skills/agentdev-git-worktree/references/worktree-operations.md`

## 検証

`check_integrity.ts` を実行し、ReferencePath カテゴリの NG を確認:

- 修正前: ReferencePath 99 OK / **1 NG**（cross-skill NG: `references/worktree-operations.md` at `.opencode/skills/agentdev-case-run-execution-adapter/SKILL.md:87`）
- 修正後: ReferencePath **101 OK / 0 NG**

参考: 全体終了コード 1 は本件と無関係の既存 NG（`req-range-staleness` in project-docs-and-specs.md、`command-capture-duty` in case-close.md）によるもの。本 PR の対象ファイルに関する ReferencePath NG は 0 になった。

## Findings / Capture候補

なし。1行の参照パス修正のみ。

## SPEC確定候補

なし。
