### PR TITLE
test(integrity): valid fixture の expanded-readme-sync NG を解消 (REQ-0108-268)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -45,6 +45,10 @@ function writeFile(p: string, content: string): void {
   writeFileSync(p, content, "utf-8");
 }
 
+// REQ-0108-268: fixture には check_integrity.ts と cli_utils.ts のみコピーする。
+// baseline ファイル（baselines/ir-055-baseline.json）はコピーしないことで、
+// valid fixture は本番の baseline 既知違反から独立し、既知違反の変更が
+// valid fixture 系の成否に影響しない。
 function copyScripts(fixtureRoot: string): void {
   const dest = join(
     fixtureRoot,
@@ -135,10 +139,26 @@ function buildValidFixture(root: string): void {
   );
   writeFileSync(join(specsDir, "patterns.md"), "# Patterns\n", "utf-8");
 
+  // REQ-0108-268: foundations/system.md は expanded-readme-sync チェック対象。
+  // agentdev/ 配下の全コマンド名を含め、同チェックを OK にする。
   mkdirp(join(specsDir, "foundations"));
   writeFileSync(
     join(specsDir, "foundations", "system.md"),
-    "# System (foundations)\n",
+    [
+      "# System (foundations)",
+      "",
+      "## Commands",
+      "",
+      "| Command | Description |",
+      "|---------|-------------|",
+      "| `/agentdev/test-cmd` | Test command |",
+      "| `/agentdev/case-run` | case-run |",
+      "| `/agentdev/case-close` | case-close |",
+      "| `/agentdev/req-save` | req-save |",
+      "| `/agentdev/case-open` | case-open |",
+      "| `/agentdev/case-auto` | case-auto |",
+      "",
+    ].join("\n"),
     "utf-8",
   );
   writeFileSync(


### PR DESCRIPTION
## 概要

Issue #1377: check_integrity.test.ts の valid fixture 系テストが baseline 登録済みの既知違反の影響を受けず、安定して通過するテストデータ構成への見直し（REQ-0108-268）。

## 実装内容

valid fixture（buildValidFixture）の `docs/specs/foundations/system.md` がコマンド表なしで作られていたため、`expanded-readme-sync` チェックで6件 NG になり、valid fixture 系テスト3件が失敗していた。

- `docs/specs/foundations/system.md` に `agentdev/` 配下の全コマンド名（test-cmd, case-run, case-close, req-save, case-open, case-auto）を含むコマンド表を追加し、`expanded-readme-sync` を OK にした
- `copyScripts` 関数に、baseline ファイル（`baselines/ir-055-baseline.json`）をコピーしないことで valid fixture が本番 baseline 既知違反から独立していることを明示するコメントを追加した（REQ-0108-268 テストデータ分離要件の文書化）

Issue 本文の仮説「CanonicalBoundary / CaptureBoundary の baseline 既知違反が valid fixture に影響している可能性」を検証した結果、実際には CaptureBoundary（7件）/CanonicalBoundary（1件）は valid fixture で全て OK であり、真の原因は `expanded-readme-sync` であった。valid fixture は invalid fixture と別ディレクトリで分離されており、かつ `copyScripts` が baseline をコピーしないため、本番 baseline 既知違反の変更は valid fixture 系に影響しない構成である。

## 完了条件

- [ ] main ブランチで check_integrity.test.ts を実行した際、valid fixture 系の失敗が 0 件であること
- [ ] baseline 既知違反（CanonicalBoundary / CaptureBoundary 等）と valid fixture のテストデータが分離されており、既知違反の変更が valid fixture 系に影響しないこと

## テスト結果

worktree（chore/issue-1377）で実行:

```
$ bun test ./.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
65 pass
0 fail
173 expect() calls
Ran 65 tests across 1 file. [7.30s]
```

修正前は valid fixture 系3件が失敗（`exits with code 0`、`has zero ng results`、`accepts --classification flag without error`）。修正後は全65テスト合格、valid fixture 系の失敗 0 件。

別テストファイル `tests/check_integrity.test.ts`（14件、Issue #657 regression）も全て合格。

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| valid fixture 系テスト失敗数 | 0 件 | 0 件 | OK |
| expanded-readme-sync NG 数（valid fixture） | 0 件 | 0 件 | OK |
| テストデータ分離（baseline 非コピー明示） | 明示済み | baseline 非依存 | OK |

## Findings/ Capture候補

### intake

該当なし

### learning

該当なし

## SPEC確定候補

該当なし

## 関連Issue

Issue #1377
