### PR TITLE
feat(integrity): findRepoRoot に worktree 解決方式を追加 (REQ-0145-014)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts
@@ -18,6 +18,7 @@
  *   --base-ref <git-ref>          git diff の base ref（--files と排他）
  *   --json                        JSON 出力
  *   --fail-level strict|warning   失敗扱いとする最低レベル（デフォルト strict）
+ *   --root <path>                 明示的リポジトリルート（REQ-0145-014: worktree/CI 対応）
  *
  * 責務境界は全体監査と不変。実行タイミングと対象を保存工程内の変更ファイルへ狭めるだけ。
  * 本機構は REQ-0108-153 delta guard の具体化である。
@@ -29,6 +30,7 @@ import {
   EXIT_ERROR,
   type FindingRoute,
   type FindingCategory,
+  findRepoRoot,
 } from "./cli_utils.ts";
 
 const path = require("path") as typeof import("path");
@@ -38,7 +40,7 @@ const SCRIPT_NAME = "check_changed_docs.ts";
 const DESCRIPTION =
   "Targeted docs integrity guard for save workflows (REQ-0158-003)";
 const USAGE =
-  "bun run check_changed_docs.ts --workflow <name> [--files <path...> | --base-ref <git-ref>] [--json] [--fail-level strict|warning]";
+  "bun run check_changed_docs.ts --workflow <name> [--files <path...> | --base-ref <git-ref>] [--json] [--fail-level strict|warning] [--root <path>]";
 
 type Workflow = "req-save" | "spec-save" | "case-close" | "docs-check";
 type FailLevel = "strict" | "warning";
