### PR TITLE
fix(integrity): <harness> placeholder 除外パターン実装修復 (Refs: #1546)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -3654,6 +3654,9 @@ function isInsideCodeBlock(lines: string[], lineIndex: number): boolean {
  */
 function isTemplatePlaceholder(refPath: string): boolean {
   if (/\{[^}]*\}/.test(refPath)) return true;
+  // REQ-0144-025 / ADR-0136: <harness> 等の angle-bracket placeholder は
+  // 実ファイルを指さない抽象表記のため検査対象外とする。
+  if (/<[a-zA-Z][a-zA-Z0-9_-]*>/.test(refPath)) return true;
   return false;
 }
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_reference_paths.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_reference_paths.test.ts
@@ -299,6 +299,32 @@ describe("checkScriptTemplateReferencePaths", () => {
     const placeholderNg = refNg.filter((r) => r.evidence?.includes("{"));
     expect(placeholderNg.length).toBe(0);
   });
+  it("does not flag angle-bracket placeholders like <harness> (REQ-0144-025)", () => {
+    const root = join(TEMP_ROOT, "angle-placeholder-path");
+    buildMinimalFixture(root);
+    copyScripts(root);
+    const cmdDir = join(root, ".opencode", "commands", "agentdev");
+    writeFileSync(
+      join(cmdDir, "test-cmd.md"),
+      [
+        "---",
+        "description: Test",
+        "agent: oracle",
+        "---",
+        "",
+        "起動手段、実行制御パラメータは AGENTS.md および references/<harness>.md 参照。",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const result = runScriptJson(root);
+    expect(result.report).not.toBeNull();
+    const refNg = (result.report!.results || []).filter(
+      (r) => r.category === "ReferencePath" && r.level === "ng",
+    );
+    const harnessNg = refNg.filter((r) => r.evidence?.includes("<harness>"));
+    expect(harnessNg.length).toBe(0);
+  });
   it("reports ng for missing repo-root-relative references", () => {
     const root = join(TEMP_ROOT, "root-rel-missing");
     buildMinimalFixture(root);


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

Issue #1546。`scripts/check_integrity.ts` の `ReferencePath` 検査が、抽象参照表記 `references/<harness>.md` をリテラルパスと解釈し reference-path-existence NG を恒常的に出力していた問題（REQ-0144-025）を修正する。

ADR-0136 は `<harness>` を harness 固有の実行メモ配置先（`AGENTS.md` または `references/<harness>.md`）を指す正規の抽象 placeholder として定義している。この placeholder 由来の NG が main リポジトリで11件（worktree ではジャンクション未伝播により5件）恒常的に報告されていた。

## 変更内容
<!-- 【必須】 -->

`isTemplatePlaceholder()` を拡張し、`{xxx}` 形式に加え `<xxx>` 形式（angle-bracket placeholder）も検査対象外とする。

- `.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts`
  - `isTemplatePlaceholder()` に `<[a-zA-Z][a-zA-Z0-9_-]*>` の判定を追加（REQ-0144-025 / ADR-0136 準拠）
  - 根因: `SCRIPT_TEMPLATE_REF_PATTERNS` の第3パターン `references/[^/\s"'')\]]+\.md` が `<harness>` を捕捉するが、従来の `isTemplatePlaceholder()` は `{xxx}` 形式のみ対応で `<xxx>` 形式を未対応だったため、`<harness>` を含むパスが placeholder として扱われず NG を出力していた（パターン不備）
  - 安全性: `<` `>` は Windows ファイル名で禁止されており、Unix 系でもパス成分として極めて稀。`<[a-zA-Z][a-zA-Z0-9_-]*>` の語彙制限により HTML タグや比較演算子との誤一致を回避
- `.opencode/skills/repo-agentdev-integrity/scripts/check_reference_paths.test.ts`
  - `references/<harness>.md` を含むコマンドファイルが NG にならないことを検証する回帰テストを追加（curly-brace placeholder 既存テストの直後に配置）

## Files Checked

- targeted docs guard (`check_changed_docs.ts`): **SKIPPED**（変更ファイルが `.opencode/skills/repo-agentdev-integrity/scripts/` 配下のみで `docs/**` 配下ではないため、MUST DO #7 に基づきスキップ）
- `check_extensions.ts` (IR-056): **SKIPPED**（`src/opencode/commands/agentdev/**/*.md` を変更していないため対象外、MUST DO #8 に基づきスキップ）

## 完了条件
<!-- 【必須】 -->

Issue #1546 の完了条件に対する達成状況（最終完了判定は case-close 責務）。

- [x] AG-001: REQ-0144-025 の実装修復が完遂されていること
  - [x] 除外パターン実装の現状を確認し、実装漏れ・パターン不備・検査ロジック側の解釈違いを切り分けたこと → **パターン不備**（`isTemplatePlaceholder()` が `<xxx>` 形式に未対応）
  - [x] `scripts/check_integrity.ts` 実行で `references/<harness>.md` 抽象参照表記に起因する reference-path-existence NG が0件であること（参考: 起票時点 11件、worktree では5件）
- [x] AG-002: TS-003「check_integrity.ts 実行による `<harness>` placeholder false positive 解消確認」の pass_criteria を達成すること
  - [x] `<harness>` placeholder に起因する NG が0件であり、TS-003 pass_criteria が達成されていること
  - [ ] Issue #1516 由来の未完 TS-003 を close すること（※ case-close 工程にて Issue 側で完了状態を反映）

※ 最終チェックボックス状態の更新は case-close 責務。本 PR では実装と検証完遂まで。

## テスト結果
<!-- 【必須】 -->

### TS-001 (target AG-001): reference-path-existence の `<harness>` placeholder 由来 NG 件数

| 項目 | 結果 |
|------|------|
| 検証手順 | `scripts/check_integrity.ts` を実行し reference-path-existence カテゴリの `<harness>` 由来 NG 件数を確認 |
| Before（修正前） | worktree で5件（main リポジトリ想定11件）。`case-auto.md:65/97/138`、`case-run.md:141/213`。main リポジトリではさらに `agentdev-case-run-execution-adapter/SKILL.md` 5件、`agentdev-architecture-advisory/SKILL.md` 1件 |
| After（修正後） | **0件**（worktree 実測） |
| pass_criteria | `references/<harness>.md` 抽象参照表記に起因する NG が0件 → **PASS** |
| 新規 false positive | なし（全体 NG: 224件 → 219件、Δ=-5 で `<harness>` 5件の減少と完全一致） |

### TS-002 (target AG-002): フル実行での最終確認

| 項目 | 結果 |
|------|------|
| 検証手順 | TS-001 合格後、`scripts/check_integrity.ts` フル実行結果を確認 |
| `<harness>` placeholder 起因 NG | **0件** |
| pass_criteria | `<harness>` placeholder 起因 NG 0件、TS-003 pass_criteria 達成 → **PASS** |

### ユニットテスト

- `check_reference_paths.test.ts`: 21 pass / 0 fail（新規 `<harness>` テスト含む、62 expect() calls）
- `check_integrity.test.ts`: 68 pass / 0 fail（177 expect() calls）

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| `<harness>` 起因 reference-path-existence NG | 0件（5件→0件、main リポジトリ想定11件→0件） | 0件 | PASS |
| 全体 NG 差分 | 224件→219件（Δ=-5） | Δ=-5（減少のみ、新規 false positive なし） | PASS |
| check_reference_paths.test.ts | 21 pass / 0 fail | 0 fail | PASS |
| check_integrity.test.ts | 68 pass / 0 fail | 0 fail | PASS |
| 変更ファイル数 | 2 | スコープ内（`<harness>` 除外パターン実装修復のみ） | PASS |

## Findings・Capture候補
<!-- 【必須】 -->

### docs-integrity

該当なし（`docs/**` 配下の変更なし、`check_changed_docs.ts` スキップ）。

### stale-reference

該当なし（QG-3 staleness 結果: 差異なし、実装対象ファイルは worktree 内で現行存在確認済み）。

### その他 Findings

- worktree 内で `.opencode/skills/agentdev-*` のジャンクションが未伝播（既知の Windows + junction 環境制約、case-run オーケストレーションナレッジベース「準備フェーズの既知の制約」参照）。このため worktree での実測値は5件。main リポジトリ（ジャンクション伝播済み）では11件。修正は `isTemplatePlaceholder()` の純粋な検出ロジック拡張のため、入力ファイル種別（cmd / SKILL.md）によらず同一の効果を得る。 capture 候補としては learning/intake いずれにも該当しない（既知制約の再確認）。
- `tsc --noEmit --strict` では Node.js 型定義未インストール由来の既存エラーが多数検出されるが、実ランタイムは bun であり `bun test` が全件合格しているため影響なし。本 PR の編集（3行追加）に起因する型エラーは0件。

## SPEC確定候補

該当なし。本変更は REQ-0144-025（要件化済み）の実装修復のみであり、新規 SPEC レベルの詳細（schema、enum、判定表、内部アルゴリズム等）は発生しない。`isTemplatePlaceholder()` の拡張対象 placeholder 形式（`{xxx}` / `<xxx>`）は ADR-0136 で既定義。

## Test Strategy

- **TS-001 (AG-001)**: 修正前後で `check_integrity.ts` を実行し `<harness>` placeholder 由来 NG 件数を比較。Before 5件 → After 0件。on_failure トリガーなし（fix-and-reverify 不要）。
- **TS-002 (AG-002)**: フル実行で最終確認。`<harness>` 起因 NG 0件を確認。on_failure トリガーなし。
- **回帰テスト**: `check_reference_paths.test.ts` へ `<harness>` placeholder の non-NG 検証を追加。curly-brace 既有テストと対で配置。

## 関連Issue

Refs #1546

- 関連: REQ-0144-025、ADR-0136、Issue #1516（TS-003 由来）