### PR TITLE
feat(agentdev): add standard skill agentdev-project-extensions (#1404)

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -122,6 +122,7 @@ SPEC は commands / skills / workflows の 3 層ディレクトリ構造を持�
 | [skills/agentdev-conventional-commits.md](skills/agentdev-conventional-commits.md) | draft | 補助 | conventional commits |
 | [skills/agentdev-skill-authoring.md](skills/agentdev-skill-authoring.md) | draft | 補助 | skill authoring |
 | [skills/agentdev-backlog-integration.md](skills/agentdev-backlog-integration.md) | draft | 補助 | backlog integration |
+| [skills/agentdev-project-extensions.md](skills/agentdev-project-extensions.md) | draft | 補助 | project extensions 読み込み |
 
 `repo-agentdev-integrity` は repo-local、配布対象外のため対象外。
 

--- a/docs/specs/skills/agentdev-project-extensions.md
+++ b/docs/specs/skills/agentdev-project-extensions.md
@@ -1,0 +1,72 @@
+---
+title: agentdev-project-extensions SPEC
+status: draft
+created: 2026-07-04
+updated: 2026-07-04
+---
+
+# agentdev-project-extensions SPEC
+
+## 目的
+
+実行時に自分に対応する project extension（`.agentdev/extensions/**`）を読み込み、プロジェクト固有の文脈、規約、検査、受け入れゲート、禁止事項を解決する標準 skill である。配布 command/skill 本文をプロジェクト非依存に保ち、プロジェクト固有情報を実行時に与える仕組みの中核を担う。
+
+## 適用対象
+
+### USE FOR
+
+- command/skill が自分に対応する extension を読み込む際の探索、読み取り契約
+- extension 不在時、破損時の標準的な扱い
+- context/rules/checks/acceptance_gates/must_not の5セクション読み取り
+- extension が追加・拡張であり上書きでないことの扱い
+- rules/checks から project-local skill 委譲対象の抽出
+
+### DO NOT USE FOR
+
+- extension schema の定義（基盤 SPEC `foundations/project-extensions.md` の責務）
+- extension 構造の診断、検査（`/agentdev/inspect-extensions` command の責務）
+- 配布 command/skill 本文の変更
+- project-local skill の実装（各適用プロジェクトの責務）
+
+## 提供する判断・操作
+
+| 判断・操作 | 内容 |
+|---|---|
+| extension 探索 | command は `.agentdev/extensions/commands/<command>.yaml`、skill は `.agentdev/extensions/skills/<skill>.yaml` を対応 extension として特定する |
+| 不在時の扱い | 対応 extension が存在しない場合は空 extension として扱い、標準動作で続行する |
+| 破損時の扱い | 対応 extension が破損している場合はエラーを表示し、当該 extension を無視して標準動作で続行する |
+| 5セクション読み取り | context, rules, checks, acceptance_gates, must_not を読み取る |
+| 追加・拡張の扱い | extension の内容は配布 command/skill 本文の動作に追加され、既存動作を置き換えない |
+| 委譲対象抽出 | rules/checks の `skill:` フィールドから project-local skill 委譲対象を抽出する |
+
+## 参照する references
+
+- なし（本 skill の動作契約は SKILL.md 本文に集約）
+
+## 現在の動作
+
+- extension は標準 command/skill の上書きではなく、追加・拡張のみ（G01）
+- 自分に対応する extension（1件）のみを読み、他 command/skill の extension は読まない（G02）
+- 破損 extension で処理全体を停止しない（G03）
+- 委譲先 project-local skill の中身には関与しない（G04）
+- rules/checks の初期契約では `action`, `required`, `fail_on` を採用しない。呼び出された skill は extension entry の `id`, `when`, `skill` および周辺文脈をもとに判断する
+- 配布 command/skill 本文にプロジェクト固有文書の具体参照を持たせない（G05）。プロジェクト固有参照は extension 経由でのみ与える
+
+## 対象外
+
+- extension schema、配置、命名の定義（基盤 SPEC `foundations/project-extensions.md`）
+- extension 構造の診断（`/agentdev/inspect-extensions`）
+- project-local skill の実装（各適用プロジェクトの責務）
+- extension 自体の作成、編集（プロジェクト側の責務）
+
+## 検証観点
+
+- SKILL.md が存在し、6つの責務（extension 探索、不在時空 extension 扱い、破損時エラー表示と無視、5セクション読み取り、上書きでないことの扱い、委譲対象抽出）が全て定義されていること
+- 配布物参照境界（SKILL.md 本文にプロジェクト固有文書の具体ID、具体パス、固定URLを持たない）が遵守されていること
+
+## See Also
+
+- [foundations/project-extensions.md](../foundations/project-extensions.md)（project-extensions 機構の基盤 SPEC）
+- [commands/inspect-extensions.md](../commands/inspect-extensions.md)（保守診断 command SPEC）
+- REQ-0160（Project Extensions 機構と配布物参照境界）
+- ADR-0135（Project Extensions Architecture）

--- a/src/opencode/skills/agentdev-project-extensions/SKILL.md
+++ b/src/opencode/skills/agentdev-project-extensions/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: agentdev-project-extensions
+description: Resolves project-specific extensions (.agentdev/extensions/**) for a given command or skill at runtime. Handles extension discovery, absence/corruption fallback, 5-section reading (context/rules/checks/acceptance_gates/must_not), additive-not-override treatment, and project-local skill delegation target extraction. USE FOR: resolving project extensions for a command or skill, reading extension context/rules/checks, extracting project-local skill delegation targets. DO NOT USE FOR: defining extension schema, diagnosing extension structure, modifying distribution command/skill bodies, implementing project-local skills.
+---
+
+# Project Extensions
+
+実行時に自分に対応する project extension を読み込み、プロジェクト固有の文脈、規約、検査、受け入れゲート、禁止事項を解決する。
+配布 command/skill 本文はプロジェクト非依存であり、プロジェクト固有情報は `.agentdev/extensions/**` 経由で実行時に与えられる。
+
+## 担当、非担当
+
+### 担当
+
+| 責務 | 内容 |
+|------|------|
+| extension 探索 | 対応 extension ファイル（1件）の特定と読み込み |
+| extension 不在時の扱い | 空 extension として扱い、標準動作で続行 |
+| extension 破損時の扱い | エラー表示と無視、標準動作で続行 |
+| 5セクション読み取り | context/rules/checks/acceptance_gates/must_not の読み取り |
+| 上書きでないことの扱い | extension は追加・拡張であり、標準動作を置き換えない |
+| 委譲対象抽出 | rules/checks から project-local skill 委譲対象の抽出 |
+
+### DO NOT USE FOR
+
+- extension schema の定義（本機構を定義する基盤 SPEC の責務）
+- extension 構造の診断、検査（保守診断 command の責務）
+- 配布 command/skill 本文の変更
+- project-local skill の実装（各適用プロジェクトの責務）
+- extension 自体の作成、編集（プロジェクト側の責務）
+
+## 標準配置
+
+extension は以下の配置を持つ。command と skill で対応ディレクトリが異なる。
+
+```text
+.agentdev/extensions/commands/<command>.yaml
+.agentdev/extensions/skills/<skill>.yaml
+```
+
+## extension の基本構造
+
+extension は以下の基本構造を持つ。
+
+```yaml
+version: 1
+kind: command-extension  # または skill-extension
+id: /agentdev/<command>  # または <skill>
+
+context: []
+rules: []
+checks: []
+acceptance_gates: []
+must_not: []
+```
+
+acceptance_gates は受け入れ条件ではなく、完了判定本体でもない。command/skill extension によって追加される実行完了前ゲートである。
+
+## 責務ごとの手順
+
+### 1. 対応 extension ファイルの探索
+
+- command は `.agentdev/extensions/commands/<command>.yaml` を対象とする
+- skill は `.agentdev/extensions/skills/<skill>.yaml` を対象とする
+- 当該 extension ファイルのみを読み、自分に対応しない extension は読まない
+
+### 2. extension 不在時の空 extension 扱い
+
+対応 extension ファイルが存在しない場合は、空 extension として扱い標準動作で続行する。extension 不在はエラーではなく、配布 command/skill 単体で動作する通常状態である。
+
+### 3. extension 破損時のエラー表示と無視
+
+対応 extension ファイルが破損している場合（YAML 構文エラー、必須フィールド欠落等）は以下の手順をとる:
+
+1. エラーメッセージを表示する（対象 extension ファイルパスと破損理由を含む）
+2. 当該 extension を無視する
+3. 空 extension として扱い、標準動作で続行する
+
+破損 extension により処理全体を停止しない。利用者はエラーメッセージから拡張設定の修正を判断できる。
+
+### 4. 5セクション読み取り
+
+extension が持つ以下の5セクションを読み取る。
+
+| セクション | 意味 |
+|---|---|
+| context | command/skill に追加で与える文脈 |
+| rules | command/skill に追加で守らせる規約 |
+| checks | command/skill に追加で実行させる検査 |
+| acceptance_gates | command/skill extension が追加する実行完了前ゲート |
+| must_not | command/skill に追加で課す禁止事項 |
+
+各セクションは配列であり、複数の entry を持てる。entry は空配列でもよい。
+
+### 5. 上書きでなく追加・拡張であることの扱い
+
+extension の内容は配布 command/skill 本文の動作に**追加**され、既存動作を**置き換えない**。
+
+- extension の context は、配布 command/skill が持つ文脈に追加される
+- extension の rules、checks は、配布 command/skill の手順に追加で課される
+- extension の must_not は、配布 command/skill の禁止事項に追加される
+- extension の acceptance_gates は、配布 command/skill の完了判定の前に追加で実行される
+
+### 6. 委譲対象の抽出
+
+rules/checks の entry に `skill:` フィールドで具体的な project-local skill 名が記述されている場合、それを委譲対象として抽出する。
+
+extension entry の形式:
+
+```yaml
+rules:
+  - id: <rule-id>
+    when: <条件>
+    skill: <project-local-skill-name>
+
+checks:
+  - id: <check-id>
+    when: <条件>
+    skill: <project-local-skill-name>
+```
+
+初期契約では `action`, `required`, `fail_on` は採用しない。呼び出された skill は extension entry の `id`, `when`, `skill` および周辺文脈をもとに判断する。
+
+AgentDevFlow 標準は `skill:` 構文を定義するが、委譲先 skill の中身には関与しない。各適用プロジェクトが project-local skill を用意し、rules/checks の中身を定義する。
+
+## ハイブリッド方式
+
+extension 原本は各プロジェクトが所有する。AgentDevFlow 本体は初期テンプレート、schema、検査、保守 command を提供し、consumer はテンプレートを初期値として取り込みカスタマイズする。
+
+## ガードレール
+
+- G01: extension は標準 command/skill の上書きではなく、追加・拡張のみ。配布 command/skill 本文の動作を置き換えない
+- G02: 自分に対応する extension（1件）のみを読み、他の command/skill の extension は読まない
+- G03: 破損 extension で処理全体を停止しない（エラー表示 + 無視 + 標準動作で続行）
+- G04: 委譲先 project-local skill の中身には関与しない。委譲先の実装は各適用プロジェクトの責務
+- G05: 配布 command/skill 本文にプロジェクト固有文書の具体参照（具体ID、具体パス、固定URL）を持たせない。プロジェクト固有参照は extension 経由でのみ与える
+
+## See Also
+
+- 本機構を定義する基盤 SPEC（extension schema、配置、実行時読み込み契約、project-local skill 委譲、配布物参照境界）
+- 保守診断 command（extension 一覧化、構造確認、path 実在確認、skill 存在確認、旧参照リスト機構残存検出を担う）


### PR DESCRIPTION
## 概要

Epic #1403 Wave 1 子 Issue #1404 の実装。
標準 skill `agentdev-project-extensions` を実装し、実行時の project extension 読み込み機構を提供する。

## 実装内容

- `src/opencode/skills/agentdev-project-extensions/SKILL.md`（新規作成）
  - 6つの責務: extension 探索、不在時空 extension 扱い、破損時エラー表示と無視、5セクション読み取り（context/rules/checks/acceptance_gates/must_not）、上書きでなく追加・拡張であることの扱い、委譲対象抽出
  - 配布物参照境界を遵守（SKILL.md 本文に具体 ADR/REQ/SPEC ID、具体パス、固定URLを持たない）
- `docs/specs/skills/agentdev-project-extensions.md`（新規作成、SPEC draft）
- `docs/specs/README.md`: skill SPEC 一覧へ登録

## 受け入れ基準

- [x] `src/opencode/skills/agentdev-project-extensions/SKILL.md` が存在する
- [x] extension 探索機能（`.agentdev/extensions/skills/agentdev-project-extensions.yaml` の読み込み）が定義されている
- [x] extension 不在時の空 extension 扱い（標準動作で続行）が定義されている
- [x] extension 破損時のエラー表示と無視（標準動作で続行）が定義されている
- [x] context/rules/checks/acceptance_gates/must_not の5セクション読み取りが定義されている
- [x] extension が上書きでなく追加・拡張であることの扱いが定義されている
- [x] rules/checks から project-local skill 委譲対象を抽出する機能が定義されている
- [x] `docs/specs/skills/agentdev-project-extensions.md`（SPEC）が作成され、`docs/specs/README.md` の skill SPEC 一覧に登録されている
- [x] 配布物参照境界（command/skill 本文にADR/REQ/SPEC具体IDを持たせない）がSKILL.md本文で遵守されている

## テスト戦略 (TS-004)

- id: TS-004
- verification: `src/opencode/skills/agentdev-project-extensions/SKILL.md` が存在することを確認。6つの責務が定義されていることを確認。
- pass_criteria: skill が存在し、6つの責務が全て定義されている。
- 結果: **PASS** — SKILL.md 存在確認済み、6責務（探索/不在時/破損時/5セクション/上書きでない/委譲抽出）全て定義済み。配布物参照境界の grep 検査で具体ID/パス/URL 0件を確認。

## Findings / Capture候補

なし。

## SPEC確定候補

なし。

---
Parent: #1403
Closes #1404
