### PR TITLE
docs: conventional-commits skill に auto-close 回避ガイドラインを追加 (#1425)

### DIFF
--- a/src/opencode/commands/agentdev/case-close.md
+++ b/src/opencode/commands/agentdev/case-close.md
@@ -246,6 +246,8 @@ Issue close 手続き（理由: completed、`agentdev-gh-cli`）
 
 `agentdev-git-worktree` に従い `.agentdev/` 配下を commit/push。learning と intake を同一 commit に含める
 
+> **auto-close 回避の留意点**: 本コマンド名 `case-close` は "close" を含む複合語である。コミットメッセージに `(case-close #N)` 等のコマンド名と Issue 番号の近接表記を用いると、GitHub が "close" を auto-close キーワードと誤認し Issue を意図せずクローズするリスクがある。コミットメッセージのフォーマットは `agentdev-conventional-commits` skill の「GitHub auto-close 回避ガイドライン」に従い、コマンド名と Issue 番号を分離し `#` 記号による近接参照を避けること（例: `case-close for Issue N`）。
+
 ### Step 12: 完了報告
 
 完了報告templateに従って出力。結果状態に応じた種別を選択:

--- a/src/opencode/skills/agentdev-conventional-commits/SKILL.md
+++ b/src/opencode/skills/agentdev-conventional-commits/SKILL.md
@@ -34,3 +34,27 @@ description: Generates commit messages following Conventional Commits v1.0.0 spe
 | `Feat:` → 大文字 | `feat:` 全て小文字 |
 | ピリオド `機能を追加。` | ピリオド省略 `機能を追加` |
 | 英語と日本語の混在 | 全て日本語で統一 |
+
+## GitHub auto-close 回避ガイドライン
+
+コミットメッセージに GitHub auto-close キーワード（`close`/`closes`/`closed`/`fix`/`fixes`/`fixed`/`resolve`/`resolves`/`resolved`）を含む複合語と `#N`（Issue 番号参照）を近接して記述する場合、GitHub が複合語内の部分文字列を auto-close キーワードとして誤認し、意図せず Issue をクローズするリスクがある。
+
+### リスク事例
+
+- `case-close` 等の "close" を含むコマンド名（複合語）と `#N` を括弧内で併存させた表記（例: `(case-close #1403)`）で、GitHub が "close" を auto-close キーワードとして認識し、直後の `#1403` をクローズ対象として解釈する
+- `disclose`/ `closed-loop` 等、"close" を含む他の複合語でも同様の誤認が発生し得る
+
+### 回避策
+
+コマンド名と Issue 番号を分離し、`#` 記号による Issue 参照を避ける:
+
+| 回避策 | 例 |
+|--------|-----|
+| コマンド名と番号を分離（`#` 省略） | `case-close for Epic 1403` |
+| 括弧内表記を避ける | `Epic 1403 の case-close` |
+
+括弧内にコマンド名 + Issue 番号を併記する必要がある場合は、複合語内に auto-close キーワードが含まれないか確認すること。
+
+### 意図的クローズ表記の運用維持
+
+本ガイドラインは「auto-close キーワードを含む複合語と `#N` の近接併存」のみを対象とする。意図的なクローズ表記（`fixes #123` 等）の運用は維持する。フッター参照形式（`Refs: #N`（参照）/ `Closes: #N`（クローズ））も従来通り使用可能である。


### PR DESCRIPTION
## 概要

Issue #1425 の実装。`agentdev-conventional-commits` skill に GitHub auto-close 回避ガイドラインを追加し、`case-close` command の commit message 生成ステップ（Step 11）に留意点を追記する。

コミットメッセージで "(case-close #N)" 等の括弧内コマンド名+issue番号表記を用いた際、GitHub が "close" を auto-close キーワードの部分文字列として認識し、意図せず Issue をクローズする事象（commit ecfd327a での Epic #1403 自動クローズ）への対応。

## 変更内容

### ACT-SKILL-001: `src/opencode/skills/agentdev-conventional-commits/SKILL.md`

「GitHub auto-close 回避ガイドライン」セクションを新規追加。以下を明記:

- **リスク事例**: `case-close` 等の "close" を含む複合語と `#N` の近接併存で GitHub が auto-close キーワードと誤認する旨。`disclose`/ `closed-loop` 等の他の複合語でも同様の誤認が発生し得る旨
- **回避策**: コマンド名と Issue 番号を分離し `#` 記号による Issue 参照を避ける（例: `case-close for Epic 1403`）
- **意図的クローズ表記の運用維持**: `fixes #123` 等の意図的クローズ表記、`Refs: #N`/ `Closes: #N` のフッター参照形式は従来通り使用可能

### ACT-CMD-001: `src/opencode/commands/agentdev/case-close.md`

Step 11（ドメイン状態永続化）に auto-close 回避の留意点を追記。本コマンド名 `case-close` が "close" を含む複合語である旨の注意喚起と、`agentdev-conventional-commits` skill のガイドラインへの参照を含む。

## 完了条件

- [x] `src/opencode/skills/agentdev-conventional-commits/SKILL.md` に auto-close 回避ガイドラインセクションが追加されていること（AG-001, ACT-SKILL-001）
- [x] 当該ガイドラインが「複合語内の部分文字列認識リスク」を明記していること（AG-001）
- [x] 当該ガイドラインが「# 省略による回避策」を明記していること（AG-001）
- [x] 当該ガイドラインが意図的クローズ表記（"fixes #123" 等）の運用維持を明記していること（AG-003）
- [x] `src/opencode/commands/agentdev/case-close.md` の commit message 生成ステップ（Step 11）に auto-close 回避の留意点が追記されていること（AG-002, ACT-CMD-001）
- [x] 上記留意点が `agentdev-conventional-commits` skill を参照していること（AG-002）

## テスト戦略

- **TS-001 (AG-001 / ACT-SKILL-001): pass** — SKILL.md にガイドラインセクションが存在し、3点（複合語内の部分文字列認識リスク、# 省略による回避策、意図的クローズ表記の運用維持）を含むことを確認
- **TS-002 (AG-002 / ACT-CMD-001): pass** — case-close.md Step 11 に留意点が記述され、`agentdev-conventional-commits` skill への参照と case-close コマンド名が "close" を含む複合語である旨の注意喚起を含むことを確認
- **TS-003 (AG-003): pass** — SKILL.md が意図的クローズ表記（`fixes #123` 等）の運用維持を明記していることを確認

## QG-3 (Implementation Deviation Gate)

**no-deviation** — 実装は Issue 完了条件に完全合致。スコープ拡大なし。REQ-0131 は case-open 判断により未更新（ACT-SKILL-001 単独で auto-close 回避が十分と判断）。本変更は docs_chore（ガイドライン追記）であり、SPEC/REQ への影響なし。

## Findings / Capture候補

（該当なし）

## SPEC確定候補

（該当なし）

## 備考

- work_type: docs_chore（ガイドライン追記）
- source RU: RU-0025（learning 由来、commit ecfd327a での Epic #1403 自動クローズ事象）
- case-close Step 3-1 にて extensions 整合性検査（IR-056、`check_extensions.ts` strict 実行）の実施を推奨。本 PR は `src/opencode/commands/agentdev/**/*.md` および `src/opencode/skills/agentdev-*/SKILL.md` を変更するため対象
