### PR TITLE
docs(agentdev): learning-capture の deferred.md 参照を inbox.md のみに是正 #1418

### DIFF
--- a/src/opencode/skills/agentdev-learning-capture/SKILL.md
+++ b/src/opencode/skills/agentdev-learning-capture/SKILL.md
@@ -67,9 +67,9 @@ description: Agent-first extraction and capture of learnings from problems auton
 
 学びの保存先：
 - `.agentdev/learning/inbox.md`（最新の学び。常にここに追加）
-- `.agentdev/learning/deferred.md`（過去の学び。`/agentdev/learning-promote` 実行時に移動）
 
-inbox.md、deferred.mdが存在しない場合、エージェントは当該ファイルを作成してから追記する。
+inbox.mdが存在しない場合、エージェントは当該ファイルを作成してから追記する。
+`deferred.md` は `/agentdev/learning-promote` のみが管理し、capture は参照・作成しない。
 
 ### ファイル操作とgit永続化の分離
 


### PR DESCRIPTION
## 概要

Issue #1418: learning skill 群の `archive/active.md` 参照残存11箇所の是正。

PR #1402 で SPEC 側（`docs/specs/skills/agentdev-learning-pipeline.md` L28）が `archive/active.md` → `deferred.md` にリネームされた後、learning skill 群 3ファイルに旧パス参照が残留していた問題の是正。

## 背景・前提状態の確認

本 Issue 起票時点（2026-07-05 12:35 JST）より前に、以下の PR が既にマージ済みでした:

- **PR #1412** (2026-07-05 00:17): `chore(learning): learning pipeline の living pool を deferred.md に単一化` — learning-pipeline/SKILL.md（5箇所）、learning-capture/SKILL.md（2箇所）、learning-capture/references/example.md（4箇所）の `archive/active.md` → `deferred.md` リネームを完了済み
- **PR #1415** (2026-07-05 02:36): `docs(agentdev): align .agentdev/README.md and related skills with current artifact lifecycle` — 関連 skill の lifecycle 整合

これにより、Issue #1418 の主たる完了条件（TS-001: `rg "archive/active\.md" src/opencode/skills/agentdev-learning-*/` = 0件）は**本 PR 以前に既にパス**しています。

## 完了条件ごとの対応状況

| 完了条件 | 対応状況 | 根拠 |
|----------|----------|------|
| learning-pipeline/SKILL.md の archive/active.md 参照（5箇所）を deferred.md に是正 | **既対応**（PR #1412） | 5箇所とも `deferred.md` 化済み、SPEC L28 と整合 |
| learning-capture/SKILL.md の archive/active.md 参照（2箇所）を inbox.md のみ参照・作成に修正 | **本 PR で対応** | Prerequisites セクションの `deferred.md` 行を削除し、capture は `inbox.md` のみ参照・作成する役割に是正 |
| learning-capture/example.md の archive/active.md 参照（4箇所）を inbox.md 参照に置換または削除 | **変更不要**（Findings参照） | 詳細は Findings セクション参照 |
| `rg "archive/active\.md" src/opencode/skills/agentdev-learning-*/` = 0件 | **パス** | PR #1412/#1415 で既に0件化済み、本 PR でも0件確認 |

## 変更内容

### `src/opencode/skills/agentdev-learning-capture/SKILL.md` Prerequisites セクション

learning-capture SPEC（`docs/specs/skills/agentdev-learning-capture.md` L12, L33）は capture が `inbox.md` のみに書き込むことを明記。learning-pipeline SKILL.md L27 も「deferred.md は promote が管理し、capture は参照しない」と明記。

しかし Prerequisites セクションは `deferred.md` を capture の保存先として列出し、capture が `deferred.md` を作成対象とする記述が残存していた（PR #1412 で `archive/active.md` → `deferred.md` にリネームされたが、役割記述の不正確さは残存）。

**修正内容**:
- `deferred.md` を capture の保存先リストから削除
- ファイル作成対象を `inbox.md` のみに限定
- `deferred.md` は `/agentdev/learning-promote` のみが管理し、capture は参照・作成しない旨を明記

## テスト戦略 検証結果

### TS-001

```
$ rg "archive/active\.md" src/opencode/skills/agentdev-learning-capture src/opencode/skills/agentdev-learning-pipeline
# EXIT 1 (no matches found) — 0件確認
```

**判定**: PASS

## QG-3 実装乖離チェック

- **乖離分類**: scope-partial（一部スコープ変更）
- **内容**: example.md の4箇所（L160, L162, L163, L173）について、Issue は inbox.md への置換または削除を求めたが、変更せず。詳細は Findings 参照
- **推奨アクション**: ユーザー承認（example.md の deferred.md 参照は promote の動作として事実正確であり、変更不要と判断）

## Findings / Capture候補

### example.md の deferred.md 参照（4箇所）について

Issue 完了条件 #3 は `learning-capture/references/example.md` の4箇所（L160, L162, L163, L173）を `inbox.md` 参照への置換または削除を求めている。

これらの参照はすべて「全パイプライン実例（3層フロー全体）」セクション内の **Layer 2（Analysis フェーズ）** および **Layer 3（Promotion フェーズ）** に位置する。これらの Layer は `/agentdev/learning-promote` の動作を記述しており、`deferred.md` は promote が管理する成果物として事実正確に参照されている。

- L160: `inbox.md + deferred.md のエントリを問題クラス分類` — promote が inbox + deferred の両方を読み取る事実正確な記述
- L162: `deferred.md の古い単発レアケースを prune` — promote の prune 動作の正確な記述
- L163: `inbox.md の全エントリを deferred.md に移動` — promote の移動動作の正確な記述
- L173: `deferred.md から promote 時 prune` — promote の prune 動作の正確な記述

これらを `inbox.md` に置換すると promote の動作説明として事実誤認となる。capture の役割（Layer 1）は既に `inbox.md` のみ正しく記述されているため、役割境界の混同は発生していない。

**判断根拠**: Issue の修正指示は `archive/active.md` → `deferred.md` リネーム前の状態を前提としていた。PR #1412 でリネーム完了後、これらの参照は promote の動作として事実正確となったため、変更不要と判断した。

### Issue 前提の陳腐化

Issue #1418 は「PR #1402 実施後に archive/active.md 参照が11箇所残留」という前提で起票されたが、実際には PR #1412（2026-07-05 00:17）および PR #1415（2026-07-05 02:36）が Issue 起票（2026-07-05 12:35）前に既にリネームを完了していた。本 PR は残存する役割記述の不正確さ（capture が deferred.md を管理対象とする記述）のみを是正する。

Refs: #1418
