### PR TITLE
tentative_classification バリデーション契約の相互参照追加（REQ-0155-008、#1217）

### DIFF
--- a/docs/specs/commands/backlog-review.md
+++ b/docs/specs/commands/backlog-review.md
@@ -43,7 +43,7 @@ updated: 2026-06-22
 
 - Step 1: 実行前同期（`git pull --ff-only`）
 - Step 2: 成果物検出（引数有無切り替え（引数あり: 指定ファイルのみ / 引数なし: `promoted/` 全件））
-- Step 3: 成果物読込、分析 + 暫定分類付与（`agentdev-backlog-integration` 参照）。暫定分類は `docs/specs/foundations/document-model.md` の文書7分類モデルを参照して付与し、RU frontmatter `tentative_classification` に記録する（REQ-0155-004）。暫定分類は後続 `/agentdev/req-define` で最終確定される候補であり、本コマンドが確定しない
+- Step 3: 成果物読込、分析 + 暫定分類付与（`agentdev-backlog-integration` 参照）。暫定分類は `docs/specs/foundations/document-model.md` の文書7分類モデルを参照して付与し、RU frontmatter `tentative_classification` に記録する（REQ-0155-004）。`tentative_classification` の許容値、7値以外入力時・フィールド欠落時の取り扱いは REQ-0155-008、後述「tentative_classification フィールド仕様」に定める。暫定分類は後続 `/agentdev/req-define` で最終確定される候補であり、本コマンドが確定しない
 - Step 4: 統合分割判定 + depends_on 依存解決 + ユーザー承認（判断の確定、REQ-0147-003）（`agentdev-backlog-integration` 参照）
 - Step 5: 矛盾検出（矛盾検出時のみ追加判断を求める（REQ-0147-009））。矛盾なしの場合、Step 4 の統合、分割判定承認を RU 生成承認として扱い、単一承認で処理する。自動解決しない（G05）
 - Step 6: RU 生成（採用済み成果物の単純コピー（パススルー）は禁止（G03、REQ-0105））

--- a/docs/specs/commands/req-define.md
+++ b/docs/specs/commands/req-define.md
@@ -44,7 +44,7 @@ updated: 2026-06-26
 - Step 5: 要件展開（`agentdev-req-analysis` 分析観点）
   - Step 5-1: 変更影響候補抽出
     - RU 由来キーワード抽出 + glob/grep 前処理による explore 委譲スコープの絞り込み（REQ-0102-072）。絞り込みは explore 委譲の調査優先対象リストのみに適用（ヒントでありハードフィルタではない）し、実ファイル列挙（REQ-0102-002）の完全性は維持する
-  - Step 5-2: 分類ゲート（REQ-0155-004 最終分類確定ステップ）（変更後仕様 or 反映作業、REQ/SPEC 境界判定）。RU 入力の暫定分類（backlog-review が `tentative_classification` に付与）が存在する場合、`docs/specs/foundations/document-model.md` の文書7分類モデルに照らして最終分類を確定し暫定分類を上書きする
+  - Step 5-2: 分類ゲート（REQ-0155-004 最終分類確定ステップ）（変更後仕様 or 反映作業、REQ/SPEC 境界判定）。RU 入力の暫定分類（backlog-review が `tentative_classification` に付与）が存在する場合、`docs/specs/foundations/document-model.md` の文書7分類モデルに照らして最終分類を確定し暫定分類を上書きする。確定時のバリデーション（暫定分類の7値チェック、フィールド欠落時の停止、最終分類上書き値の7値チェック）は後述「tentative_classification 最終確定のバリデーション（REQ-0155-008）」に定める
   - Step 5-3: 文書分類妥当性検証（SPEC 分離基準違反残留検出）
   - Step 5-4: ADR要否確認ゲート（`agentdev-architecture-advisory` oracle 連携）
     - oracle 入力標準テンプレート使用 + 出力 4 ラベル構造要求（REQ-0102-073）。ラベル構造は soft-contract（ADR-0124）とし、分類権限は親が保持する


### PR DESCRIPTION
## 概要

Issue #1217（REQ-0155-008 tentative_classification enum 厳密検証）の実装。

前工程（req-save/spec-save, commit d25b3cf6）で REQ-0155-008、backlog-review.md「tentative_classification フィールド仕様」セクション、req-define.md「tentative_classification 最終確定のバリデーション（REQ-0155-008）」セクションは保存済み。本 PR は QG-3 検証で発見されたトレーサビリティ改善（Step 記述と新規バリデーション契約の相互参照）を追加する。

## 変更内容

- docs/specs/commands/backlog-review.md Step 3: tentative_classification の許容値・逸脱時・欠落時の取り扱いが REQ-0155-008 および後述「tentative_classification フィールド仕様」セクションに定められている旨の相互参照を追加
- docs/specs/commands/req-define.md Step 5-2: 暫定分類確定時のバリデーション（7値チェック・欠落時停止・上書き値チェック）が後述「tentative_classification 最終確定のバリデーション（REQ-0155-008）」セクションに定められている旨の相互参照を追加

## QG-3（実装偏差ゲート）: no-deviation

Issue 完了条件と REQ-0155-008、backlog-review.md/req-define.md SPEC の照合結果:

| 完了条件 | 状態 | 根拠 |
|---|---|---|
| REQ-0155-008 が (a)7値許容、(b)逸脱・欠落取り扱い、(c)両段階範囲内 を含む | 達成 | docs/requirements/REQ-0155.md（commit d25b3cf6 で保存） |
| backlog-review.md に許容値7値一覧・7値以外入力時挙動・フィールド欠落時挙動 | 達成 | 「tentative_classification フィールド仕様」セクション |
| req-define.md に Step 5-2 の 7値チェック・欠落時停止・上書き値チェック | 達成 | 「tentative_classification 最終確定のバリデーション」セクション |

本 PR の相互参照追加は Issue 対象 SPEC のトレーサビリティ改善であり、契約内容の変更・scope 拡大を含まない。

## テスト戦略結果

- TS-001（REQ-0155-008）: 合格。3点（7値許容、逸脱・欠落取り扱い、両段階範囲内要件）を全て含む
- TS-002（backlog-review.md）: 合格。許容値7値一覧、7値以外入力時挙動（RU生成停止）、フィールド欠落時挙動（付与必須・欠落RU不生成）の3点を含む
- TS-003（req-define.md）: 合格。Step 5-2 バリデーション手順が3点（7値チェック、欠落時停止、上書き値チェック）を含み、7値の定義参照先（backlog-review.md）が明記されている

## SPEC確定候補

backlog-review.md、req-define.md に追加された新規セクション（tentative_classification フィールド仕様、Step 5-2 バリデーション）は本 PR で実装検証済み。case-close での draft→accepted 昇格候補。

Closes #1217