### PR TITLE
feat(agentdev): add files_checked empty warning to docs guard (#1461)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts
@@ -592,6 +592,13 @@ function runWorkflowChecks(
 } {
   const failures: Failure[] = [];
   const warnings: string[] = [];
+  // files_checked 空時警告（REQ-0158）: 検査対象ファイルが検出されなかった場合、
+  // --files 指定の不備・PR 変更ファイル取得失敗・検査対象パス誤りの見逃しを防ぐ
+  if (changedFiles.length === 0) {
+    warnings.push(
+      "files_checked is empty: no files were checked. Verify --files specification and PR changed file list.",
+    );
+  }
   const allTargets = [...changedFiles, ...coupledFiles];
 
   if (profile.rules.includes("obsolete-spec-path")) {

--- a/src/opencode/commands/agentdev/case-close.md
+++ b/src/opencode/commands/agentdev/case-close.md
@@ -125,6 +125,11 @@ PR 本文の `## SPEC確定候補` セクションから SPEC 確定フロー（
     ```
 
    JSON 出力の `failures` に strict severity が含まれる場合はマージを停止し、対象ファイルを修正して再実行する。`full_docs_check_recommended` が true の場合は `/repo/docs-check`（全体監査）の実行をユーザーに提案する。draft→accepted 等の SPEC status 変更時は `spec_readme_update_required` を Step 3-2 SPEC 確定フローに反映する
+   - **files_checked 空時の確認（REQ）**: targeted docs guard の JSON 出力で `files_checked` が空の場合、検査見逃しリスクとして扱う。`warnings` 配列に検査対象ファイル未検出の警告が出力されるため、以下を確認する。確認を経ずに `files_checked` 空のまま完了扱いとしない:
+     1. 警告を検査見逃しのリスクとして認識する
+     2. `--files` 指定の妥当性を確認する（PR 変更ファイル一覧の再取得、パス指定の確認）
+     3. 必要に応じて `--files` を修正して再実行、または対象ファイルを手動確認する
+     4. 空の理由が正当（対象ファイルが本当に変更されていない等）であることを確認してから続行する
 
 **Step 3-2**: SPEC 確定フロー。
 PR 本文の `## SPEC確定候補` セクション（case-run/ driver が記録）を読み取り、SPEC の確定、昇格を処理する。


### PR DESCRIPTION
## 概要

Issue #1461 の case-run 実装。case-close docs guard の false-clean 予防として、`check_changed_docs.ts` の `files_checked` 空時 warning 出力（AG-007）と `case-close` の files_checked 空時確認ステップ（AG-006）を実装する。

REQ/SPEC は前工程の req-save/spec-save で main 反映済み。本 PR は source ファイル実装のみ。

Closes #1461

## 変更内容

### AG-007: `check_changed_docs.ts` — files_checked 空時 warning 出力

- `.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts`
- `runWorkflowChecks` 内で `changedFiles`（= JSON 出力の `files_checked`）が空の場合、`warnings` 配列に検査対象ファイル未検出の警告を追加
- 警告メッセージ: `files_checked is empty: no files were checked. Verify --files specification and PR changed file list.`
- 既存の `warnings` 配列へ追加（新規フィールド不作成）

### AG-006: `case-close.md` — files_checked 空時確認ステップ

- `src/opencode/commands/agentdev/case-close.md` Step 3-1
- targeted docs guard の JSON 出力で `files_checked` が空の場合の確認手順を追加:
  1. 警告を検査見逃しリスクとして認識
  2. `--files` 指定の妥当性確認（PR 変更ファイル一覧の再取得、パス指定の確認）
  3. 必要に応じた `--files` 再実行または手動確認
  4. 空の理由が正当であることを確認してから続行
- 確認を経ずに `files_checked` 空のまま完了扱いしない旨を明記

## 完了条件

- [x] `scripts/check_changed_docs.ts` に files_checked 空時 warning 出力が実装されていること（AG-007）
- [x] files_checked 空時、warnings 配列に検査対象ファイル未検出の警告が含まれること（TS-004 (1)）
- [x] case-close が files_checked 空の結果を受け取った際、`--files` 再実行または対象ファイル確認ステップが規定されていること（TS-004 (2)／AG-006）
- [~] REQ-0131-030 / REQ-0158 / SPEC case-close.md セクション: 前工程（req-save / spec-save）で main 反映済み

## テスト結果（TS-004）

### TS-004 (1): files_checked 空時 warning 出力

```
$ bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
    --workflow case-close --files nonexistent.md --json
{
  "workflow": "case-close",
  "files_checked": [],
  "warnings": [
    "files_checked is empty: no files were checked. Verify --files specification and PR changed file list."
  ],
  ...
}
```

files_checked 空 → warnings 配列に警告含まれる。合格。

正常系（実ファイル指定）では warnings が空になることを確認済み:
```
$ bun run ...check_changed_docs.ts --workflow case-close --files src/opencode/commands/agentdev/case-close.md --json
{ "files_checked": ["src/opencode/commands/agentdev/case-close.md"], "warnings": [], ... }
```

### TS-004 (2): case-close 確認ステップ

`case-close.md` Step 3-1 に files_checked 空時確認ステップ（4手順）を実装。コード実行ではなく手順規定のため、source diff で確認。

## QG-3 検証結果

- `check_changed_docs.ts --workflow case-run --base-ref origin/main --json`: failures なし（exit 0）
- `check_extensions.ts`（IR-056、case-close.md 変更のため必須）: `ok: true`, failures 0
- `check_integrity.ts`: 本ブランチ 28 new NG (delta)。origin/main（変更なし）は 30 new NG (delta) であり、本変更による新規違反導入なし（baseline drift は main 既存）。追加行（case-close.md L128-132）に IR-055 違反なし

## Findings / Capture候補

（なし）