### PR TITLE
feat(integrity): check_changed_docs.ts Phase 3 対象確定ロジック移行、doc_inputs_check_required 削除 (REQ-0158, Wave 2 #1474)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts
@@ -592,13 +592,9 @@ function runWorkflowChecks(
 } {
   const failures: Failure[] = [];
   const warnings: string[] = [];
-  // files_checked 空時警告（REQ-0158）: 検査対象ファイルが検出されなかった場合、
-  // --files 指定の不備・PR 変更ファイル取得失敗・検査対象パス誤りの見逃しを防ぐ
-  if (changedFiles.length === 0) {
-    warnings.push(
-      "files_checked is empty: no files were checked. Verify --files specification and PR changed file list.",
-    );
-  }
+  // files_checked 空時の分岐判定は main() 側で行う（REQ-0158 Phase 3）。
+  // check_changed_docs.ts は対象選定の十分性を判定せず、対象が空の場合は
+  // 「対象ファイルが検出されなかった」旨のメッセージを main() で生成する。
   const allTargets = [...changedFiles, ...coupledFiles];
 
   if (profile.rules.includes("obsolete-spec-path")) {
@@ -798,9 +794,31 @@ function main(): void {
     spec_readme_update_required: runResult.specReadmeUpdateRequired,
     requirements_readme_update_required: runResult.requirementsReadmeUpdateRequired,
     full_docs_check_recommended: runResult.fullDocsCheckRecommended,
-    doc_inputs_check_required: runResult.docInputsCheckRequired,
+    extensions_check_required: runResult.extensionsCheckRequired,
     declared_files_check: runResult.declaredFilesCheck,
   };
+
+  // Phase 3（REQ-0158）: 対象確定の命令側移行。
+  // --files 指定で files_checked が空の場合は FAILURE、--base-ref 指定で空の場合は WARNING。
+  // check_changed_docs.ts は対象選定の十分性を判定せず、対象ファイル未検出のみを報告する。
+  if (report.files_checked.length === 0) {
+    if (parsed.files.length > 0) {
+      report.failures.push({
+        rule_id: "TARGET-EMPTY",
+        severity: "strict",
+        file: "",
+        line: 0,
+        message:
+          "対象ファイルが検出されませんでした（--files 指定）。指定ファイルが workflow profile の対象外、または存在しません。",
+        expected:
+          "--files に対象ファイルを正しく指定してください（workflow profile の appliesTo に一致するファイルである必要があります）",
+      });
+    } else if (parsed.baseRef) {
+      report.warnings.push(
+        "対象ファイルが検出されませんでした（--base-ref 指定）。git diff 結果が空、または workflow profile の対象外です。",
+      );
+    }
+  }
 
   if (parsed.json) {
     emitJson(report);

--- a/docs/specs/commands/case-close.md
+++ b/docs/specs/commands/case-close.md
@@ -111,19 +111,19 @@ case-close は check_integrity.ts（全体監査）を使用しない（case-clo
 
 ※上記は全て肯定表現である（REQ-0144-002, REQ-0144-003 準拠）。
 
-### files_checked 空時警告と確認ステップ（REQ-0131-030, REQ-0158）
+### files_checked 空時の取扱い（REQ-0131-030, REQ-0158 Phase 3）
 
-targeted docs guard（check_changed_docs.ts）の実行結果で `files_checked` が空の場合、検査対象ファイルが検出されなかったことを示す。これは `--files` 指定の不備、PR 変更ファイル取得の失敗、または検査対象パスの誤りの可能性がある。
+targeted docs guard（check_changed_docs.ts）の実行結果で `files_checked` が空の場合、検査対象ファイルが検出されなかったことを示す。case-close は `--files` で PR 変更ファイル一覧を指定するため、Phase 3 契約により FAILURE（exit code 非ゼロ）として報告される。
 
-#### check_changed_docs.ts 側の出力（AG-007）
+#### check_changed_docs.ts 側の出力（AG-007, REQ-0158 Phase 3）
 
-`files_checked` が空の場合、`warnings` 配列に検査対象ファイル未検出の警告を追加する。警告メッセージは検査対象ファイルが検出されなかった旨と `--files` 指定の確認を促す内容とする。
+`--files` 指定で `files_checked` が空の場合、`failures` 配列に severity `strict` の FAILURE を追加する（exit code 非ゼロ）。メッセージは対象ファイルが検出されなかった旨を示す。`--base-ref` 指定で空の場合は WARNING となる（case-close は `--files` を使用するため対象外）。check_changed_docs.ts は対象選定の十分性を判定せず、対象ファイル未検出のみを報告する。
 
 #### case-close 側の確認ステップ（AG-006）
 
-case-close は targeted docs guard の結果で `files_checked` が空の場合、以下を行う:
+case-close は targeted docs guard が FAILURE を返した場合、以下を行う:
 
-1. 警告を検査見逃しのリスクとして認識する
+1. FAILURE を検査見逃しのリスクとして認識する
 2. `--files` 指定の妥当性を確認する（PR 変更ファイル一覧の再取得、パス指定の確認）
 3. 必要に応じて `--files` での再実行、または対象ファイルの手動確認を行う
 4. 空の理由が正当（対象ファイルが本当に変更されていない等）であることを確認してから続行する


### PR DESCRIPTION
## 概要

Epic #1472 Wave 2: Phase 3（対象確定の命令側移行）と Phase 4（コマンド別最小監査範囲）を実装。

REQ-0158 Phase 3-4 のうち、Phase 3 実装修正（check_changed_docs.ts の `--files/--base-ref` 分岐ロジック）と、コンパイルエラー級バグ（`doc_inputs_check_required` 参照）の解消を実施。Phase 4 の各コマンド SPEC 最小監査範囲定義は spec-save / Wave 1 で既に完了済み（後述「Phase 4 完了状態」参照）。

## 変更内容

### Phase 3: 対象確定ロジック修正（check_changed_docs.ts）

- **`--files` 指定で `files_checked` が空の場合**: `failures` 配列に severity `strict` の `TARGET-EMPTY` FAILURE を追加（exit code 非ゼロ）
- **`--base-ref` 指定で `files_checked` が空の場合**: `warnings` 配列に警告メッセージを追加（exit code 0）
- **対象選定の十分性判定を廃止**: `runWorkflowChecks` の汎用 `files_checked` 空警告ブロックを削除。check_changed_docs.ts は対象選定の十分性を判定せず、対象ファイル未検出のみを報告する。分岐判定は `main()` 側で実装（コマンド側の責務）
- **メッセージ方針**: 「対象選定の十分性」ではなく「対象ファイルが検出されなかった」旨のメッセージ

### コンパイルエラー級バグ修正（check_changed_docs.ts:801）

- `doc_inputs_check_required: runResult.docInputsCheckRequired,` を削除（存在しないプロパティ参照）
- `extensions_check_required: runResult.extensionsCheckRequired,` を追加（interface と一致）

### case-close SPEC 整合性更新（docs/specs/commands/case-close.md）

- `files_checked 空時警告と確認ステップ` セクションを Phase 3 挙動へ更新
- check_changed_docs.ts は `--files` 指定で空の場合 FAILURE を返すため、case-close 側の確認ステップも FAILURE 受領に合わせて更新

## Phase 4 完了状態（既に完了済み）

Phase 4（コマンド別最小監査範囲）は spec-save / Wave 1 で既に完了済み:

- `docs/specs/commands/req-save.md`: 「req-save が使用する検査ツール」セクションあり、integrity-contracts.md マトリックス表へ参照リンクあり
- `docs/specs/commands/spec-save.md`: 「spec-save が使用する検査ツール」セクションあり、参照リンクあり
- `docs/specs/commands/case-run.md`: 「case-run が使用する検査ツール」セクションあり、参照リンクあり
- `docs/specs/commands/case-close.md`: 「case-close が使用する検査ツール」セクションあり、参照リンクあり
- `docs/specs/integrity/integrity-contracts.md`: Workflow×ツールマトリックス表（SSoT）完備、`--files/--base-ref` 分岐契約明記済み

## テスト結果（TS-003）

TS-003（AG-003）の検証項目を手動実行で確認:

| 検証項目 | 結果 |
|---|---|
| `--files` 指定で files_checked 空 → exit code FAILURE（非ゼロ） | PASS（exit code 1、TARGET-EMPTY strict failure） |
| `--base-ref` 指定で files_checked 空 → warnings 配列に警告、exit code WARNING 扱い | PASS（exit code 0、warnings にメッセージ追加） |
| check_changed_docs.ts が対象選定の十分性を判定しない | PASS（メッセージは「対象ファイルが検出されなかった」旨） |
| `doc_inputs_check_required` プロパティ参照が削除されている | PASS（grep で 0 件、runResult 経由参照なし） |
| `extensions_check_required` が TargetedDocsReport object literal に存在 | PASS（JSON 出力で確認） |

### 実行コマンド例

```bash
# Test 1: --files + empty → FAILURE
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
  --workflow req-save --files README.md --json
# exit code: 1, failures: [TARGET-EMPTY strict]

# Test 2: --base-ref + empty → WARNING
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
  --workflow req-save --base-ref HEAD --json
# exit code: 0, warnings: [対象ファイルが検出されませんでした]
```

### コンパイル状態

プロジェクトは bun runtime 直接実行方式（tsconfig.json / package.json を scripts 配下に持たない）。`bunx tsc --noEmit` は lib/target 設定不足で環境起因の型エラーを多数出すが、実行時検証（bun run）で正常動作を確認済み。`doc_inputs_check_required` 参照削除により、存在しないプロパティ参照のコンパイルエラー級バグは解消。

## 完了条件対応

### Phase 3
- [x] check_changed_docs.ts で `--files` 指定時の `files_checked:[]` が FAILURE（exit code 非ゼロ）
- [x] check_changed_docs.ts で `--base-ref` 指定時の `files_checked:[]` が WARNING（warnings 配列に警告含む）
- [x] check_changed_docs.ts が対象選定の十分性を判定しないこと
- [x] check_changed_docs.ts から `doc_inputs_check_required` プロパティ参照が削除されていること
- [x] integrity-contracts.md のスクリプト契約セクションに `--files/--base-ref` 分岐契約が明記されていること（既存、Wave 1 完了）

### Phase 4
- [x] req-save.md に最小監査範囲が定義されていること（既存、spec-save 完了）
- [x] spec-save.md に最小監査範囲が定義されていること（既存、spec-save 完了）
- [x] case-run.md に最小監査範囲（永続文書更新契機）が定義されていること（既存、spec-save 完了）
- [x] case-close.md に最小監査範囲（永続文書更新契機）が定義されていること（既存、spec-save 完了）
- [x] 各コマンド SPEC から integrity-contracts.md の Workflow×ツールマトリックス表へ参照リンクが張られていること（既存、spec-save 完了）

## Findings / Capture候補

### docs-integrity

targeted docs guard（case-run profile）を自変更へ適用:
- failures: 0件
- warnings: 0件
- `requirements_readme_update_required: true` は case-run profile の既存挙動（REQ- ファイル以外の docs 変更時の informational flag）。本 PR では case-close.md のみ変更のため requirements README 更新は不要。実害なし。

### pre-existing（Wave 1 残課題、本 PR スコープ外）

各コマンド SPEC（req-save.md:79, spec-save.md:90, case-close.md:100）の「JSON 出力」フィールド一覧が古く、`extensions_check_required` と `declared_files_check` が未記載。これは TS-001（Wave 1, TargetedDocsReport 型一致）の残課題。integrity-contracts.md（Phase 2 SSoT）には11フィールド全て記載済みのため、各コマンド SPEC の記載は補完的。Wave 3 または別途 spec-save で追随推奨。

## SPEC確定候補

なし。Phase 3 実装は integrity-contracts.md（Phase 1 SPEC 配置、Wave 1 完了）の契約に従い、新たな SPEC レベルの詳細発見なし。

Refs: #1474
