### PR TITLE
docs: REQ-0143-004 Step 番号適用対象明確化 (Step番号なしSPECは適用対象外)

### DIFF
--- a/docs/specs/authoring/command-file-format.md
+++ b/docs/specs/authoring/command-file-format.md
@@ -2,7 +2,7 @@
 title: "コマンドファイルフォーマット規約"
 status: accepted
 created: 2026-06-22
-updated: 2026-07-02
+updated: 2026-07-03
 ---
 
 # コマンドファイルフォーマット規約
@@ -104,9 +104,9 @@ command SPEC（`docs/specs/commands/*.md`）が記述する Step 番号構成は
 - **サブステップ採番**: `Step N-M` の M は `1` から開始する（`Step N-0` は使用しない）。QG ゲート、事前検証等の「先行サブステップ」も `N-1` 以降の番号を採番すること
 - **独立フェーズの Step 0 扱い**: 従来 `Step 0` として独立番号を与えられていたフェーズ（例: セッションコンテキスト検知、フェーズ判定、実行前同期、引き継ぎ停止判定）は、command 定義の Step 1（または後続 Step）に統合し、独立した `Step 0` としては扱わない
 
-**適用対象**: `docs/specs/commands/*.md` の全 command SPEC（`_template.md` を含む）
+**適用対象**: `docs/specs/commands/*.md` のうち、Step 番号構成を記述する command SPEC（`_template.md` を含む）。Step 番号を持たない command SPEC（読み取り専用、分類系の `inspect-skills.md`、`inspect-promote.md`、`inspect-doc-inputs.md` 等で `### Step N` 見出しを使用しない SPEC）は適用対象外とする（REQ-0143-004）。これらの SPEC は対応する command 定義ファイルと比較すべき Step 番号構成を持たないため、一致検証の対象とならない。
 
-**検証**: 各 command/SPEC ペアについて、SPEC の Step 番号と command 定義の Step 番号が同一フェーズで一致することを確認する。
+**検証**: 各 command/SPEC ペアについて、SPEC の Step 番号と command 定義の Step 番号が同一フェーズで一致することを確認する。ただし SPEC が Step 番号を記述しない場合は検証対象外とする。
 ずれを検出した場合、SPEC 側を command 定義へ一致させる。
 
 ## 他 SPEC との関係


### PR DESCRIPTION
## 概要

Issue #1389 (OU-002): REQ-0143-004 Step 番号適用対象明確化

`command-file-format.md` の「command SPEC と command 定義の Step 番号一致（REQ-0143-004）」節において、Step 番号を持たない command SPEC は適用対象外であることを明文化した。

## 変更内容

- **適用対象の明確化**: 従来「全 command SPEC」としていた適用対象を「Step 番号構成を記述する command SPEC」に限定し、`inspect-skills.md`、`inspect-promote.md`、`inspect-doc-inputs.md` 等で `### Step N` 見出しを使用しない読み取り専用・分類系 SPEC を適用対象外として明記した（REQ-0143-004）
- **検証文の補足**: SPEC が Step 番号を記述しない場合は検証対象外とする旨を追記
- **frontmatter updated**: 2026-07-03 に更新

## 完了条件の検証

- [x] REQ-0143-004 の適用対象が明確化されている（Step 番号を持たない command SPEC は適用対象外であることが文書化されている）
- [x] 先頭 Step 扱い、採番開始位置の詳細が SPEC（docs/specs/authoring/command-file-format.md）に配置されている（既存の採番開始位置、独立フェーズの Step 0 扱い節で既出、本 PR で適用対象を補完）
- [x] REQ-0143-004 に対する IR-044 warning が解消されている（REQ-0143-004 本文の Step 番号語句は数字リテラルを伴わず、IR-044 Step 番号直接参照検出の非検出語句に該当するため本来検出対象外。req-save で REQ-0143-004 が更新済みであり warning 発生箇所なし）

## テスト戦略 (TS-002)

- verification: REQ-0143-004 の適用対象明確化、Step 番号なし SPEC の取り扱い文書化、IR-044 warning 解消を確認
- pass_criteria: 適用対象明確化済み。Step 番号不要 SPEC の取り扱い文書化済み。IR-044 warning 解消済み（数字なし Step 番号語句は非検出対象）
- 結果: PASS

Parent Epic: #1387