### PR TITLE
integrity-rule-catalog.md の散文英語候補を網羅検証し識別子 vs 散文普通名詞を判定・置換（OU-005, RU-0015）

### DIFF
--- a/docs/specs/integrity-rule-catalog.md
+++ b/docs/specs/integrity-rule-catalog.md
@@ -938,7 +938,7 @@ REQ/SPEC 責務範囲を規定する META 規則行（enum/format/schema 等 SPE
 | 対象 | 判定 | 根拠 |
 |------|------|------|
 | REQ-NNNN-MMM 形式 + SPEC 種別列挙（enum/format/schema 等）を名指しする責務範囲規定行 | 免除（META 規則行） | REQ-0145-012。当該行は SPEC 詳細の記述ではなく責務範囲の規定 |
-| SPEC 詳細そのものを列挙する行（enum 値 A/B/C の一覧、fixture の具体件数と内容の羅列） | 免除しない（true positive 候補） | 件数・内容を規定する行は責務範囲規定ではない |
+| SPEC 詳細そのものを列挙する行（enum 値 A/B/C の一覧、テストデータ（fixture）の具体件数と内容の羅列） | 免除しない（true positive 候補） | 件数・内容を規定する行は責務範囲規定ではない |
 
 **inspect-docs へ委譲した文脈免除（docs-check 対象外）**:
 
@@ -1133,7 +1133,7 @@ grep ベース実装は推論ベースを置き換えるのではなく、補助
 | related_spec | [integrity-rule-catalog.md, integrity-contracts.md] |
 | gate_level | full-audit, delta-guard |
 | false_positive_risk | 中。agentdev-gh-cli 許容ファイル（standard-procedures.md）を除外対象に含めない場合 false positive が発生する。除外リストの厳密な適用で抑制する |
-| regression_test | (追加予定)。gh 直接記述を含む fixture で検出されること、standard-procedures.md で検出されないことを検証する |
+| regression_test | (追加予定)。gh 直接記述を含むテストデータ（fixture）で検出されること、standard-procedures.md で検出されないことを検証する |
 | baseline_status | new |
 | finding_route | intake |
 | triage_action | 検出された gh 直接記述を agentdev-gh-cli 手続き委譲に置き換える。除外対象外の正当な gh 記述（standard-procedures.md 内）はそのまま |


### PR DESCRIPTION
## 概要