@@ -74,6 +76,7 @@ interface ParsedArgs {
   failLevel: FailLevel;
   declaredFiles: string[];
   help: boolean;
+  root?: string; // REQ-0145-014
 }
 
 function parseArgs(args: string[]): ParsedArgs {
@@ -127,6 +130,11 @@ function parseArgs(args: string[]): ParsedArgs {
       }
       parsed.failLevel = v as FailLevel;
       i++;
+    } else if (a === "--root") { // REQ-0145-014
+      const v = args[i + 1];
+      if (!v) throw new Error("--root requires a value");
+      parsed.root = v;
+      i++;
     } else if (a === "--declared-files") {
       i++;
       while (i < args.length && !args[i].startsWith("--")) {
@@ -152,6 +160,7 @@ function printHelp(): void {
   console.error("  --base-ref <ref>    git base ref to compute changed files");
   console.error("  --json              emit JSON report (default: text)");
   console.error("  --fail-level <lvl>  strict (default) | warning");
+  console.error("  --root <path>        explicit repository root (REQ-0145-014: worktree/CI support)");
   console.error("  --declared-files <path...>  declared doc update targets in Issue/PR (optional)");
 }
 
@@ -721,7 +730,7 @@ function main(): void {
     (typeof import.meta !== "undefined" && (import.meta as any).dir) ||
     __dirname ||
     process.cwd();
-  const root = findRepoRoot(scriptDir);
+  const root = findRepoRoot(scriptDir, { explicitRoot: parsed.root });
 
   const profile = profileFor(parsed.workflow);
   const changedFiles = resolveChangedFiles(root, parsed.files, parsed.baseRef);
@@ -769,17 +778,6 @@ function main(): void {
       ? report.failures.length > 0
       : report.failures.some((f) => f.severity === "strict");
   process.exit(hasFailures ? EXIT_NG : EXIT_OK);
-}
-
-function findRepoRoot(startPath: string): string {
-  let cur = startPath;
-  for (let i = 0; i < 20; i++) {
-    if (fs.existsSync(path.join(cur, ".git"))) return cur;
-    const parent = path.dirname(cur);
-    if (parent === cur) break;
-    cur = parent;
-  }
-  return startPath;
 }
 
 if (import.meta.main) {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -7417,7 +7417,7 @@ async function main(): Promise<void> {
     (typeof import.meta !== "undefined" && (import.meta as any).dir) ||
     __dirname ||
     process.cwd();
-  const root = findRepoRoot(scriptDir);
+  const root = findRepoRoot(scriptDir, { explicitRoot: options.root });
 
   if (args.includes("--update-ir055-baseline")) {
     updateIr055Baseline(root);

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_templates.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_templates.ts
@@ -57,7 +57,9 @@ function main(): void {
     printHelp(SCRIPT_NAME, DESCRIPTION, USAGE);
     process.exit(EXIT_OK);
   }
-  const repoRoot = findRepoRoot(import.meta.dir);
+  const repoRoot = findRepoRoot(import.meta.dir, {
+    explicitRoot: options.root,
+  });
   const templatesDir = path.join(repoRoot, TEMPLATE_REL_DIR);
   if (!fs.existsSync(templatesDir)) {
     console.error(`Templates directory not found: ${templatesDir}`);

--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.test.ts
@@ -54,6 +54,14 @@ describe("parseArgs", () => {
     expect(parseArgs(["--dry-run"]).dryRun).toBe(true);
   });
 
+  it("parses --root with a value (REQ-0145-014)", () => {
+    expect(parseArgs(["--root", "/tmp/repo"]).root).toBe("/tmp/repo");
+  });
+
+  it("throws when --root has no value (REQ-0145-014)", () => {
+    expect(() => parseArgs(["--root"])).toThrow(/--root requires a value/);
+  });
+
   it("collects positional paths", () => {
     const opts = parseArgs(["foo", "bar/baz"]);
     expect(opts.paths).toEqual(["foo", "bar/baz"]);
@@ -332,5 +340,88 @@ describe("findRepoRoot", () => {
     const start = path.resolve("C:\\WINDOWS\\TEMP");
     const result = findRepoRoot(start);
     expect(result).toBe(start);
+  });
+
+  it("honors explicit --root option over filesystem walk (REQ-0145-014)", () => {
+    const path = require("path");
+    const fs = require("fs");
+    const os = require("os");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "frt-explicit-"));
+    try {
+      const root = findRepoRoot(process.cwd(), { explicitRoot: tmp });
+      expect(root).toBe(path.resolve(tmp));
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("honors AGENTDEV_INTEGRITY_ROOT env var when no --root (REQ-0145-014)", () => {
+    const path = require("path");
+    const fs = require("fs");
+    const os = require("os");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "frt-env-"));
+    const prev = process.env.AGENTDEV_INTEGRITY_ROOT;
+    process.env.AGENTDEV_INTEGRITY_ROOT = tmp;
+    try {
+      const root = findRepoRoot(process.cwd());
+      expect(root).toBe(path.resolve(tmp));
+    } finally {
+      if (prev === undefined) delete process.env.AGENTDEV_INTEGRITY_ROOT;
+      else process.env.AGENTDEV_INTEGRITY_ROOT = prev;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers explicit --root over env var (REQ-0145-014)", () => {
+    const path = require("path");
+    const fs = require("fs");
+    const os = require("os");
+    const tmpExplicit = fs.mkdtempSync(path.join(os.tmpdir(), "frt-ex-"));
+    const tmpEnv = fs.mkdtempSync(path.join(os.tmpdir(), "frt-env2-"));
+    const prev = process.env.AGENTDEV_INTEGRITY_ROOT;
+    process.env.AGENTDEV_INTEGRITY_ROOT = tmpEnv;
+    try {
+      const root = findRepoRoot(process.cwd(), { explicitRoot: tmpExplicit });
+      expect(root).toBe(path.resolve(tmpExplicit));
+    } finally {
+      if (prev === undefined) delete process.env.AGENTDEV_INTEGRITY_ROOT;
+      else process.env.AGENTDEV_INTEGRITY_ROOT = prev;
+      fs.rmSync(tmpExplicit, { recursive: true, force: true });
+      fs.rmSync(tmpEnv, { recursive: true, force: true });
+    }
+  });
+
+  it("detects worktree root via .git file (REQ-0145-014)", () => {
+    const path = require("path");
+    const fs = require("fs");
+    const os = require("os");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "frt-wt-"));
+    try {
+      const wtRoot = path.join(tmp, "wt");
+      const wtScripts = path.join(wtRoot, "sub", "dir");
+      fs.mkdirSync(wtScripts, { recursive: true });
+      fs.writeFileSync(path.join(wtRoot, ".git"), "gitdir: /fake/path");
+      const root = findRepoRoot(wtScripts);
+      expect(root).toBe(path.resolve(wtRoot));
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to .git directory when .opencode is absent (REQ-0145-014)", () => {
+    const path = require("path");
+    const fs = require("fs");
+    const os = require("os");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "frt-gitdir-"));
+    try {
+      const repoRoot = path.join(tmp, "repo");
+      const nested = path.join(repoRoot, "a", "b");
+      fs.mkdirSync(nested, { recursive: true });
+      fs.mkdirSync(path.join(repoRoot, ".git"));
+      const root = findRepoRoot(nested);
+      expect(root).toBe(path.resolve(repoRoot));
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
@@ -72,6 +72,7 @@ export interface CliOptions {
   dryRun: boolean;
   classification: boolean; // REQ-0108-196
   paths: string[];
+  root?: string; // REQ-0145-014: explicit repo root for worktree/CI
 }
 
 export function parseArgs(args: string[]): CliOptions {
@@ -92,6 +93,11 @@ export function parseArgs(args: string[]): CliOptions {
       options.dryRun = true;
     } else if (arg === "--classification") { // REQ-0108-196
       options.classification = true;
+    } else if (arg === "--root") { // REQ-0145-014
+      const v = args[i + 1];
+      if (!v) throw new Error("--root requires a value");
+      options.root = v;
+      i++;
     } else if (!arg.startsWith("-")) {
       options.paths.push(arg);
     }
@@ -114,6 +120,7 @@ OPTIONS:
   --json            Output results in JSON format
   --dry-run         Show what would be checked without running checks
   --classification  Enable document classification policy checks (REQ-0108-196)
+  --root <path>     Explicit repository root (REQ-0145-014: worktree/CI support)
   --update-ir055-baseline  Regenerate IR-055 baseline file from current violations
 
 EXIT CODES:
@@ -530,16 +537,88 @@ export function writeReportFile(root: string, report: IntegrityReport): string {
   return filePath;
 }
 
-export function findRepoRoot(startPath: string): string {
+/**
+ * Resolve the repository root for integrity scans (REQ-0145-014).
+ *
+ * Resolution priority:
+ *   1. options.explicitRoot  — `--root` CLI arg (highest priority)
+ *   2. AGENTDEV_INTEGRITY_ROOT env var — CI/local explicit override
+ *   3. worktree detection    — walk up for a `.git` *file* (worktree admin pointer)
+ *   4. main repo detection   — walk up for `.opencode` (existing behavior), then `.git` dir
+ *
+ * The worktree branch lets check_integrity.ts resolve the worktree root when
+ * invoked inside `.worktrees/{N}-{type}/`, instead of falling through to the
+ * main repo root. CI (check_changed_docs.ts --base-ref) and local development
+ * both get consistent results because the same resolver is used.
+ */
+export function findRepoRoot(
+  startPath: string,
+  options?: { explicitRoot?: string },
+): string {
   const { resolve, dirname, join } = require("path");
+  const fs = require("fs") as typeof import("fs");
+
+  // 1. explicit --root
+  if (options?.explicitRoot) {
+    return resolve(options.explicitRoot);
+  }
+
+  // 2. env var
+  const envRoot = process.env.AGENTDEV_INTEGRITY_ROOT;
+  if (envRoot) {
+    return resolve(envRoot);
+  }
+
+  // 3. worktree detection: .git file (worktree admin pointer) walking up
   let dir = resolve(startPath);
   for (let i = 0; i < 20; i++) {
-    if (require("fs").existsSync(join(dir, ".opencode"))) {
+    const dotGitPath = join(dir, ".git");
+    if (fs.existsSync(dotGitPath)) {
+      try {
+        const stat = fs.statSync(dotGitPath);
+        // `.git` as a file → git worktree root (admin pointer to main repo).
+        // `.git` as a directory → main repo root, handled in step 4.
+        if (stat.isFile()) {
+          return dir;
+        }
+      } catch {
+        // stat failed; keep walking
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  // 4. main repo fallback: walk up for `.opencode` (existing behavior)
+  dir = resolve(startPath);
+  for (let i = 0; i < 20; i++) {
+    if (fs.existsSync(join(dir, ".opencode"))) {
       return dir;
     }
     const parent = dirname(dir);
     if (parent === dir) break;
     dir = parent;
   }
+
+  // 5. final fallback: walk up for `.git` directory (main repo without .opencode,
+  //    preserves check_changed_docs.ts local findRepoRoot semantics)
+  dir = resolve(startPath);
+  for (let i = 0; i < 20; i++) {
+    const dotGitPath = join(dir, ".git");
+    if (fs.existsSync(dotGitPath)) {
+      try {
+        if (fs.statSync(dotGitPath).isDirectory()) {
+          return dir;
+        }
+      } catch {
+        // ignore
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
   return resolve(startPath);
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/lint_skills.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/lint_skills.ts
@@ -323,7 +323,9 @@ function main(): void {
     process.exit(EXIT_OK);
   }
 
-  const repoRoot = findRepoRoot(import.meta.dir);
+  const repoRoot = findRepoRoot(import.meta.dir, {
+    explicitRoot: options.root,
+  });
   const skillsDir = path.join(repoRoot, ".opencode", "skills");
   if (!fs.existsSync(skillsDir)) {
     console.error(`Skills directory not found: ${skillsDir}`);


### PR DESCRIPTION
## 概要

Issue #1379: `check_integrity.ts` の `findRepoRoot` が worktree 環境で正しく動作するよう、root 解決方式を見直す。

REQ: REQ-0145-014
work_type: maintenance

## 課題

`findRepoRoot` がスクリプト配置位置起点で main repo root を返す設計のため、git worktree 内での編集結果に対する整合性検証が直接的に行えなかった。CI では `check_changed_docs.ts --base-ref origin/main` が変更ファイルスコープで代用していたが、ローカル開発環境での worktree 検証体験が低下していた。

## 実装内容

`cli_utils.ts` の `findRepoRoot` を拡張し、以下の優先順位で root を解決するよう変更した。

1. `--root` 引数（最優先、明示指定）
2. 環境変数 `AGENTDEV_INTEGRITY_ROOT`
3. worktree 検出（`.git` ファイル検出による worktree ルート特定）
4. フォールバック: 既存の `.opencode` 探索 → `.git` ディレクトリ探索

### 変更ファイル

- `cli_utils.ts`: `findRepoRoot` の拡張、`CliOptions` に `root?` 追加、`parseArgs` の `--root` 解析、`printHelp` の `--root` 行追加
- `check_integrity.ts`: 呼び出し元を `findRepoRoot(scriptDir, { explicitRoot: options.root })` に更新
- `check_changed_docs.ts`: ローカル `findRepoRoot` を削除し `cli_utils.ts` の共通実装へ統合。`ParsedArgs` に `root?` 追加、`parseArgs` の `--root` 解析、USAGE/help 更新
- `check_templates.ts`: 呼び出し元を `options.root` 付きに更新
- `lint_skills.ts`: 呼び出し元を `options.root` 付きに更新
- `cli_utils.test.ts`: `parseArgs` の `--root` テスト、`findRepoRoot` の explicit root / env var / worktree 検出 / `.git` ディレクトリ fallback テスト追加

### 設計判断

- `check_changed_docs.ts` のローカル `findRepoRoot`（`.git` 探索）を廃止し `cli_utils.ts` の共通実装へ統合した。これにより CI とローカル開発で同一の root 解決ロジックを利用し、検証結果の一貫性を保証する。
- worktree 検出は `git rev-parse --show-toplevel`（`child_process` 依存）ではなく、ファイルシステムベースの `.git` ファイル検出を採用した。`check_integrity.ts` の既存 `isInsideWorktree`（REQ-0145-010）と同じ決定論的アプローチで、プロセス依存がない。

## 完了条件

- [x] `findRepoRoot` が `--root` 引数、環境変数、worktree 検出のいずれかにより worktree ルートを正しく解決すること
- [x] worktree 環境内で `check_integrity.ts` を実行した際、root が worktree パスに解決されること
- [x] CI 環境（`check_changed_docs.ts --base-ref origin/main`）とローカル開発環境で一貫した検証結果が得られること

※完了条件チェックボックスは case-close QG-4 で評価・更新される。本 PR では実装と検証のみ実施。

## テスト戦略 (TS-003) 結果

- **verification**: worktree 環境内で `check_integrity.ts` を実行し、`findRepoRoot` が worktree ルートを正しく検出することを確認。CI 環境（`check_changed_docs.ts --base-ref`）との検証結果一貫性を確認。
- **pass_criteria**: worktree 内で root が worktree パスに解決され、ローカルと CI で一貫した検証結果が得られること。
- **結果**: PASS

検証証跡:
- `findRepoRoot(scriptDir)` in worktree → `C:\Users\ogatay\work\agent-dev-flow\.worktrees\1379-chore`（worktree パス）
- `findRepoRoot(cwd, { explicitRoot: '/custom/path' })` → `C:\custom\path`
- `findRepoRoot(cwd)` with `AGENTDEV_INTEGRITY_ROOT=/env/override` → `C:\env\override`
- `check_integrity.ts --dry-run --json` in worktree → 全パスが worktree 配下に解決される
- `check_changed_docs.ts --workflow docs-check --base-ref origin/main --json` in worktree → exit 0、正常動作
- `bun test cli_utils.test.ts` → 42 pass / 0 fail（新規 7 テスト含む）

## 検証結果

- `cli_utils.test.ts`: 42 pass / 0 fail
- worktree 内での実データによる動作確認: 全完了条件 PASS

### worktree 環境固有の既知制約

worktree 内では `.opencode/commands/agentdev/`、`.opencode/skills/agentdev-workflow-templates/templates/` 等、一部 junction が再作成されない（SKILL.md「準備フェーズの既知の制約」参照）。これにより `commands_*.test.ts`、`check_templates.test.ts` 等、junction 依存テストが worktree 内で false positive となる。これは本 Issue 対象外であり、本 PR の変更によるものではない。

## Findings / Capture候補

（なし。本筋外の発見事項なし）

## SPEC確定候補

- `findRepoRoot` の root 解決優先順位（`--root` > env var > worktree 検出 > `.opencode` 探索 > `.git` ディレクトリ探索）を SPEC `repo-agentdev-integrity` の root 解決仕様として確定候補とする。
- 環境変数名 `AGENTDEV_INTEGRITY_ROOT` はSPECレベルの命名規約として確定候補。他の integrity 系スクリプトでも同一名を利用することを推奨。

## L2 タイムスタンプ（REQ-0151-009）

- worktree 設定 (Step 5): 開始 2026-07-03T13:34:12+09:00, 終了 2026-07-03T13:34:37+09:00 (25秒)
- Sisyphus-Junior 実行 (Step 6): 開始 2026-07-03T13:34:37+09:00, 終了 2026-07-03T13:48:30+09:00
- worktree クリーンアップ (Step 8): 未実施（case-close の責務。本 PR では worktree/branch 削除を行わない）