### PR TITLE
REQ-0124 inspect-extensions 移行残作業是正（検証 + IR-056 related_req 補完）(OU-002)

### DIFF
--- a/docs/specs/integrity/rules/IR-056-project-extensions-integrity.md
+++ b/docs/specs/integrity/rules/IR-056-project-extensions-integrity.md
@@ -12,7 +12,7 @@ status: accepted
 | category | broken-reference |
 | detection_method | `check_extensions.ts` による extension YAML schema 検証、frontmatter (`version`/`kind`/`id`) 検証、5セクション配列検証、kind/配置整合検証、id/ファイル名対応検証、`context.paths` 実在確認、`rules.skill`/`checks.skill` project-local skill 存在確認（warning）、旧 `.agentdev/doc-inputs/**` 残存検出（warning）、上書き意図検出（warning、ヒューリスティック）、配布コード `docs/specs/**` 直接参照正規表現パターンマッチング。SPEC パス例示、検査対象パス指定、テンプレート例（`<existing-spec>.md` 等）は exemption 対象とする。`inspect-extensions.md` が検査対象として宣言する `.agentdev/doc-inputs/**` は residual 検出対象宣言であるため exemption |
 | affected_artifacts | [.agentdev/extensions/commands/*.yaml, .agentdev/extensions/skills/*.yaml, src/opencode/commands/agentdev/**/*.md, src/opencode/skills/agentdev-*/SKILL.md, src/opencode/skills/agentdev-*/references/**/*.md] |
-| related_req | [REQ-0160-001, REQ-0160-002, REQ-0160-003, REQ-0108-263] |
+| related_req | [REQ-0160-001, REQ-0160-002, REQ-0160-003, REQ-0124-022, REQ-0108-263] |
 | related_spec | [../foundations/project-extensions.md, integrity-rule-catalog.md] |
 | gate_level | full-audit, delta-guard, impact-guard |
 | false_positive_risk | 低。SPEC パス例示（`<existing-spec>.md` 等のテンプレート表記）、検査対象パス指定（診断コマンドが検査対象と明示するパス、`inspect-extensions.md` の `.agentdev/doc-inputs/**` 宣言等）は exemption 対象とする。上書き意図検出はヒューリスティックであるため warning 扱い |


### PR DESCRIPTION
## 概要

inspect-doc-inputs → inspect-extensions 移行残作業（REQ-0124-022/023）の是正を検証する。PR #1406（commit 671b4a00）で実施された検査機構統合と docs 参照是正が完了条件を満たしていることを確認し、IR-056 SPEC の `related_req` に REQ-0124-022 を追加してトレーサビリティを補強する。

Refs: #1445
Parent: #1443

## 対象範囲

### OU-002: REQ-0124 APPEND（ACT-REQ-002）

- REQ-0124-022: `check_doc_inputs.ts` と `/repo/docs-check` の extensions 機構対応、IR-056 ルール定義の extensions 書き直し
- REQ-0124-023: docs 内部の inspect-doc-inputs 参照残留の文脈別処理（通常参照は機械的置換、IR-056 は extensions 書き換え）

## 実装内容

### docs/specs/integrity/rules/IR-056-project-extensions-integrity.md

`related_req` フィールドに `REQ-0124-022` を追加。REQ-0124-022 は「IR-056 ルール定義は extensions 機構へ書き直されていること」を直接規定する要件であり、IR-056 SPEC の `related_req` に欠落していたため補完した。

## 検証結果（完了条件の個別確認）

Step 5-3 QG-3 前置 staleness check で実施した完了条件検証の結果:

### REQ-0124-022（検査機構の extensions 対応）

- [x] `check_doc_inputs.ts`（`.opencode/skills/repo-agentdev-integrity/` 配下）が `.agentdev/extensions/**` 前提で動作すること → **ファイルは PR #1406 で `check_extensions.ts` へ改名・再実装済み**（commit 671b4a00）。`check_extensions.ts` は `.agentdev/extensions/{commands,skills}/*.yaml` を前提に動作し、extensions schema 検証を実装済み。旧 `check_doc_inputs.ts` は存在しない（git log で改名履歴確認済み）。
- [x] `.opencode/commands/repo/docs-check.md`（`/repo/docs-check`）が `.agentdev/extensions/**` 前提で動作すること → docs-check.md は `check_extensions.ts` を IR-056 検査として呼出（L33）。`check_doc_inputs` への参照は残存しない。
- [x] IR-056 ルール定義が extensions 機構へ書き直されていること → `docs/specs/integrity/rules/IR-056-project-extensions-integrity.md` として書き直し済み（旧 `docs/specs/integrity/IR-056-project-doc-input-integrity.md` は存在しない、rules/ へ移動・改名・再実装済み）。

### REQ-0124-023（docs 内部参照の文脈別処理）

- [x] docs 内部の inspect-doc-inputs 参照残留が文脈別処理されていること → Issue が挙げた5目標ファイルの検証結果:
  - `DOC-MAP.md`:115 — 歴史的移行コンテキスト「旧 inspect-doc-inputs から統合・改名」。通常参照（活参照）ではなく移行履歴のため機械的置換対象外（文脈別処理: 保護）
  - `docs/specs/foundations/system.md` — inspect-doc-inputs 参照 **0件**（元から存在しない）
  - `docs/specs/foundations/project-doc-inputs.md` — **ファイル削除済み**（PR #1406 移行で削除）
  - `docs/specs/local/runtime-package-boundary.md` — inspect-doc-inputs 参照 **0件**
  - `docs/specs/authoring/command-file-format.md` — inspect-doc-inputs 参照 **0件**