OU-005 (#1167, source_ru: RU-0015): `docs/specs/integrity-rule-catalog.md` の散文英語候補（`baseline`, `provider`, `variant`, `fixture` 等）を網羅的 grep で抽出し、per-instance で識別子（英語維持正解）vs 散文普通名詞（推奨訳語置換必要）を判定した。判定基準には `docs/specs/backticks-identifier-threshold.md`（OU-001 #1164 accepted）と `docs/specs/document-type-responsibilities.md` 訳語表（SSoT）を適用し、PR #1084 の SUB-D 判定前例との整合性を担保した。

PR #1084 で既に置換済みの 3 インスタンス（IR-026/IR-031 description, L1195 相当）は再置換対象外。本 PR は残存インスタンスの網羅検証が主体。

## 変更内容

対象ファイル: `docs/specs/integrity-rule-catalog.md`（1 ファイル、2 行変更）

散文普通名詞と判定した 2 インスタンス（いずれも `fixture`）を推奨訳語へ置換:

| 行 | 変更前 | 変更後 | 根拠 |
|---|---|---|---|
| L941 | `fixture の具体件数と内容の羅列` | `テストデータ（fixture）の具体件数と内容の羅列` | 散文中の bare 英語普通名詞。推奨訳語 `テストデータ`（document-type-responsibilities.md 訳語表）。gloss は PR #1084 `valid fixture` → `有効なテストデータ（valid fixture）` 前例に準拠 |
| L1136 | `gh 直接記述を含む fixture で検出されること` | `gh 直接記述を含むテストデータ（fixture）で検出されること` | 同上 |

## per-instance 判定結果

候補語（`baseline`, `provider`, `variant`, `fixture`）の出現箇所をすべて分類。`provider` は 0 件。

### 識別子（英語維持正解、置換対象外）

| 種別 | 出現箇所 | 判定根拠 |
|---|---|---|
| フィールド名 `baseline_status` | L27 schema 定義 + L49/69/.../1137 の IR エントリ 53 箇所 | YAML/Markdown フィールド名（backticks-identifier-threshold.md「frontmatter キー、YAML フィールド名」） |
| ファイル名・パス | L148 `command_fixtures.test.ts`、L419/422 `baseline.json`、L479 `scripts/tests/fixtures/`、L1130/1210 `standard-procedures.md`、L1131/1234 `check_integrity.test.ts` | ファイル名・ディレクトリパス（同 SPEC「ファイル名、ディレクトリパス」） |
| JSON フィールド | L422 `known_findings` | JSON フィールド名 |
| リスト値（enum 相当） | L423 `[baseline, integrity reports]`、L583/603/623/643/663/683/703/723/743/763/783/803/823/843/863/883/903/923 `[commands, command projection, ...]`、L1208 `baseline_status: new` | affected_artifacts リスト値・field:value（PR #1084 前例: `[current ADR]` enum 値は英語維持） |
| kebab-case 複合技術語 | L414 `baseline-known`、L770 `retired-ADR-current-baseline-ref` | 英字 kebab-case 技術識別子（PR #1084 前例: `baseline-known` 複合技術語は英語維持） |
| ビュー名・固有名 | L775/778/795/798 `Current Baseline View`、`Retired View` | CamelCase 系固有名詞（ビュー名） |
| テーブル内技術複合ラベル | L1234 `fixture drift detection` | テーブル責務ラベル。同セルで `drift 自動検出` が英語 `drift` を維持する規則と整合。機能名としての複合技術語 |
| フィールド参照 | L1162 `baseline_status 管理`、L1207 `baseline_status、severity`、L961 削除注記内 `baseline_status: resolved` | フィールド名参照 |

### 散文普通名詞（推奨訳語置換済）

| 行 | 表記 | 推奨訳語 | 状態 |
|---|---|---|---|
| L279/282 | `種別パス（variant path）` | 種別パス（variant→種別） | 既存・日本語主 + gloss |
| L291 | `種別（variant）` | 種別 | 既存・日本語主 + gloss |
| L427/431 | `基準（baseline）` | 基準 | 既存・日本語主 + gloss |
| L775 | `現行基準（current baseline）` | 基準 | 既存・日本語主 + gloss |
| L915 | `テストデータ詳細（fixture detail）` | テストデータ詳細 | 既存・日本語主 + gloss |
| L941 | `テストデータ（fixture）の具体件数` | テストデータ | **本 PR で置換** |
| L1136 | `テストデータ（fixture）で検出` | テストデータ | **本 PR で置換** |
| L1210 | `有効なテストデータ（valid fixture）` | テストデータ | PR #1084 で置換済 |

## 検証

### TS-005 検証結果

- verification: `integrity-rule-catalog.md` で `baseline`, `provider`, `variant`, `fixture` 等の候補を grep 抽出（79 単語出現、69 行）、per-instance で識別子 vs 散文普通名詞の判定結果を上記「per-instance 判定結果」表に記録
- pass_criteria 達成:
  - 候補語の全出現箇所が識別子（英語維持正解）または散文普通名詞（推奨訳語置換済）のいずれかに分類済み
  - **未分類残存: 0 件**
  - **散文普通名詞残存（bare 英語）: 0 件**（L941/L1136 の 2 インスタンスを本 PR で置換）
  - PR #1084 で既に置換済の 3 インスタンス（IR-026/IR-031 description, L1195 相当）は再置換対象外として明示的に扱った（L1210 が該当、上記表に PR #1084 由来として記録）
- on_failure: 該当なし（fix-and-reverify 不要、初回で pass_criteria 達成）

### 再 grep 結果（機械横断是正 REQ-0153 Step 3-4）

置換後に同一 grep（`baseline|provider|variant|fixture`）を再実行し、未分類残存 0 件・散文普通名詞（bare 英語）残存 0 件を確認した。

### 判定基準 SSoT

- `docs/specs/backticks-identifier-threshold.md`（OU-001 #1164 accepted）: 識別子（backticks 必須）と一般名詞（backticks 任意）の機械判定閾値
- `docs/specs/document-type-responsibilities.md` 訳語表: `fixture→テストデータ/検査データ`、`variant→種別/バリエーション/形式`、`provider→提供元`、`baseline→基準`（フィクスチャ/バリアント/プロバイダ/ベースラインは非許容）
- PR #1084 SUB-D 判定前例: `current ADR→現行ADR`、`valid fixture→有効なテストデータ（valid fixture）`、identifier として `[current ADR]`/backtick 識別子/`{variant}.md`/`baseline-known` は英語維持

## QG-3（観点5 機械横断是正）

- 変更ファイル: 1（`docs/specs/integrity-rule-catalog.md`）。2 insertion / 2 deletion
- スコープ: Issue #1167 のみ。無関係ファイル変更なし
- 再 grep 0 件確認: 上記の通り達成

## Findings / Capture候補

- **スコープ境界（候補語 "等" の解釈）**: 本 OU の候補語は TS-005 に明示される `baseline`, `provider`, `variant`, `fixture` の 4 種（provider は 0 件）に限定した。`document-type-responsibilities.md` 訳語表には `finding→検出事項` 等、本ファイルに出現する他の散文英語普通名詞も掲載されるが、これらは本 OU の TS-005 候補語ではないため対象外とした（G14 スコープ拡大禁止）。`finding` 等の他候補語の網羅検証が必要な場合は独立 OU として切り出すことを推奨する
- **gloss 形式 `日本語（英語）` の扱い**: `基準（baseline）` 等、日本語主語 + 英語 gloss の形式は PR #1084 `有効なテストデータ（valid fixture）` 出力形式と合致するため「推奨訳語置換済」として再置換対象外とした。gloss は識別子（baseline.json / baseline_status / artifact list 値）へのクロスリファレンス機能を保持する
- **L1234 `fixture drift detection` 判定**: テーブル責務ラベル列内の技術複合語で、同セルが `drift 自動検出`（英語 `drift` 維持）を採用する規則と整合するため識別子（技術複合ラベル）として英語維持した。テーブルラベルという文脈依存の境界ケースであり、backticks-identifier-threshold.md「文脈依存の境界ケースは機械判定対象外」に該当する

## SPEC確定候補

- `backticks-identifier-threshold.md`「文脈依存の境界ケース（英字複合語の識別子/普通名詞揺らぎ）は機械判定対象外とし、サンプリング查読へ委譲」の運用実績 1 件（L1234 `fixture drift detection`）。本境界ケースのサンプリング查読による判定結果を記録。SPEC 本文の判定表に追記すべき境界ケース実例として case-close Step 3 の SPEC 確定チェック入力に供する

Refs: #1167