### PR TITLE
REQ-0161 検証自己参照の構造的到達不能解消（check_integrity.ts baseline-aware strict pass）(OU-001)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/baselines/ng-baseline.json
+++ b/.opencode/skills/repo-agentdev-integrity/baselines/ng-baseline.json
@@ -1,0 +1,273 @@
+{
+  "version": 1,
+  "rule_id": "NG-BASELINE",
+  "generated_at": "2026-07-05",
+  "entries": [
+    {
+      "category": "ADR",
+      "check": "accepted-adr-only-citation",
+      "file": "README.md",
+      "evidence": "ADR-0134",
+      "count": 1
+    },
+    {
+      "category": "ADR",
+      "check": "accepted-adr-only-citation",
+      "file": "docs/specs/integrity/rules/IR-058-distribution-untracked-skill-reference.md",
+      "evidence": "ADR-0134",
+      "count": 1
+    },
+    {
+      "category": "ADR",
+      "check": "accepted-adr-only-citation",
+      "file": "docs/specs/local/runtime-package-boundary.md",
+      "evidence": "ADR-0134",
+      "count": 1
+    },
+    {
+      "category": "Canonical",
+      "check": "abolished-skill-references",
+      "file": "docs/specs/integrity/rules/IR-021-retired-skill-reference-detection.md",
+      "evidence": "agentdev-workflow-reporting",
+      "count": 1
+    },
+    {
+      "category": "Canonical",
+      "check": "req-range-staleness",
+      "file": "docs/guides/project-docs-and-specs.md",
+      "evidence": "REQ-0101 から REQ-0158",
+      "count": 1
+    },
+    {
+      "category": "CanonicalConflict",
+      "check": "gh-direct-invocation",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gh pr view",
+      "count": 1
+    },
+    {
+      "category": "CanonicalConflict",
+      "check": "obsolete-spec-path",
+      "file": "docs/adr/ADR-0126.md",
+      "evidence": "これは上書き保護のアーキテクチャ不変量である。",
+      "count": 1
+    },
+    {
+      "category": "CanonicalConflict",
+      "check": "obsolete-spec-path",
+      "file": "docs/adr/ADR-0131.md",
+      "evidence": "- 変換プロンプト資産（transform/generate.md, review.md）が不要になる。",
+      "count": 1
+    },
+    {
+      "category": "CanonicalConflict",
+      "check": "obsolete-spec-path",
+      "file": "docs/adr/ADR-0131.md",
+      "evidence": "この場合、直接生成方式の変換プロンプト、全削除再生成、`generated_by` 上書き保護は不要になり、link mode（`.opencode/` 配下を src 配下へ接続）へ統一できる。",
+      "count": 3
+    },
+    {
+      "category": "CanonicalConflict",
+      "check": "obsolete-spec-path",
+      "file": "docs/adr/ADR-0131.md",
+      "evidence": "link mode 自体は可逆だが、現行契約（REQ-0141-007 直接生成、032 変換スクリプト不使用、033 全削除再生成）と変換プロンプト資産を破棄する点で、文書体系、運用モデルの根本変更であり、ADR で判断根拠を残さないと履歴が失われる。",
+      "count": 1
+    },
+    {
+      "category": "CanonicalConflict",
+      "check": "obsolete-spec-path",
+      "file": "docs/adr/ADR-0131.md",
+      "evidence": "`generated_by` 識別子による上書き保護とジャンクション環境での生成停止を安全制約として宣言した。",
+      "count": 1
+    },
+    {
+      "category": "CanonicalConflict",
+      "check": "obsolete-spec-path",
+      "file": "docs/guides/glossary.md",
+      "evidence": "| `generated_by` 識別子 | ADR-0126 時代のローカル版生成物に付与された識別情報。値は `local-opencode-transform`。link mode への移行後は付与されず、上書き保護も廃止された（ADR-0131 decision #5）。IR-046/048 は link mode 移行前の生成物が混在する環境向けの整合性検証語彙として残る |",
+      "count": 1
+    },
+    {
+      "category": "CanonicalConflict",
+      "check": "req-spec-boundary-violation",
+      "file": "docs/requirements/REQ-0108.md",
+      "evidence": "REQ-0108-268: docs-check 回帰テストの valid fixture は baseline 登録済みの既知違反の影響を受けず、安定して通過するテストデータ構成であること。既知違反と valid fixture の分離が不十分な場合はテストデータ構成を見直すこと（REQ-0108-055、REQ-0108-258 関連）",
+      "count": 1
+    },
+    {
+      "category": "CanonicalConflict",
+      "check": "req-spec-boundary-violation",
+      "file": "docs/requirements/REQ-0140.md",
+      "evidence": "REQ-0140-028: docs/requirements/REQ-*.md の要件行は操作主体（command 名、skill 名、ユーザー、システム）を明示すること。ただし enum 定義、派生ルール、システム側判断ルールなど主体明示が不要な場合はこの限りでないこと",
+      "count": 1
+    },
+    {
+      "category": "CanonicalConflict",
+      "check": "req-spec-boundary-violation",
+      "file": "docs/requirements/REQ-0144.md",
+      "evidence": "REQ-0144-009: システムは copyScripts 本採用環境下で fixture drift を自動検出する仕組みを提供すること",
+      "count": 1
+    },
+    {
+      "category": "CanonicalConflict",
+      "check": "req-spec-boundary-violation",
+      "file": "docs/requirements/REQ-0149.md",
+      "evidence": "REQ-0149-009: agentdev-gh-cli の WRITE 手続きは Windows 環境においてコンソールエンコーディング初期化（standard-procedures Section2 Step0）を必須前置すること。UTF-8 BOM なしファイルの編集結果の mojibake 化を排除すること",
+      "count": 1
+    },
+    {
+      "category": "CanonicalConflict",
+      "check": "req-spec-boundary-violation",
+      "file": "docs/requirements/REQ-0153.md",
+      "evidence": "REQ-0153-001: case-run は機械的テキスト置換または複数ディレクトリ横断の是正を含む PR について、置換対象パターンの再 grep 結果が 0 件であることを完了証拠とすること。ただし「0 件」は意味論的に正しい置換対象範囲（自然言語記述）での 0 件を指し、構造データ（YAML frontmatter、fenced code block 内字句等）への誤付与による 0 件は完了証拠として無効とする（PR #1334 事例）",
+      "count": 1
+    },
+    {
+      "category": "LifecycleBoundary",
+      "check": "retired-req-primary-ref",
+      "file": "docs/specs/commands/inspect-docs.md",
+      "evidence": "REQ-0115",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-adr-ref",
+      "file": "docs/specs/integrity/rules/IR-025-retired-adr-path-rule.md",
+      "evidence": "ADR-0000",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-adr-ref",
+      "file": "docs/specs/integrity/rules/IR-025-retired-adr-path-rule.md",
+      "evidence": "ADR-0099",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-file-link",
+      "file": "docs/specs/authoring/command-file-format.md",
+      "evidence": "../requirements/REQ-0143.md",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-file-link",
+      "file": "docs/specs/local/runtime-package-boundary.md",
+      "evidence": "../guides/consumer-project-setup.md",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-file-link",
+      "file": "docs/specs/quality/quality-gates.md",
+      "evidence": "../../src/opencode/skills/agentdev-quality-gates/SKILL.md",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-req-ref",
+      "file": "docs/specs/integrity/rules/IR-044-req-spec-boundary-violation-detection.md",
+      "evidence": "REQ-9001",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-req-ref",
+      "file": "docs/specs/integrity/rules/IR-044-req-spec-boundary-violation-detection.md",
+      "evidence": "REQ-9013",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-req-ref",
+      "file": "docs/specs/integrity/rules/IR-044-req-spec-boundary-violation-detection.md",
+      "evidence": "REQ-9005",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-req-ref",
+      "file": "docs/specs/integrity/rules/IR-044-req-spec-boundary-violation-detection.md",
+      "evidence": "REQ-9008",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-req-ref",
+      "file": "docs/specs/integrity/rules/IR-044-req-spec-boundary-violation-detection.md",
+      "evidence": "REQ-9006",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-req-ref",
+      "file": "docs/specs/integrity/rules/IR-044-req-spec-boundary-violation-detection.md",
+      "evidence": "REQ-9009",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-req-ref",
+      "file": "docs/specs/integrity/rules/IR-044-req-spec-boundary-violation-detection.md",
+      "evidence": "REQ-9011",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-req-ref",
+      "file": "docs/specs/integrity/rules/IR-044-req-spec-boundary-violation-detection.md",
+      "evidence": "REQ-9010",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "broken-req-ref",
+      "file": "docs/specs/integrity/rules/IR-044-req-spec-boundary-violation-detection.md",
+      "evidence": "REQ-9012",
+      "count": 1
+    },
+    {
+      "category": "LinkIntegrity",
+      "check": "retired-req-as-current",
+      "file": "docs/specs/commands/inspect-docs.md",
+      "evidence": "REQ-0115",
+      "count": 1
+    },
+    {
+      "category": "RuntimeReference",
+      "check": "runtime-unresolved-reference",
+      "file": "src/opencode/commands/agentdev/case-open.md",
+      "evidence": "src/opencode/",
+      "count": 1
+    },
+    {
+      "category": "RuntimeReference",
+      "check": "runtime-unresolved-reference",
+      "file": "src/opencode/commands/agentdev/inspect-extensions.md",
+      "evidence": "src/opencode/",
+      "count": 3
+    },
+    {
+      "category": "integrity-rule-gap",
+      "check": "skill-category-gap",
+      "file": ".opencode/skills/repo-agentdev-integrity/SKILL.md",
+      "evidence": "Obsolete spec path",
+      "count": 1
+    },
+    {
+      "category": "integrity-rule-gap",
+      "check": "skill-category-gap",
+      "file": ".opencode/skills/repo-agentdev-integrity/SKILL.md",
+      "evidence": "Distribution reference boundary",
+      "count": 1
+    },
+    {
+      "category": "integrity-rule-gap",
+      "check": "skill-category-gap",
+      "file": ".opencode/skills/repo-agentdev-integrity/SKILL.md",
+      "evidence": "Targeted docs guard",
+      "count": 1
+    }
+  ]
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
@@ -63,6 +63,69 @@ const EXTENSIONS_COMMANDS_DIR = ".agentdev/extensions/commands";
 const EXTENSIONS_SKILLS_DIR = ".agentdev/extensions/skills";
 const LEGACY_DOC_INPUTS_DIR = ".agentdev/doc-inputs";
 
+// REQ-0161-005: baseline-aware strict pass. Mirrors check_integrity.ts NG
+// baseline: baseline-known strict failures are demoted to warning (report-only),
+// only strict failures exceeding the baseline cause ok=false. The baseline is
+// regenerated explicitly via --update-ng-baseline.
+const NG_BASELINE_PATH = path.join(
+  ".opencode",
+  "skills",
+  "repo-agentdev-integrity",
+  "baselines",
+  "check-extensions-baseline.json",
+);
+
+interface ExtensionsNgBaselineEntry {
+  check: number;
+  check_name: string;
+  file: string | null;
+  message: string | null;
+  count: number;
+}
+
+interface ExtensionsNgBaseline {
+  version: number;
+  rule_id: "CHECK-EXTENSIONS-NG-BASELINE";
+  generated_at: string;
+  entries: ExtensionsNgBaselineEntry[];
+}
+
+function extBaselineKey(
+  check: number,
+  checkName: string,
+  file: string | null,
+  message: string | null,
+): string {
+  return `${check}\t${checkName}\t${file ?? ""}\t${message ?? ""}`;
+}
+
+function loadExtensionsNgBaseline(
+  repoRoot: string,
+): ExtensionsNgBaseline | null {
+  const baselineAbs = path.join(repoRoot, NG_BASELINE_PATH);
+  const content = readText(baselineAbs);
+  if (!content) return null;
+  try {
+    return JSON.parse(content) as ExtensionsNgBaseline;
+  } catch {
+    return null;
+  }
+}
+
+function writeExtensionsNgBaseline(
+  repoRoot: string,
+  baseline: ExtensionsNgBaseline,
+): void {
+  const baselineAbs = path.join(repoRoot, NG_BASELINE_PATH);
+  const dir = path.dirname(baselineAbs);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    baselineAbs,
+    JSON.stringify(baseline, null, 2) + "\n",
+    "utf-8",
+  );
+}
+
 // Heuristic override-intent phrases (check #8). Extension is additive-only.
 const OVERRIDE_PHRASES = [
   "置き換える",
@@ -585,8 +648,42 @@ export function checkExtensions(repoRoot: string): CheckReport {
     }
 
     const strictFailures = failures.filter((f) => f.severity === "strict");
+    // REQ-0161-005: baseline-aware pass. Demote baseline-known strict failures
+    // to warning so only new (delta) strict failures cause ok=false.
+    const baseline = loadExtensionsNgBaseline(repoRoot);
+    let newStrictCount = strictFailures.length;
+    if (baseline) {
+      const baselineIndex = new Map<string, number>();
+      for (const entry of baseline.entries) {
+        const key = extBaselineKey(
+          entry.check,
+          entry.check_name,
+          entry.file,
+          entry.message,
+        );
+        baselineIndex.set(key, entry.count);
+      }
+      const emitted = new Map<string, number>();
+      for (const f of failures) {
+        if (f.severity !== "strict") continue;
+        const key = extBaselineKey(
+          f.check,
+          f.check_name,
+          f.file ?? null,
+          f.message ?? null,
+        );
+        const baselineCount = baselineIndex.get(key) ?? 0;
+        const n = emitted.get(key) ?? 0;
+        emitted.set(key, n + 1);
+        if (n < baselineCount) {
+          f.severity = "warning";
+          f.message = `[baseline-known] ${f.message} (check-extensions baseline, not yet cleaned)`;
+        }
+      }
+      newStrictCount = failures.filter((f) => f.severity === "strict").length;
+    }
     return {
-      ok: strictFailures.length === 0,
+      ok: newStrictCount === 0,
       failures,
       stats,
     };
@@ -595,11 +692,54 @@ export function checkExtensions(repoRoot: string): CheckReport {
   }
 }
 
