### PR TITLE
chore(docs): ガイドの REQ 範囲表記を現行 REQ-0162/53件に修正 (Refs: #1548)

### DIFF
--- a/docs/guides/project-docs-and-specs.md
+++ b/docs/guides/project-docs-and-specs.md
@@ -23,7 +23,7 @@ DOC-MAP（文書探索入口：索引）
 要件定義の永続基準。
 システムが満たすべき要件を記述する。
 
-- 現行 REQ は REQ-0101 から REQ-0161 までの 52 件（REQ-0111, REQ-0115, REQ-0116, REQ-0117, REQ-0118, REQ-0120, REQ-0121, REQ-0122 は廃止、履歴参照のみ）
+- 現行 REQ は REQ-0101 から REQ-0162 までの 53 件（REQ-0111, REQ-0115, REQ-0116, REQ-0117, REQ-0118, REQ-0120, REQ-0121, REQ-0122 は廃止、履歴参照のみ）
 - 旧 REQ（REQ-0001〜REQ-0050 [全て廃止]）は `docs/requirements/retired/` に移動済み。履歴参照に限定する
 - 旧 REQ と新 REQ の対応関係は `docs/requirements/mapping-table.md` に記録
 


### PR DESCRIPTION
## 概要

Issue #1548。`docs/guides/project-docs-and-specs.md` の REQ 範囲・件数表記（行26）が旧値（REQ-0161/52件）のままであり、REQ-0162 追加に伴う更新漏れにより `check_integrity.ts` が `req-range-staleness` NG を恒常検出していた。当該ガイドの表記を現行値（REQ-0162/53件）に修正し、あわせて同ガイド内の同種表記の横断確認と REQ-0144-018 自動更新仕組みの現状確認を行う。

## 変更内容

- `docs/guides/project-docs-and-specs.md` 行26 の REQ 範囲・件数表記を現行値に更新
  - Before: `現行 REQ は REQ-0101 から REQ-0161 までの 52 件`
  - After: `現行 REQ は REQ-0101 から REQ-0162 までの 53 件`
  - 廃止 REQ リスト（REQ-0111, 0115, 0116, 0117, 0118, 0120, 0121, 0122）は現状維持（`docs/requirements/README.md` の記載と一致）

同ガイド内の同種表記（ADR 範囲等）は親 QG-3 で横断確認済み。行41「ADR-0101 以降」/ 行42「ADR-0001〜0099」は番号帯のみで件数表記なし、修正不要。

## Files Checked

- `docs/guides/project-docs-and-specs.md`（修正対象、AG-001）
- `docs/requirements/REQ-0144.md`（REQ-0144-018 SPEC 確認、AG-002）
- `src/opencode/commands/agentdev/req-save.md`（自動更新仕組み有無確認、AG-002）
- `docs/specs/integrity/rules/IR-018-req-range-notation-freshness.md`（検出ルール SPEC）

## 完了条件

- [x] docs/guides/project-docs-and-specs.md の REQ 範囲・件数表記が現行値（REQ-0101 から REQ-0162 までの 53 件）に一致していること（REQ-0144-007 対応、AG-001）
- [x] docs/guides/project-docs-and-specs.md 内の同種範囲・件数表記（ADR 範囲等）が全て現行値に一致していること（REQ-0144-007 横断準拠、AG-001）
- [x] check_integrity.ts 実行時、docs/guides/project-docs-and-specs.md 起因の req-range-staleness NG が 0 件であること（AG-001）
- [x] REQ-0144-018 の自動更新仕組みの現状（実装有無・機能状況）が文書化されていること。仕組み不在・機能不全の場合、case-run Findings に記録され、後続 intake item として引き渡す準備が整っていること（REQ-0144-018 対応、AG-002）

※ 完了条件チェックボックスは case-close 責務のため PR 時点では参考記載。SSoT は Issue #1548 本文。

## テスト結果

### TS-001（AG-001）: PASS

`check_integrity.ts` で `req-range-staleness` カテゴリの該当 NG が解消したことを確認。

| 項目 | Before | After |
|---|---|---|
| summary.ng | 219 | 218 (-1) |
| summary.ok | 312 | 313 (+1) |
| req-range-staleness NG（docs/guides/project-docs-and-specs.md 起因）| 1件 | **0件** |
| req-range-staleness check level | ng | **ok** ("REQ range and count consistent across all documents (53 active REQs, REQ-0101~REQ-0162)") |

pass_criteria「docs/guides/project-docs-and-specs.md に起因する req-range-staleness NG が0件」「同ガイド内の REQ 範囲・件数表記が全て現行（REQ-0162/53件）に一致」の両方を満たす。

### TS-002（AG-002）: PASS（record-in-findings で完遂）

REQ-0144-018 自動更新仕組みの現状確認結果は下記「Findings・Capture候補」セクションの `### AG-002 findings` に記録済み。pass_criteria「自動更新仕組みの現状が文書化され、後続 intake item として引き渡す準備が整っていること」を満たす。

### targeted docs guard（REQ-0158）: PASS

```
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
  --workflow case-run --base-ref origin/main --json
```

| 項目 | 結果 |
|---|---|
| files_checked | docs/guides/project-docs-and-specs.md |
| coupled_files_checked | docs/DOC-MAP.md, docs/README.md |
| failures | [] |
| warnings | [] |
| full_docs_check_recommended | false |

`doc_map_update_required` / `spec_readme_update_required` / `requirements_readme_update_required` はヒューリスティックフラグ（連動ファイル確認推奨）。DOC-MAP は REQ 範囲表記なし、requirements/README は親 QG-3 で現行値（REQ-0162/53件）確認済み、SPEC README は REQ 範囲表記なし。実 failures 空のため合格。

### check_extensions.ts（IR-056）: スキップ

`src/opencode/commands/agentdev/**/*.md` の変更なしのためスキップ（IR-056 対象外）。

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| check_integrity.ts req-range-staleness NG（対象ガイド起因） | 0件 | 0件 | ✅ |
| targeted docs guard failures | 0件 | 0件 | ✅ |
| worktree 内判定ヘルパー | worktree 内（隔離済み） | worktree 内 | ✅ |
| ファイル編集スコープ | docs/guides/project-docs-and-specs.md のみ | worktree root 配下のみ | ✅ |

## Findings・Capture候補

### docs-integrity

該当なし。targeted docs guard（failures=[]）および check_integrity.ts（対象ガイド起因 NG=0）のいずれも strict severity の問題なし。

### stale-reference

該当なし。同ガイド内の ADR 範囲表記（行41「ADR-0101 以降」/ 行42「ADR-0001〜0099」）は番号帯のみで件数表記を含まず、REQ-0144-007 の横断対象外（親 QG-3 確認済み）。

### AG-002 findings

**REQ-0144-018 自動更新仕組みの現状確認結果**

REQ-0144-018 は2つの要素要件から構成される:

1. **検出ロジック**（"docs-check の req-range 検出ロジックは docs/guides/*.md と vocabulary-registry.md に記載の時点REQ番号を動的に参照し、実REQ最大番号と照合。時点REQ番号が実REQ最大番号より古い場合、安定NGとして検出"）
   - **状態: 実装済み・機能している**
   - 証拠: 本 Issue の修正前に `check_integrity.ts` が `docs/guides/project-docs-and-specs.md` 起因の `req-range-staleness` NG を 1 件検出（Before）し、修正後に 0 件になった（After）。検出ロジックは動的参照・照合を正常に実行している。

2. **自動更新仕組み**（"新規REQ確定時（req-save 完了後）に、docs/guides/*.md と vocabulary-registry.md の REQ 範囲表記を自動更新する仕組みを提供する"）
   - **状態: 未実装**
   - 根拠:
     - `src/opencode/commands/agentdev/req-save.md` Step 1〜12 に `docs/guides/*.md` の REQ 範囲表記を更新するステップは存在しない
     - 同ガイドレール G02（ファイル操作制約）は req-save の編集スコープを `docs/requirements/**`, `docs/adr/**`, `docs/README.md`, `.agentdev/drafts/**` のみに制限しており、`docs/guides/**` を明示的に除外している
     - Step 5「インデックス、ハブ更新」が更新対象とするのは `docs/requirements/README.md`（REQ インデックス）、`docs/README.md`（ドキュメントハブ）、`docs/DOC-MAP.md`（探索経路）のみで、ガイドの範囲・件数表記は含まない
     - REQ-0162 追加時にガイドが追従しなかった事実（本 Issue）が、自動更新仕組み不在を裏付ける
   - 影响: 新規 REQ が確定するたびにガイドの範囲表記が陳腐化し、`check_integrity.ts` が恒常 NG を検出する。手動修正（本 Issue 等）が必要になる。

**後続 intake item 引継準備**

本 Issue のスコープ外（実装修復は後続 intake 経由で処理）。以下の内容で intake item 化を想定:

- 分類: intake（運用是正）
- 対象 REQ: REQ-0144-018（自動更新仕組み部分）
- 作業候補: req-save 完了後に `docs/guides/*.md`（と `vocabulary-registry.md`）の REQ 範囲・件数表記を自動更新する仕組みの設計・実装。ガードレール G02 の拡張、または req-save とは別工程（post-req-save フック等）での実装を検討
- 注意: 自動更新の副作用（廃止 REQ リストの更新等）も併せて検討が必要。本 Issue では「REQ 最大番号・件数」のみ手動修正し、廃止 REQ リストは現状維持とした

## SPEC確定候補

該当なし。本 Issue は既存 SPEC（REQ-0144-018、IR-018）の実装修復であり、新たな SPEC レベルの詳細（schema、enum、判定表、内部アルゴリズム等）の発見なし。

## Test Strategy

- TS-001 (AG-001): check_integrity.ts 実行で req-range-staleness NG が解消したことを Before/After で検証（PASS）。pass_criteria「docs/guides/project-docs-and-specs.md 起因 NG 0件」「同ガイド内 REQ 範囲・件数表記が全て現行（REQ-0162/53件）に一致」を満たす。
- TS-002 (AG-002): REQ-0144-018 自動更新仕組みの現状を文書化し、後続 intake item 引継準備を整えた（record-in-findings で完遂、PASS）。スコープ外のため Findings 記録のみで実装修復は行わない。

## 関連Issue

Refs #1548
