### PR TITLE
spec-save: target_area ベースのセクション置換ロジック (REQ-0136-027/028)

### DIFF
--- a/src/opencode/commands/agentdev/spec-save.md
+++ b/src/opencode/commands/agentdev/spec-save.md
@@ -65,7 +65,10 @@ SPEC 対象 artifact_actions がない場合は no-op で完了。
 
 `draft-data` の `artifact_actions`（`artifact: spec`）の全 entry を処理する:
 - **create**: 新規 SPEC ファイルを frontmatter（`title`, `status: draft`, `created`, `updated`）付きで作成し、action の `content` をセクションとして記載
-- **update**: 既存 SPEC ファイルの該当セクションへ action の `content` を追記し、frontmatter `updated` を更新。`status` は変更しない
+- **update**:
+  - `target_area` 指定時（operation が `update`/`spec-update`）: 対象 SPEC ファイル内で `target_area` に一致する見出し行を検索し、セクション置換を行う（REQ-0136-027）。詳細は後述「target_area ベースのセクション置換ロジック」
+  - `target_area` 未指定時: 既存 SPEC ファイルの該当セクションへ action の `content` を追記（後方互換、REQ-0136-028）
+  - frontmatter `updated` を更新。`status` は変更しない
 - 各 action の `target_area`（指定時）に応じた適切なセクション見出しを用いる
 
 **Step 5-1**: 複数 SPEC action の並列化（REQ-0114-091/093） — 異なる `target` パスの SPEC create/update は並列化可能。同一 SPEC ファイルへの複数 action は順序依存のため直列サブセットとして分離する。詳細は後述「case-auto 並列委譲モデル」セクション参照
@@ -96,6 +99,29 @@ Step 8 の status 変更を commit 対象に含める。
 ### Step 11: 完了報告
 
 完了報告 template に従い、保存した SPEC 一覧（新規/追記別）、スキップ有無、follow-up（安定契約例外で除外した候補）を出力
+
+## target_area ベースのセクション置換ロジック（REQ-0136-027/028）
+
+`operation: update` / `operation: spec-update` において action の `target_area` が指定された場合、spec-save は対象 SPEC ファイル内で `target_area` に一致する見出し行を検索し、セクション置換を行う。
+
+### マッチング規則
+
+- 対象 SPEC ファイル内の見出し行を走査し、`target_area` と完全一致する見出し行を検索する（見出しテキスト部分の一致）
+- 当該見出し行から次の同レベル（または上位レベル）見出し行の直前までを「セクション」として特定する
+  - 例: `### X` で検索した場合、次の `###` / `##` / `#` 見出し行の直前までを範囲とする
+- 特定したセクションを action の `content` で置換する
+
+### 複数マッチ時の挙動
+
+`target_area` に一致する見出しが複数存在する場合、最初のマッチを採用し warn を出力する。
+
+### 未検出時の挙動
+
+`target_area` に一致する見出しが存在しない場合、当該 action をスキップし、follow-up として「target_area 未検出、operation を spec-create へ切り替えを推奨」を報告する（全体中止しない）。
+
+### 後方互換（target_area 未指定）
+
+`target_area` が未指定の draft（旧形式）、または `operation` が `create`/`spec-create` の場合は従来の「追記」動作を維持する（REQ-0136-028）。`target_area` が指定された場合のみ「置換」動作を適用し、既存 draft の破壊を防ぐ。
 
 ## case-auto 並列委譲モデル（REQ-0114-091/093）
 


### PR DESCRIPTION
## 概要

Issue #1142 の実装。spec-save command の Step 5 に target_area ベースのセクション置換ロジックを追記した（REQ-0136-027/028）。

## 変更内容

- \src/opencode/commands/agentdev/spec-save.md\ Step 5 の update 項目を「target_area 指定時は置換、未指定時は追記」に更新
- \## target_area ベースのセクション置換ロジック（REQ-0136-027/028）\ セクション追記（マッチング規則、複数マッチ時の挙動、未検出時の挙動、後方互換）
- docs/specs/commands/spec-save.md の「## target_area ベースのセクション置換ロジック」セクションと整合

## 完了条件

- [x] Step 5 に target_area ベースのセクション置換ロジック（見出し検索、セクション範囲特定、置換）が追記されている（REQ-0136-027 適合）
- [x] 複数マッチ時（最初のマッチ採用 + warn 出力）、未検出時（スキップ + follow-up 報告）の扱いが明記されている（REQ-0136-027 適合）
- [x] target_area 未指定、operation が create/spec-create の場合は従来の追記動作が維持されることが明記されている（REQ-0136-028 適合、後方互換）
- [x] 変更が docs/specs/commands/spec-save.md のセクション「## target_area ベースのセクション置換ロジック」と整合する

## QG-3: Implementation Deviation Gate

- **判定**: pass（no-deviation）
- **対象**: git diff（変更ファイル 1 件）
- 完了条件4項目すべて実装済み、REQ-0136-027/028 適合、スコープ外変更なし、SPEC と整合

## Findings / Capture候補

- TS-003/TS-004 の検証について: 今回の実装はコマンド定義ファイル（Markdown）の更新であり、実行ベースの検証（spec-save コマンドの実行による動作確認）は case-close QG-4 で実施予定。仕様レビューでは REQ-0136-027/028 適合、docs/specs/commands/spec-save.md との整合を確認済み。

## SPEC確定候補

（なし。docs/specs/commands/spec-save.md は既に spec-save で ACT-SPEC-002 として処理済み、commit 0d3660c9）

refs: #1142