### PR TITLE
docs(specs): SPEC frontmatter status 統一付与 (Issue #1327)

### DIFF
--- a/docs/specs/integrity/rules/IR-001-req-frontmatter-id-filename.md
+++ b/docs/specs/integrity/rules/IR-001-req-frontmatter-id-filename.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-001: 現行 REQ frontmatter id ↔ ファイル名
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-002-req-required-frontmatter.md
+++ b/docs/specs/integrity/rules/IR-002-req-required-frontmatter.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-002: 現行 REQ 必須 frontmatter fields
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-003-active-retired-req-id-conflict.md
+++ b/docs/specs/integrity/rules/IR-003-active-retired-req-id-conflict.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-003: Active/廃止 REQ ID 重複
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-004-req-index-actual-consistency.md
+++ b/docs/specs/integrity/rules/IR-004-req-index-actual-consistency.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-004: REQ index ↔ 現行 REQ 一致
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-005-adr-req-bidirectional-reference.md
+++ b/docs/specs/integrity/rules/IR-005-adr-req-bidirectional-reference.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-005: ADR ↔ REQ 相互参照存在
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-006-command-allowed-frontmatter.md
+++ b/docs/specs/integrity/rules/IR-006-command-allowed-frontmatter.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-006: Command frontmatter 許可フィールド
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-007-skill-name-dir-match.md
+++ b/docs/specs/integrity/rules/IR-007-skill-name-dir-match.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-007: Skill frontmatter name ↔ dir
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-008-skill-references-existence.md
+++ b/docs/specs/integrity/rules/IR-008-skill-references-existence.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-008: Skill references/ 存在
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-009-obsolete-namespace-residual.md
+++ b/docs/specs/integrity/rules/IR-009-obsolete-namespace-residual.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-009: 旧 namespace 残存
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-010-adr-status-normalization.md
+++ b/docs/specs/integrity/rules/IR-010-adr-status-normalization.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-010: ADR status 正規化
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-011-mapping-table-full-coverage.md
+++ b/docs/specs/integrity/rules/IR-011-mapping-table-full-coverage.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-011: Mapping table 全件記録
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-012-template-required-sections.md
+++ b/docs/specs/integrity/rules/IR-012-template-required-sections.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-012: Template 必須セクション
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-013-variant-path-existence.md
+++ b/docs/specs/integrity/rules/IR-013-variant-path-existence.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-013: 完了報告種別実在
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-014-singular-reference-dir-residual.md
+++ b/docs/specs/integrity/rules/IR-014-singular-reference-dir-residual.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-014: reference/ 残存検出
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-015-retired-req-current-ref-detection.md
+++ b/docs/specs/integrity/rules/IR-015-retired-req-current-ref-detection.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-015: 廃止 REQ 現行参照検出
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-016-source-projection-integrity.md
+++ b/docs/specs/integrity/rules/IR-016-source-projection-integrity.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-016: Source/projection 整合性
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-017-docmap-actual-consistency.md
+++ b/docs/specs/integrity/rules/IR-017-docmap-actual-consistency.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-017: DOC-MAP ↔ 実体整合性
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-018-req-range-notation-freshness.md
+++ b/docs/specs/integrity/rules/IR-018-req-range-notation-freshness.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-018: REQ 範囲表記鮮度
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-019-guide-req-contract-content-detection.md
+++ b/docs/specs/integrity/rules/IR-019-guide-req-contract-content-detection.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-019: Guide 要件定義、契約記述検出
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-020-baseline-known-vs-new-finding.md
+++ b/docs/specs/integrity/rules/IR-020-baseline-known-vs-new-finding.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-020: 基準既知（baseline-known）と新規 finding の区別
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-021-retired-skill-reference-detection.md
+++ b/docs/specs/integrity/rules/IR-021-retired-skill-reference-detection.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-021: 廃止済み skill 参照検出
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-022-req-internal-consistency.md
+++ b/docs/specs/integrity/rules/IR-022-req-internal-consistency.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-022: REQ 内部整合性
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-023-integrity-artifact-validator-drift.md
+++ b/docs/specs/integrity/rules/IR-023-integrity-artifact-validator-drift.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-023: Integrity artifact validator drift
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-024-command-readme-actual.md
+++ b/docs/specs/integrity/rules/IR-024-command-readme-actual.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-024: Command README ↔ 実体
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-025-retired-adr-path-rule.md
+++ b/docs/specs/integrity/rules/IR-025-retired-adr-path-rule.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-025: 廃止 ADR path 規則
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-026-adr-misclassification-sign.md
+++ b/docs/specs/integrity/rules/IR-026-adr-misclassification-sign.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-026: ADR 誤分類兆候検出
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-027-retired-adr-current-authority-citation.md
+++ b/docs/specs/integrity/rules/IR-027-retired-adr-current-authority-citation.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-027: 廃止 ADR 現行根拠引用検出
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-028-command-top-step-int-only.md
+++ b/docs/specs/integrity/rules/IR-028-command-top-step-int-only.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-028: Command 最上位 Step 整数化
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-029-command-alphabet-substep-prohibition.md
+++ b/docs/specs/integrity/rules/IR-029-command-alphabet-substep-prohibition.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-029: Command 英字サブステップ禁止
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-030-subagent-verbatim-conditional-return.md
+++ b/docs/specs/integrity/rules/IR-030-subagent-verbatim-conditional-return.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-030: Subagent verbatim 条件付き返却
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-031-findings-capture-heading-unification.md
+++ b/docs/specs/integrity/rules/IR-031-findings-capture-heading-unification.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-031: Findings / Capture候補 見出し統一
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-032-delegation-type-on-result-envelope-prohibition.md
+++ b/docs/specs/integrity/rules/IR-032-delegation-type-on-result-envelope-prohibition.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-032: delegation_type/on_result 必須 envelope 禁止
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-033-lightweight-delegation-primary-pattern-prohibition.md
+++ b/docs/specs/integrity/rules/IR-033-lightweight-delegation-primary-pattern-prohibition.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-033: lightweight-delegation primary pattern 禁止
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-034-skill-internal-section-step-reference-detection.md
+++ b/docs/specs/integrity/rules/IR-034-skill-internal-section-step-reference-detection.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-034: Skill 内部 section / protocol / Step 参照検出
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-035-skill-see-also-detection-perspective.md
+++ b/docs/specs/integrity/rules/IR-035-skill-see-also-detection-perspective.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-035: Skill See Also 検出観点
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-036-adr-work-means-detection.md
+++ b/docs/specs/integrity/rules/IR-036-adr-work-means-detection.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-036: ADR-work-means-detection
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-037-retired-adr-current-baseline-ref.md
+++ b/docs/specs/integrity/rules/IR-037-retired-adr-current-baseline-ref.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-037: retired-ADR-current-baseline-ref
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-038-adr-index-consistency.md
+++ b/docs/specs/integrity/rules/IR-038-adr-index-consistency.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-038: ADR-index-consistency
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-039-index-req-title-consistency.md
+++ b/docs/specs/integrity/rules/IR-039-index-req-title-consistency.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-039: index-req-title-consistency
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-040-retired-req-authority-comment.md
+++ b/docs/specs/integrity/rules/IR-040-retired-req-authority-comment.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-040: retired-req-authority-comment
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-041-retired-req-broken-link.md
+++ b/docs/specs/integrity/rules/IR-041-retired-req-broken-link.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-041: retired-req-broken-link
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-042-hardcoded-req-count.md
+++ b/docs/specs/integrity/rules/IR-042-hardcoded-req-count.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-042: hardcoded-req-count
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-043-retired-readme-coverage.md
+++ b/docs/specs/integrity/rules/IR-043-retired-readme-coverage.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-043: retired-readme-coverage
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-044-req-spec-boundary-violation-detection.md
+++ b/docs/specs/integrity/rules/IR-044-req-spec-boundary-violation-detection.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-044: REQ/SPEC 境界違反検出
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-046-consumer-generated-repo-type-fp-prevention.md
+++ b/docs/specs/integrity/rules/IR-046-consumer-generated-repo-type-fp-prevention.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-046: consumer-generated リポジトリ種別誤検知防止
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-047-src-opencode-local-link-origin-dir-structure.md
+++ b/docs/specs/integrity/rules/IR-047-src-opencode-local-link-origin-dir-structure.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-047: src/opencode-local/ link 先原本領域ディレクトリ構成
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-048-generated-by-identifier-integrity.md
+++ b/docs/specs/integrity/rules/IR-048-generated-by-identifier-integrity.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-048: generated_by 識別子整合性
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-049-command-file-format-violation.md
+++ b/docs/specs/integrity/rules/IR-049-command-file-format-violation.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-049: Command file format violation
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-050-load-skills-command-mis-specification.md
+++ b/docs/specs/integrity/rules/IR-050-load-skills-command-mis-specification.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-050: load_skills command 誤指定検出
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-051-executor-skill-notation-misrecognition.md
+++ b/docs/specs/integrity/rules/IR-051-executor-skill-notation-misrecognition.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-051: 実行主体の skill 表記誤認検出
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-052-completion-grep-pattern-design.md
+++ b/docs/specs/integrity/rules/IR-052-completion-grep-pattern-design.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-052: 完了条件 grep パターン設計（REQ-0145-011）
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-053-gh-direct-invocation-detection.md
+++ b/docs/specs/integrity/rules/IR-053-gh-direct-invocation-detection.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-053: gh 直接記述検出
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-054-draft-spec-abandonment-detection.md
+++ b/docs/specs/integrity/rules/IR-054-draft-spec-abandonment-detection.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-054: draft SPEC 放置検出
 
 | Field | Value |

--- a/docs/specs/integrity/rules/IR-055-runtime-unresolved-reference.md
+++ b/docs/specs/integrity/rules/IR-055-runtime-unresolved-reference.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-055: runtime-unresolved-reference（配布物内の導入先未解決参照検出）
 
 | Field | Value |

--- a/docs/specs/responsibilities/artifact-contracts.md
+++ b/docs/specs/responsibilities/artifact-contracts.md
@@ -1,5 +1,6 @@
 ---
 updated: 2026-06-21
+status: accepted
 ---
 
 # アーティファクト契約


### PR DESCRIPTION
## 概要

Issue #1327 の実装。docs/specs/ 配下の SPEC ファイルのうち frontmatter `status` を持たない 55 ファイルへ `status` frontmatter を付与し、ADR-0123 で定義される `draft`/`accepted` ライフサイクルへ統一した。

docs/specs/README.md の各 SPEC 一覧表の `status` 列は先行 draft1/draft2 (#1323〜#1326) で集約済みであり、本 PR 時点で `-` 表示は残存していなかった。本 PR は SPEC ファイル本体の frontmatter 整備のみを扱う。

## 変更内容

### 変更対象 (55 ファイル、217 insertions / 0 deletions)

| 区分 | ファイル | 変更 |
|------|---------|------|
| docs/specs/integrity/rules/IR-001〜IR-055 | 54 ファイル | frontmatter 未所有のため `---\nstatus: accepted\n---\n\n` を冒頭へ新規付与 |
| docs/specs/responsibilities/artifact-contracts.md | 1 ファイル | 既存 frontmatter (`updated: 2026-06-21`) へ `status: accepted` を 1 行追加 |

### 変更差分サンプル

```
diff --git a/docs/specs/integrity/rules/IR-001-req-frontmatter-id-filename.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # IR-001: 現行 REQ frontmatter id ↔ ファイル名

diff --git a/docs/specs/responsibilities/artifact-contracts.md
@@ -1,5 +1,6 @@
 ---
 updated: 2026-06-21
+status: accepted
 ---
```

### 変更対象外

- docs/specs/README.md: 既に全 SPEC 一覧表の `status` 列が集約済み（先行 PR #1324/#1326）のため変更なし
- 既に frontmatter `status` を持つ 71 ファイル（`accepted` 27 + `draft` 44、OS 付与前時点）は変更対象外
- artifact-contracts.md 以外の responsibilities/ 配下 SPEC は既に status 保持済みのため対象外

## スコープ参照

- work_type: docs_chore / scale: standard / OU-001 / source RU: RU-0004, RU-0005
- 関連 ADR: ADR-0123（status 値定義: draft / accepted）、ADR-0110（DOC-MAP の位置づけ）
- 関連要件: REQ-0154-001（SPEC status の単一追跡情報源）、REQ-0154-003（基盤SPEC を含む全 SPEC の status 集約）

## テスト戦略検証結果

### TS-001: 全 SPEC ファイルが frontmatter `status` を持つ + README.md に `-` 表示なし

- **verification**: `docs/specs/**/*.md`（README.md 除く、126 ファイル）を走査し frontmatter `status` の存在を確認。`docs/specs/README.md` の全 SPEC 一覧表の `status` 列を確認。
- **結果**: **PASS**
  - 126 ファイル全てが frontmatter `status` を持つ（missing: 0 件）
  - status 値内訳: `accepted` 81 / `draft` 45
  - README.md の SPEC 一覧表で `status` 列に `-` の行は 0 件

### TS-002: 全 SPEC の status 値が `draft` または `accepted`

- **verification**: 全 SPEC ファイルの frontmatter `status` 値を収集し、ADR-0123 定義値へ一致を検査。
- **結果**: **PASS**
  - 不適切な値、空文字、typo を含む SPEC: 0 件
  - 全て `draft` (45) または `accepted` (81) のいずれか

## QG-3 (実装乖離) 判定

- **判定**: **no-deviation**
- **根拠**:
  - 完了条件 3 項目（TS-001 × 2、TS-002 × 1）すべて pass
  - Issue 本文の提案内容（status frontmatter 付与、docs/specs/README.md status 列反映）を忠実に実装
  - スコープ拡大なし: `updated` フィールド等の追加フィールドは付与せず、`status` 的確な最小変更のみ
  - 予期せぬリファクタリングなし: ファイル本文・テーブル・リンク等の既存構造は無変更（diff は全ファイル pure insertion、deletion 0）
  - IR-054 (draft SPEC 放置検出) は draft SPEC のみ対象であり、本 PR で追加した 55 ファイルは全て `accepted` のため検出対象外

## Findings / Capture候補

特になし。本 PR は機械的 frontmatter 付与のみであり、本筋外の発見事項無し。

## SPEC確定候補

特になし。SPEC 本文のスキーマ、enum、判定表、内部アルゴリズム等の発見なし。

## 参考

- 対象 Issue: #1327
- 起点 main HEAD: 5cdf6155
- 先行 PR: #1323 / #1324 (draft1)、#1325 / #1326 (draft2)

Refs: #1327
