### PR TITLE
inspect archive廃止（OU-001,002,010）

### DIFF
--- a/src/opencode/commands/agentdev/inspect-promote.md
+++ b/src/opencode/commands/agentdev/inspect-promote.md
@@ -5,7 +5,7 @@ agent: sisyphus
 
 # inspect-promote
 
-`.agentdev/inspect/inbox/` の検出事項を分類（promote/ defer/ reject）し、採用した検出事項を `.agentdev/inspect/promoted/` へ、却下した検出事項を `.agentdev/inspect/archive/rejected/` へ移動する。
+`.agentdev/inspect/inbox/` の検出事項を分類（promote/ defer/ reject）し、採用した検出事項を `.agentdev/inspect/promoted/` へ保存し、却下した検出事項は即時削除する（`archive/rejected/` 廃止）。
 明示的な `--auto` opt-in 時は、高確信度の検出事項を HITL を経ずに `.agentdev/intake/promoted/` へ自動投入し、intake/backlog パイプラインへ流入させる。
 
 ## 入力
@@ -16,7 +16,7 @@ agent: sisyphus
 ## 出力
 
 - `.agentdev/inspect/promoted/*.md`（手動 promote 採用済み、RU 化対象）
-- `.agentdev/inspect/archive/rejected/*.md`（却下済み）
+- reject 検出事項は即時削除（`archive/rejected/` 廃止）。reject 時の commit message に却下理由を含める（AG-006、監査証跡の補強）
 - `.agentdev/intake/promoted/inspect-auto-*.md`（`--auto` 時の自動 promote 成果物。backlog-review へ流入）
 - `.agentdev/inspect/promoted/auto-promote-log.md`（`--auto` 実行ログ。append-only）
 - セッション内完了報告
@@ -66,7 +66,7 @@ agent: sisyphus
 承認された promote 対象検出事項を `.agentdev/inspect/promoted/` へ保存。元の inbox file は削除
 ### Step 7: reject 処理
 
-承認された reject 対象検出事項を `.agentdev/inspect/archive/rejected/` へ移動
+承認された reject 対象検出事項は即時削除する。reject 時の commit message に却下理由を含める（AG-006、監査証跠の補強）
 ### Step 8: defer 処理
 
 defer となった検出事項は `.agentdev/inspect/inbox/` に残置。intake/ learning 送付の推奨を報告
@@ -75,7 +75,7 @@ defer となった検出事項は `.agentdev/inspect/inbox/` に残置。intake/
 promote/ defer/ reject/ auto-promote の判定結果と後続 route を提示。`--auto` 実行時は投入件数、投入先一覧、ログパスを含める
 ### Step 10: .agentdev/ 変更の commit と push
 
- - `git diff --name-only` で `.agentdev/inspect/` および `.agentdev/intake/` 配下の変更を確認（auto-promote の intake/promoted/ 投入、promoted/rejected への移動、inbox 削除、auto-promote-log 更新を含む）
+ - `git diff --name-only` で `.agentdev/inspect/` および `.agentdev/intake/` 配下の変更を確認（auto-promote の intake/promoted/ 投入、promoted/ への保存、reject に伴う inbox 削除、auto-promote-log 更新を含む）
  - **変更なし時**: commit/push せず「変更なし」と報告
  - **変更あり時**:
  1. `git add` は `.agentdev/inspect/` と `.agentdev/intake/` のみ対象
@@ -87,7 +87,7 @@ promote/ defer/ reject/ auto-promote の判定結果と後続 route を提示。
 
 - G01: ユーザーの明示的な承認なしに採用済み成果物を生成しない（`--auto` による自動 promote 対象を除く）
 - G02: promote された検出事項のみを `.agentdev/inspect/promoted/` へ保存する
-- G03: reject された検出事項は `.agentdev/inspect/archive/rejected/` へ移動する
+- G03: reject された検出事項は即時削除される（`archive/rejected/` への移動は廃止）。即時削除以外の取扱を禁止する
 - G04: defer された検出事項は `.agentdev/inspect/inbox/` に残す
 - G05: docs-check ルール／検査データ追加候補は独立 route とせず、採用済み成果物の要件化方向または受け入れ条件に含める
 - G06: `--auto` は明示 opt-in の場合のみ有効。省略時は自動 promote を一切行わない


