### PR TITLE
docs(guides): project-docs-and-specs.md の SPEC 一覧テーブルを docs/README.md 参照へ縮退 (OU-003/RU-0007)

### DIFF
--- a/docs/guides/project-docs-and-specs.md
+++ b/docs/guides/project-docs-and-specs.md
@@ -54,22 +54,8 @@ DOC-MAP（文書探索入口：索引）
 「今どう動いているか」を記述する。
 リポジトリ内部の設計文書であり、実行時配布物の依存先ではない（ADR-0103, ADR-0104）。
 
-| SPEC | 内容 |
-|------|------|
-| system.md | コマンドシステムの構成 |
-| patterns.md | 実装パターンと文書フォーマット |
-| design-principles.md | 設計原則 |
-| quality-specs.md | 品質基準、検証ルール |
-| quality-gates.md | 品質ゲート（QG-1〜QG-4） |
-| document-model.md | 文書種別の責務マトリックス |
-| artifact-contracts.md | アーティファクト間契約 |
-| artifact-responsibilities.md | アーティファクト責務定義 |
-| integrity-contracts.md | 整合性検査分類フレームワーク |
-| integrity-rule-catalog.md | 整合性ルールカタログ |
-| workflow-contracts.md | ワークフロー契約の雛形 |
-| runtime-package-boundary.md | 実行時パッケージ境界 |
-| rule-ownership.md | ルール所有権 |
-| req-impact-map.md | REQ 影響マップ |
+> 現行 SPEC の一覧は `docs/README.md`（基盤 SPEC 一覧）を正とする。
+> 本ガイドでは SPEC 一覧を複製しない。
 
 ## DOC-MAP（文書探索入口）
 


### PR DESCRIPTION
## 概要

Issue #1343（OU-003/RU-0007）の対応。docs/guides/project-docs-and-specs.md の独自 SPEC 一覧テーブルを削除し、docs/README.md 基盤 SPEC 一覧への参照リンクへ縮退した。AG-005、AG-006、TS-005、TS-006 に基づく機械的修正。

## 変更内容

- `docs/guides/project-docs-and-specs.md`: SPEC セクションの独自 SPEC 一覧テーブル（14エントリ、L57-72）を削除し、REQ セクション（L30-31）と同じ参照縮退パターンの blockquote 参照リンクへ置換。
  - 削除前: `| SPEC | 内容 |` 形式の独自テーブル（system.md / patterns.md / document-model.md 等 14 件）。説明表現が DOC-MAP.md と異なり二重メンテ状態。
  - 置換後: `> 現行 SPEC の一覧は docs/README.md（基盤 SPEC 一覧）を正とする / 本ガイドでは SPEC 一覧を複製しない`
- 適用パターン: REQ-0140-030（ガイドファイル名列挙の参照縮退）と同一。ADR-0103（基準文書優先原則）に従い DOC-MAP.md / docs/README.md を正とする。

## 完了条件の確認

- [x] project-docs-and-specs.md の SPEC 説明（patterns.md、document-model.md 等）が DOC-MAP.md の現行表現と一致すること。ガイド層での独自表現が存在しないこと（TS-005、AG-005）
  - → テーブル削除により独自 SPEC 説明表現は 0 件。DOC-MAP.md との表現ブレ発生箇所なし。
- [x] project-docs-and-specs.md 内に独自の SPEC 一覧テーブルが存在しないこと（0 件）。docs/README.md 基盤 SPEC 一覧への参照リンクが 1 件以上存在すること（TS-006、AG-006）
  - → SPEC 一覧テーブル 0 件、docs/README.md 参照リンク 1 件（L57）。

## テスト戦略（TS）検証結果

### TS-005（AG-005: SPEC 説明表現の DOC-MAP.md 一致）

- **verification**: project-docs-and-specs.md の SPEC 説明と DOC-MAP.md の現行表現を比較。
- **結果**: PASS。テーブル削除によりガイド層に SPEC 個別説明行（`| <file>.md | <desc> |` 形式）は 0 件。DOC-MAP.md と異なる独自表現の発生箇所なし。
- **pass_criteria**: 両者の SPEC 説明表現が一致、ガイド層での独自表現なし → 満たす。

### TS-006（AG-006: 独自 SPEC 一覧テーブルの削除と参照リンク設置）

- **verification**: project-docs-and-specs.md に独自 SPEC 一覧テーブルが存在しないこと、docs/README.md 参照リンクが存在することを確認。
- **結果**: PASS。
  - 独自 SPEC 一覧テーブル: 0 件（`| SPEC |` ヘッダー行、SPEC ファイル名列挙 row ともに grep 0 件）。
  - docs/README.md 参照リンク: 1 件（L57 `> 現行 SPEC の一覧は docs/README.md（基盤 SPEC 一覧）を正とする。`）。
- **pass_criteria**: 独自テーブル 0 件、参照リンク 1 件以上 → 満たす。

## QG-3（実装乖離）判定

- **判定**: no-deviation（乖離なし）。
- 完了条件 AG-005/AG-006 を機械的に実装。ADR-0103（基準文書優先原則）準拠。REQ-0140-030 と同一の参照縮退パターンを適用。スコープ外変更・実装修正不要項目なし。

## Findings / Capture候補

なし。本 Issue は独立 OU（depends_on 空）、他 draft/RU/Issue（#1341, #1342）への干渉なし。

## SPEC確定候補

なし。

Refs: #1343