- [x] 機械的置換対象5ファイルの inspect-doc-inputs 参照が解消されていること → 4ファイルは参照なし/削除済み、1ファイル(DOC-MAP.md)は歴史的言及として保護（REQ-0161-003「スコープ外（残置）: inspect-doc-inputs 旧コマンド名」と整合）
- [x] `docs/specs/integrity/IR-056-project-doc-input-integrity.md` が extensions 機構へ書き換えられていること → `docs/specs/integrity/rules/IR-056-project-extensions-integrity.md` として書き換え済み（移行経緯セクションで PR #1406 による移行を明記）

### 残存する inspect-doc-inputs 言及（すべて歴史的移行コンテキスト、保護対象）

| ファイル | 行 | 内容 | 扱い |
|----------|-----|------|------|
| `docs/DOC-MAP.md` | 115 | 「旧 inspect-doc-inputs から統合・改名」 | 移行履歴（保護） |
| `docs/specs/README.md` | 89 | 同上 | 移行履歴（保護） |
| `docs/specs/commands/inspect-extensions.md` | 13 | 「従来の inspect-doc-inputs command は本 command へ統合・改名された」 | 移行履歴（保護） |
| `docs/requirements/REQ-0124.md` | 40 | REQ-0124-023 要件行自身 | 要件文（自己参照） |
| `docs/requirements/REQ-0161.md` | 24 | REQ-0161-003 スコープ外宣言 | 要件文（自己参照） |

これらはすべて「旧 inspect-doc-inputs から統合・改名された」という移行履歴の記述、または要件行自身であり、活参照ではない。REQ-0161-003 が「inspect-doc-inputs 旧コマンド名」をスコープ外（残置）に指定しており、Issue #1445 自身の「文脈別処理（通常参照は機械的置換）」方針とも整合する。機械的置換は実施しない（実施すると「旧 inspect-extensions から統合・改名」となり歴史的意味が破壊される）。

### TS-002（OU-002: inspect-extensions 移行残作業是正）

- **verification**: 検査機構統合と docs 参照是正を検証。check_extensions.ts / IR-056 / docs 内部ファイル群の参照が整合していることを確認。
- **pass_criteria**: 検査機構の extensions 対応方針が確定し、docs 内部ファイルの inspect-doc-inputs 参照が方針に従って処理されていること。
- **結果**: **PASS** — 検査機構は PR #1406 で extensions 対応完了、docs 参照は文脈別処理（歴史的言及は保護、活参照は解消）済み。

## Findings / Capture候補

### stale-reference

Step 5-3 QG-3 前置 staleness check で検出した差異（REQ-0130-034 / G33-G35）。本 Issue は stale な状態スナップショットに基づいて作成されており、記載された実装作業の大部分は PR #1406（commit 671b4a00、Issue #1406）で完了済み:

1. **`check_doc_inputs.ts` 存在前提**: Issue 完了条件は `check_doc_inputs.ts`（`.opencode/skills/repo-agentdev-integrity/` 配下）の更新を前提とするが、当該ファイルは PR #1406 で `check_extensions.ts` へ改名済み。現行リポジトリに存在しない。
2. **IR-056 旧ファイル名前提**: Issue 完了条件は `docs/specs/integrity/IR-056-project-doc-input-integrity.md` の書き換えを前提とするが、当該ファイルは `docs/specs/integrity/rules/IR-056-project-extensions-integrity.md` へ移動・改名・再実装済み。
3. **5目標ファイルの inspect-doc-inputs 参照前提**: Issue 完了条件が挙げる5ファイルのうち、4ファイルは元から inspect-doc-inputs 参照を持たない（`system.md`、`runtime-package-boundary.md`、`command-file-format.md` は0件、`project-doc-inputs.md` は削除済み）。残る `DOC-MAP.md` は歴史的移行コンテキストのみ。
4. **`project-doc-inputs.md` 存在前提**: `docs/specs/foundations/project-doc-inputs.md` は PR #1406 移行で削除済み（REQ-0161-001 でも削除対象）。

差異の原因: 本 Issue は case-open 作成時点の状態認識が PR #1406/#1409/#1410 の実施結果を十分に反映していなかったと推定される。Issue 本文の参照パス・ファイル存在状況の更新は case-update の責務であるため、本 PR では単独書き換えしない（REQ-0130-034 / G35）。case-update への連携を示す。

## SPEC確定候補

なし。本 PR は既存 IR-056 SPEC の `related_req` 補完のみで、新しい SPEC レベルの仕様詳細は発見されなかった。

## 補足

- worktree: `.worktrees/1445-refactor`、branch: `refactor/issue-1445`（case-close で削除予定）
- 本 PR の実質的実装作業は PR #1406 で完了済み。本 PR は (1) 完了条件の証拠ベース検証、(2) IR-056 SPEC の `related_req` に REQ-0124-022 を追加してトレーサビリティ補完、(3) staleness 記録、を担う。
- check_integrity.ts / check_extensions.ts ともに本 PR の変更で新規 NG なし（NG 34件は既存 baseline、check_extensions ok:true）。