### PR DESCRIPTION
## 概要

Epic #1395（`.agentdev/` 配下のアーカイブ運用見直し）Wave 1 子Issue #1396 の実装。inspect ドメインの `archive/rejected/` を廃止し、reject 後の即時削除と reject commit message への却下理由記載を `inspect-promote` コマンド定義（`src/opencode/commands/agentdev/inspect-promote.md`）に反映する。

## 変更内容

`src/opencode/commands/agentdev/inspect-promote.md` の5箇所を更新（OU-010 実装反映）:

1. **概要（line 8）**: 「`archive/rejected/` へ移動」→「即時削除（`archive/rejected/` 廃止）」
2. **出力（line 19）**: `archive/rejected/*.md` パス削除 →「reject 検出事項は即時削除。reject 時の commit message に却下理由を含める（AG-006、監査証跡の補強）」
3. **Step 7 reject 処理（line 69）**: `archive/rejected/` 移動 → 即時削除 ＋ 却下理由 commit message 規定
4. **Step 10（line 78）**: 「promoted/rejected への移動」→「promoted/ への保存、reject に伴う inbox 削除」
5. **G03（line 90）**: `archive/rejected/` 移動 → 即時削除（即時削除以外の取扱禁止）

`REQ-0124`, `REQ-0126`（`docs/requirements/`）と `docs/specs/commands/inspect-promote.md` は前工程（commit 3beadaec）で更新済み。本 PR は実行時 command 定義ファイルを SPEC へ追従させる。

## test strategy 検証結果

### TS-001（AG-001: inspect archive 廃止）— 合格

- `REQ-0124.md`: `archive/rejected` 0件（REQ-0124-012, REQ-0103-140, REQ-0103-146, REQ-0124-006 すべて即時削除規定）
- `REQ-0126.md`: `archive/rejected` 0件（REQ-0126-005, REQ-0126-009 とも削除/push 規定）
- `docs/specs/commands/inspect-promote.md`: archive/rejected パス参照なし、reject 即時削除規定あり（line 23, 46, 60）
- `src/opencode/commands/agentdev/inspect-promote.md`: SPEC と整合（line 8, 19, 69, 90 で即時削除規定）。残存 `archive/rejected` は「廃止」否定文脈のみ（SPEC と同一表現）

### TS-006-partial（AG-006: inspect-promote reject commit message）— 合格

- `docs/specs/commands/inspect-promote.md` line 23: 「reject 時の commit message に却下理由を含める（AG-006、監査証跠の補強）」記載あり
- `src/opencode/commands/agentdev/inspect-promote.md` line 19, 69: 同旨を実装に反映

## スコープ境界（G14）

- intake ドメイン（`intake-promote.md`, `agentdev-intake-pipeline/references/intake-promotion.md`）→ Wave 2 #1397 に委譲
- learning ドメイン（`archive/active.md` → `deferred.md`）→ Wave 3 #1398 に委譲
- `docs/guides/intake-learning-backlog-flow.md` の該当箇所（line 30-53 Intake / line 64 Learning）→ それぞれ Wave 2/3 対象

## Findings / Capture候補

（なし）

## SPEC確定候補

（なし）

## L2 タイムスタンプ（REQ-0151-009, REQ-0130-028）

- Step 5（worktree 設定）開始: 2026-07-04T00:12:15+09:00
- Step 5（worktree 設定）終了: 2026-07-04T00:17:09+09:00（設定時間: 約4分54秒）
- Step 6（実装）開始: 2026-07-04T00:17:09+09:00
- Step 6（実装）終了: PR 作成完了時刻（case-run 完了報告に記載）

## 備考

- `call_omo_agent` が explore/librarian のみ対応（Sisyphus-Junior agent 型を起動できない）のため、`agentdev-case-run-execution-adapter` skill の「task() 起動失敗時事後処理」に準じて worktree 内で直接実装し PR 化した。実装完了・検証完了しているため `completed(pr)` として扱う。

Refs: #1396
