### PR TITLE
feat(integrity): REQ-0145 exemption 境界ガード句実装 (isBehaviorPredicateContext, #1290)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -942,6 +942,8 @@ function buildIr044Fixture(root: string): void {
       "| REQ-9007 | IR-044 fixture |",
       "| REQ-9008 | IR-044 fixture |",
       "| REQ-9009 | IR-044 fixture |",
+      "| REQ-9010 | IR-044 fixture |",
+      "| REQ-9011 | IR-044 fixture |",
       "",
     ].join("\n"),
     "utf-8",
@@ -1126,6 +1128,48 @@ function buildIr044Fixture(root: string): void {
     "utf-8",
   );
 
+  // REQ-9010: true positive — behavior predicate with count rule (REQ-0145-013 guard).
+  // Line contains "仕組みが存在すること" (behavior predicate) AND "3件" (count rule).
+  // REQ-0145-013 guard rejects exemption → still detected as SPEC detail violation.
+  writeFileSync(
+    join(reqDir, "REQ-9010.md"),
+    [
+      "---",
+      "id: REQ-9010",
+      "title: IR-044 behavior predicate with count rule (guard)",
+      "created: 2025-01-01",
+      "updated: 2025-01-01",
+      "---",
+      "",
+      "| ID | 要件 |",
+      "|----|------|",
+      "| REQ-9010-001 | fixture drift を検出し 3件 以上の違反を記録する仕組みが存在すること |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // REQ-9011: false positive — behavior predicate without count rule (REQ-0145-012/013).
+  // Line contains "仕組みが存在すること" (behavior predicate) and no count/content rule.
+  // Exemption applies → NOT detected.
+  writeFileSync(
+    join(reqDir, "REQ-9011.md"),
+    [
+      "---",
+      "id: REQ-9011",
+      "title: IR-044 behavior predicate exemption (no count)",
+      "created: 2025-01-01",
+      "updated: 2025-01-01",
+      "---",
+      "",
+      "| ID | 要件 |",
+      "|----|------|",
+      "| REQ-9011-001 | fixture drift を自動検出する仕組みが存在すること |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
   // Empty adr/specs/skills to satisfy other checks minimally
   mkdirp(join(root, "docs", "adr"));
   mkdirp(join(root, "docs", "specs"));
@@ -1184,6 +1228,30 @@ describe("IR-044 req-spec-boundary-violation (REQ-0108-259)", () => {
         res.check === "req-spec-boundary-violation" &&
         res.level === "warning" &&
         (res.evidence ?? "").includes("REQ-9009"),
+    );
+    expect(violations.length).toBe(0);
+  });
+
+  it("detects true positive: behavior predicate with count rule (REQ-0145-013 guard rejects exemption)", () => {
+    const r = runScript(IR044_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const violations = parsed.results.filter(
+      (res: { check: string; level: string; evidence?: string }) =>
+        res.check === "req-spec-boundary-violation" &&
+        res.level === "warning" &&
+        (res.evidence ?? "").includes("REQ-9010"),
+    );
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does NOT flag behavior predicate without count rule (REQ-0145-012 exemption)", () => {
+    const r = runScript(IR044_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const violations = parsed.results.filter(
+      (res: { check: string; level: string; evidence?: string }) =>
+        res.check === "req-spec-boundary-violation" &&
+        res.level === "warning" &&
+        (res.evidence ?? "").includes("REQ-9011"),
     );
     expect(violations.length).toBe(0);
   });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -6115,6 +6115,22 @@ const IR044_SIGNAL_PATTERNS: ReadonlyArray<{ signal: string; pattern: RegExp }> 
     },
   ];
 
+// REQ-0145-013: 件数・内容規定検出。予防的ガード句の判定根拠。
+function hasCountOrContentRule(line: string): boolean {
+  return /\d+\s*(件|個|本|つ|種類|項目|以上|以下)|最大\s*\d+|最小\s*\d+/.test(
+    line,
+  );
+}
+
+// REQ-0145-012/013: behavior predicate context 判定。契約・状態・禁止の記述文脈を検出する。
+// REQ-0145-013 予防的ガード句: 件数・内容規定を含む行は exemption を拒否する。
+function isBehaviorPredicateContext(line: string): boolean {
+  if (hasCountOrContentRule(line)) {
+    return false;
+  }
+  return /が\s*存在\s*すること|を\s*禁止\s*する|を\s*許可\s*しない/.test(line);
+}
+
 function checkReqSpecBoundaryViolation(root: string): CheckResult[] {
   const results: CheckResult[] = [];
   const reqDir = path.join(root, "docs", "requirements");
@@ -6150,6 +6166,11 @@ function checkReqSpecBoundaryViolation(root: string): CheckResult[] {
 
       for (const { signal, pattern } of IR044_SIGNAL_PATTERNS) {
         if (pattern.test(stripped)) {
+          // REQ-0145-012/013: behavior predicate context は exemption 対象。
+          // 件数・内容規定を含む行は isBehaviorPredicateContext が false を返し拒否される。
+          if (isBehaviorPredicateContext(stripped)) {
+            break;
+          }
           foundViolation = true;
           results.push(
             warn(


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

Issue #1290: REQ-0145 exemption 境界ガード句実装要件。
check_integrity.ts の isBehaviorPredicateContext 関数に、件数・内容規定検出時の exemption 拒否ガード句を実装する。SPEC IR-044 で規定済みの「件数・内容規定を含む場合は免除しない」を実装レベルで保証する。

## 実装内容
<!-- 【必須】 -->

- `hasCountOrContentRule(line)`: 件数表現（N件/N個/N以上/N以下等）および数量制限（最大N/最小N）を検出する helper 関数を新規追加
- `isBehaviorPredicateContext(line)`: behavior predicate context（契約・状態・禁止の振る舞い述語）を判定する関数を新規追加。REQ-0145-013 予防的ガード句として件数・内容規定を含む行は exemption を拒否する（false を返す）
- `checkReqSpecBoundaryViolation`: IR-044 検出ループ内で `isBehaviorPredicateContext` による exemption 判定を追加。件数・内容規定を含まない behavior predicate 文脈の行は SPEC キーワードが偶発的に含まれていても exemption 対象とする
- テスト追加: REQ-9010（count rule あり→検出）、REQ-9011（count rule なし→exempt）

## 完了条件
<!-- 【必須】 -->

- [x] REQ-0145 にexemption境界ガード句実装要件（REQ-0145-013）が追記されていること（req-save完了済み）
- [x] check_integrity.ts の isBehaviorPredicateContext に件数・内容規定検出時の exemption 拒否ロジックが実装されていること
- [x] 件数・内容規定を含む行のテストケースが追加され、exemption が拒否されることが検証されていること（REQ-9010）
- [x] 既存の exemption 対象ケースが回帰しないこと（既存10違反は全件維持、回帰なし）
- [x] check_integrity.ts のユニットテストが全件成功すること（44 pass / 0 fail）

## テスト結果
<!-- 【必須】 -->

`bun test check_integrity.test.ts`: 44 pass / 0 fail / 93 expect() calls
新規テストケース:
- `detects true positive: behavior predicate with count rule (REQ-0145-013 guard rejects exemption)` — REQ-9010（"3件 以上" 含む）が検出されることを検証
- `does NOT flag behavior predicate without count rule (REQ-0145-012 exemption)` — REQ-9011（count rule なし）が exemption されることを検証

実REQでの検証: 既存10違反は全件維持（回帰なし）。behavior predicate exemption は が存在すること/を禁止する/を許可しない の何れかを含む行のみ適用されるため、既存違反行には影響しない。

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| unit test pass rate | 44/44 | 全件成功 | ✅ |
| 既存違反の回帰 | 0件減少 | 回帰なし | ✅ |
| 新規 exemption 対象外（count rule）検出 | REQ-9010 で検出 | guard 有効 | ✅ |

## Findings/ Capture候補
<!-- 【必須】 -->

### intake

該当なし

### learning

該当なし

## 決定事項
<!-- 【任意】 -->

- behavior predicate の判定は「が存在すること」「を禁止する」「を許可しない」の3パターンに限定した。実装指示（"実装は〜" 等）は exemption 対象外としている（実REQの REQ-9005 "実装は Step 3 で..." が検出対象として維持されることを確認）
- 件数表現のパターンは「N件/N個/N本/Nつ/N種類/N項目/N以上/N以下/最大N/最小N」を対象とした。内容規定（具体要件の列挙）は文脈依存が高いため、数量制限の機械的パターンに限定している

## 関連Issue
<!-- 【必須】 -->

Closes #1290
