### PR TITLE
agentdev-req-file-manager SKILL.md更新 + 新規決定的スクリプト作成

### DIFF
--- a/src/opencode/skills/agentdev-req-file-manager/SKILL.md
+++ b/src/opencode/skills/agentdev-req-file-manager/SKILL.md
@@ -302,6 +302,52 @@ updated: YYYY-MM-DD
 
 ---
 
+## Scripts（決定的処理）
+
+`scripts/` 配下の決定的スクリプトが、本スキルが規定する採番・検証・検索処理を機械的に実行する（design-principles.md 第5節「Script は決定的でテスト可能な処理を担う」、REQ-0103-159/160、AG-002/006）。LLM 推論で実行していた決定的処理をスクリプトへ委譲することで、番号の重複・欠番埋め・frontmatter 不整合を確実に防止する。
+
+配置先: `src/opencode/skills/agentdev-req-file-manager/scripts/`（REQ-0103-159）。実装は TypeScript、決定的（純粋関数）、テスト付き（`tests/*.test.ts`、REQ-0103-160）。
+
+### I/O 契約（REQ-0103-160）
+
+| 項目 | 規約 |
+|------|------|
+| 入力 | argv（ファイル/ディレクトリパス）または stdin（JSON） |
+| 出力 | stdout に JSON |
+| エラー | 非ゼロ終了コード + stderr にエラーメッセージ |
+| 副作用 | なし（純粋関数、ファイル I/O は入力読み込みのみ） |
+
+### スクリプト一覧
+
+| スクリプト | 役割 | 入力 | 出力 JSON |
+|-----------|------|------|-----------|
+| `alloc-req-number.ts` | REQ番号採番（max+1、欠番埋め禁止） | argv[2]=REQ dir | `{ ok, allocated: "REQ-NNNN", max }` |
+| `alloc-adr-number.ts` | ADR番号採番（max+1、欠番埋め禁止） | argv[2]=ADR dir | `{ ok, allocated: "ADR-NNNN", max }` |
+| `alloc-composite-id.ts` | 要件行ID採番（REQ-NNNN-MMM、max+1） | argv[2]=REQ file, argv[3]=req番号（省略可） | `{ ok, allocated: "REQ-NNNN-MMM", req, max }` |
+| `check-frontmatter-consistency.ts` | frontmatter id ↔ ファイル名整合性 | argv[2]=dir, argv[3]=kind(req\|adr) | `{ ok, errors[], warnings[] }` |
+| `check-entry-existence.ts` | README/DOC-MAP/mapping-table エントリ存在 | argv[2]=id, argv[3..]=files、または stdin JSON | `{ ok, errors[], warnings[], found[] }` |
+| `check-change-impact.ts` | 変更範囲検証（許可パスリストとの積集合） | argv[2]=changed-list-file, argv[3]=allowed-list-file、または stdin JSON | `{ ok, errors[], warnings[], violations[] }` |
+| `search-target-area.ts` | SPEC ファイル内 target_area 見出し検索 | argv[2]=target_area, argv[3..]=spec files、または stdin JSON | `{ ok, matches: [{file, line, text}] }` |
+
+### 実行方法
+
+```bash
+# bun 経由で直接実行（REQ-0103-160: LLM は bash 経由で呼び出し）
+bun src/opencode/skills/agentdev-req-file-manager/scripts/src/alloc-req-number.ts docs/requirements
+
+# stdin JSON 入力
+echo '{"id":"REQ-0103","files":["docs/requirements/README.md"]}' | bun src/opencode/skills/agentdev-req-file-manager/scripts/src/check-entry-existence.ts
+
+# テスト実行（npm test または bun test）
+cd src/opencode/skills/agentdev-req-file-manager/scripts && npm test
+```
+
+### req-save / spec-save からの呼び出し
+
+req-save と spec-save は本スクリプト群を bash 経由で呼び出し、JSON 結果を parse して意味判断（NG 時の対応等）を行う（REQ-0103-160）。これにより REQ番号採番、ADR番号採番、要件行ID採番、frontmatter 整合性確認、エントリ存在確認、変更範囲検証、target_area 検索を LLM 推論ではなく機械的に実行する（design-principles.md 第5節「決定的処理の Script 委譲原則」）。
+
+---
+
 ## REQ-ID 安定ID 規約
 
 REQ-ID（`REQ-{NNNN}`）は安定IDであり、ファイル配置に依存しない。

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/.gitignore
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/README.md
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/README.md
@@ -1,0 +1,50 @@
+# agentdev-req-file-manager scripts
+
+REQ/ADR/SPEC ファイル管理の決定的処理スクリプト群（REQ-0103-159/160、AG-002/006、design-principles.md 第5節）。
+
+## 構成
+
+```
+scripts/
+├── package.json
+├── tsconfig.json
+├── lib/
+│   ├── result.ts                    # 結果型と stdout/stderr ヘルパー
+│   ├── frontmatter.ts               # frontmatter parse、ID 形式抽出（純粋関数）
+│   └── fs-helpers.ts                # ファイル名/番号/ゼロ埋めヘルパー
+├── src/
+│   ├── alloc-req-number.ts          # REQ番号採番（max+1、欠番埋め禁止）
+│   ├── alloc-adr-number.ts          # ADR番号採番（max+1、欠番埋め禁止）
+│   ├── alloc-composite-id.ts        # 要件行ID採番（REQ-NNNN-MMM、max+1）
+│   ├── check-frontmatter-consistency.ts  # frontmatter id ↔ ファイル名整合性
+│   ├── check-entry-existence.ts     # README/DOC-MAP/mapping-table エントリ存在
+│   ├── check-change-impact.ts       # 変更範囲検証（許可パスリストとの積集合）
+│   └── search-target-area.ts        # SPEC ファイル内 target_area 見出し検索
+└── tests/
+    └── *.test.ts                    # 各スクリプトの core 純粋関数テスト
+```
+
+## I/O 契約（REQ-0103-160）
+
+- 入力: argv（ファイル/ディレクトリパス）または stdin（JSON）
+- 出力: stdout に JSON
+- エラー: 非ゼロ終了コード + stderr にエラーメッセージ
+- 副作用: なし（純粋関数、ファイル I/O は入力読み込みのみ）
+
+## 実行方法
+
+```bash
+# 依存関係インストール（初回のみ）
+bun install
+
+# テスト実行
+bun test         # または npm test
+
+# 型チェック
+bun run tsc --noEmit   # または npm run typecheck
+
+# 個別スクリプト実行
+bun src/alloc-req-number.ts ../../../docs/requirements
+```
+
+各スクリプトの詳細な I/O は親 SKILL.md の「Scripts（決定的処理）」セクション参照。

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/bun.lock
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "agentdev-req-file-manager-scripts",
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
+        "typescript": "^5.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/lib/frontmatter.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/lib/frontmatter.ts
@@ -1,0 +1,66 @@
+/**
+ * Frontmatter と ID 形式の parse ヘルパー（純粋関数）。
+ *
+ * Markdown ヘッダの `---` 区切り frontmatter を抽出し、
+ * REQ-NNNN / ADR-NNNN / REQ-NNNN-MMM 形式の ID から番号を取り出す。
+ */
+
+export type Frontmatter = Record<string, string>;
+
+/**
+ * Markdown 本文から frontmatter ブロックを抽出してパースする。
+ * frontmatter がない場合は null を返す。
+ *
+ * 対応 YAML サブセット:
+ *   - `key: value` 単純スカラー
+ *   - 値のクォート（"…" / '…'）は除去
+ *   - 配列や入れ子には未対応（本スキルの frontmatter はフラット scalar 的運用）
+ */
+export function parseFrontmatter(content: string): Frontmatter | null {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
+  if (!match || match[1] === undefined) return null;
+  return parseYamlScalars(match[1]);
+}
+
+function parseYamlScalars(yaml: string): Frontmatter {
+  const result: Frontmatter = {};
+  for (const line of yaml.split(/\r?\n/)) {
+    const m = /^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/.exec(line);
+    if (!m || m[1] === undefined || m[2] === undefined) continue;
+    const key = m[1];
+    const raw = m[2].trim();
+    result[key] = stripQuotes(raw);
+  }
+  return result;
+}
+
+function stripQuotes(value: string): string {
+  if (value.length < 2) return value;
+  const first = value[0]!;
+  const last = value[value.length - 1]!;
+  if (first === last && (first === '"' || first === "'")) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/** `REQ-NNNN` 形式から数値を取り出す。未整形式は null。 */
+export function extractReqNumber(id: string): number | null {
+  const m = /^REQ-(\d{4})$/.exec(id);
+  return m && m[1] ? parseInt(m[1], 10) : null;
+}
+
+/** `ADR-NNNN` 形式から数値を取り出す。未整形式は null。 */
+export function extractAdrNumber(id: string): number | null {
+  const m = /^ADR-(\d{4})$/.exec(id);
+  return m && m[1] ? parseInt(m[1], 10) : null;
+}
+
+/** `REQ-NNNN-MMM` 形式から { req, row } を取り出す。未整形式は null。 */
+export function extractCompositeIdNumbers(
+  id: string,
+): { req: number; row: number } | null {
+  const m = /^REQ-(\d{4})-(\d{3})$/.exec(id);
+  if (!m || !m[1] || !m[2]) return null;
+  return { req: parseInt(m[1], 10), row: parseInt(m[2], 10) };
+}

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/lib/fs-helpers.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/lib/fs-helpers.ts
@@ -1,0 +1,59 @@
+/**
+ * ファイル名・番号・ゼロ埋めヘルパー（純粋関数中心）。
+ *
+ * fs I/O 関数は本ファイル内に隔離し、コア計算は純粋関数として扱う。
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** ファイル名 `REQ-NNNN.md` から番号を取り出す。 */
+export function reqNumberFromFilename(filename: string): number | null {
+  const m = /^REQ-(\d{4})\.md$/.exec(filename);
+  return m && m[1] ? parseInt(m[1], 10) : null;
+}
+
+/** ファイル名 `ADR-NNNN.md` から番号を取り出す。 */
+export function adrNumberFromFilename(filename: string): number | null {
+  const m = /^ADR-(\d{4})\.md$/.exec(filename);
+  return m && m[1] ? parseInt(m[1], 10) : null;
+}
+
+/** 指定ディレクトリ直下の `.md` ファイル名一覧（非再帰）。存在しない場合は空配列。 */
+export function listMarkdownFiles(dir: string): string[] {
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isFile() && e.name.endsWith(".md"))
+      .map((e) => e.name);
+  } catch {
+    return [];
+  }
+}
+
+/** ファイル内容を読む I/O ヘルパー（純粋関数ではない）。 */
+export function readFileContent(path: string): string {
+  return readFileSync(path, "utf-8");
+}
+
+/** パス結合ヘルパー（テスト容易性のためラップ）。 */
+export function joinPath(...segments: string[]): string {
+  return join(...segments);
+}
+
+/** 4桁ゼロ埋め。 */
+export function pad4(n: number): string {
+  return n.toString().padStart(4, "0");
+}
+
+/** 3桁ゼロ埋め。 */
+export function pad3(n: number): string {
+  return n.toString().padStart(3, "0");
+}
+
+/** 正の整数のみを max 計算対象とする（NaN/負数を弾く）。 */
+export function safeMax(numbers: number[]): number {
+  const valid = numbers.filter((n) => Number.isFinite(n) && n > 0);
+  if (valid.length === 0) return 0;
+  return valid.reduce((a, b) => (a > b ? a : b));
+}

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/lib/result.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/lib/result.ts
@@ -1,0 +1,50 @@
+/**
+ * 共通結果型と stdout/stderr 出力ヘルパー（REQ-0103-160 I/O 契約）。
+ *
+ * 全スクリプトの出力 JSON は成功時は ok: true を含み、
+ * エラー時は非ゼロ終了コード + stderr メッセージとする。
+ */
+
+export type AllocOk = {
+  ok: true;
+  allocated: string;
+  max: number;
+};
+
+export type AllocErr = {
+  ok: false;
+  error: string;
+};
+
+export type AllocResult = AllocOk | AllocErr;
+
+export type CheckOk = {
+  ok: true;
+  errors: string[];
+  warnings: string[];
+};
+
+export type CheckErr = {
+  ok: false;
+  error: string;
+};
+
+export type CheckResult = CheckOk | CheckErr;
+
+export type SearchOk = {
+  ok: true;
+  matches: Array<{ file: string; line: number; text: string }>;
+};
+
+export type SearchResult = SearchOk | CheckErr;
+
+/** stdout に JSON を出力する（argv/stdin → stdout JSON 契約）。 */
+export function emitJson(value: unknown): void {
+  process.stdout.write(JSON.stringify(value, null, 2) + "\n");
+}
+
+/** stderr にエラーを出力し非ゼロ終了コードで終了する。 */
+export function emitError(message: string, code = 1): never {
+  process.stderr.write(message + "\n");
+  process.exit(code);
+}

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/package.json
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "agentdev-req-file-manager-scripts",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Deterministic scripts for REQ/ADR/SPEC file management (REQ-0103-159/160, AG-002/006). Pure functions, argv/stdin input, stdout JSON output.",
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/src/alloc-adr-number.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/src/alloc-adr-number.ts
@@ -1,0 +1,69 @@
+/**
+ * ADR番号採番スクリプト（AG-002、AG-006、REQ-0103-159/160）。
+ *
+ * 既存の ADR ファイル群から最大番号を特定し、その +1 を採番する。
+ * 欠番埋め禁止（agentdev-adr-file-manager 採番ルール）。
+ *
+ * I/O:
+ *   入力: argv[2] = ADR ディレクトリパス（例: docs/adr）
+ *   出力: stdout に JSON { ok: true, allocated: "ADR-NNNN", max: N }
+ *   エラー: 非ゼロ終了コード + stderr メッセージ
+ */
+
+import { listMarkdownFiles, joinPath, readFileContent, pad4, adrNumberFromFilename, safeMax } from "../lib/fs-helpers.ts";
+import { extractAdrNumber } from "../lib/frontmatter.ts";
+import { emitJson, emitError } from "../lib/result.ts";
+
+/** 既存番号のリストから次番号（max+1）を計算する（純粋関数）。 */
+export function nextAdrNumber(existingNumbers: number[]): number {
+  const max = safeMax(existingNumbers);
+  return max + 1;
+}
+
+/** 番号から `ADR-NNNN` 形式の ID を生成する（純粋関数）。 */
+export function formatAdrId(n: number): string {
+  return `ADR-${pad4(n)}`;
+}
+
+async function main(): Promise<void> {
+  const dir = process.argv[2];
+  if (!dir) {
+    emitError("Usage: alloc-adr-number <adr-dir>");
+  }
+
+  const files = listMarkdownFiles(dir!);
+  const numbers: number[] = [];
+  for (const filename of files) {
+    const fromName = adrNumberFromFilename(filename);
+    if (fromName !== null) {
+      numbers.push(fromName);
+      continue;
+    }
+    const content = readFileContent(joinPath(dir!, filename));
+    const fm = parseFrontmatterForAdr(content);
+    if (fm !== null) {
+      numbers.push(fm);
+    }
+  }
+
+  const max = safeMax(numbers);
+  const next = nextAdrNumber(numbers);
+  emitJson({ ok: true, allocated: formatAdrId(next), max });
+}
+
+function parseFrontmatterForAdr(content: string): number | null {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
+  if (!match || match[1] === undefined) return null;
+  for (const line of match[1].split(/\r?\n/)) {
+    const m = /^id:\s*(.*)$/.exec(line);
+    if (m && m[1] !== undefined) {
+      const n = extractAdrNumber(m[1].trim());
+      if (n !== null) return n;
+    }
+  }
+  return null;
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/src/alloc-composite-id.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/src/alloc-composite-id.ts
@@ -1,0 +1,82 @@
+/**
+ * 複合ID（要件行ID）採番スクリプト（AG-002、AG-006、REQ-0103-159/160）。
+ *
+ * 指定 REQ ファイル本文から既存の `REQ-NNNN-MMM` 形式の要件行IDを抽出し、
+ * その最大行番号 + 1 を採番する。欠番埋め禁止。
+ *
+ * I/O:
+ *   入力: argv[2] = 対象 REQ ファイルパス、argv[3] = 親 REQ 番号（例: 0103、オプション・ファイル名から推定）
+ *   出力: stdout に JSON { ok: true, allocated: "REQ-NNNN-MMM", req: N, max: M }
+ *   エラー: 非ゼロ終了コード + stderr メッセージ
+ */
+
+import { readFileContent, pad3, pad4, reqNumberFromFilename, safeMax } from "../lib/fs-helpers.ts";
+import { extractCompositeIdNumbers } from "../lib/frontmatter.ts";
+import { emitJson, emitError } from "../lib/result.ts";
+import { basename } from "node:path";
+
+/** 既存の行番号リストから次の行番号（max+1）を計算する（純粋関数）。 */
+export function nextRowNumber(existingRows: number[]): number {
+  const max = safeMax(existingRows);
+  return max + 1;
+}
+
+/** REQ番号と行番号から `REQ-NNNN-MMM` 形式のIDを生成する（純粋関数）。 */
+export function formatCompositeId(req: number, row: number): string {
+  return `REQ-${pad4(req)}-${pad3(row)}`;
+}
+
+/**
+ * 本文から `REQ-NNNN-MMM` 形式のIDを全て抽出する（純粋関数）。
+ * 重複除去は行わない（重複は整合性チェックの対象）。
+ */
+export function extractAllCompositeIds(content: string): string[] {
+  const re = /REQ-(\d{4})-(\d{3})/g;
+  const ids: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    if (m[0]) ids.push(m[0]);
+  }
+  return ids;
+}
+
+async function main(): Promise<void> {
+  const filePath = process.argv[2];
+  if (!filePath) {
+    emitError("Usage: alloc-composite-id <req-file-path> [req-number]");
+  }
+
+  // 親 REQ 番号の決定: argv[3] 優先、無ければファイル名から推定
+  let reqNumber: number | null = null;
+  const explicit = process.argv[3];
+  if (explicit) {
+    reqNumber = Number.parseInt(explicit, 10);
+    if (!Number.isFinite(reqNumber) || reqNumber <= 0) {
+      emitError(`Invalid req-number: ${explicit}`);
+    }
+  } else {
+    reqNumber = reqNumberFromFilename(basename(filePath!));
+  }
+  if (reqNumber === null) {
+    emitError("req-number is required (argv[3] or filename REQ-NNNN.md)");
+  }
+
+  const content = readFileContent(filePath!);
+  const ids = extractAllCompositeIds(content);
+  const rows: number[] = [];
+  for (const id of ids) {
+    const parsed = extractCompositeIdNumbers(id);
+    if (parsed === null) continue;
+    if (parsed.req === reqNumber) {
+      rows.push(parsed.row);
+    }
+  }
+
+  const max = safeMax(rows);
+  const next = nextRowNumber(rows);
+  emitJson({ ok: true, allocated: formatCompositeId(reqNumber!, next), req: reqNumber, max });
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/src/alloc-req-number.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/src/alloc-req-number.ts
@@ -1,0 +1,72 @@
+/**
+ * REQ番号採番スクリプト（AG-002、AG-006、REQ-0103-159/160）。
+ *
+ * 既存の REQ ファイル群から最大番号を特定し、その +1 を採番する。
+ * 欠番があっても埋めない（REQ-NNNN 安定 ID 規約）。
+ *
+ * I/O:
+ *   入力: argv[2] = REQ ディレクトリパス（例: docs/requirements）
+ *   出力: stdout に JSON { ok: true, allocated: "REQ-NNNN", max: N }
+ *   エラー: 非ゼロ終了コード + stderr メッセージ
+ */
+
+import { listMarkdownFiles, joinPath, readFileContent, pad4, reqNumberFromFilename, safeMax } from "../lib/fs-helpers.ts";
+import { extractReqNumber } from "../lib/frontmatter.ts";
+import { emitJson, emitError } from "../lib/result.ts";
+
+/** 既存番号のリストから次番号（max+1）を計算する（純粋関数）。空の場合は 1。 */
+export function nextReqNumber(existingNumbers: number[]): number {
+  const max = safeMax(existingNumbers);
+  return max + 1;
+}
+
+/** 番号から `REQ-NNNN` 形式の ID を生成する（純粋関数）。 */
+export function formatReqId(n: number): string {
+  return `REQ-${pad4(n)}`;
+}
+
+async function main(): Promise<void> {
+  const dir = process.argv[2];
+  if (!dir) {
+    emitError("Usage: alloc-req-number <req-dir>");
+  }
+
+  const files = listMarkdownFiles(dir!);
+  const numbers: number[] = [];
+  for (const filename of files) {
+    // ファイル名由来
+    const fromName = reqNumberFromFilename(filename);
+    if (fromName !== null) {
+      numbers.push(fromName);
+      continue;
+    }
+    // frontmatter id 由来（ファイル名が REQ-NNNN.md でない場合のフォールバック）
+    const content = readFileContent(joinPath(dir!, filename));
+    const fm = parseFrontmatterForReq(content);
+    if (fm !== null) {
+      numbers.push(fm);
+    }
+  }
+
+  const max = safeMax(numbers);
+  const next = nextReqNumber(numbers);
+  emitJson({ ok: true, allocated: formatReqId(next), max });
+}
+
+function parseFrontmatterForReq(content: string): number | null {
+  // テスト容易性のため frontmatter.ts の関数を直接呼ばず、ここで簡易抽出
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
+  if (!match || match[1] === undefined) return null;
+  for (const line of match[1].split(/\r?\n/)) {
+    const m = /^id:\s*(.*)$/.exec(line);
+    if (m && m[1] !== undefined) {
+      const n = extractReqNumber(m[1].trim());
+      if (n !== null) return n;
+    }
+  }
+  return null;
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/src/check-change-impact.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/src/check-change-impact.ts
@@ -1,0 +1,114 @@
+/**
+ * 変更範囲検証スクリプト（AG-002、AG-006、REQ-0103-159/160）。
+ *
+ * 変更対象ファイルパスのリストと、許可パスリスト（glob 風プレフィックス）を比較し、
+ * 許可範囲外の変更を検出する。req-save G02 / spec-save G02 のファイル操作制約を
+ * 機械的に検証するために使用する。
+ *
+ * I/O:
+ *   入力: argv[2] = 変更ファイルパスを1行1件で並べたテキストファイルパス
+ *         argv[3] = 許可パスプレフィックスを1行1件で並べたテキストファイルパス
+ *         または stdin に JSON { changed: string[], allowed: string[] }
+ *   出力: stdout に JSON { ok: boolean, errors: string[], warnings: string[], violations: string[] }
+ *   エラー: 非ゼロ終了コード + stderr メッセージ
+ */
+
+import { readFileContent } from "../lib/fs-helpers.ts";
+import { emitJson, emitError } from "../lib/result.ts";
+
+export type ChangeImpactResult = {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  violations: string[];
+};
+
+/** 前方一致マッチ（`docs/requirements/**` は `docs/requirements/` で始まるパス全てにマッチ）。 */
+export function pathMatchesPrefix(path: string, prefixPattern: string): boolean {
+  if (prefixPattern === "**" || prefixPattern === "**/*") return true;
+  if (!prefixPattern.includes("**")) {
+    return path === prefixPattern;
+  }
+  const prefix = prefixPattern.replace(/\/\*+$/, "");
+  if (path === prefix) return true;
+  if (path.startsWith(prefix + "/")) return true;
+  return false;
+}
+
+/** 変更パスリストの各要素が許可リストのいずれかにマッチするか検証する（純粋関数）。 */
+export function checkChangeImpact(
+  changedPaths: readonly string[],
+  allowedPatterns: readonly string[],
+): ChangeImpactResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const violations: string[] = [];
+
+  for (const changed of changedPaths) {
+    const matched = allowedPatterns.some((p) => pathMatchesPrefix(changed, p));
+    if (!matched) {
+      violations.push(changed);
+    }
+  }
+
+  if (violations.length > 0) {
+    errors.push(`${violations.length} path(s) outside allowed scope`);
+  }
+
+  return { ok: errors.length === 0, errors, warnings, violations };
+}
+
+async function main(): Promise<void> {
+  // argv 入力: changedFile allowedFile
+  if (process.argv[2] && process.argv[3]) {
+    const changedRaw = readFileContent(process.argv[2]!);
+    const allowedRaw = readFileContent(process.argv[3]!);
+    const changed = parsePathList(changedRaw);
+    const allowed = parsePathList(allowedRaw);
+    emitJson(checkChangeImpact(changed, allowed));
+    return;
+  }
+
+  // stdin JSON 入力: { changed: string[], allowed: string[] }
+  const stdinContent = await readStdin();
+  if (stdinContent) {
+    let parsed: { changed?: unknown; allowed?: unknown };
+    try {
+      parsed = JSON.parse(stdinContent);
+    } catch {
+      emitError(`Invalid JSON on stdin: ${stdinContent}`);
+    }
+    if (!Array.isArray(parsed.changed) || !Array.isArray(parsed.allowed)) {
+      emitError('stdin JSON must be { changed: string[], allowed: string[] }');
+    }
+    emitJson(
+      checkChangeImpact(
+        parsed.changed as string[],
+        parsed.allowed as string[],
+      ),
+    );
+    return;
+  }
+
+  emitError('Usage: check-change-impact <changed-paths-file> <allowed-patterns-file>  OR  stdin JSON { changed: string[], allowed: string[] }');
+}
+
+function parsePathList(content: string): string[] {
+  return content
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !l.startsWith("#"));
+}
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return "";
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/src/check-entry-existence.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/src/check-entry-existence.ts
@@ -1,0 +1,104 @@
+/**
+ * README / DOC-MAP / mapping-table のエントリ存在確認スクリプト
+ * （AG-002、AG-006、REQ-0103-159/160）。
+ *
+ * 指定 ID（例: REQ-0103、ADR-0128）が、対象インデックスファイル本文に
+ * 出現するかを確認する。出現しない場合はエラーとして報告する。
+ *
+ * I/O:
+ *   入力: argv[2] = 検索対象 ID（例: REQ-0103）
+ *         argv[3..] = インデックスファイルパス群（可変長）
+ *         または stdin に JSON { id: string, files: string[] }
+ *   出力: stdout に JSON { ok: boolean, errors: string[], warnings: string[], found: string[] }
+ *   エラー: 非ゼロ終了コード + stderr メッセージ
+ */
+
+import { readFileContent } from "../lib/fs-helpers.ts";
+import { emitJson, emitError } from "../lib/result.ts";
+
+export type EntryResult = {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  found: string[];
+};
+
+/**
+ * 指定 ID がファイル本文に含まれるかを判定する（純粋関数）。
+ * 単純な部分文字列探索（インデックスファイルは ID をそのまま記載する運用）。
+ */
+export function idExistsInContent(id: string, content: string): boolean {
+  return content.includes(id);
+}
+
+/**
+ * 複数ファイルに対して ID の存在を確認し、結果を集約する（純粋関数）。
+ * found は ID が見つかったファイルパスのリスト。
+ */
+export function checkIdInFiles(
+  id: string,
+  files: ReadonlyArray<{ path: string; content: string }>,
+): EntryResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const found: string[] = [];
+  for (const f of files) {
+    if (idExistsInContent(id, f.content)) {
+      found.push(f.path);
+    }
+  }
+  if (found.length === 0) {
+    errors.push(`id "${id}" not found in any of the provided index files`);
+  }
+  return { ok: errors.length === 0, errors, warnings, found };
+}
+
+async function main(): Promise<void> {
+  // argv 入力: id file1 [file2 ...]
+  if (process.argv[2] && process.argv[3]) {
+    const id = process.argv[2]!;
+    const files = process.argv.slice(3).map((path) => ({
+      path,
+      content: readFileContent(path),
+    }));
+    emitJson(checkIdInFiles(id, files));
+    return;
+  }
+
+  // stdin JSON 入力: { id, files: string[] }
+  const stdinContent = await readStdin();
+  if (stdinContent) {
+    let parsed: { id?: unknown; files?: unknown };
+    try {
+      parsed = JSON.parse(stdinContent);
+    } catch {
+      emitError(`Invalid JSON on stdin: ${stdinContent}`);
+    }
+    if (typeof parsed.id !== "string" || !Array.isArray(parsed.files)) {
+      emitError('stdin JSON must be { id: string, files: string[] }');
+    }
+    const files = (parsed.files as unknown[]).map((path) => {
+      if (typeof path !== "string") {
+        emitError(`files entries must be strings, got: ${typeof path}`);
+      }
+      return { path: path!, content: readFileContent(path!) };
+    });
+    emitJson(checkIdInFiles(parsed.id as string, files));
+    return;
+  }
+
+  emitError('Usage: check-entry-existence <id> <file1> [file2 ...]  OR  stdin JSON { id, files: string[] }');
+}
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return "";
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/src/check-frontmatter-consistency.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/src/check-frontmatter-consistency.ts
@@ -1,0 +1,94 @@
+/**
+ * frontmatter id ↔ ファイル名整合性確認スクリプト（AG-002、AG-006、REQ-0103-159/160）。
+ *
+ * 指定ディレクトリ配下の `REQ-NNNN.md` / `ADR-NNNN.md` について、
+ * frontmatter の `id:` とファイル名が一致するか検証する。
+ *
+ * I/O:
+ *   入力: argv[2] = 検証対象ディレクトリパス
+ *         argv[3] = kind（"req" | "adr"、デフォルト: ファイル名から推定）
+ *   出力: stdout に JSON { ok: boolean, errors: string[], warnings: string[] }
+ *   エラー時: ok: false, errors に理由。致命的I/Oエラーは非ゼロ終了コード + stderr
+ */
+
+import { listMarkdownFiles, joinPath, readFileContent, reqNumberFromFilename, adrNumberFromFilename } from "../lib/fs-helpers.ts";
+import { parseFrontmatter, extractReqNumber, extractAdrNumber } from "../lib/frontmatter.ts";
+import { emitJson, emitError } from "../lib/result.ts";
+
+export type ConsistencyIssue = {
+  file: string;
+  filenameNumber: number | null;
+  frontmatterId: string | null;
+  frontmatterNumber: number | null;
+};
+
+/** ファイル名と frontmatter id の番号一致を検証する（純粋関数）。 */
+export function checkSingleFile(
+  filename: string,
+  content: string,
+  kind: "req" | "adr",
+): { ok: boolean; issues: ConsistencyIssue } {
+  const filenameNumber =
+    kind === "req" ? reqNumberFromFilename(filename) : adrNumberFromFilename(filename);
+  const fm = parseFrontmatter(content);
+  const frontmatterId = fm?.id ?? null;
+  let frontmatterNumber: number | null = null;
+  if (frontmatterId !== null) {
+    frontmatterNumber =
+      kind === "req" ? extractReqNumber(frontmatterId) : extractAdrNumber(frontmatterId);
+  }
+
+  const ok =
+    filenameNumber !== null &&
+    frontmatterNumber !== null &&
+    filenameNumber === frontmatterNumber;
+
+  return {
+    ok,
+    issues: {
+      file: filename,
+      filenameNumber,
+      frontmatterId,
+      frontmatterNumber,
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const dir = process.argv[2];
+  const kind = (process.argv[3] as "req" | "adr" | undefined) ?? "req";
+  if (!dir) {
+    emitError("Usage: check-frontmatter-consistency <dir> [req|adr]");
+  }
+  if (kind !== "req" && kind !== "adr") {
+    emitError(`kind must be "req" or "adr", got: ${kind}`);
+  }
+
+  const files = listMarkdownFiles(dir!);
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  for (const filename of files) {
+    // REQ/ADR 以外の .md（README.md 等）はスキップ
+    const isTarget =
+      (kind === "req" && /^REQ-\d{4}\.md$/.test(filename)) ||
+      (kind === "adr" && /^ADR-\d{4}\.md$/.test(filename));
+    if (!isTarget) continue;
+
+    const content = readFileContent(joinPath(dir!, filename));
+    const result = checkSingleFile(filename, content, kind);
+    if (!result.ok) {
+      const i = result.issues;
+      const expected = i.filenameNumber !== null ? `${kind.toUpperCase()}-${String(i.filenameNumber).padStart(4, "0")}` : "(no filename number)";
+      errors.push(
+        `${filename}: frontmatter id "${i.frontmatterId ?? "(missing)"}" does not match expected "${expected}"`,
+      );
+    }
+  }
+
+  emitJson({ ok: errors.length === 0, errors, warnings });
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/src/search-target-area.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/src/search-target-area.ts
@@ -1,0 +1,124 @@
+/**
+ * target_area 見出し検索スクリプト（AG-002、AG-006、REQ-0103-159/160）。
+ *
+ * 指定 SPEC ファイル群から、target_area（Markdown 見出し行）を検索する。
+ * spec-save の update 操作で、target_area に一致するセクションを特定するために使用する。
+ *
+ * マッチ規約（docs/specs/commands/spec-save.md の target_area ベースのセクション置換ロジックに準拠）:
+ *   - 完全一致: 見出しテキストが target_area に完全一致
+ *   - 前方一致: 見出しテキストが target_area で始まる
+ *   - 複数マッチ時は warning（spec-save G09 で置換拒否の根拠）
+ *   - 未検出時は空配列（spec-save でスキップ判定）
+ *
+ * I/O:
+ *   入力: argv[2] = target_area 文字列（見出しテキスト）
+ *         argv[3] = 検索対象 SPEC ファイルパス
+ *         または stdin に JSON { target_area: string, files: string[] }
+ *   出力: stdout に JSON { ok: true, matches: [{file, line, text}] }
+ *   エラー: 非ゼロ終了コード + stderr メッセージ
+ */
+
+import { readFileContent } from "../lib/fs-helpers.ts";
+import { emitJson, emitError, type SearchOk } from "../lib/result.ts";
+
+export type Match = {
+  file: string;
+  line: number;
+  text: string;
+};
+
+/**
+ * 1ファイルの本文から target_area にマッチする見出しを抽出する（純粋関数）。
+ * 見出し行（# で始まる行）のみを対象とする。
+ */
+export function findTargetAreaHeadings(
+  targetArea: string,
+  content: string,
+  filePath: string,
+): Match[] {
+  const matches: Match[] = [];
+  const lines = content.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const headingMatch = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (!headingMatch || headingMatch[2] === undefined) continue;
+    const headingText = headingMatch[2].trim();
+    if (headingMatchesTarget(headingText, targetArea)) {
+      matches.push({ file: filePath, line: i + 1, text: line });
+    }
+  }
+  return matches;
+}
+
+/** 完全一致 または 前方一致（target_area で始まる見出し）。 */
+export function headingMatchesTarget(headingText: string, targetArea: string): boolean {
+  if (headingText === targetArea) return true;
+  if (headingText.startsWith(targetArea)) return true;
+  return false;
+}
+
+/**
+ * 複数ファイルに対して target_area を検索し、結果を集約する（純粋関数）。
+ * matches が空でもエラーとはしない（spec-save 側でスキップ判定）。
+ * 複数マッチは呼び出し元で warning 判断の材料とするため、全て返す。
+ */
+export function searchTargetArea(
+  targetArea: string,
+  files: ReadonlyArray<{ path: string; content: string }>,
+): SearchOk {
+  const matches: Match[] = [];
+  for (const f of files) {
+    matches.push(...findTargetAreaHeadings(targetArea, f.content, f.path));
+  }
+  return { ok: true, matches };
+}
+
+async function main(): Promise<void> {
+  // argv 入力: target_area file
+  if (process.argv[2] && process.argv[3]) {
+    const targetArea = process.argv[2]!;
+    const files = process.argv.slice(3).map((path) => ({
+      path,
+      content: readFileContent(path),
+    }));
+    emitJson(searchTargetArea(targetArea, files));
+    return;
+  }
+
+  // stdin JSON 入力: { target_area, files: string[] }
+  const stdinContent = await readStdin();
+  if (stdinContent) {
+    let parsed: { target_area?: unknown; files?: unknown };
+    try {
+      parsed = JSON.parse(stdinContent);
+    } catch {
+      emitError(`Invalid JSON on stdin: ${stdinContent}`);
+    }
+    if (typeof parsed.target_area !== "string" || !Array.isArray(parsed.files)) {
+      emitError('stdin JSON must be { target_area: string, files: string[] }');
+    }
+    const files = (parsed.files as unknown[]).map((path) => {
+      if (typeof path !== "string") {
+        emitError(`files entries must be strings, got: ${typeof path}`);
+      }
+      return { path: path!, content: readFileContent(path!) };
+    });
+    emitJson(searchTargetArea(parsed.target_area as string, files));
+    return;
+  }
+
+  emitError('Usage: search-target-area <target_area> <spec-file> [spec-file...]  OR  stdin JSON { target_area: string, files: string[] }');
+}
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return "";
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/tests/alloc-adr-number.test.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/tests/alloc-adr-number.test.ts
@@ -1,0 +1,30 @@
+import { test, expect, describe } from "bun:test";
+import { nextAdrNumber, formatAdrId } from "../src/alloc-adr-number.ts";
+
+describe("nextAdrNumber", () => {
+  test("returns 1 for empty list", () => {
+    expect(nextAdrNumber([])).toBe(1);
+  });
+
+  test("returns max+1 for non-empty list", () => {
+    expect(nextAdrNumber([127, 128, 129])).toBe(130);
+  });
+
+  test("does not backfill gaps", () => {
+    expect(nextAdrNumber([101, 105])).toBe(106);
+  });
+
+  test("ignores invalid values", () => {
+    expect(nextAdrNumber([131, -1, Number.NaN])).toBe(132);
+  });
+});
+
+describe("formatAdrId", () => {
+  test("zero-pads to 4 digits", () => {
+    expect(formatAdrId(1)).toBe("ADR-0001");
+  });
+
+  test("preserves 4-digit numbers", () => {
+    expect(formatAdrId(131)).toBe("ADR-0131");
+  });
+});

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/tests/alloc-composite-id.test.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/tests/alloc-composite-id.test.ts
@@ -1,0 +1,44 @@
+import { test, expect, describe } from "bun:test";
+import {
+  nextRowNumber,
+  formatCompositeId,
+  extractAllCompositeIds,
+} from "../src/alloc-composite-id.ts";
+
+describe("nextRowNumber", () => {
+  test("returns 1 for empty list", () => {
+    expect(nextRowNumber([])).toBe(1);
+  });
+
+  test("returns max+1 for non-empty list", () => {
+    expect(nextRowNumber([1, 2, 3])).toBe(4);
+  });
+
+  test("does not backfill gaps", () => {
+    expect(nextRowNumber([1, 5, 10])).toBe(11);
+  });
+});
+
+describe("formatCompositeId", () => {
+  test("formats REQ-NNNN-MMM with zero-padding", () => {
+    expect(formatCompositeId(103, 1)).toBe("REQ-0103-001");
+    expect(formatCompositeId(1234, 56)).toBe("REQ-1234-056");
+  });
+});
+
+describe("extractAllCompositeIds", () => {
+  test("extracts all REQ-NNNN-MMM patterns from content", () => {
+    const content = `
+Some text REQ-0103-001 and REQ-0103-002.
+REQ-0102-005 is also matched.
+Not REQ-0103 or REQ-NNNN-MMM pattern.
+`;
+    const ids = extractAllCompositeIds(content);
+    expect(ids).toEqual(["REQ-0103-001", "REQ-0103-002", "REQ-0102-005"]);
+  });
+
+  test("returns empty array when no IDs match", () => {
+    const content = "No IDs here";
+    expect(extractAllCompositeIds(content)).toEqual([]);
+  });
+});

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/tests/alloc-req-number.test.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/tests/alloc-req-number.test.ts
@@ -1,0 +1,38 @@
+import { test, expect, describe } from "bun:test";
+import { nextReqNumber, formatReqId } from "../src/alloc-req-number.ts";
+
+describe("nextReqNumber", () => {
+  test("returns 1 for empty list", () => {
+    expect(nextReqNumber([])).toBe(1);
+  });
+
+  test("returns max+1 for non-empty list", () => {
+    expect(nextReqNumber([101, 102, 103])).toBe(104);
+  });
+
+  test("returns max+1 ignoring gaps (no backfill)", () => {
+    expect(nextReqNumber([101, 103])).toBe(104);
+  });
+
+  test("returns max+1 when list has single element", () => {
+    expect(nextReqNumber([152])).toBe(153);
+  });
+
+  test("ignores non-positive and NaN values", () => {
+    expect(nextReqNumber([101, -5, 0, Number.NaN])).toBe(102);
+  });
+});
+
+describe("formatReqId", () => {
+  test("zero-pads to 4 digits", () => {
+    expect(formatReqId(1)).toBe("REQ-0001");
+  });
+
+  test("preserves 4-digit numbers", () => {
+    expect(formatReqId(1234)).toBe("REQ-1234");
+  });
+
+  test("preserves 5-digit numbers", () => {
+    expect(formatReqId(12345)).toBe("REQ-12345");
+  });
+});

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/tests/check-change-impact.test.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/tests/check-change-impact.test.ts
@@ -1,0 +1,64 @@
+import { test, expect, describe } from "bun:test";
+import { pathMatchesPrefix, checkChangeImpact } from "../src/check-change-impact.ts";
+
+describe("pathMatchesPrefix", () => {
+  test("matches path within globbed directory", () => {
+    expect(pathMatchesPrefix("docs/requirements/REQ-0103.md", "docs/requirements/**")).toBe(true);
+  });
+
+  test("matches exact file path when no glob", () => {
+    expect(pathMatchesPrefix("docs/README.md", "docs/README.md")).toBe(true);
+  });
+
+  test("does not match path outside directory", () => {
+    expect(pathMatchesPrefix("docs/specs/foo.md", "docs/requirements/**")).toBe(false);
+  });
+
+  test("matches draft directory glob", () => {
+    expect(pathMatchesPrefix(".agentdev/drafts/req-draft-1.md", ".agentdev/drafts/**")).toBe(true);
+  });
+
+  test("does not match sibling directory", () => {
+    expect(pathMatchesPrefix("docs/adr/ADR-0101.md", "docs/requirements/**")).toBe(false);
+  });
+
+  test("bare ** matches everything", () => {
+    expect(pathMatchesPrefix("any/path/file.txt", "**")).toBe(true);
+  });
+});
+
+describe("checkChangeImpact", () => {
+  test("ok when all changes are within allowed paths", () => {
+    const result = checkChangeImpact(
+      ["docs/requirements/REQ-0103.md", "docs/adr/ADR-0128.md"],
+      ["docs/requirements/**", "docs/adr/**"],
+    );
+    expect(result.ok).toBe(true);
+    expect(result.violations).toEqual([]);
+  });
+
+  test("reports violations when changes are outside allowed paths", () => {
+    const result = checkChangeImpact(
+      ["docs/requirements/REQ-0103.md", "src/index.ts"],
+      ["docs/requirements/**"],
+    );
+    expect(result.ok).toBe(false);
+    expect(result.violations).toEqual(["src/index.ts"]);
+    expect(result.errors).toHaveLength(1);
+  });
+
+  test("handles empty changed list", () => {
+    const result = checkChangeImpact([], ["docs/requirements/**"]);
+    expect(result.ok).toBe(true);
+    expect(result.violations).toEqual([]);
+  });
+
+  test("reports multiple violations", () => {
+    const result = checkChangeImpact(
+      ["src/a.ts", "src/b.ts", "docs/requirements/REQ-0103.md"],
+      ["docs/requirements/**"],
+    );
+    expect(result.violations).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(result.errors[0]).toContain("2 path");
+  });
+});

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/tests/check-entry-existence.test.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/tests/check-entry-existence.test.ts
@@ -1,0 +1,48 @@
+import { test, expect, describe } from "bun:test";
+import { idExistsInContent, checkIdInFiles } from "../src/check-entry-existence.ts";
+
+describe("idExistsInContent", () => {
+  test("returns true when id is substring of content", () => {
+    expect(idExistsInContent("REQ-0103", "REQ-0103 is here")).toBe(true);
+  });
+
+  test("returns false when id is absent", () => {
+    expect(idExistsInContent("REQ-9999", "REQ-0103 is here")).toBe(false);
+  });
+
+  test("returns true for partial matches within larger tokens", () => {
+    expect(idExistsInContent("REQ-0103", "REQ-0103-001 row")).toBe(true);
+  });
+});
+
+describe("checkIdInFiles", () => {
+  test("ok when id is found in at least one file", () => {
+    const files = [
+      { path: "README.md", content: "# Index\nREQ-0103\n" },
+      { path: "DOC-MAP.md", content: "Other content" },
+    ];
+    const result = checkIdInFiles("REQ-0103", files);
+    expect(result.ok).toBe(true);
+    expect(result.found).toEqual(["README.md"]);
+  });
+
+  test("not ok when id is found in no files", () => {
+    const files = [
+      { path: "README.md", content: "# Index\nREQ-0101\n" },
+    ];
+    const result = checkIdInFiles("REQ-9999", files);
+    expect(result.ok).toBe(false);
+    expect(result.found).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+  });
+
+  test("returns all files where id is found", () => {
+    const files = [
+      { path: "README.md", content: "REQ-0103" },
+      { path: "DOC-MAP.md", content: "REQ-0103 here too" },
+      { path: "mapping-table.md", content: "no match" },
+    ];
+    const result = checkIdInFiles("REQ-0103", files);
+    expect(result.found).toEqual(["README.md", "DOC-MAP.md"]);
+  });
+});

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/tests/check-frontmatter-consistency.test.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/tests/check-frontmatter-consistency.test.ts
@@ -1,0 +1,74 @@
+import { test, expect, describe } from "bun:test";
+import { checkSingleFile } from "../src/check-frontmatter-consistency.ts";
+
+describe("checkSingleFile", () => {
+  test("ok when REQ filename matches frontmatter id", () => {
+    const content = `---
+id: REQ-0103
+title: "Test"
+created: 2026-01-01
+updated: 2026-01-01
+---
+
+# Body`;
+    const result = checkSingleFile("REQ-0103.md", content, "req");
+    expect(result.ok).toBe(true);
+    expect(result.issues.filenameNumber).toBe(103);
+    expect(result.issues.frontmatterNumber).toBe(103);
+  });
+
+  test("not ok when REQ filename does not match frontmatter id", () => {
+    const content = `---
+id: REQ-0102
+title: "Mismatch"
+---
+
+Body`;
+    const result = checkSingleFile("REQ-0103.md", content, "req");
+    expect(result.ok).toBe(false);
+    expect(result.issues.filenameNumber).toBe(103);
+    expect(result.issues.frontmatterNumber).toBe(102);
+  });
+
+  test("not ok when frontmatter id is missing", () => {
+    const content = `---
+title: "No id"
+---
+
+Body`;
+    const result = checkSingleFile("REQ-0103.md", content, "req");
+    expect(result.ok).toBe(false);
+    expect(result.issues.frontmatterId).toBeNull();
+    expect(result.issues.frontmatterNumber).toBeNull();
+  });
+
+  test("not ok when frontmatter is entirely missing", () => {
+    const content = "# Body without frontmatter";
+    const result = checkSingleFile("REQ-0103.md", content, "req");
+    expect(result.ok).toBe(false);
+    expect(result.issues.frontmatterId).toBeNull();
+  });
+
+  test("ok when ADR filename matches frontmatter id", () => {
+    const content = `---
+id: ADR-0128
+title: "Decision"
+---
+
+# Body`;
+    const result = checkSingleFile("ADR-0128.md", content, "adr");
+    expect(result.ok).toBe(true);
+    expect(result.issues.filenameNumber).toBe(128);
+  });
+
+  test("strips quotes from frontmatter id value", () => {
+    const content = `---
+id: "REQ-0103"
+---
+
+Body`;
+    const result = checkSingleFile("REQ-0103.md", content, "req");
+    expect(result.ok).toBe(true);
+    expect(result.issues.frontmatterId).toBe("REQ-0103");
+  });
+});

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/tests/search-target-area.test.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/tests/search-target-area.test.ts
@@ -1,0 +1,72 @@
+import { test, expect, describe } from "bun:test";
+import {
+  headingMatchesTarget,
+  findTargetAreaHeadings,
+  searchTargetArea,
+} from "../src/search-target-area.ts";
+
+describe("headingMatchesTarget", () => {
+  test("exact match", () => {
+    expect(headingMatchesTarget("目的", "目的")).toBe(true);
+  });
+
+  test("prefix match (heading starts with target)", () => {
+    expect(headingMatchesTarget("目的と背景", "目的")).toBe(true);
+  });
+
+  test("no match when heading does not start with target", () => {
+    expect(headingMatchesTarget("別の見出し", "目的")).toBe(false);
+  });
+});
+
+describe("findTargetAreaHeadings", () => {
+  test("finds matching heading lines", () => {
+    const content = `# Title
+
+## 目的
+
+本文
+
+### 目的 - 詳細
+
+more text`;
+    const matches = findTargetAreaHeadings("目的", content, "spec.md");
+    expect(matches).toHaveLength(2);
+    expect(matches[0]!.line).toBe(3);
+    expect(matches[1]!.line).toBe(7);
+  });
+
+  test("returns empty when no headings match", () => {
+    const content = "# Title\n\nbody without target";
+    const matches = findTargetAreaHeadings("目的", content, "spec.md");
+    expect(matches).toEqual([]);
+  });
+
+  test("does not match non-heading lines", () => {
+    const content = `本文中に 目的 という単語があっても`;
+    const matches = findTargetAreaHeadings("目的", content, "spec.md");
+    expect(matches).toEqual([]);
+  });
+});
+
+describe("searchTargetArea", () => {
+  test("aggregates matches across multiple files", () => {
+    const files = [
+      { path: "a.md", content: "## 目的\nbody" },
+      { path: "b.md", content: "# 目的と概要\nbody" },
+      { path: "c.md", content: "## 別のセクション\nbody" },
+    ];
+    const result = searchTargetArea("目的", files);
+    expect(result.ok).toBe(true);
+    expect(result.matches).toHaveLength(2);
+    expect(result.matches[0]!.file).toBe("a.md");
+    expect(result.matches[1]!.file).toBe("b.md");
+  });
+
+  test("returns empty matches when nothing found (not an error)", () => {
+    const files = [{ path: "a.md", content: "## 別\nbody" }];
+    const result = searchTargetArea("目的", files);
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([]);
+  });
+});

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/tsconfig.json
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "lib/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## 概要

Issue #1151 の実装。`src/opencode/skills/agentdev-req-file-manager/` 配下に決定的処理スクリプト群を新設し、SKILL.md に scripts セクションを追記（ACT-SPEC-005 対応）。

## 変更内容

### 新規作成: `scripts/` ディレクトリ（REQ-0103-159）

7つの決定的 TypeScript スクリプト（design-principles.md 第5節「Script」責務、AG-002/006）:

| スクリプト | 役割 |
|-----------|------|
| `alloc-req-number.ts` | REQ番号採番（max+1、欠番埋め禁止） |
| `alloc-adr-number.ts` | ADR番号採番（max+1、欠番埋め禁止） |
| `alloc-composite-id.ts` | 要件行ID採番（REQ-NNNN-MMM、max+1） |
| `check-frontmatter-consistency.ts` | frontmatter id ↔ ファイル名整合性確認 |
| `check-entry-existence.ts` | README/DOC-MAP/mapping-table エントリ存在確認 |
| `check-change-impact.ts` | 変更範囲検証（許可パスリストとの積集合） |
| `search-target-area.ts` | SPEC ファイル内 target_area 見出し検索 |

インフラ:
- `package.json` / `tsconfig.json`（bun + 厳格 TypeScript）
- `lib/`（result.ts, frontmatter.ts, fs-helpers.ts 共通ヘルパー）
- `tests/*.test.ts`（全7スクリプト、50テスト）
- `bun.lock`、`.gitignore`、`README.md`

### 更新: `SKILL.md`（ACT-SPEC-005）

「整合性チェック」セクションの後に「Scripts（決定的処理）」セクションを新設:
- I/O 契約（REQ-0103-160）: argv/stdin → stdout JSON、エラー時は非ゼロ終了コード + stderr
- スクリプト一覧表（役割、入力、出力 JSON schema）
- 実行方法（bun 経由）
- req-save/spec-save からの呼び出し方針

## 完了条件の達成

- [x] `src/opencode/skills/agentdev-req-file-manager/scripts/` ディレクトリが作成されている（REQ-0103-159）
- [x] REQ番号採番スクリプト（max+1）が作成されている（AG-002, AG-006）
- [x] ADR番号採番スクリプトが作成されている
- [x] 複合ID採番スクリプトが作成されている
- [x] frontmatter id↔ファイル名整合性確認スクリプトが作成されている
- [x] README/DOC-MAP/mapping-table エントリ存在確認スクリプトが作成されている
- [x] 変更範囲検証スクリプト（許可パスリストとの積集合）が作成されている
- [x] target_area 見出し検索スクリプトが作成されている
- [x] 全スクリプトが TypeScript で記述され、決定的（純粋関数）である（REQ-0103-160）
- [x] 全スクリプトの I/O が argv/stdin → stdout JSON 形式である（REQ-0103-160）
- [x] 全スクリプトに対応するテスト（tests/*.test.ts）が作成されている（AG-006）
- [x] npm test で全テストが green（AG-006, TS-002）
- [x] `src/opencode/skills/agentdev-req-file-manager/SKILL.md` に scripts セクションが追記されている（ACT-SPEC-005）
- [x] SKILL.md の scripts セクションに全スクリプトの入力（argv/stdin）、出力（JSON）、エラー時の挙動が定義されている（ACT-SPEC-005）
- [x] docs/specs/design-principles.md 第5節「Script は決定的処理」と SKILL.md の scripts 記述が矛盾しない（SPEC適合性）

## テスト戦略検証

### TS-002（決定的スクリプト作成）

- **verification**: `npm test` で全スクリプトのテスト（正案例・異案例）を実行
- **pass_criteria**: 全スクリプトのテストが green — **50 pass / 0 fail 達成**
- 実行結果:
  ```
  50 pass
  0 fail
  74 expect() calls
  Ran 50 tests across 7 files. [57ms]
  ```
- 型チェック（`tsc --noEmit`）: エラーなし
- 実データ動作確認:
  - `alloc-req-number.ts docs/requirements` → `{ ok: true, allocated: "REQ-0153", max: 152 }`
  - `alloc-adr-number.ts docs/adr` → `{ ok: true, allocated: "ADR-0133", max: 132 }`
  - `check-frontmatter-consistency.ts docs/requirements req` → `{ ok: true, errors: [], warnings: [] }`

### TS-003（決定的処理のスクリプト経由処理）

- 本 Issue はスクリプト作成まで。req-save/spec-save コマンド定義からのスクリプト呼び出し確認は子Issue #1152（Wave 2）の完了後。TS-003 の on_failure にも「正しい呼び出し確認は子Issue #1152 の完了後」と明記済み

## SPEC 適合性

- **design-principles.md 第5節**: 「Script は決定的でテスト可能な処理を担う。validation、transformation、generation、formatting 等の純粋関数、決定的処理に限定」→ 全スクリプトが純粋関数で実装、テスト付き
- **REQ-0103-159**: scripts/ 配下に7種類の決定的スクリプト配置 → 達成
- **REQ-0103-160**: TypeScript、決定的、テスト可能、argv/stdin → stdout JSON → 達成

## Findings / Capture候補

- TypeScript テスト基盤が本リポジトリで初めて導入された。agent-dev-flow は docs-only リポジトリだったが、今後スクリプト群追加に伴い JS エコシステム（package.json, tsconfig.json, bun.lock）の運用が始まる。配布物管理（runtime-package-boundary.md）への影響は要確認（capture候補: runtime-package-boundary に scripts/ 配下の取り扱い追記が必要か）

## SPEC確定候補

- `docs/specs/skills/agentdev-req-file-manager.md`（存在する場合）に scripts/ の I/O 契約を SPEC として確定する候補。現在 SKILL.md に記載しているが、SPEC 一覧（`docs/specs/skills/`）にも反映するかは case-close で判断
- `runtime-package-boundary.md` に `src/opencode/skills/*/scripts/` 配下の配布対象・配布方法（bun.lock を含めるか等）を追記すべき候補

## 関連

- Parent Epic: #1149
- Wave: Wave 1（#1150, #1151 並列）
- AG-002: req-save/spec-save の決定的処理を scripts/ で実行
- AG-006: 新規決定的スクリプト（TypeScript、純粋関数、tests/*.test.ts、argv/stdin → stdout JSON）
- ACT-SPEC-005: SKILL.md への scripts セクション追記（spec-save G02/G03 でスキップされていた対象）
- 依存関係: Wave 2 の #1152（req-save/spec-save コマンド定義更新）が本スクリプト群の存在を前提とする

Refs #1151
