### PR TITLE
docs(integrity): REQ-0156-010/011/012 運用手順参照可能性を yaml ヘッダと IR-057 rule へ追記 (Issue #1359, OU-003 FINAL)

### DIFF
--- a/docs/specs/integrity/obsolete-path-map.yaml
+++ b/docs/specs/integrity/obsolete-path-map.yaml
@@ -6,15 +6,32 @@
 # IR-057 obsolete-spec-path-after-domain-split が現行文書、原本、配置先、
 # 検査スクリプトに旧パスが残っていないことを検証するための参照データである。
 #
-# 各エントリのスキーマ:
-#   old      : 旧SPEC直下パス（docs/specs/<name>.md 形式）
-#   new      : 現行ドメイン分割パス（docs/specs/<domain>/<name>.md 形式）
-#   severity : ng（旧直下パス参照は不整合として扱う）
-#   scope    : 検査対象範囲（include / exclude の glob リスト）
+# ファイル構成（REQ-0156-011 スキーマ）:
+#   scope          : 検査対象範囲。全エントリで共有する top-level フィールド。
+#                    include / exclude は glob リスト。exclude は必ず
+#                    docs/requirements/retired/** と docs/adr/retired/** を含める。
+#   entries[]      : 旧→新パス対応エントリのリスト。各エントリは以下を持つ:
+#     old          : 旧SPEC直下パス（docs/specs/<name>.md 形式）
+#     new          : 現行ドメイン分割パス（docs/specs/<domain>/<name>.md 形式）
+#     severity     : ng（旧直下パス参照は不整合として扱う）
+#   legacy_local_generation_vocabulary[] : link mode 統一（ADR-0131）で廃止された
+#                    直接生成方式語彙の検出リスト（REQ-0141-004）。
+#   generated_by_combination_rule        : generated_by と local-opencode-transform
+#                    の組み合わせ検出ルール。
 #
 # 検査対象外（scope.exclude）は履歴参照領域。retired/ 配下は旧パスを履歴として
 # 残すことを許容するため、IR-057 検査から除外する。現行ADRに歴史的経緯として
 # 旧パスを記載する場合は rule 側で例外登録する（IR-057 rule ファイル参照）。
+#
+# 運用手順（REQ-0156-010、REQ-0156-006 の具体化）:
+#   docs/specs/ 配下でドメイン分割による移送が発生した場合、移送実行者は
+#   移送単位（移動したファイルごと）で entries へ旧パスと新パスの対応を追記する。
+#   手順:
+#     1. 移送対象ファイルの docs/specs/ 直下パス（old）と移送先ドメインパス（new）を確認
+#     2. entries へ old / new / severity="ng" のエントリを追加
+#     3. check_integrity.ts（IR-057）を実行し、旧パス混入が検出できることを確認（REQ-0156-012）
+#     4. scope.exclude から retired 領域が除外されていることを維持
+#   追記漏れを防ぐため、移送 PR のレビューで本 yaml の追記有無を必ず確認する。
 
 version: "1"
 

--- a/docs/specs/integrity/rules/IR-057-obsolete-spec-path-after-domain-split.md
+++ b/docs/specs/integrity/rules/IR-057-obsolete-spec-path-after-domain-split.md
@@ -62,6 +62,10 @@ status: accepted
 
 本ルールは `obsolete-path-map.yaml` 新規導入に伴うものであり、baseline 0 で開始する。full audit を即 fail gate 化する。
 
+## エントリ追記手順（REQ-0156-010）
+
+`docs/specs/` 配下でドメイン分割による移送が発生した場合、移送実行者は移送単位で `obsolete-path-map.yaml` の `entries` へ旧パス（`old`）と新パス（`new`）の対応を追記する。追記後、`check_integrity.ts` で IR-057 を実行し、旧パス混入が検出できることを確認する（REQ-0156-012）。スキーマ詳細および手順の逐次ステップは `obsolete-path-map.yaml` ヘッダコメントの「運用手順（REQ-0156-010）」セクションを参照。
+
 ## See Also
 
 - [obsolete-path-map.yaml](../obsolete-path-map.yaml)


### PR DESCRIPTION
## 概要

Issue #1359 (case-auto Draft 2 OU-003, FINAL OU) の検証タスク。REQ-0156-010/011/012（`obsolete-path-map.yaml` 運用要件）の施行確定を目的とする。

REQ-0156-010/011/012 は req-save 工程（commit c8874f92）で REQ-0156 へ APPEND 済み、OU-001（PR #1356）で `obsolete-path-map.yaml`（22 旧パス + vocabulary）と IR-057 を実装済み。本 PR は当該マップの網羅性、IR-057 の検出能力、運用手順の参照可能性を検証し、参照可能性のギャップを補完する。

## 変更内容

### `docs/specs/integrity/obsolete-path-map.yaml`
ヘッダコメント整理:
- スキーマ説明を「各エントリのスキーマ」から「ファイル構成（REQ-0156-011 スキーマ）」へ変更。`scope` が全エントリで共有する top-level フィールドであることを明記（従来は per-entry スキーマの一部のように読め、REQ-0156-011 の文言と実装の解釈が曖昧だった）
- `legacy_local_generation_vocabulary`、`generated_by_combination_rule` の説明を追加
- **運用手順（REQ-0156-010、REQ-0156-006 の具体化）セクションを新規追加**: 移送発生時の追記手順（4ステップ）と PR レビューでの追記確認を明記

### `docs/specs/integrity/rules/IR-057-obsolete-spec-path-after-domain-split.md`
- **エントリ追記手順（REQ-0156-010）セクションを新規追加**: 移送時の追記義務と yaml ヘッダの運用手順セクションへの参照を明記

## 検証結果（TS-001）

### Verify-1: 網羅性・スキーマ準拠（完了条件 #1, #2）
- `obsolete-path-map.yaml` の22 entries が AG-001 が列挙した22旧SPEC直下パス（system, patterns, design-principles, document-model, document-type-responsibilities, artifact-contracts, artifact-responsibilities, req-impact-map, quality-specs, quality-gates, req-health-metrics, spec-health-metrics, integrity-rule-catalog, integrity-contracts, rule-ownership, docs-spec-rebuild-integrity, backticks-identifier-threshold, local-generation, local-case-file, runtime-package-boundary, command-file-format, workflow-contracts）をすべて網羅
- 各エントリが old / new / severity を持ち、severity は全件 `ng`（REQ-0156-011 準拠）
- top-level `scope.exclude` が `docs/requirements/retired/**` と `docs/adr/retired/**` を含む

### Verify-2: IR-057 旧直下パス参照 failures 0件（完了条件 #3, REQ-0156-012）
`bun run check_integrity.ts --json` を実行:
- IR-057 "Old SPEC direct path reference" 検出: **0件**（22 entries のいずれの旧パスも現行文書・原本・配置先・検査スクリプトに残存しない）
- summary: ok=286, ng=105, warning=20, info=536（編集前後で不変、regression なし）

### Verify-3: 検出能力クロスチェック（完了条件 #4）
- 意図的旧パス注入テスト: `docs/specs/system.md` と `docs/specs/quality-specs.md` を含むテストファイルを生成し `check_integrity.ts` を実行 → IR-057 が2件とも検出、`expected` フィールドで現行パス（`docs/specs/foundations/system.md`, `docs/specs/quality/quality-specs.md`）を正しく提示
- `scope.exclude` 検証: `docs/adr/retired/` 配下に旧パスを含むテストファイルを配置 → IR-057 は当該ファイルを検査対象外として正しく除外
- テストファイルは検証後に削除、working tree clean を確認

### Verify-4: 運用手順の参照可能性（完了条件 #5）
- 変更前: yaml ヘッダに運用手順の記載なく、IR-057 rule ファイルにも移送時追記手順の記載なし（ギャップ）
- 変更後: yaml ヘッダに「運用手順（REQ-0156-010）」セクションを追加（4ステップ + PR レビュー確認）、IR-057 rule ファイルに「エントリ追記手順（REQ-0156-010）」セクションを追加し yaml ヘッダへ誘導

## 完了条件チェックボックス（Issue #1359）

- [x] `obsolete-path-map.yaml` が AG-001 の既存ドメイン分割移送22件を網羅、各エントリが old/new/severity スキーマに準拠（top-level scope は include/exclude を保持）
- [x] REQ-0156-011 要件（severity=ng、scope.exclude に retired 領域2件）が実際のエントリと整合
- [x] IR-057 を `check_integrity.ts` で実行し、旧直下パス参照 failures が 0件（REQ-0156-012）
- [x] IR-057 検出能力をクロスチェック（意図的旧パス埋め込みで検出確認、scope.exclude で retired 領域除外を確認）
- [x] REQ-0156-010 運用手順が yaml ヘッダコメントおよび IR-057 rule ファイルから参照可能（ギャップを補完する追記を実施）

## L2 タイムスタンプ計測（REQ-0151-009, REQ-0130-028）

- worktree 設定（Step 5）: 2026-07-02 開始〜終了（origin/main = e6f0891b から .worktrees/1359-feature 作成）
- Sisyphus-Junior 実行（Step 6）: task() 起動〜PR作成直前（検証4項 + ドキュメント補完）
- worktree クリーンアップ（Step 8）: PR 作成後に実施予定（case-close 側で削除しない）

## Findings / Capture候補

### Finding-1: legacy local generation vocabulary 残存20件（intake 候補）
IR-057 で20件の `Legacy local generation vocabulary` 検出あり（旧直下パスとは別カテゴリ）。OU-002（PR #1358）で core 滞留語彙除去を実施したが、以下のファイルに `上書き保護`、`直接生成方式`、`生成フロー`、`再生成`、`transform/generate.md` 等の link mode 廃止語彙が残存:

- `docs/adr/ADR-0126.md` (1件)
- `docs/adr/ADR-0131.md` (5件: 歴史経緯記載の可能性あり、context による要確認)
- `docs/guides/glossary.md` (1件)
- `docs/specs/local/runtime-package-boundary.md` (1件)
- `docs/specs/skills/agentdev-gh-cli.md` (1件)
- `src/opencode/commands/agentdev/case-open.md` (2件)
- `src/opencode/skills/agentdev-gh-cli/references/retry.md` (4件)
- `src/opencode/skills/agentdev-gh-cli/SKILL.md` (1件)
- `src/opencode/skills/agentdev-issue-management/references/issue-operation-safety.md` (2件)
- `src/opencode/skills/agentdev-workflow-orchestration/references/subagent-protocol.md` (1件)

本 Issue の対象外（Issue #1359 は旧直下パス検証が主眼）。別途 intake 処理で段階解消を推奨。ただし一部は ADR の歴史経緯説明コンテキスト（`isIr057HistoricalAdrContext` で免除されるべき）の可能性があり、ルール側の履歴マーカー判定の精緻化も検討課題。

### Finding-2: REQ-0156-011 スキーマ文言の曖昧性（learning 候補）
REQ-0156-011「各エントリは old、new、severity、scope（include、exclude）を持つこと」の表現は、`scope` を per-entry フィールドのように読める。実装（IR-057 rule file 明記、check_integrity.ts 実装）は `scope` を top-level 共有フィールドとして扱っており、運用上は妥当。REQ 側の表現を「ファイルは scope を持ち、各エントリは old/new/severity を持つ」等に整理すると誤読を防げる。本 PR では yaml ヘッダで実装に合うよう明記し、REQ 文言の修正は別 Issue で扱うことを推奨。

## SPEC確定候補

特になし。本 PR は検証とドキュメント補完が主で、新たな SPEC レベルの仕様発見はない。

## テスト確認

- `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts --json`: 正常終了。編集前後で summary 変更なし（ok=286, ng=105, warning=20, info=536）。本 PR による regression なし
- YAML パース検証: 22 entries 正常解析、全エントリ old/new/severity フィールド完備

Refs: #1359
