### PR TITLE
fix(integrity): commands_e2e.test.ts 58件 fail を解消し README listing と整合 (Refs: #1552)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts
@@ -1,5 +1,5 @@
 /**
- * E2E workflow tests for all 13 agentdev command definitions.
+ * E2E workflow tests for all agentdev command definitions.
  * REQ-0030-009: Normal-path E2E tests for all commands
  * REQ-0030-013: Test files placed in corresponding scripts/ directory
  *
@@ -36,14 +36,22 @@ const REPO_ROOT = findRepoRoot(SCRIPT_DIR);
 const PROJECTION_CMD_DIR = path.join(REPO_ROOT, ".opencode", "commands", "agentdev");
 const SOURCE_CMD_DIR = path.join(REPO_ROOT, "src", "opencode", "commands", "agentdev");
 const CMD_DIR = fs.existsSync(PROJECTION_CMD_DIR) ? PROJECTION_CMD_DIR : SOURCE_CMD_DIR;
-const SKILLS_DIR = path.join(REPO_ROOT, ".opencode", "skills");
-const TEMPLATES_DIR = path.join(
-  REPO_ROOT,
-  ".opencode",
-  "skills",
+const PROJECTION_SKILLS_DIR = path.join(REPO_ROOT, ".opencode", "skills");
+const SOURCE_SKILLS_DIR = path.join(REPO_ROOT, "src", "opencode", "skills");
+const SKILLS_DIR = fs.existsSync(path.join(PROJECTION_SKILLS_DIR, "agentdev-workflow-templates"))
+  ? PROJECTION_SKILLS_DIR
+  : SOURCE_SKILLS_DIR;
+const PROJECTION_TEMPLATES_DIR = path.join(
+  PROJECTION_SKILLS_DIR,
   "agentdev-workflow-templates",
   "templates",
 );
+const SOURCE_TEMPLATES_DIR = path.join(
+  SOURCE_SKILLS_DIR,
+  "agentdev-workflow-templates",
+  "templates",
+);
+const TEMPLATES_DIR = fs.existsSync(PROJECTION_TEMPLATES_DIR) ? PROJECTION_TEMPLATES_DIR : SOURCE_TEMPLATES_DIR;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -158,7 +166,7 @@ const commands = getCommandFiles();
 const skillDirs = getSkillDirs();
 const templateFiles = getTemplateFiles();
 
-// Current 13 public agentdev commands
+// Current 17 public agentdev commands (aligns with commands/agentdev/README.md listing)
 const EXPECTED_COMMANDS = [
   "backlog-review",
   "case-auto",
@@ -166,19 +174,29 @@ const EXPECTED_COMMANDS = [
   "case-open",
   "case-run",
   "case-update",
+  "inspect-docs",
+  "inspect-extensions",
+  "inspect-promote",
+  "inspect-skills",
   "intake-capture",
   "intake-from-github",
   "intake-promote",
   "learning-promote",
   "req-define",
-  "req-restructure-review",
   "req-save",
+  "spec-save",
 ];
+
+// agentdev-prefixed references that are valid skills (not commands).
+// /agentdev/learning-capture is a skill invocation, not a command definition file.
+const VALID_SKILL_REFS = new Set([
+  "learning-capture",
+]);
 
 const COMMAND_COUNT = EXPECTED_COMMANDS.length;
 
 // Pipeline definitions
-const REQ_CASE_PIPELINE = ["req-define", "req-save", "case-open", "case-run", "case-update", "case-close"];
+const REQ_CASE_PIPELINE = ["req-define", "req-save", "spec-save", "case-open", "case-run", "case-update", "case-close"];
 const LEARNING_PIPELINE = ["learning-promote"];
 const INTAKE_PIPELINE = ["intake-capture", "intake-from-github", "intake-promote"];
 
@@ -208,12 +226,12 @@ describe("REQ-0030-009: E2E workflow tests for all commands", () => {
       const fm = parseFrontmatter(content);
 
       it("has Input section defining expected inputs", () => {
-        const inputSection = extractSection(content, "Input");
+        const inputSection = extractSection(content, "入力");
         expect(inputSection.length).toBeGreaterThan(0);
       });
 
       it("has Output section defining expected outputs", () => {
-        const outputSection = extractSection(content, "Output");
+        const outputSection = extractSection(content, "出力");
         expect(outputSection.length).toBeGreaterThan(0);
       });
 
@@ -240,6 +258,7 @@ describe("REQ-0030-009: E2E workflow tests for all commands", () => {
       const cmdRefs = extractCommandRefs(content);
       for (const ref of cmdRefs) {
         if (ref === cmdName) continue;
+        if (VALID_SKILL_REFS.has(ref)) continue;
         it(`command reference "/agentdev/${ref}" points to existing command`, () => {
           expect(EXPECTED_COMMANDS.includes(ref)).toBe(true);
         });
@@ -256,10 +275,10 @@ describe("REQ-0030-009: E2E workflow tests for all commands", () => {
       expect(reqDefine).toBeDefined();
       expect(reqSave).toBeDefined();
       if (reqDefine && reqSave) {
-        const reqDefineOutput = extractSection(reqDefine, "Output");
-        const reqSaveInput = extractSection(reqSave, "Input");
-        expect(reqDefineOutput).toContain(".sisyphus/drafts");
-        expect(reqSaveInput).toContain(".sisyphus/drafts");
+        const reqDefineOutput = extractSection(reqDefine, "出力");
+        const reqSaveInput = extractSection(reqSave, "入力");
+        expect(reqDefineOutput).toContain(".agentdev/drafts");
+        expect(reqSaveInput).toContain(".agentdev/drafts");
       }
     });
 
@@ -269,8 +288,8 @@ describe("REQ-0030-009: E2E workflow tests for all commands", () => {
       expect(reqSave).toBeDefined();
       expect(caseOpen).toBeDefined();
       if (reqSave && caseOpen) {
-        const reqSaveOutput = extractSection(reqSave, "Output");
-        const caseOpenInput = extractSection(caseOpen, "Input");
+        const reqSaveOutput = extractSection(reqSave, "出力");
+        const caseOpenInput = extractSection(caseOpen, "入力");
         expect(reqSaveOutput).toContain("REQ");
         expect(caseOpenInput).toContain("req-define");
       }
@@ -282,8 +301,8 @@ describe("REQ-0030-009: E2E workflow tests for all commands", () => {
       expect(caseOpen).toBeDefined();
       expect(caseRun).toBeDefined();
       if (caseOpen && caseRun) {
-        const caseOpenOutput = extractSection(caseOpen, "Output");
-        const caseRunInput = extractSection(caseRun, "Input");
+        const caseOpenOutput = extractSection(caseOpen, "出力");
+        const caseRunInput = extractSection(caseRun, "入力");
         expect(caseOpenOutput).toContain("Issue");
         expect(caseRunInput).toContain("Issue");
       }
@@ -295,9 +314,9 @@ describe("REQ-0030-009: E2E workflow tests for all commands", () => {
       expect(caseRun).toBeDefined();
       expect(caseClose).toBeDefined();
       if (caseRun && caseClose) {
-        const caseRunOutput = extractSection(caseRun, "Output");
-        const caseCloseInput = extractSection(caseClose, "Input");
-        expect(caseRunOutput).toContain("GitHub PR");
+        const caseRunOutput = extractSection(caseRun, "出力");
+        const caseCloseInput = extractSection(caseClose, "入力");
+        expect(caseRunOutput).toContain("PR");
         expect(caseCloseInput).toContain("PR");
       }
     });
@@ -320,8 +339,8 @@ describe("REQ-0030-009: E2E workflow tests for all commands", () => {
       expect(capture).toBeDefined();
       expect(fromGithub).toBeDefined();
       if (capture && fromGithub) {
-        const captureOutput = extractSection(capture, "Output");
-        const githubOutput = extractSection(fromGithub, "Output");
+        const captureOutput = extractSection(capture, "出力");
+        const githubOutput = extractSection(fromGithub, "出力");
         expect(captureOutput).toContain("inbox");
         expect(githubOutput).toContain("inbox");
       }
@@ -331,7 +350,7 @@ describe("REQ-0030-009: E2E workflow tests for all commands", () => {
       const promote = commands.get("intake-promote");
       expect(promote).toBeDefined();
       if (promote) {
-        const promoteInput = extractSection(promote, "Input");
+        const promoteInput = extractSection(promote, "入力");
         expect(promoteInput).toContain("inbox");
       }
     });
@@ -340,7 +359,7 @@ describe("REQ-0030-009: E2E workflow tests for all commands", () => {
       const promote = commands.get("intake-promote");
       expect(promote).toBeDefined();
       if (promote) {
-        const promoteOutput = extractSection(promote, "Output");
+        const promoteOutput = extractSection(promote, "出力");
         expect(promoteOutput).toContain("promoted");
       }
     });
@@ -355,57 +374,46 @@ describe("REQ-0030-009: E2E workflow tests for all commands", () => {
         const content = commands.get(cmdName);
         expect(content).toBeDefined();
         if (content) {
-          expect(content).toMatch(/## Guardrails/);
+          expect(content).toMatch(/## ガードレール/);
         }
       });
     }
   });
 
-  // ─── Template coverage per command ───────────────────────────────────────
+  // ─── Template skill coverage per command ─────────────────────────────────
+  // case-open/close reference templates through `agentdev-workflow-templates` skill.
+  // case-update uses its own templates under commands/agentdev/templates/case-update/.
+  describe("Template skill coverage for issue/PR-creating commands", () => {
+    it("case-open references agentdev-workflow-templates skill", () => {
+      const content = commands.get("case-open");
+      expect(content).toBeDefined();
+      if (content) {
+        expect(content).toMatch(/agentdev-workflow-templates/);
+      }
+    });
 
-  describe("Template coverage for issue/PR-creating commands", () => {
-    const commandsUsingTemplates = [
-      { cmd: "case-open", expectedTemplates: ["issue_desc_feature.md", "issue_desc_bug.md"] },
-      { cmd: "case-close", expectedTemplates: ["issue_comment_feature_implementation.md", "issue_comment_bug_record.md"] },
-      { cmd: "case-update", expectedTemplates: ["issue_comment_update.md", "issue_comment_review_ng.md"] },
-    ];
-    for (const { cmd, expectedTemplates } of commandsUsingTemplates) {
-      describe(`${cmd} template references`, () => {
-        const content = commands.get(cmd);
-        if (!content) return;
-        const refs = extractTemplateRefs(content);
-        for (const tmpl of expectedTemplates) {
-          it(`references template "${tmpl}"`, () => {
-            expect(refs.includes(tmpl)).toBe(true);
-          });
-        }
-      });
-    }
+    it("case-close references agentdev-workflow-templates skill", () => {
+      const content = commands.get("case-close");
+      expect(content).toBeDefined();
+      if (content) {
+        expect(content).toMatch(/agentdev-workflow-templates/);
+      }
+    });
+
+    it("case-update references its own template directory", () => {
+      const content = commands.get("case-update");
+      expect(content).toBeDefined();
+      if (content) {
+        expect(content).toMatch(/templates\/case-update\//);
+      }
+    });
   });
 
   // ─── Agent type consistency ──────────────────────────────────────────────
 
   describe("Agent type consistency per pipeline", () => {
-    it("interactive commands use prometheus agent", () => {
-      const interactiveCommands = ["req-define"];
-      for (const cmd of interactiveCommands) {
-        const content = commands.get(cmd);
-        expect(content).toBeDefined();
-        if (content) {
-          const fm = parseFrontmatter(content);
-          expect(fm?.["agent"]).toBe("prometheus");
-        }
-      }
-    });
-    it("file/GitHub operation commands use sisyphus agent", () => {
-      const sisyphusCommands = [
-        "req-save", "case-open", "case-run", "case-update", "case-close",
-        "case-auto", "backlog-review",
-        "intake-capture", "intake-from-github", "intake-promote",
-        "learning-promote",
-        "req-restructure-review",
-      ];
-      for (const cmd of sisyphusCommands) {
+    it("all agentdev commands use sisyphus agent", () => {
+      for (const cmd of EXPECTED_COMMANDS) {
         const content = commands.get(cmd);
         expect(content).toBeDefined();
         if (content) {


### PR DESCRIPTION
## 概要

`commands_e2e.test.ts` の 58件 fail を解消する。主因は廃止コマンド（`req-restructure-review` 等）への README listing 要求がテスト期待値に残存していた点。本 PR はテスト期待値を現存コマンド一覧（17件）に一致させ、併せて README listing（`src/opencode/commands/agentdev/README.md`）との整合性を確認する。

配布物 Markdown のエンコーディング（AG-002）と REQ-0108-270/271（AG-003）は前工程で既に整備済みであり、本 PR はその確認結果を併記する。

## 変更内容

### AG-001: `commands_e2e.test.ts` 期待値整合（OU-001 メイン対象）

対象ファイル: `.opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts`（1 file changed, 74 insertions, 66 deletions）。

- `EXPECTED_COMMANDS`: 13件 → 17件へ更新
  - 廃止: `req-restructure-review`
  - 追加: `inspect-docs`, `inspect-extensions`, `inspect-promote`, `inspect-skills`, `spec-save`
- `VALID_SKILL_REFS` を新設し `learning-capture` を登録。`/agentdev/learning-capture` は skill 起動であり command 定義ではないため、command 参照整合判定から除外
- `REQ_CASE_PIPELINE` へ `spec-save` を挿入（`req-define → req-save → spec-save → case-open → case-run → case-update → case-close`）
- セクション見出し照合を `Input`/`Output` → `入力`/`出力` へ日本語化（現行コマンド定義の実態に整合）
- パス参照 `.sisyphus/drafts` → `.agentdev/drafts` へ修正
- pipeline 期待値 `GitHub PR` → `PR` へ簡素化（`case-close` 側の表記に揃える）
- Template coverage 検査を skill 参照判定へ再構成。`case-open`/`case-close` は `agentdev-workflow-templates` skill を参照、`case-update` は独自 `templates/case-update/` を参照
- Agent type 一貫性検査を「全 command が `sisyphus` を使用する」単一 `it` へ統合（かつての `prometheus`/`sisyphus` 二分は現行コマンド定義と不整合だった）
- `## Guardrails` → `## ガードレール` へ日本語見出し照合へ統一
- `SKILLS_DIR`/`TEMPLATES_DIR` へ projection（`.opencode/`）/ source（`src/opencode/`）の fallback 解決を追加。worktree ジャンクション未伝播環境でもテストが通るよう配慮

### AG-002: 配布物 Markdown エンコーディング（確認結果）

スコープ確認の結果、要変換ファイルは 0件。配布物は既に BOM なし UTF-8 へ準拠済み。検査対象:

- `src/opencode/` 配下 161件（`*.md`, `*.ps1`）: BOM なし UTF-8 違反 0件
- `src/opencode/` 配下 163件（`*.md`, `*.ps1`, `*.ts`, `*.json`, `*.yaml`, `*.yml`）: BOM なし UTF-8 違反 0件
- `.opencode/` 配下 8件（`*.md`, `*.ps1`）: BOM なし UTF-8 違反 0件

変換ファイルリスト: 該当なし（変換不要）。AG-002 の pass_criteria は既存状態で充足。

### AG-003: REQ-0108-270/271 確認

commit `d9480642`（既に main 取り込み）で要件追記完了を確認。本 PR では確認のみ実施、`docs/requirements/REQ-0108.md` 等の REQ/ADR/SPEC ファイルは編集していない。

- REQ-0108-270: commands_e2e.test.ts のテスト期待値と現存コマンド一覧の一致要求、廃止コマンドの除外を明文化
- REQ-0108-271: 配布物 Markdown のエンコーディング基準（BOM なし UTF-8）を明文化
- REQ-0108 全体要件行数: 39行（健全圏内、0-50 行の範囲内）
- REQ-0108-258（テストデータ構成は実ファイル構成を反映）との整合性: 確認。テスト期待値（`EXPECTED_COMMANDS`）は現行 `src/opencode/commands/agentdev/README.md` の listing（17件）と完全一致

## Files Checked

- `.opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts`（修正）
- `src/opencode/commands/agentdev/README.md`（参照確認、編集なし。17件の listing とテスト期待値が一致）
- `src/opencode/commands/agentdev/*.md`（17ファイルの存在確認、スキル拡張から参照）
- `docs/requirements/REQ-0108.md`（AG-003 確認、編集なし。39行、d9480642 で 270/271 追記済み）
- `docs/specs/quality/req-health-metrics.md`（参照確認、編集なし。REQ-0108 の行数参照が陳腐化、後述の Findings 参照）
- 配布物 Markdown エンコーディング一括走査（`src/opencode/`, `.opencode/` 配下、BOM 違反 0件）

## 完了条件

- [ ] AG-001-1: 廃止コマンド（`req-restructure-review` 等）の一覧を整理し、README listing と `commands_e2e.test.ts` のテスト期待値を現存コマンド一覧に一致させる
- [ ] AG-001-2: `commands_e2e.test.ts` の fail 件数が 0件であること（TS-001 pass_criteria、参考: 現行 58件）
- [ ] AG-002-1: 配布物 Markdown ファイル全てが BOM なし UTF-8 であること（TS-002 pass_criteria）
- [ ] AG-002-2: `commands_e2e.test.ts` でエンコーディング起因の fail が 0件であること（TS-002 pass_criteria）
- [ ] AG-003-1: REQ-0108-270/271 が正しく追記されていること（確認のみ、req-save 工程で commit d9480642 完了）
- [ ] AG-003-2: REQ-0108 の要件行数が SPEC 基準内であること（確認のみ、req-save 報告: 39行、健全圏内）

完了条件チェックボックスの最終完了判定は case-close 責務。本 PR は実装と検証結果を提示する。

## テスト結果

### TS-001（AG-001）: PASS（前回セッションで検証済み）

- Before: 58件 fail（廃止コマンド `req-restructure-review` の README listing 要求違反、セクション見出し英語/日本語不整合、`templates` 参照形式不整合等が混在）
- After: 0件 fail（テスト期待値を README listing 17件と一致）
- 廃止コマンド一覧整理結果: `req-restructure-review` の1件。`inspect-*` 4件と `spec-save` の5件を新規に EXPECTED_COMMANDS へ追加し、計17件へ整合

### TS-002（AG-002）: PASS（前回セッションで検証済み、本セッションで実態再確認）

- Before 想定: 配布物 Markdown に cp932 / UTF-8 BOM 付きファイルが混在する想定
- After 実測: BOM なし UTF-8 違反ファイル 0件（要変換ファイル 0件）。配布物は既に BOM なし UTF-8 へ準拠
- 変換ファイルリスト: 該当なし

### TS-003（AG-003）: PASS（前回セッションで検証済み）

- REQ-0108-270/271: commit `d9480642` で正しく追記済み（既に main）
- REQ-0108 要件行数: 39行（健全圏内、0-50 行）
- REQ-0108-258 整合性: テスト期待値（`EXPECTED_COMMANDS`）と README listing（17件）が完全一致

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| commands_e2e.test.ts fail 件数 | 0件 | 0件 | PASS |
| EXPECTED_COMMANDS vs README listing 一致 | 17/17件一致 | 完全一致 | PASS |
| 配布物 Markdown BOM 違反件数 | 0件 | 0件 | PASS |
| REQ-0108 要件行数 | 39行 | 0-50行（健全圏） | PASS |
| targeted docs guard | SKIPPED（`.opencode/skills/repo-agentdev-integrity/scripts/` 配下のみ編集、`docs/**` 対象外） | 対象外 | N/A |
| check_extensions.ts | SKIPPED（`src/opencode/commands/agentdev/**/*.md` 未編集） | 対象外 | N/A |

## Findings・Capture候補

### docs-integrity

- **REQ-0108 の SPEC 参照値表（22行）陳腐化**（intake item 候補）: `docs/specs/quality/req-health-metrics.md:95` が `REQ-0108 | 22 | +0` を記載しているが、実際の REQ-0108 は d9480642 での 270/271 追記により 39行（+17行相当）。`docs-check` または `inspect-docs` 系での自動検出機構（AG-004、OU-002 で別 case 検討）が整備されれば、SPEC 参照値表の陳腐化も自動検出対象となる。本 PR スコープ外のため REQ/REQ-health-metrics SPEC の修正は行わず、capture 候補として記録する
- **targeted docs guard**: SKIPPED。変更ファイル `.opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts` は `docs/**` 配下ではなく、`check_changed_docs.ts` の対象外。`docs/**` 配下を編集していないため full docs check 推奨も発生しない
- **check_extensions.ts**: SKIPPED。`src/opencode/commands/agentdev/**/*.md` を未編集。テストファイル（`.ts`）の修正のみであり、command frontmatter / extension YAML の整合性検査対象外

### stale-reference

- **廃止コマンド一覧整理結果**（学習・参照用）:
  - 廃止確定: `req-restructure-review`（`EXPECTED_COMMANDS` から削除）
  - 追加: `inspect-docs`, `inspect-extensions`, `inspect-promote`, `inspect-skills`, `spec-save`
  - Net: 13件 → 17件（+5件、-1件）
- **テスト期待値と README listing の同期必要性**（再発防止知見候補）: コマンド追加・廃止時に `src/opencode/commands/agentdev/README.md` と `commands_e2e.test.ts` の `EXPECTED_COMMANDS` を同時更新する運用が REQ-0108-270 で明文化された。以後のコマンド追加・廃止時は両者を同時更新し、テストドリフトを再発させない。この運用ルール自体は AG-004（OU-002 別 case）での機構検討 material になる可能性あり
- **前回セッション引き継ぎ情報のズレ**（capture 候補）: 前回セッション引継ぎプロンプトは「TS-002 で配布物 Markdown のエンコーディングを BOM なし UTF-8 に統一（変換ファイルリストは git diff で確認）」と記載していたが、実態は worktree HEAD = `origin/main`（b0a00fe1）でエンコーディング変更差分なし、配布物は既に BOM なし UTF-8 へ準拠済み。「検証 PASS」の表現と実装 diff の有無の整合性を取る属人性を減らすため、TS の pass 記録時には "no-op confirmed" と "conversion applied" を明示的に区別する運用改善が learning 候補になる

## SPEC確定候補

該当なし。本 PR は既存 REQ-0108-270/271（d9480642 で確定済み）の実装であり、新たな SPEC レベルの詳細は発生していない。

## Test Strategy

Issue #1552 のテスト戦略に基づく検証結果（全項目処理済み、record-in-findings なし）。

- **TS-001（AG-001）**: PASS。fix-and-reverify ループを経て fail 件数 58→0 を達成。`commands_e2e.test.ts` を改修し、`EXPECTED_COMMANDS` を README listing と一致させた
- **TS-002（AG-002）**: PASS。配布物 Markdown エンコーディングは BOM なし UTF-8 へ既に準拠（no-op confirmed）。`commands_e2e.test.ts` でエンコーディング起因の fail は 0件
- **TS-003（AG-003）**: PASS。REQ-0108-270/271 の追記（commit `d9480642`）を確認。要件行数 39行（健全圏内）、REQ-0108-258 との整合性を確認

## 関連Issue

Refs #1552

