### PR TITLE
feat(agentdev): implement IR-053 gh-direct-invocation detection (REQ-0152, #1146)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -1120,3 +1120,166 @@ describe("IR-044 req-spec-boundary-violation (REQ-0108-259)", () => {
     expect(violations.length).toBeGreaterThanOrEqual(1);
   });
 });
+
+// ─── IR-053: gh direct invocation detection (REQ-0152-001/002) ────────────────
+// Dedicated fixture covering:
+//   - true positive: direct gh invocation in prose (outside code block)
+//   - code-block exemption: gh inside a fenced block is not flagged
+//   - exclusion path: standard-procedures.md (REQ-0149-003) is never flagged
+
+const IR053_ROOT = join(TEMP_ROOT, "ir053");
+
+function buildIr053Fixture(root: string): void {
+  // Minimal docs skeleton so the validator script runs.
+  const reqDir = join(root, "docs", "requirements");
+  mkdirp(reqDir);
+  writeFileSync(
+    join(reqDir, "README.md"),
+    [
+      "# Requirements",
+      "",
+      "| ID | Title |",
+      "|----|-------|",
+      "| REQ-9101 | IR-053 fixture |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  writeFileSync(
+    join(reqDir, "REQ-9101.md"),
+    [
+      "---",
+      "id: REQ-9101",
+      "title: IR-053 fixture",
+      "created: 2025-01-01",
+      "updated: 2025-01-01",
+      "---",
+      "",
+      "Body.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  mkdirp(join(root, "docs", "adr"));
+  writeFileSync(join(root, "docs", "adr", "README.md"), "# ADR\n", "utf-8");
+  mkdirp(join(root, "docs", "specs"));
+  writeFileSync(join(root, "docs", "specs", "README.md"), "# SPEC\n", "utf-8");
+
+  // True positive: direct gh invocation in prose (inline code span, NOT a code block).
+  const cmdDir = join(root, "src", "opencode", "commands", "agentdev");
+  mkdirp(cmdDir);
+  writeFileSync(
+    join(cmdDir, "violation-cmd.md"),
+    [
+      "---",
+      "description: violation command",
+      "agent: test-agent",
+      "---",
+      "",
+      "# Violation command",
+      "",
+      "Issue を作成するときは `gh issue create` を直接実行すること。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // Code-block exemption: gh invocation inside a fenced block must NOT be flagged.
+  const sampleSkillDir = join(
+    root,
+    "src",
+    "opencode",
+    "skills",
+    "agentdev-sample-skill",
+  );
+  mkdirp(sampleSkillDir);
+  writeFileSync(
+    join(sampleSkillDir, "SKILL.md"),
+    [
+      "---",
+      "name: agentdev-sample-skill",
+      "---",
+      "",
+      "# Sample skill",
+      "",
+      "## USE FOR",
+      "",
+      "- sample",
+      "",
+      "## 例",
+      "",
+      "```sh",
+      "gh issue view 123",
+      "```",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // Exclusion path: standard-procedures.md may use gh directly (REQ-0149-003).
+  const ghCliRefDir = join(
+    root,
+    "src",
+    "opencode",
+    "skills",
+    "agentdev-gh-cli",
+    "references",
+  );
+  mkdirp(ghCliRefDir);
+  writeFileSync(
+    join(ghCliRefDir, "standard-procedures.md"),
+    [
+      "# Standard Procedures",
+      "",
+      "gh pr create --title \"{title}\" --body-file {body}",
+      "gh issue edit {N} --body-file {body}",
+      "gh pr merge {N} --squash",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+describe("IR-053 gh-direct-invocation (REQ-0152-001/002)", () => {
+  beforeAll(() => {
+    mkdirp(IR053_ROOT);
+    buildIr053Fixture(IR053_ROOT);
+    copyScripts(IR053_ROOT);
+  });
+
+  it("detects direct gh invocation in prose (true positive)", () => {
+    const r = runScript(IR053_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const violations = parsed.results.filter(
+      (res: { check: string; level: string; file?: string }) =>
+        res.check === "gh-direct-invocation" &&
+        res.level === "warning" &&
+        (res.file ?? "").includes("violation-cmd.md"),
+    );
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("exempts gh invocation inside fenced code blocks", () => {
+    const r = runScript(IR053_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const inCodeBlock = parsed.results.filter(
+      (res: { check: string; level: string; file?: string }) =>
+        res.check === "gh-direct-invocation" &&
+        res.level === "warning" &&
+        (res.file ?? "").includes("agentdev-sample-skill"),
+    );
+    expect(inCodeBlock.length).toBe(0);
+  });
+
+  it("excludes standard-procedures.md (REQ-0149-003 permitted file)", () => {
+    const r = runScript(IR053_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const inExcluded = parsed.results.filter(
+      (res: { check: string; level: string; file?: string }) =>
+        res.check === "gh-direct-invocation" &&
+        res.level === "warning" &&
+        (res.file ?? "").includes("standard-procedures.md"),
+    );
+    expect(inExcluded.length).toBe(0);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -6180,6 +6180,106 @@ function checkReqSpecBoundaryViolation(root: string): CheckResult[] {
   return results;
 }
 
+// ─── IR-053: gh direct invocation detection (REQ-0152-001, REQ-0152-002) ──────
+// Detects direct `gh (issue|pr) (create|edit|view|comment|merge|close|list|status)`
+// invocations embedded in command/skill definitions. Direct gh CLI usage bypasses
+// the agentdev-gh-cli delegation base (REQ-0149) and must route through it.
+// Scan targets (REQ-0152-001):
+//   src/opencode/commands/agentdev/*.md
+//   src/opencode/skills/agentdev-*/**/*.md
+// Exclusion (REQ-0152-002, REQ-0149-003 permitted file):
+//   src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md
+// Code-block contents are exempt (example/pattern description, REQ-0108-254).
+// Severity: heuristic (warn / exit 1).
+
+const IR053_GH_DIRECT_PATTERN =
+  /\bgh\s+(issue|pr)\s+(create|edit|view|comment|merge|close|list|status)\b/i;
+
+// Exemption paths (repo-root-relative, forward-slash normalized).
+const IR053_EXEMPT_PATHS: RegExp[] = [
+  /src\/opencode\/skills\/agentdev-gh-cli\/references\/standard-procedures\.md$/,
+];
+
+function walkMarkdown(dirPath: string, acc: string[]): void {
+  if (!fs.existsSync(dirPath)) return;
+  for (
+    const entry of fs.readdirSync(dirPath, { withFileTypes: true }) as import("fs").Dirent[]
+  ) {
+    const full = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      walkMarkdown(full, acc);
+    } else if (entry.name.endsWith(".md")) {
+      acc.push(full);
+    }
+  }
+}
+
+function collectAgentdevSkillMarkdown(skillRoot: string): string[] {
+  // Walk src/opencode/skills/agentdev-*/**/*.md recursively.
+  const collected: string[] = [];
+  if (!fs.existsSync(skillRoot)) return collected;
+  for (const dir of listDirs(skillRoot)) {
+    if (!dir.startsWith("agentdev-")) continue;
+    walkMarkdown(path.join(skillRoot, dir), collected);
+  }
+  return collected;
+}
+
+function checkGhDirectInvocation(root: string): CheckResult[] {
+  const results: CheckResult[] = [];
+
+  const commandDir = path.join(root, "src", "opencode", "commands", "agentdev");
+  const skillRoot = path.join(root, "src", "opencode", "skills");
+
+  const targets: string[] = [];
+  if (fs.existsSync(commandDir)) {
+    for (const f of listFiles(commandDir)) targets.push(path.join(commandDir, f));
+  }
+  for (const f of collectAgentdevSkillMarkdown(skillRoot)) targets.push(f);
+
+  let foundViolation = false;
+  for (const fullPath of targets) {
+    const relPath = resolveRelative(fullPath, root);
+    if (IR053_EXEMPT_PATHS.some((re) => re.test(relPath))) continue;
+    const content = readText(fullPath);
+    if (!content) continue;
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (isInsideCodeBlock(lines, i)) continue;
+      const match = lines[i].match(IR053_GH_DIRECT_PATTERN);
+      if (match) {
+        foundViolation = true;
+        results.push(
+          warn(
+            "CanonicalConflict",
+            "gh-direct-invocation",
+            `Direct gh CLI invocation 'gh ${match[1]} ${match[2]}' detected — route via agentdev-gh-cli delegation (IR-053, REQ-0152-001)`,
+            relPath,
+            i + 1,
+            {
+              evidence: match[0],
+              expected:
+                "delegate gh CLI access through agentdev-gh-cli procedures (REQ-0149)",
+              route: "intake",
+            },
+          ),
+        );
+      }
+    }
+  }
+
+  if (!foundViolation) {
+    results.push(
+      ok(
+        "CanonicalConflict",
+        "gh-direct-invocation",
+        "No direct gh CLI invocations detected in command/skill definitions (IR-053, REQ-0152-001)",
+      ),
+    );
+  }
+  return results;
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   let options;
@@ -6328,6 +6428,7 @@ async function main(): Promise<void> {
     ...checkMappingTableHistoryLabels(root),
     ...checkReqVerificationBasis(root),
     ...checkReqSpecBoundaryViolation(root), // IR-044 (REQ-0108-259)
+    ...checkGhDirectInvocation(root), // IR-053 (REQ-0152-001/002)
     ...checkSisyphusJuniorUlwLoopMisclassification(root), // REQ-0144-013
   ];
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
@@ -394,6 +394,7 @@ const CHECK_TO_FINDING_CATEGORY: Record<string, FindingCategory> = {
   "adr-status-normalization": "canonical-conflict",
   "workflow-status-prohibition": "canonical-conflict",
   "lifecycle-boundary": "canonical-conflict",
+  "gh-direct-invocation": "canonical-conflict",
   "readme-index-sync": "broken-reference",
   "adr-readme-index-sync": "broken-reference",
   "spec-readme-index-sync": "broken-reference",


### PR DESCRIPTION
## 概要

Issue #1146 / REQ-0152（gh 直接記述機械検出）の実装。`check_integrity.ts` に新規ルール IR-053 を追加し、command/skill 定義中の gh CLI 直接呼出しを機械検出する。

## 関連

- Issue: closes #1146
- REQ: REQ-0152（rows 001/002 — gh 直接記述機械検出）
- SPEC: `docs/specs/integrity-rule-catalog.md` IR-053 エントリ（既存、本PRでは変更しない）
- 関連 PR: #1107（agentdev-gh-cli SPEC 正典化、REQ-0149-003 許容ファイル）

## 実装内容

### IR-053 検出関数（`check_integrity.ts`）

`checkGhDirectInvocation(root)` を追加。既存ルール（IR-044 `checkReqSpecBoundaryViolation` 等）と同じ構造に従う。

- **検出パターン**: `/\bgh\s+(issue|pr)\s+(create|edit|view|comment|merge|close|list|status)\b/i`
- **スキャン対象**（REQ-0152-001）:
  - `src/opencode/commands/agentdev/*.md`
  - `src/opencode/skills/agentdev-*/**/*.md`（再帰、`agentdev-` プレフィックスディレクトリのみ）
- **除外対象**（REQ-0152-002 / REQ-0149-003 許容ファイル）:
  - `src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md`
- **code block 内部**は検出対象外（`integrity-rule-catalog.md` 対象ファイル設計の一般ポリシー。`isInsideCodeBlock` で適用）
- **severity**: heuristic（warn / exit 1）。IR-044 と同じ warn レベル
- **category**: `CanonicalConflict` / finding_category `canonical-conflict`（SPEC 準拠）。route は SPEC `finding_route: intake` に合わせ `intake` を明示設定

`main()` の results 配列に `...checkGhDirectInvocation(root)` を登録。`cli_utils.ts` の `CHECK_TO_FINDING_CATEGORY` に `"gh-direct-invocation": "canonical-conflict"` を追加（finding_category 整合性）。

### 回帰テスト（`check_integrity.test.ts` IR-044 正規スイート）

IR-053 専用 fixture と3テストを追加:

1. **真陽性検出**: prose 内の `` `gh issue create` `` を warning で検出（`violation-cmd.md`）
2. **code block 除外**: フェンスブロック内 `gh issue view` は検出しない（`agentdev-sample-skill/SKILL.md`）
3. **除外パス**: `standard-procedures.md` の `gh pr create` 等は検出しない（REQ-0149-003）

## 検証結果（evidence）

### 検出前後

実リポジトリで `check_integrity.ts --json` を実行:

```
summary: { ok: 209, ng: 0, warning: 13, info: 3 }
gh-direct-invocation: level "ok"
  message: "No direct gh CLI invocations detected in command/skill definitions (IR-053, REQ-0152-001)"
```

- IR-053 は active（results に `gh-direct-invocation` エントリが現れる）
- 実リポジトリの gh 直接記述 29件はすべて除外ファイル `standard-procedures.md` 内 → false positive 0件（ng: 0）
- 既存の13 warning はすべて本ルール以前からのもの。本ルールは1件の ok のみ追加

### テスト

```
bun test check_integrity.test.ts
54 pass / 0 fail / 112 expect() calls
```

新規3テスト（IR-053）すべて pass。既存テスト（valid fixture zero-ng/zero-warning、IR-044、Issue #657 regression の zero-warnings drift detection）すべて green。両 test suite（`scripts/check_integrity.test.ts` + `scripts/tests/check_integrity.test.ts`）準拠。

### TS 型

当該スクリプト群は tsconfig/@types/node 未導入で bun 実行時 globals に依存する既存構造。本差分は既存パターン（`require`/`fs`/`path`/`warn`/`ok`）に一致し、新規エラーカテゴリを導入しない。検証の SSoT は `bun test`（54 pass）。

## QG-3（実装乖離ゲート）

- REQ-0152-001（検出）: ✓ 正規表現・スキャン対象が SPEC と整合、真陽性テスト合格
- REQ-0152-002（スコープ・除外整合）: ✓ 除外対象が REQ-0149-003 許容ファイルと一致、除外テスト合格（standard-procedures.md は false positive なし）
- スコープ: ✓ REQ/SPEC ファイル・IR-053 SPEC エントリは未変更、IR-053 実装+テスト+1行マッピングのみ

## 備考

- 本PRはマージしない（case-close がマージ担当）
- worktree `.worktrees/1146-feature` / branch `feature/issue-1146` は維持（case-close がクリーンアップ）

## Findings / Capture候補

（該当なし — 本筋外の発見事項なし）

### intake

（なし）

### learning

（なし）

## SPEC確定候補

（なし — IR-053 SPEC エントリは既に確定済み。実装で判明した SPEC レベルの追加詳細なし）
