### PR TITLE
OU-002: REQ-0148 depends_on・連結成分ベース構成に伴う command 整合

### DIFF
--- a/src/opencode/commands/agentdev/req-define.md
+++ b/src/opencode/commands/agentdev/req-define.md
@@ -165,7 +165,7 @@ Step 7 の構造化 `draft-data` 形式（`# draft-data` fenced YAML block）で
 - G10: 要件doc構造は req-draft.md テンプレート（構造化 `draft-data` 形式）に従う
 - G11: ADR閾値以上の判断は `agentdev-adr-guidelines` へ
 - G12: work_type 判定基準は `agentdev-workflow-lifecycle` を参照
-- G13: req-define は Issue 階層を決定しない。Issue 階層の決定は case-open の責務範囲
+- G13: req-define は Issue 階層を決定しない。`depends_on`（必須依存のみ）は case-open が execution_unit 構成（連結成分判定）に使用する依存情報であり、最終 Issue 構成は case-open が決定する
 - G14: req-define は draft に `operation_units` セクションを出力し、`execution_groups` セクションは出力しないこと（038）。単一REQ操作の場合も 1 件の OU として出力する。Epic/ Wave/ Issue 構成の生成は case-open の責務である
 - G15: SPEC 分離基準に該当する要件行候選は REQ 要件行に残留させず、`draft-data` の `artifact_actions`（`artifact: spec`）へ分離すること。安定契約例外は分離対象外
 - G16: ADR判断が必要な変更（ADR要否確認ゲート）では ADR 判断前に `agentdev-architecture-advisory` を参照する。oracle は ADR 要否、推奨方向、設計リスク、根拠を返し、最終的な ADR 作成判断は親エージェントが行う


### PR DESCRIPTION
## 概要

OU-002（REQ-0148-002）の depends_on・連結成分ベース構成に伴い、req-define command 定義を整合させた。

## 変更内容

- `src/opencode/commands/agentdev/req-define.md` G13 を更新
  - `depends_on`（必須依存のみ）は case-open が execution_unit 構成（連結成分判定）に使用する依存情報である旨を明記
  - 最終 Issue 構成は case-open が決定する旨を明記

## 完了条件の確認

- [x] REQ-0148-002 の要件行が「depends_on = 必須依存のみ + case-open 連結成分判定」に一致（req-save 完了済み、確認のみ）
- [x] req-define 関連 command 定義が REQ-0148-002 と整合（depends_on が case-open の execution_unit 構成に使用される旨が G13 に反映）
- [x] 「最終 Issue 構成は case-open が決定する」旨が command 定義で確認できる（G13 に明記）
- [x] 弱依存・関連依存・推奨順等が depends_on から除外されていることが command 定義で確認できる（G13 で depends_on を必須依存のみと明記）

## テスト戦略 TS-001 検証結果

- REQ-0148-002 の depends_on 定義が「必須依存のみ」+「case-open 連結成分判定に使用」に一致 ✓
- 除外リストが明記されている ✓
- command 定義に旧記述が残存しない ✓

## Findings / Capture候補

（なし）

## SPEC確定候補

（なし）

Refs: #1203
Parent: #1201
