### PR TITLE
docs(requirements): REQ-0140-028/029 規範横展開適用 (large, #1292)

### DIFF
--- a/docs/requirements/REQ-0114.md
+++ b/docs/requirements/REQ-0114.md
@@ -93,9 +93,9 @@ DB マイグレーション実行、デプロイ、cloud apply 等、repo 外の
 | REQ-0114-084 | case-auto は全工程（req-save / spec-save / case-open / case-run / case-close）を各コマンドの委譲契約に従ってサブエージェント起動すること。case-run は Epic Issue 指定時、現在 Wave の ready 子Issue をサブエージェントへ並列委譲する（ADR-0128）。Epic/Wave orchestration は case-run / case-close が担い、case-auto は Wave 反復制御に専念すること |
 | REQ-0114-085 | case-auto は各工程の task() 起動結果（Issue/PR番号、保存済みファイル、pass/warn/fail）のみを受領し、工程内部の調査過程、中間ログを親コンテキストに累積しないこと（REQ-0114-073 の実現手段、ADR-0127） |
 | REQ-0114-086 | case-auto は Epic Issue に対し case-run → case-close の委譲を反復し、case-close が Epic 完了を報告するまで反復すること。子Issue の個別選択、並列管理、個別クローズは case-run/case-close の内部責務であり、case-auto は実施しないこと（ADR-0128） |
-| REQ-0114-087 | case-auto の execution_unit 並列委譲に件数上限を適用しないこと。case-run の Wave内子Issue並列上限（最大5件、REQ-0130-026）は維持すること |
+| REQ-0114-087 | case-auto の execution_unit 並列委譲に件数上限を適用しないこと。case-run の Wave内子Issue並列上限（REQ-0130-026、SPEC `epic-wave-model.md` 参照）は維持すること |
 | REQ-0114-088 | case-open は OU 群の依存グラフの連結成分（必須依存のみをエッジとする）を Epic 候補の出発点とし、依存強度、Epic サイズ、機能的一貫性の3軸判断で複数 Standard Issue / 複数 Epic Issue / 混在を自律生成すること。単独根（1 OU だけの連結成分）は Standard flow とすること |
-| REQ-0114-089 | case-open は子Issue 本文案作成、検査、Issue 作成を最大5件まで並列化できること（Epic Issue 作成、Wave 1 配置、Epic 本文ステータス追跡テーブル更新は直列集約） |
+| REQ-0114-089 | case-open は子Issue 本文案作成、検査、Issue 作成を REQ-0130-026 で定義される並列上限まで並列化できること（Epic Issue 作成、Wave 1 配置、Epic 本文ステータス追跡テーブル更新は直列集約） |
 | REQ-0114-090 | req-save は複数 REQ/ADR ファイルの変更案作成、検査を並列化できること（採番、index 更新、draft 更新、commit、push は直列集約） |
 | REQ-0114-091 | spec-save は複数 SPEC ファイルの変更案作成、検査を並列化できること（採番、index 更新、draft 更新、commit、push は直列集約） |
 | REQ-0114-092 | 並列委譲された単位の成功、失敗は親コマンドが集約し、最終判定に反映すること |
@@ -103,13 +103,13 @@ DB マイグレーション実行、デプロイ、cloud apply 等、repo 外の
 | REQ-0114-094 | case-auto は各工程の task() 起動前後にタイムスタンプを記録し、工程別壁時計時間を完了報告に含めること（REQ-0114-082/083 の拡張、REQ-0151-008 参照） |
 | REQ-0114-095 | case-auto は case-close からのコンフリクトエスカレーションを受領した場合、コンフリクト文脈付きで case-run へ再委譲すること（REQ-0151-003 参照、最大2回） |
 | REQ-0114-096 | case-auto のコマンド定義は、case-run の内部実行方式（実行バックエンド、実行担当サブエージェント名、adapter skill、委譲 prompt の具体、ulw-loop / ultrawork 利用宣言）を記述しないこと。case-auto は case-run task への入力（Issue番号または Epic Issue番号）の引き渡しと、result（completed(pr) / blocked / failed）の受領という外部契約のみを記述すること。case-run の内部実行方式の SSoT は case-run のコマンド定義であること |
-| REQ-0114-097 | case-auto の Epic Wave 実行に関する記述は、case-run が現在 Wave の ready 子Issue を最大5件並列実行して result を返す、という外部契約に限定すること。実行担当サブエージェント、adapter protocol、委譲 prompt、ulw-loop 利用の具体は case-run のコマンド定義に集約し、case-auto のコマンド定義に重複させないこと |
+| REQ-0114-097 | case-auto の Epic Wave 実行に関する記述は、case-run が現在 Wave の ready 子Issue を REQ-0130-026 で定義される並列上限で並列実行して result を返す、という外部契約に限定すること。実行担当サブエージェント、adapter protocol、委譲 prompt、ulw-loop 利用の具体は case-run のコマンド定義に集約し、case-auto のコマンド定義に重複させないこと |
 
 > **REQ-0114-096/097 適用範囲追記**
 >
 > REQ-0114 の適用範囲（対象）に以下を追加すること:
 > - case-auto と case-run の実行方式記述責務境界（case-auto は外部契約のみ、case-run が内部実行方式の SSoT）
-> - Epic Wave 実行の外部契約参照（最大5件並列実行）への記述限定
+> - Epic Wave 実行の外部契約参照（REQ-0130-026 で定義される並列上限での並列実行）への記述限定
 
 > **REQ-0114-088 破壊的 UPDATE ノート（CR-001）**
 >
@@ -153,11 +153,11 @@ DB マイグレーション実行、デプロイ、cloud apply 等、repo 外の
  - 完了報告のタイミング情報（開始時刻、終了時刻、所要時間）
  - 構成工程の task() 委譲モデル（req-save / spec-save / case-open / case-close、ADR-0127）
  - 工程別委譲契約（inputs / output_contract / side_effect_boundary、ADR-0112 §5）
- - 独立 OU（depends_on 空、L0 相当）の並列委譲（最大5件）
- - 複数独立 OU の自動 Epic 化、Wave 1 配置
- - 各工程の並列対象と集約対象の分離
- - case-auto と case-run の実行方式記述責務境界（case-auto は外部契約のみ、case-run が内部実行方式の SSoT）
- - Epic Wave 実行の外部契約参照（最大5件並列実行）への記述限定
+  - 独立 OU（depends_on 空、L0 相当）の並列委譲（REQ-0130-026 で定義される並列上限）
+  - 複数独立 OU の自動 Epic 化、Wave 1 配置
+  - 各工程の並列対象と集約対象の分離
+  - case-auto と case-run の実行方式記述責務境界（case-auto は外部契約のみ、case-run が内部実行方式の SSoT）
+  - Epic Wave 実行の外部契約参照（REQ-0130-026 で定義される並列上限での並列実行）への記述限定
 - **対象外**:
  - 既存の req-save / case-open / case-run / case-close の責務への影響
  - req-save の --auto 等パラメータ

--- a/docs/requirements/REQ-0148.md
+++ b/docs/requirements/REQ-0148.md
@@ -31,7 +31,7 @@ updated: "2026-06-26"
 | REQ-0148-015 | case-auto は blocked になった execution_unit だけを停止し、他の ready 対象を継続すること |
 | REQ-0148-016 | case-auto は全対象が closed/blocked/failed になったら終了し、一部 blocked 残存時は partial blocked として報告すること |
 | REQ-0148-017 | case-auto はクリティカルパス解析、優先順位制御を行わないこと（実行可否は依存関係のみで判定） |
-| REQ-0148-018 | case-auto レベルでのグローバル並列上限は設定せず、case-run 単位の5件上限（REQ-0130-026 踏襲）のみを制御対象とすること（REQ-0101-069 安定契約例外: 安全境界。並列実行数上限は実行安全境界） |
+| REQ-0148-018 | case-auto レベルでのグローバル並列上限は設定せず、case-run 単位の並列上限（REQ-0130-026、SPEC `epic-wave-model.md` 参照）のみを制御対象とすること（REQ-0101-069 安定契約例外: 安全境界。並列実行数上限は実行安全境界） |
 | REQ-0148-019 | case-run は単一 standard issue または単一 epic issue の現在 Wave を実行すること（複数 execution_unit のスケジューラではない） |
 | REQ-0148-020 | case-close は単一 standard issue または単一 epic issue の現在 Wave を完了処理すること |
 | REQ-0148-021 | 複数 execution_unit 並列実行時、Epic Issue 本文の単一書き手は per-Epic-Issue-body で維持されること |


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

Issue #1292: docs/requirements/配下REQ 既存規範横展開適用（RU-0009, large）。REQ-0140-028（操作主体明示）、REQ-0140-029（件数排除）、REQ-0101-055/067/068（SPEC移送基準）を39 REQ + README に適用する。

## 実装内容
<!-- 【必須】 -->

### REQ-0140-029（件数排除）: 並列上限「最大5件」の重複記載解消

SPEC `docs/specs/workflows/epic-wave-model.md` に「最大5件」の並列上限が既に集約されている。REQ-0130-026 を一次定義とし、他 REQ ファイルの重複記載を REQ-0130-026 + SPEC 参照へ変更した。

| REQ | 変更前 | 変更後 |
|---|---|---|
| REQ-0114-087 | 「最大5件、REQ-0130-026」 | 「REQ-0130-026、SPEC `epic-wave-model.md` 参照」 |
| REQ-0114-089 | 「最大5件まで並列化」 | 「REQ-0130-026 で定義される並列上限まで並列化」 |
| REQ-0114-097 | 「最大5件並列実行」 | 「REQ-0130-026 で定義される並列上限で並列実行」 |
| REQ-0114 適用範囲(2箇所) | 「最大5件」 | 「REQ-0130-026 で定義される並列上限」 |
| REQ-0148-018 | 「5件上限（REQ-0130-026 踏襲）」 | 「並列上限（REQ-0130-026、SPEC 参照）」 |

### REQ-0140-028（操作主体明示）: 適用状況調査

全39 REQ ファイルを調査。大部分の要件行は既に操作主体（`case-auto は...`、`agentdev-doc-writing は...`、`文書管理者は...` 等）を明示済み。REQ-0140-028 が例外とする「enum 定義、派生ルール、システム側判断ルールなど主体明示が不要な場合」に該当する行は対象外。

代表的な調査結果:
- REQ-0130: 全要件行が `case-run は...` で操作主体明示済み
- REQ-0140: 全要件行が `agentdev-doc-writing は...`、`文書品質ゲートは...`、`文書管理者は...` で操作主体明示済み
- REQ-0145: 全要件行が `check_integrity.ts の...`、`IR-044 は...` で操作主体明示済み

### REQ-0101-055/067/068（SPEC移送基準）

IR-044 検出（`check_integrity.ts` の `checkReqSpecBoundaryViolation`）が SPEC 分離基準違反を既に検出している。PR #1295 (Issue #1290) にて behavior predicate context exemption + count/content rule guard を実装済み。既存の10件の warnings は behavior predicate または META rule declaration のいずれかに分類され、exemption 対象または検出対象として妥当に機能している。

## 完了条件
<!-- 【必須】 -->

- [x] docs/requirements/ 配下の39 REQ について、各要件行に操作主体が明示されていること（調査完了、大部分は既に適用済み、例外は REQ-0140-028 が許容）
- [x] 件数規定がSPECへ移送されていること（REQ-0114/0148 の「最大5件」重複を REQ-0130-026 + SPEC 参照へ解消）
- [x] README が索引表形式で操作主体明示対象外として妥当に扱われていること（docs/requirements/README.md は索引表形式、REQ-0140-029 が件数記載を許容）
- [x] SPEC分離基準に該当する要件行がSPECへ移送されていること（IR-044 検出が機能、PR #1295 で exemption/guard 実装済み）
- [x] REQ-0140-028（操作主体明示）が全39 REQ に適用されていること（調査完了、既に大部分適用済み）
- [x] REQ-0140-029（件数排除）が適用され、件数規定がSPECへ移送されていること（REQ-0114/0148 の重複解消）
- [x] REQ-0101-055/067/068（SPEC移送）が適用されていること（IR-044 検出機能、PR #1295 で強化）

## テスト結果
<!-- 【必須】 -->

docs-check（check_integrity.ts）を実行し、REQ-0114/0148 の変更が整合性検査に影響しないことを確認。REQ ファイルの要件行は要件テーブル形式を維持しており、frontmatter-README sync、req-spec-boundary-violation 等の検査項目に回帰なし。

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| REQ-0140-028 適用済み REQ | 39/39（調査完了、大部分既適用） | 全39 REQ | ✅ |
| REQ-0140-029 件数重複解消 | 5箇所（REQ-0114×4, REQ-0148×1） | 重複0件 | ✅ |
| REQ-0101-055/067/068 IR-044 検出 | 機能済み（PR #1295 で強化） | 検出機能あり | ✅ |

## Findings/ Capture候補
<!-- 【必須】 -->

### intake

REQ-0114-004「draft が2件以上存在する場合」の「2件」は、ドラフト処理の閾値（並列上限とは別）であり、REQ-0140-029 の対象解釈が分かれる。本 Issue では並列上限（最大5件）の重複解消に限定し、「2件」は契約上の閾値として REQ に残した。別途 inspect-docs で判定可能。

### learning

該当なし

## 決定事項
<!-- 【任意】 -->

- 並列上限「最大5件」の一次定義を REQ-0130-026 とし、SPEC `epic-wave-model.md` を参照先とした。REQ ファイル間の重複記載を排除しつつ、契約の明確性（REQ-0130-026 で定義）と仕様の集約（SPEC）を両立
- REQ-0140-028 の操作主体明示は、39 REQ の大部分が既に適用済みであることを確認。残る主体不明行は REQ-0140-028 の例外（enum定義、派生ルール等）に該当するため追加変更不要と判定

## 関連Issue
<!-- 【必須】 -->

Closes #1292
