### PR TITLE
feat(integrity): REQ-0145-015 検出ルール説明文除外パターンの SPEC 明文化

### DIFF
--- a/docs/specs/integrity/integrity-contracts.md
+++ b/docs/specs/integrity/integrity-contracts.md
@@ -197,7 +197,7 @@ docs-check は baseline 運用（IR-055）と path exemption（`IR055_EXEMPT_PAT
 
 | 除外種別 | 対象 | 根拠 |
 |----------|------|------|
-| ルール自己参照 | `vocabulary-registry.md`、`integrity-rule-catalog.md`、`integrity-contracts.md`、`rules/IR-055-*.md`、`baselines/ir-055-baseline.json` | 検出ルール自体の記述、正規語彙の対照表はルールを説明するためにパターンを列挙する。これを検出するとルール自身が NG となるため自己参照除外とする |
+| ルール自己参照 | `vocabulary-registry.md`、`integrity-rule-catalog.md`、`integrity-contracts.md`、`rules/IR-*.md`（全IRルールファイル、REQ-0145-015）、`baselines/ir-055-baseline.json` | 検出ルール自体の記述、正規語彙の対照表はルールを説明するためにパターンを列挙する。これを検出するとルール自身が NG となるため自己参照除外とする。個別 IR ルールファイル（`rules/IR-*.md`）は検出ルールの説明文であり、例示用 ID、廃止 skill 例、廃止 ADR 番号帯例示は自己参照的な説明資料であるため、全検出関数（broken-reference, abolished-skill-references, obsolete-spec-path 等）の検出スコープから除外する（REQ-0145-015） |
 | コードブロック内部 | ` ``` ` で囲まれた範囲 | 例示、パターン説明は検出対象外（integrity-rule-catalog.md「対象ファイル設計」準拠） |
 | template placeholder | `{xxx}` 形式のプレースホルダーを含む行 | プレースホルダーは実参照ではない |
 | retired 領域 | `docs/requirements/retired/**`、`docs/adr/retired/**` | 履歴参照用。旧表記を履歴として残すことを許容する |


### PR DESCRIPTION
## 概要

REQ-0145-015（検出ルール説明文除外パターン）の SPEC 明文化。

## 変更内容

- `docs/specs/integrity/integrity-contracts.md`「正当な除外」セクションのルール自己参照を `rules/IR-055-*.md` から `rules/IR-*.md`（全IRルールファイル）へ拡張。REQ-0145-015 が要求する「検出ルール説明文（`docs/specs/integrity/rules/IR-*.md`）を検出スコープから除外」を SPEC へ明文化（完了条件の1つ）。

## 検証

- 本 PR は SPEC 明文化のみ。check_integrity.ts による rules/IR-*.md 起源 NG 件数検証（TS-001）は後続 PR で実施（実装未対応のため）。

## Findings / Capture候補

### env-constraint

本 Issue は case-auto → case-run 経由で起動された。本環境では `call_omo_agent` が explore/librarian のみ許可し、Sisyphus-Junior 起動不可。adapter protocol「task() 起動失敗時事後処理」に従い case-run 本体が Sisyphus-Junior 責務を代行。さらに project extension must_not（src/opencode/** 読込禁止）により、Issue 完了条件の核心作業が実施不可。

### unimplemented-items

以下は must_not（src/opencode/** 読込禁止）および task() 委譲不可のため本 PR では未実装。別環境（task() 委譲可能、must_not 緩和）での実施が必要。

- check_integrity.ts 修正（REQ-0145-015 実装本体）: 検出関数（broken-reference, abolished-skill-references, obsolete-spec-path 等）が `docs/specs/integrity/rules/IR-*.md` を検出スコープから除外する実装。src/opencode/ 配下のため must_not
- vocabulary-registry.md 除外コンテキスト実装: `.opencode/skills/repo-agentdev-integrity/references/vocabulary-registry.md`（src/opencode/ 配下の junction）のため must_not
- (B-3) categoryToCheckPattern map へ3カテゴリ追加: `check_integrity.ts` の category-to-check-pattern map（src/opencode/ 配下）への実装。must_not。なお integrity-rule-catalog.md line 231 が「categoryToCheckPattern map への新カテゴリ追加を不要」とする現行 SPEC 方針と (B-3) が矛盾しており、SPEC 整合性調整も別途必要

### stale-reference

case-run Step 5-3 QG-3 前置 staleness check で検出した差異（REQ-0130-034）:

- 対象パス: `docs/specs/integrity/vocabulary-registry.md`（Issue #1464 完了条件が参照）。現行リポジトリに存在しない。実パスは `.opencode/skills/repo-agentdev-integrity/references/vocabulary-registry.md`
- 対象パス: `scripts/check_integrity.ts`（Issue #1464 が略記）。実パスは `.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts`
- 検査結果件数: Issue #1463 は「安定 NG 36件」と記載。現行計測は NG 19件（new delta）+ baseline-known 41件。差異あり（baseline 運用変更、REQ-0144-018/024 適用前のため）

### case-update-request

Issue #1464 本文の参照パス（`docs/specs/integrity/vocabulary-registry.md`, `scripts/check_integrity.ts`）を現行実パスへ更新することを case-update へ委譲（REQ-0130-034 準拠、case-run 単独では Issue 本文を書き換えない）。

## SPEC確定候補

（本 PR では新規 SPEC 詳細の発見なし。ただし integrity-rule-catalog.md line 231「categoryToCheckPattern map への新カテゴリ追加不要」方針と (B-3) 要求の矛盾は SPEC 確定候補として case-close で判断が必要）

## 備考

- Wave 1 並列委譲の前提（task() 委譲）が本環境で成立しないため case-run 本体が Sisyphus-Junior 責務を代行。must_not 制約により実施可能範囲が限定され、本 PR は部分実装
- 本 PR のみで Issue #1464 完了条件の全ては満たさない。別環境での追補が必要

Refs: #1464