+function updateExtensionsNgBaseline(
+  repoRoot: string,
+  failures: CheckFailure[],
+): void {
+  const summary = new Map<string, ExtensionsNgBaselineEntry>();
+  for (const f of failures) {
+    const key = extBaselineKey(
+      f.check,
+      f.check_name,
+      f.file ?? null,
+      f.message ?? null,
+    );
+    const existing = summary.get(key);
+    if (existing) {
+      existing.count++;
+    } else {
+      summary.set(key, {
+        check: f.check,
+        check_name: f.check_name,
+        file: f.file ?? null,
+        message: f.message ?? null,
+        count: 1,
+      });
+    }
+  }
+  const baseline: ExtensionsNgBaseline = {
+    version: 1,
+    rule_id: "CHECK-EXTENSIONS-NG-BASELINE",
+    generated_at: new Date().toISOString().slice(0, 10),
+    entries: [...summary.values()].sort((a, b) => a.check - b.check),
+  };
+  writeExtensionsNgBaseline(repoRoot, baseline);
+  console.error(
+    `[check_extensions] NG baseline regenerated: ${baseline.entries.length} entries (${failures.length} total failures).`,
+  );
+}
+
 if (require.main === module) {
   const args = process.argv.slice(2);
-  const repoRoot = args[0] || process.cwd();
   const json = args.includes("--json");
+  const updateBaseline = args.includes("--update-ng-baseline");
+  const positional = args.filter((a) => !a.startsWith("--"));
+  const repoRoot = positional[0] || process.cwd();
   const report = checkExtensions(repoRoot);
+  if (updateBaseline) {
+    updateExtensionsNgBaseline(repoRoot, report.failures);
+    process.exit(0);
+  }
   if (json) {
     process.stdout.write(JSON.stringify(report, null, 2) + "\n");
   } else {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -28,7 +28,7 @@ import {
 const SCRIPT_NAME = "check_integrity.ts";
 const DESCRIPTION = "AgentDevFlow artifact integrity validator";
 const USAGE =
-  "bun run check_integrity.ts [--help] [--json] [--dry-run] [--classification] [--update-ir055-baseline]";
+  "bun run check_integrity.ts [--help] [--json] [--dry-run] [--classification] [--update-ir055-baseline] [--update-ng-baseline]";
 
 const path = require("path") as typeof import("path");
 const fs = require("fs") as typeof import("fs");
@@ -441,6 +441,33 @@ function checkReqReadmeIndexSync(reqDir: string, root: string): CheckResult[] {
   return results;
 }
 
+// REQ-0161-004: deletion self-reference exclusion.
+// A REQ that mandates deletion of specific legacy IDs (REQ-NNNN / ADR-NNNN)
+// legitimately mentions those IDs in its requirement rows — the REQ describes
+// what it deletes. Such mentions are self-references, not dangling pointers.
+// Without this exclusion, the deletion requirement becomes structurally
+// unreachable: the REQ can never pass integrity because it names its own
+// deletion targets (broken-req-ref / broken-adr-ref / adr-req-crossref).
+// Entries are keyed by repo-relative source path and the deleted IDs.
+const DELETION_SELF_REFERENCE_EXCLUSIONS: ReadonlyArray<{
+  sourceReq: string;
+  deletedIds: string[];
+}> = [
+  {
+    sourceReq: "docs/requirements/REQ-0161.md",
+    deletedIds: ["ADR-0133", "REQ-0157"],
+  },
+];
+
+function isDeletionSelfReference(
+  sourceRelPath: string,
+  refId: string,
+): boolean {
+  return DELETION_SELF_REFERENCE_EXCLUSIONS.some(
+    (e) => e.sourceReq === sourceRelPath && e.deletedIds.includes(refId),
+  );
+}
+
 function checkAdrReqCrossReference(
   reqDir: string,
   adrDir: string,
@@ -470,9 +497,13 @@ function checkAdrReqCrossReference(
     const fullPath = path.join(reqDir, file);
     const content = readText(fullPath);
     if (!content) continue;
+    const relPath = resolveRelative(fullPath, root);
     const references = content.match(/\bADR-\d{4}\b/g) || [];
     const uniqueRefs = [...new Set(references)];
     for (const ref of uniqueRefs) {
+      // REQ-0161-004: skip deletion self-references (REQ describes its own
+      // deletion targets; see DELETION_SELF_REFERENCE_EXCLUSIONS).
+      if (isDeletionSelfReference(relPath, ref)) continue;
       if (!allAdrIds.has(ref)) {
         results.push(
           ng(
@@ -1522,6 +1553,8 @@ function checkLinkIntegrity(root: string): CheckResult[] {
     for (const ref of uniqueReqRefs) {
       // REQ-0108-194: Skip template-like content with placeholders or workflow markers
       if (isTemplateLike) break;
+      // REQ-0161-004: skip deletion self-references
+      if (isDeletionSelfReference(relPath, ref)) continue;
       const activePath = path.join(root, "docs", "requirements", `${ref}.md`);
       const retiredPath = path.join(
         root,
@@ -1556,6 +1589,8 @@ function checkLinkIntegrity(root: string): CheckResult[] {
     for (const ref of uniqueAdrRefs) {
       // REQ-0108-194: Skip template-like content with placeholders or workflow markers
       if (isTemplateLike) break;
+      // REQ-0161-004: skip deletion self-references
+      if (isDeletionSelfReference(relPath, ref)) continue;
       const adrPath = path.join(root, "docs", "adr", `${ref}.md`);
       const retiredAdrPath = path.join(root, "docs", "adr", "retired", `${ref}.md`);
       if (!fs.existsSync(adrPath) && !fs.existsSync(retiredAdrPath)) {
@@ -7053,6 +7088,152 @@ function updateIr055Baseline(root: string): void {
   );
 }
 
+// ===== NG baseline (REQ-0161-005): baseline-aware strict pass =====
+// The strict pass criterion ("exit 0 only when zero NG") is structurally
+// unreachable while a known baseline of pre-existing NGs exists. REQ-0161-005
+// redefines the pass criterion as delta-aware: baseline-known NGs are demoted
+// to info (report-only), only NGs exceeding the baseline (new, caused by the
+// change under review) cause failure. The baseline is regenerated explicitly
+// via --update-ng-baseline; it is NOT auto-updated on every run.
+//
+// Bucket key: `${category}\t${check}\t${file||''}\t${evidence||''}`. A bucket
+// with current count <= baseline count is fully baseline-known.
+
+const NG_BASELINE_PATH = path.join(
+  ".opencode",
+  "skills",
+  "repo-agentdev-integrity",
+  "baselines",
+  "ng-baseline.json",
+);
+
+interface NgBaselineEntry {
+  category: string;
+  check: string;
+  file: string | null;
+  evidence: string | null;
+  count: number;
+}
+
+interface NgBaseline {
+  version: number;
+  rule_id: "NG-BASELINE";
+  generated_at: string;
+  entries: NgBaselineEntry[];
+}
+
+function ngBaselineKey(
+  category: string,
+  check: string,
+  file: string | null,
+  evidence: string | null,
+): string {
+  return `${category}\t${check}\t${file ?? ""}\t${evidence ?? ""}`;
+}
+
+function loadNgBaseline(root: string): NgBaseline | null {
+  const baselineAbs = path.join(root, NG_BASELINE_PATH);
+  const content = readText(baselineAbs);
+  if (!content) return null;
+  try {
+    return JSON.parse(content) as NgBaseline;
+  } catch {
+    return null;
+  }
+}
+
+function writeNgBaseline(root: string, baseline: NgBaseline): void {
+  const baselineAbs = path.join(root, NG_BASELINE_PATH);
+  const dir = path.dirname(baselineAbs);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(baselineAbs, JSON.stringify(baseline, null, 2) + "\n", "utf-8");
+}
+
+function summarizeNgResults(
+  results: CheckResult[],
+): Map<string, NgBaselineEntry> {
+  const summary = new Map<string, NgBaselineEntry>();
+  for (const r of results) {
+    // REQ-0161-005: baseline covers both ng and warning levels so the strict
+    // pass criterion (exit 0) is reachable while pre-existing findings remain.
+    if (r.level !== "ng" && r.level !== "warning") continue;
+    const key = ngBaselineKey(r.category, r.check, r.file ?? null, r.evidence ?? null);
+    const existing = summary.get(key);
+    if (existing) {
+      existing.count++;
+    } else {
+      summary.set(key, {
+        category: r.category,
+        check: r.check,
+        file: r.file ?? null,
+        evidence: r.evidence ?? null,
+        count: 1,
+      });
+    }
+  }
+  return summary;
+}
+
+// Demote baseline-known ng/warning to info so the exit code reflects only the
+// delta (new findings) from the baseline. Returns counts for reporting.
+function applyNgBaseline(
+  results: CheckResult[],
+  baseline: NgBaseline,
+): { demotedToInfo: number; newNg: number } {
+  const baselineIndex = new Map<string, number>();
+  for (const entry of baseline.entries) {
+    const key = ngBaselineKey(entry.category, entry.check, entry.file, entry.evidence);
+    baselineIndex.set(key, entry.count);
+  }
+
+  const currentSummary = summarizeNgResults(results);
+  const newBuckets = new Set<string>();
+  for (const [key, entry] of currentSummary) {
+    const baselineCount = baselineIndex.get(key) ?? 0;
+    if (entry.count > baselineCount) newBuckets.add(key);
+  }
+
+  const emittedPerBucket = new Map<string, number>();
+  let demotedToInfo = 0;
+  let newNg = 0;
+
+  for (const r of results) {
+    if (r.level !== "ng" && r.level !== "warning") continue;
+    const key = ngBaselineKey(r.category, r.check, r.file ?? null, r.evidence ?? null);
+    const baselineCount = baselineIndex.get(key) ?? 0;
+    const emitted = emittedPerBucket.get(key) ?? 0;
+    emittedPerBucket.set(key, emitted + 1);
+    if (emitted < baselineCount && !newBuckets.has(key)) {
+      r.level = "info";
+      r.finding_level = "observation";
+      r.message = `[baseline-known] ${r.message} (NG baseline, not yet cleaned)`;
+      demotedToInfo++;
+    } else {
+      newNg++;
+    }
+  }
+  return { demotedToInfo, newNg };
+}
+
+function updateNgBaseline(root: string, results: CheckResult[]): void {
+  const summary = summarizeNgResults(results);
+  const baseline: NgBaseline = {
+    version: 1,
+    rule_id: "NG-BASELINE",
+    generated_at: new Date().toISOString().slice(0, 10),
+    entries: [...summary.values()].sort((a, b) => {
+      if (a.category !== b.category) return a.category < b.category ? -1 : 1;
+      if (a.check !== b.check) return a.check < b.check ? -1 : 1;
+      if ((a.file ?? "") !== (b.file ?? "")) return (a.file ?? "") < (b.file ?? "") ? -1 : 1;
+      return 0;
+    }),
+  };
+  writeNgBaseline(root, baseline);
+  console.error(
+    `[integrity] NG baseline regenerated: ${baseline.entries.length} entries (${results.filter((r) => r.level === "ng").length} total NG).`,
+  );
+}
+
 // ===== IR-057: obsolete-spec-path-after-domain-split (REQ-0158-002) =====
 // Detects残留する旧SPEC直下パス参照 (`docs/specs/<name>.md`) と link mode 統一
 // (ADR-0131) に伴う廃止語彙 (`generation-flow.md`, `transform/`, `local-opencode-transform`,
@@ -7721,6 +7902,20 @@ async function main(): Promise<void> {
 
   const processed = processResults(results);
 
+  // REQ-0161-005: baseline-aware strict pass. When --update-ng-baseline is
+  // requested, snapshot the current NG set and exit. Otherwise, demote
+  // baseline-known NGs to info so the exit code reflects only the delta.
+  if (args.includes("--update-ng-baseline")) {
+    updateNgBaseline(root, processed);
+    process.exit(EXIT_OK);
+  }
+
+  const ngBaseline = loadNgBaseline(root);
+  let ngBaselineInfo: { demotedToInfo: number; newNg: number } | null = null;
+  if (ngBaseline) {
+    ngBaselineInfo = applyNgBaseline(processed, ngBaseline);
+  }
+
   const summary = computeSummary(processed);
 
   const report: IntegrityReport = {
@@ -7739,6 +7934,11 @@ async function main(): Promise<void> {
 
   const reportPath = writeReportFile(root, report);
   console.error(`Report written to: ${reportPath}`);
+  if (ngBaselineInfo) {
+    console.error(
+      `[integrity] NG baseline applied: ${ngBaselineInfo.demotedToInfo} baseline-known (demoted to info), ${ngBaselineInfo.newNg} new NG (delta).`,
+    );
+  }
 
   const exitCode = determineExitCode(summary);
   process.exit(exitCode);

--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
@@ -122,6 +122,7 @@ OPTIONS:
   --classification  Enable document classification policy checks (REQ-0108-196)
   --root <path>     Explicit repository root (REQ-0145-014: worktree/CI support)
   --update-ir055-baseline  Regenerate IR-055 baseline file from current violations
+  --update-ng-baseline     Regenerate NG baseline file from current NG set (REQ-0161-005)
 
 EXIT CODES:
   0  No issues found


### PR DESCRIPTION
## 概要

REQ-0161-004/005 の構造的到達不能を解消する。要件文書 REQ-0161.md 自身が削除対象ID（ADR-0133/REQ-0157）をリテラル含むことによる自己参照、README 過剰ヒットを除外条件として検証ロジックに実装する。また `check_integrity.ts` / `check_extensions.ts` の strict pass 基準を baseline-aware に再定義し、exit 0 到達不能性を解消する。

Refs: #1444
Parent: #1443

## 対象範囲

### OU-001: REQ-0161 UPDATE（ACT-REQ-001）

- REQ-0161-004: 完了条件に自己参照除外の修飾を追加。`rg "ADR-0133\|REQ-0157\|project-doc-inputs\|config\.yaml" docs/` が検査対象ファイル自身の記述を除外した結果 0件となるよう、検証ロジック（`DELETION_SELF_REFERENCE_EXCLUSIONS` + `isDeletionSelfReference`）を実装。
- REQ-0161-005: strict pass 基準を baseline-aware に再定義。exit 0 ではなく「当該変更起因の NG/warning 増加なし、かつ対象NG（broken-req-ref/broken-adr-ref/adr-req-crossref の REQ-0161 由来3件）解消」を pass 基準として実装。

## 実装内容

### check_integrity.ts

1. **自己参照除外ロジック（REQ-0161-004）**: `DELETION_SELF_REFERENCE_EXCLUSIONS` データ構造と `isDeletionSelfReference()` ヘルパーを追加。REQ-0161.md が ADR-0133/REQ-0157 を参照する場合、それらは削除対象を記述する自己参照であり broken reference として扱わない。`checkAdrReqCrossReference`、`checkLinkIntegrity`（broken-req-ref/broken-adr-ref ループ）に適用。
2. **NG baseline 機構（REQ-0161-005）**: IR-055 baseline パターンを一般化。`baselines/ng-baseline.json` + `--update-ng-baseline` フラグ + `applyNgBaseline()`（baseline-known NG/warning を info に格下げ）。exit code は delta（新規 NG/warning）のみで判定。

### check_extensions.ts

3. **baseline-aware strict pass（REQ-0161-005）**: `checkExtensions()` に baseline 適用ロジックを追加。baseline-known strict failure を warning に格下げ、`ok` は新規 strict failure のみで判定。`--update-ng-baseline` フラグ対応。

### cli_utils.ts

4. `printHelp` に `--update-ng-baseline` オプション追記。

## 検証結果

### TS-001（OU-001: REQ-0161 検証自己参照解消）

- **verification**: REQ-0161.md 自身の存在が検証結果に影響しないことを確認。`check_integrity.ts` / `check_extensions.ts` の baseline-aware strict pass 実装を確認。
- **pass_criteria**: REQ-0161-004/005 の完了条件が、REQ-0161.md 自身の存在に関わらず客観的に判定可能であること。
- **結果**: **PASS**
  - REQ-0161 由来3件の NG（adr-req-crossref / broken-req-ref / broken-adr-ref）が自己参照除外により 0件化（34→31 NG、3件解消）
  - check_integrity.ts: baseline 適用後 0 new NG → exit 0 到達可能
  - check_extensions.ts: ok=true, exit 0（baseline 機構実装済み、現在 0 failure のため baseline ファイル未生成）
  - テスト: check_integrity.test.ts 68 pass / 0 fail、check_extensions.test.ts 2 pass / 0 fail

### 完了条件対応

- [x] REQ-0161-004: `rg "ADR-0133\|REQ-0157\|project-doc-inputs\|config\.yaml" docs/` が、検査対象ファイル自身の記述を除外した結果 0件であること → check_integrity.ts に自己参照除外ロジック実装（REQ-0161.md 由来の broken-req-ref/broken-adr-ref/adr-req-crossref を 0件化）
- [x] `.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts` に baseline-aware strict pass 基準が実装されていること（REQ-0161-005）
- [x] `check_integrity.ts` が REQ-0161 由来3件の解消を pass 条件に含めること（REQ-0161-005）→ 自己参照除外で3件を 0件化
- [x] `.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts` に同一の baseline-aware strict pass 基準が実装されていること（REQ-0161-005）
- [x] 既存 baseline（参考: 56件）が変更起因ではないため pass 判定の対象外として扱われていること（REQ-0161-005）→ ng-baseline.json（38エントリ）で既存 NG/warning を baseline-known 扱い

## Findings / Capture候補

### stale-reference

Step 5-3 QG-3 前置 staleness check で検出した差異（REQ-0130-034 / G33-G35）:

- **検査結果件数**: Issue #1444 本文は baseline NG を「56件」と記載。現行 main（commit 08064529）での実測値は **34件**（worktree、自己参照除外前）。差異あり。件数は変動しやすい実測値スナップショットのため、差異の有無のみを判定材料とする（REQ）。原因は前工程での一部 NG 解消と推定されるが、Issue 本文の更新は case-update の責務であるため本 PR では単独書き換えしない。case-update への連携を示す。

## SPEC確定候補

なし。実装は既存 IR-055 baseline パターンの一般化であり、新しい SPEC レベルの仕様詳細は発見されなかった。

## 補足

- worktree: `.worktrees/1444-refactor`、branch: `refactor/issue-1444`（case-close で削除予定）
- baseline ファイル `ng-baseline.json` は既存 `ir-055-baseline.json` と同様に git 管理対象（参照スナップショット）。`--update-ng-baseline` で明示更新。
- check_extensions.ts は現在 0 failure のため baseline ファイル未生成（baseline 機構は実装済み、failure 発生時に `--update-ng-baseline` で生成可能）。
