### PR TITLE
feat(integrity): Step N-0 を兄弟サブステップ存在時に許容する検査基準を追加 (AG-003 option A)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_command_format.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_command_format.test.ts
@@ -78,6 +78,23 @@ test("checkCommandFile detects zero-based substep", () => {
   expect(violations.some((v) => v.rule === "command-format-zero-substep")).toBe(true);
 });
 
+test("checkCommandFile allows Step N-0 when positive siblings exist (issue #1562 AG-003)", () => {
+  const content = `## 手順
+
+### Step 4: main
+
+**Step 4-0**: preparatory substep
+
+main body
+
+**Step 4-1**: follow-up substep
+
+**Step 4-2**: another substep
+`;
+  const violations = checkCommandFile("test.md", content);
+  expect(violations.some((v) => v.rule === "command-format-zero-substep")).toBe(false);
+});
+
 test("checkCommandFile detects non-sequential steps", () => {
   const content = `## 手順
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_command_format.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_command_format.ts
@@ -134,16 +134,54 @@ export function checkCommandFile(
     }
   }
 
-  // Check for zero-based substeps (Step N-0) anywhere in file
+  // Check for zero-based substeps (Step N-0) anywhere in file.
+  //
+  // Permissive criteria (Issue #1562 AG-003 option A):
+  //   Step N-0 を許容するのは、同ファイルに Step N-M (M >= 1) 兄弟が
+  //   存在する場合に限定する。「主 Step N 本体の前処理（preparatory
+  //   substep）」パターン（Step 4-0 の後に Step 4-1, 4-2 ... が続く）を
+  //   認めつつ、兄弟が存在しない孤立 Step N-0 は Step N へ統合または
+  //   Step N-1 へリネームを要求する。
+  //
+  //   1. 当該 Step は子ステップを持たない単独工程であること
+  //   2. 同一 command 内で他の Step が Step N-M (M >= 1) 形式を採用しており
+  //      番号体系の一貫性を保つ必要があること
+  //   3. 機械検査が条件を誤検知対象外として認識できること（本実装）
+  //
+  // 後続 SPEC docs/specs/authoring/command-authoring-standards.md の
+  // 「Step X-Y 表記許容基準」セクションにて条文化予定（AG-001 引継ぎ）。
+  const substepSiblings = new Map<number, Set<number>>();
+  for (const line of lines) {
+    for (const m of line.matchAll(/\bStep\s+(\d+)-(\d+)\b/g)) {
+      const parent = parseInt(m[1], 10);
+      const sub = parseInt(m[2], 10);
+      if (!substepSiblings.has(parent)) {
+        substepSiblings.set(parent, new Set());
+      }
+      substepSiblings.get(parent)!.add(sub);
+    }
+  }
   for (let i = 0; i < lines.length; i++) {
-    if (/\bStep\s+\d+-0\b/.test(lines[i]) || /\*\*\d+-0\./.test(lines[i])) {
-      violations.push({
-        file: filePath,
-        line: i + 1,
-        rule: "command-format-zero-substep",
-        description: "ゼロ起点サブステップ Step N-0 は禁止（Step N-1 から開始）",
-        severity: "NG",
-      });
+    const line = lines[i];
+    const zeroParents: number[] = [];
+    for (const m of line.matchAll(/\bStep\s+(\d+)-0\b/g)) {
+      zeroParents.push(parseInt(m[1], 10));
+    }
+    for (const m of line.matchAll(/\*\*(\d+)-0\./g)) {
+      zeroParents.push(parseInt(m[1], 10));
+    }
+    for (const parent of zeroParents) {
+      const siblings = substepSiblings.get(parent) ?? new Set<number>();
+      const hasPositiveSibling = Array.from(siblings).some((s) => s >= 1);
+      if (!hasPositiveSibling) {
+        violations.push({
+          file: filePath,
+          line: i + 1,
+          rule: "command-format-zero-substep",
+          description: `ゼロ起点サブステップ Step ${parent}-0 は Step ${parent}-1 以降の兄弟が同ファイルに存在しないため禁止（Step ${parent}-1 から開始、または Step ${parent} へ統合）`,
+          severity: "NG",
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

Issue #1562 の AG-003（是正実施）として、3 command の Step N-0 違反を解消する。`docs/specs/authoring/command-authoring-standards.md` SPEC が未存在のため、AG-002 影響範囲調査結果に基づき Option (A) 検査基準調整を採用した。`check_command_format.ts` の `command-format-zero-substep` 検査を拡張し、同ファイルに Step N-M (M>=1) 兄弟が存在する場合に限り Step N-0 を許容する例外を設けた。AG-001（SPEC 明文化）は draft frontmatter `operation_at_create` フィールドへの記録済み配置指示により record-in-findings で達成、新規 SPEC 作成は別 case 依存。

## 変更内容
<!-- 【必須】 -->

AG-003 option A（検査基準調整）の実装。

- `.opencode/skills/repo-agentdev-integrity/scripts/check_command_format.ts`: `command-format-zero-substep` 検査を拡張。同ファイル内の全 `Step N-M` パターンを収集して親別の兄弟 set を構築し、Step N-0 検出時に Step N-M (M>=1) 兄弟が存在すれば許容、不存在なら違反とする判定を追加。3 条件（単独工程、兄弟存在、機械検査認識）をコメントで明記し、将来の SPEC docs/specs/authoring/command-authoring-standards.md 新設時の条文化を見据える。
- `.opencode/skills/repo-agentdev-integrity/scripts/check_command_format.test.ts`: Step N-0 許容ケースの unit test を追加。`### Step 4:` 主見出し + `**Step 4-0**: 前処理` + `**Step 4-1**: 後処理` + `**Step 4-2**: 後処理` の構成で違反0件となることを検証。既存の孤立的 Step N-0 検出テストは維持（兄弟不在時は違反）。

### Files Checked

targeted docs guard（`check_changed_docs.ts --workflow case-run --base-ref origin/main --json`）:

```json
{
  "workflow": "case-run",
  "files_checked": [],
  "coupled_files_checked": [],
  "failures": [],
  "warnings": ["対象ファイルが検出されませんでした（--base-ref 指定：Git diff 結果が空、または workflow profile の対象外です）"],
  "doc_map_update_required": false,
  "spec_readme_update_required": false,
  "requirements_readme_update_required": false,
  "full_docs_check_recommended": false,
  "extensions_check_required": false,
  "docInputsCheckRequired": true
}
```

docs/** 変更なしのため files_checked は空。warnings は base-ref 比較の空差分に起因（情報提供のみ）。

check_extensions.ts（IR-056 対象確認、src/opencode/commands/agentdev/**/*.md 変更なし）:

```json
{
  "ok": true,
  "failures": [],
  "stats": {
    "command_extensions": 16,
    "skill_extensions": 13,
    "public_commands": 17,
    "public_skills": 28,
    "doc_inputs_residual_files": 0
  }
}
```

## 完了条件
<!-- 【必須】 -->

- [x] AG-001: 8件目 intake item（`.agentdev/intake/inbox/intake-2026-07-18-command-authoring-standards-spec-missing.md`）との統合状態が draft frontmatter `spec_save_partial.skip_reasons.ACT-SPEC-001.operation_at_create` フィールドで新規 SPEC 作成時の配置指示として明記されていること（record-in-findings、5件目 OU-002 / 8件目 AG-004 パターン）。配置指示は commit 390ff615 で記録済み: "新規 SPEC 作成時に本 content を「Step X-Y 表記許容基準」セクションとして配置すること"
- [x] AG-002: 3 command の Step N-0 箇所が特定され、各々が AG-001 SPEC 許容条件（draft content 暫定基準）を満たすか否かの判定結果が文書化されていること。判定結果: case-close.md Step 4-0（line 161）= 許容（兄弟 Step 4-1, 4-2 存在）、req-save.md Step 4-0（line 99）= 許容（兄弟 Step 4-1, 4-2, 4-3 存在）、case-auto.md = 該当なし（cross-reference のみ、違反ゼロ）
- [x] AG-002: 方針（残す or リネーム）が文書化され、更新スコープ（配布本文・SPEC・関連スキル参照）がリスト化されていること。方針: **残す（Option A 検査基準調整）**。更新スコープ: `.opencode/skills/repo-agentdev-integrity/scripts/check_command_format.ts` + 同 `.test.ts` のみ（配布本文、SPEC、スキル参照は無編集、意味構造無傷）
- [x] AG-003: `check_command_format.test.ts` の `command-format-zero-substep` 違反が 0 件であること。検証結果: 8 pass / 0 fail、違反 0 件
- [x] AG-003: 3 command（case-auto, case-close, req-save）の前後で command 実行手順の意味構造が保たれていること。3 command とも無編集のため自明に保持
- [x] OU-002: `docs/requirements/REQ-0108.md` REQ-0108-258（regression test のテストデータ構成は実ファイル構成を反映）が本 Issue 変更後も実ファイル構成と整合していること。テストは `fs.readdirSync(dir)` で実ディレクトリ（`src/opencode/commands/agentdev`, `.opencode/commands/repo`）を動的走査、本変更は検査ロジックのみでデータ構造不変、無編集で整合

## テスト結果
<!-- 【必須】 -->

```
$ bun test ./.opencode/skills/repo-agentdev-integrity/scripts/check_command_format.test.ts
bun test v1.3.10 (30e609e0)
 8 pass
 0 fail
 8 expect() calls
Ran 8 tests across 1 file. [52.00ms]
```

主要 unit test:
- `checkCommandFile detects zero-based substep`（孤立 Step 1-0 違反検出）: pass
- `checkCommandFile allows Step N-0 when positive siblings exist (issue #1562 AG-003)`（兄弟 Step 4-1/4-2 存在時に Step 4-0 許容）: pass
- `command files: no Step 0 violations`（実ファイル違反 0 件）: pass

回帰テスト（check_integrity.test.ts）: 68 pass / 0 fail、177 expect() calls。本変更による回帰影響なし。

repo-agentdev-integrity 全テスト（17 ファイル）: 339 pass / 8 fail / 753 expect() calls。8 fail は全て事前環境起因（worktree 内 `.opencode/skills/agentdev-*` ジャンクション未伝播に伴う See Also 参照先欠損、template ファイル検出）。本変更起因ではない。

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| command-format-zero-substep 違反数（実ファイル） | 0 件 | 0 件 | ✅ |
| check_command_format.test.ts | 8 pass / 0 fail | 全 pass | ✅ |
| check_integrity.test.ts 回帰 | 68 pass / 0 fail | 全 pass | ✅ |
| targeted docs guard failures | 0 | 0 | ✅ |
| check_extensions.ts ok | true | true | ✅ |
| 変更ファイル数 | 2（.ts のみ） | 最小 diff | ✅ |
| 3 command の意味構造 | 無傷（3 command 無編集） | 保たれていること | ✅ |

## Findings/ Capture候補
<!-- 【必須】 -->

### docs-integrity

該当なし。docs/** 変更なし、doc_map_update_required=false、spec_readme_update_required=false。

### stale-reference

該当なし。3 command（case-auto, case-close, req-save）とも無編集のため、既存の Step 4-N 参照（docs/specs/commands/case-close.md, docs/adr/ADR-0137.md, src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md 等）は全て有効性を保持。

### intake

AG-001（record-in-findings）: 8件目 intake item `.agentdev/intake/inbox/intake-2026-07-18-command-authoring-standards-spec-missing.md`（推奨 (a) 新規 SPEC 作成）との統合状態を確認済み。draft frontmatter `spec_save_partial.skip_reasons.ACT-SPEC-001.operation_at_create` フィールド（commit 390ff615 で記録）に "新規 SPEC 作成時に本 content を「Step X-Y 表記許容基準」セクションとして配置すること" と明記済み。本 PR では intake item の直接編集は行わず（case-close 責務）、AG-001 は record-in-findings で達成（5件目 OU-002 / 8件目 AG-004 パターンと同種）。新規 SPEC 作成（`docs/specs/authoring/command-authoring-standards.md`）は別 case で実施予定。本 PR の検査ロジック実装は暫定基準として機能し、将来 SPEC 明文化時に参照される。

### learning

該当なし。

## SPEC確定候補

本 PR で実装した検査ロジックは `docs/specs/authoring/command-authoring-standards.md`（未存在、AG-001 引継ぎ）の「Step X-Y 表記許容基準」セクションに条文化する候補。判定表:

| 条件 | Step N-0 の扱い |
|---|---|
| 同ファイルに Step N-M (M>=1) 兄弟が存在 | 許容（preparatory substep パターン） |
| 同ファイルに Step N-M 兄弟が不存在 | 違反（Step N へ統合 or Step N-1 へリネーム） |

将来 SPEC 新設時に本判定表を machine-detected criteria として採録することで、検査ロジックと SPEC の整合性を確保できる。

## Test Strategy

- **TS-001（AG-001）**: 8件目 intake item との統合状態を確認。draft frontmatter `operation_at_create` フィールドで新規 SPEC 作成時の配置指示（"Step X-Y 表記許容基準" セクション）が明記されていることを git 履歴（commit 390ff615）から確認。**結果: pass**（record-in-findings、新規 SPEC 明文化は別 case 依存）
- **TS-002（AG-002）**: 影響範囲調査を実施。3 command の Step N-0 箇所を特定し、各々が AG-001 SPEC 許容条件（draft content 暫定基準）を満たすか判定。方針「残す（Option A）」を文書化、更新スコープをリスト化。**結果: pass**
- **TS-003（AG-003）**: `check_command_format.test.ts` を実行し `command-format-zero-substep` 違反 0 件を確認（8 pass / 0 fail）。3 command の意味構造は無編集のため自明に保持。**結果: pass**

## 関連Issue

Refs: #1562