### PR TITLE
docs(agentdev): resolve stable docs-check NGs (REQ-0144-015/016/017, #1145)

### DIFF
--- a/docs/guides/project-docs-and-specs.md
+++ b/docs/guides/project-docs-and-specs.md
@@ -23,7 +23,7 @@ DOC-MAP（文書探索入口：索引）
 要件定義の永続基準。
 システムが満たすべき要件を記述する。
 
-- 現行 REQ は REQ-0101 から REQ-0151 までの 43 件（REQ-0111, REQ-0115, REQ-0116, REQ-0117, REQ-0118, REQ-0120, REQ-0121, REQ-0122 は廃止、履歆参照のみ）
+- 現行 REQ は REQ-0101 から REQ-0152 までの 44 件（REQ-0111, REQ-0115, REQ-0116, REQ-0117, REQ-0118, REQ-0120, REQ-0121, REQ-0122 は廃止、履歆参照のみ）
 - 旧 REQ（REQ-0001〜REQ-0050 [全て廃止]）は `docs/requirements/retired/` に移動済み。履歴参照に限定する
 - 旧 REQ と新 REQ の対応関係は `docs/requirements/mapping-table.md` に記録
 

--- a/src/opencode/commands/agentdev/case-close.md
+++ b/src/opencode/commands/agentdev/case-close.md
@@ -207,7 +207,7 @@ Issue close 手続き（理由: completed、agentdev-gh-cli）
 - G18: learning と intake を同一 commit に含める
 - G19: Step 12 は結果状態を分離して報告。`.agentdev` push失敗時は完了扱いにしない
 - G20: 完了条件チェックボックスの評価、更新は case-close の専任責務。case-run/ driver/ 外部実行バックエンドは更新しない。case-close は別コンテキストで Issue 本文を再読込して最終完了判定し、更新後に再読込 VERIFY を必ず実施する
-- G21: case-close の capture 責務は回収、保存。PR 本文から intake/ learning を分離回収しドメイン状態に保存する。境界の詳細は `agentdev-workflow-orchestration/references/capture-boundaries.md` 参照
+- G21: case-close の capture 責務は回収・保存。PR 本文から intake/ learning を分離回収しドメイン状態に保存する。境界の詳細は `agentdev-workflow-orchestration/references/capture-boundaries.md` 参照
 - G22: SPEC status 昇格（draft → accepted）は case-close の責務。昇格は対象 SPEC が `draft` かつ今回の実装が SPEC 内容を検証済みの場合のみ実施する。spec-save は accepted を付与しない
 - G23: SPEC確定候補の処理（Step 3-2）は PR 本文の `## SPEC確定候補` セクションを入力とし、`## Findings / Capture候補` とは区別して扱う
 - G24: Epic Issue 本文ステータス追跡テーブルの更新は case-close のみが実施する（単一書き手制約）。case-run は Epic Issue 本文を読み取るのみで書き込まない。case-auto は Wave 反復制御のみ行い Epic Issue 本文に直接書き込まない。last-write-wins 競合防止は case-close の単一書き手で維持される


### PR DESCRIPTION
Closes #1145

## 概要

docs-check（check_integrity.ts）で報告される安定 NG を根因解消し、REQ-0144-015/016/017 の実装を完遂する。

## 変更内容

### NG 解消（AG-001, REQ-0144-015）

| NG | 対象ファイル | 修正前 | 修正後 | 解消手段 |
|----|------------|--------|--------|----------|
| req-range-staleness | `docs/guides/project-docs-and-specs.md` L26 | REQ-0151 までの 43 件 | REQ-0152 までの 44 件 | 範囲追従 |
| command-capture-duty | `src/opencode/commands/agentdev/case-close.md` G21 | 回収、保存（読点） | 回収・保存（中黒） | 文書是正 |

- case-close G21 の duty keyword は check_integrity.ts の `duties["case-close.md"].dutyKeyword`（値: `回収・保存`）と整合する複合ラベル表記。「回収・保存」は capture 責務の複合ラベルであり、流動的並列（OU-001 読点化対象）ではない
- 除外仕組み（exemption mask）は不使用（REQ-0144-015 禁止事項遵守）

### AG-002（REQ-0144-016: test suite 責務明文化）

`docs/specs/integrity-rule-catalog.md` L1228-1237 に `check_integrity test suite 責務分担` セクションが既に実装済み（commit 36c7059b）。

| test file | 責務 | 根拠 |
|-----------|------|------|
| scripts/tests/check_integrity.test.ts | fixture drift detection・Issue #657 regression 専用・copyScripts 環境下の drift 自動検出 | REQ-0144-009 |
| scripts/check_integrity.test.ts | IR-044 正規スイート・check_integrity.ts ルール適合検証 | REQ-0144-008 |

### AG-003（REQ-0144-017: IR-044 保護対象リスト是正）

`docs/specs/integrity-rule-catalog.md` L957 に是正済み経緯が既に明記済み（commit 36c7059b）。

REQ-0114-082、REQ-0144-008 は #1109 PR で SPEC 詳細が REQ から SPEC へ移行済みであり、真陽性保護対象から除外されている。

## Evidence

### docs-check before/after

| 項目 | before (36c7059b) | after (本 PR) |
|------|-------------------|---------------|
| OK | 206 | 208 |
| **NG** | **2** | **0** |
| Warning | 13 | 13 |
| Info | 3 | 3 |

### テストスイート実行結果（両系統）

- `scripts/check_integrity.test.ts`（IR-044 正規スイート）: **37 pass / 0 fail**
  - `Capture boundary checks > valid fixture: command-capture-duty checks pass for all 5 commands` pass
  - `IR-044 req-spec-boundary-violation > detects true positive` シリーズ pass
- `scripts/tests/check_integrity.test.ts`（fixture drift detection）: **14 pass / 0 fail**
  - `fixture drift detection (REQ-0144-009) > valid fixture produces zero NG` pass
  - `copied script matches source script (copyScripts sync verification)` pass

## 完了条件との適合（QG-3）

- [x] AG-001: docs-check NG 4件が全て解消され、NG 件数が 0（warning 対象外）。除外仕組み不使用（REQ-0144-015）
- [x] AG-002: test suite 2系統の責務分担表が SPEC 記載から判別可能（REQ-0144-016、36c7059b 実装済み）
- [x] AG-003: IR-044 保護対象リストから REQ-0114-082/REQ-0144-008 が除外済み、是正済み経緯明記（REQ-0144-017、36c7059b 実装済み）

## Findings / Capture候補

- **Issue 記載の安定 NG 4件のうち2件は本 case-run 実施前に既に解消済み**:
  - NG-1 (case-run-execution-adapter reference path): commit 18643295 (PR #1126) で SKILL.md 参照パス明示化により解消済み。本 case-run 時点で ReferencePath カテゴリ 0 NG を確認
  - NG-2 (japanese-tech-writing skill prefix): ADR-0020 repo-local skill により false positive と判定され、commit 574db1d0 で intake item 削除済み。当該スキルは `src/opencode/skills/` 配下に存在せず、IR-007 skill-prefix チェックの対象外
- **事前状態の数値差異**: Issue 記載の「ok 294 / ng 4 / warning 10」と実測（36c7059b）「ok 206 / ng 2 / warning 13」の差異は、Issue 作成時から 36c7059b までの間に check_integrity.ts 本体が改修（f329537d IR-045 削除/IR-044 exemption 機械化等）されたことに起因。NG 件数は 4→2 へ減少済み

## 関連

- Issue: #1145
- REQ: REQ-0144（行 015/016/017）
- SPEC: integrity-rule-catalog.md
