### PR TITLE
feat(case-auto): コマンド定義の入力解決を引数種別分岐へ同期

### DIFF
--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -20,7 +20,7 @@ agent: sisyphus
 ## 入力
 
 - Issue番号（数値）または Issue URL: 既存Issue から case-run → case-close を自走する場合
-- 要件doc: 明示パス指定/ `.agentdev/drafts/req-draft-*.md` 単一自動検出/ セッション内要件doc（3段階優先順位、構造化 `draft-data` 形式）
+- 要件doc（引数なし時は `.agentdev/drafts/req-draft-*.md` 全件処理がデフォルト / 明示パス指定 / セッション指定キーワードによるセッション内要件doc参照（暗黙判断廃止、構造化 `draft-data` 形式: REQ-0138, ADR-0124））
 
 ## 出力
 
@@ -32,8 +32,13 @@ agent: sisyphus
 ### Step 1: 入力解決
 
  - **実行開始時刻の記録**: 本 Step の冒頭（入力解決の最初の処理）で、case-auto の実行開始時刻を JST（Etc/GMT-9）、人間が読みやすい形式（例: `2026-06-21 15:30:00 JST`）で記録し、変数（`case_auto_started_at`）に保持する。この時刻は Step 7（停止時報告）および Step 8（完了報告）での所要時間算出の基準として使用する
- - **Issue番号/URL入力モード**: 引数が数値のみまたは GitHub Issue URL の場合、Issue番号として解決し case-run移行モードへ分岐する（Step 3 の Issue番号/URL入力分岐へ）。この場合、要件docの入力解決、work_type読取はスキップする
- - **要件doc入力モード**: 明示パス→draft検出（複数件含む全件処理対象）→セッション内要件docの順で入力を特定する。`.agentdev/drafts/req-draft-*.md` が2件以上存在する場合、全draftを処理対象として検出し、各draftの `operation_units` から `recommended_order` と `depends_on` に基づいて全OUの処理順序を決定する。不明時は停止しreq-define実行またはパス指定を求める
+ - **Issue番号/URL入力モード**: 引数が数値のみまたは GitHub Issue URL の場合、Issue番号として解決し case-run移行モードへ分岐する（Step 3 の Issue番号/URL入力分岐へ）。要件doc入力モードより優先して処理する（REQ-0114-068/069）。この場合、要件docの入力解決、work_type読取はスキップする
+ - **要件doc入力モード**: 引数種別に応じて以下を処理対象とする（REQ-0114-002）。数値引数/Issue URL は本モードより優先する（REQ-0114-069）:
+   - (1) 引数なし時: `.agentdev/drafts/req-draft-*.md` 全件処理（デフォルト）。draft が1件以上存在する場合は全件（1件含む）を処理対象とする（REQ-0114-004）。draft 0件の場合のみ停止し req-define 実行またはパス指定を求める。複数draft存在時は無確認で全件処理する（AG-004）
+   - (2) 明示パス指定時: 当該draftのみ処理対象。ファイル不在時は停止しエラーを報告する（REQ-0114-003）
+   - (3) セッション指定キーワード時（例: `req-define セッション`、`req-define 上記の内容`）: セッション内要件docを参照する。**暗黙判断は行わない**（REQ-0114-002、AG-003）
+   - (4) 特定不可時: 停止する（REQ-0114-005）
+   - 複数draft読み込み時の順序制御は各draftの `operation_units` から `recommended_order` / `depends_on` に基づいて全OUの処理順序を決定する（REQ-0148, ADR-0129 準拠、AG-005）
 ### Step 2: work_type 読取
 
 入力要件docの `draft-data` から work_type を取得する（参考情報、パイプライン分岐の判定には使用しない）


### PR DESCRIPTION
## 概要

case-auto コマンド定義（`src/opencode/commands/agentdev/case-auto.md`）の入力解決を、REQ-0114-002/004/069 および SPEC `docs/specs/commands/case-auto.md` へ同期する。

先行 commit `df133871` で REQ-0114 と SPEC が更新済みであり、本 PR は残余のコマンド定義同期が対象（Issue #1530 の主作業）。

## 変更内容

### 「入力」セクション（line 23）

SPEC 入力セクションと整合するよう更新。

- 変更前: `要件doc: 明示パス指定/ .agentdev/drafts/req-draft-*.md 単一自動検出/ セッション内要件doc（3段階優先順位）`
- 変更後: `要件doc（引数なし時は全件処理がデフォルト / 明示パス指定 / セッション指定キーワードによるセッション内要件doc参照（暗黙判断廃止））`

### Step 1 入力解決（line 35-41）

REQ-0114-002 の引数種別分岐（4分岐）へ書き換え。

- **Issue番号/URL入力モード**: REQ-0114-068/069 の優先性を明記
- **要件doc入力モード** 4分岐:
  - (1) 引数なし時: 全件処理デフォルト（REQ-0114-004）。draft 0件の場合のみ停止。複数draft存在時は無確認で全件処理（AG-004）
  - (2) 明示パス指定時: 当該draftのみ（REQ-0114-003）
  - (3) セッション指定キーワード時: 暗黙判断廃止（REQ-0114-002、AG-003）
  - (4) 特定不可時: 停止（REQ-0114-005）
- 複数draft読み込み時の順序制御: REQ-0148, ADR-0129 準拠を維持（AG-005）

## テスト戦略結果

| ID | status | detail |
|---|---|---|
| TS-001 | pass | REQ-0114-002 に「全件処理（デフォルト）」、REQ-0114-004 に「全件（1件含む）を処理対象」が明記済み（commit df133871）。コマンド定義 line 37 に同期記載を確認 |
| TS-002 | pass | コマンド定義 line 39 に「暗黙判断は行わない」とキーワード例（`req-define セッション`、`req-define 上記の内容`）を確認。SPEC line 18, 37 にも整合 |
| TS-003 | pass | コマンド定義に「確認プロンプト」記述なし（grep 検証済み）。「不明時は停止」は draft 0件の場合のみ適用、複数draft存在時は無確認で全件処理（AG-004、line 37） |
| TS-004 | pass | コマンド定義 line 41 に REQ-0148, ADR-0129 準拠の順序制御参照を維持（AG-005）。recommended_order / depends_on ロジック変更なし |

## check_extensions.ts 結果（IR-056）

```
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts --json
```

結果: `ok: true`, `failures: []`（異常なし）

## Findings / Capture候補

特になし。

## SPEC確定候補

特になし。本変更は SPEC（既に commit df133871 で確定済み）へのコマンド定義同期のみ。

closes #1530
