### PR TITLE
feat(specs): case-run/case-close SPEC に verification-only PR の files_checked 空確認手順を新設 (Refs: #1567)

### DIFF
--- a/docs/specs/commands/case-close.md
+++ b/docs/specs/commands/case-close.md
@@ -2,7 +2,7 @@
 title: case-close SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-07-18
+updated: 2026-07-19
 ---
 
 # case-close SPEC
@@ -127,8 +127,35 @@ case-close は targeted docs guard が FAILURE を返した場合、以下を行
 2. `--files` 指定の妥当性を確認する（PR 変更ファイル一覧の再取得、パス指定の確認）
 3. 必要に応じて `--files` での再実行、または対象ファイルの手動確認を行う
 4. 空の理由が正当（対象ファイルが本当に変更されていない等）であることを確認してから続行する
+5. PR が verification-only（変更ファイル0件）の場合、後述「verification-only PR の files_checked 空確認（REQ-0158-002）」に従い判定する
 
 上記確認を経ずに `files_checked` 空のまま完了扱いとしない。
+
+#### verification-only PR の files_checked 空確認（REQ-0158-002）
+
+verification-only PR（実装差分0件、検証のみで作成された PR）の場合、`files_checked` が空になることが正規の状態として発生する。case-close は次の手順で verification-only 判定を行い、正当と判断された場合に PASS 処理する。要件の SSoT は REQ-0158-002、verification-only PR の定義と case-run 側引継ぎ注意事项は [case-run.md](case-run.md)「verification-only PR（実装差分なし、検証のみ）（REQ-0158-002）」参照。
+
+**判定基準（全て満たすこと）**:
+
+1. PR 変更ファイル一覧（`gh pr view <PR> --json files`）が空配列であること
+2. PR 本文に verification-only である旨が明記されていること（「実装差分なし（verification-only）」等の表現）
+3. PR 本文に検証 evidence（`## 完了条件検証`、`## 変更内容` 等）が記録されており、Issue の受け入れ基準が検証のみで充足されたことが確認できること
+
+**PASS 処理**:
+
+上記3項目を全て満たす場合、case-close は verification-only PR と判定し、files_checked 空の FAILURE を PASS 処理する。判定根拠（PR 本文の verification-only 宣言、検証 evidence の参照、`gh pr view --json files` の空配列確認）を完了報告に記録する。
+
+**false-clean 3層防御との相互作用**:
+
+REQ-0158「case-close 向け false-clean 予防」節は files_checked 空を silent pass としないための3層防御（対象空時の warning 報告、`--files` 標準化、files_checked 非空の確認ステップ）を定める。REQ-0158-002 はこの3層防御を回避するものではなく、verification-only の正当性確認により3層防御の警告を吸収する経路を追加する。両者の関係は以下の通り:
+
+| 層 | REQ-0158 false-clean 予防節 | REQ-0158-002 による相互作用 |
+|---|---|---|
+| 第1層 | check_changed_docs.ts が files_checked 空を warning として報告 | warning を検知した case-close が verification-only 判定ステップへ進むトリガーとして扱う（silent pass しない） |
+| 第2層 | case-close は `--files <PR変更ファイル>` 指定を標準とする | verification-only PR では `--files` が空配列となり、それ自体が verification-only のシグナルとなる |
+| 第3層 | files_checked が空でないことの確認ステップを含める | 本ステップが verification-only 判定基準（3項目）の適用場所となる。3項目を満たさない場合は silent pass を許さず FAILURE を維持する |
+
+verification-only 判定基準3項目を満たさない files_checked 空（例: PR 本文に verification-only 宣言がない、検証 evidence がない）は silent pass を許さず、FAILURE を維持して構造化エラー停止とする。
 
 ## 対象外
 

--- a/docs/specs/commands/case-run.md
+++ b/docs/specs/commands/case-run.md
@@ -2,7 +2,7 @@
 title: case-run SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-07-18
+updated: 2026-07-19
 ---
 
 # case-run SPEC
@@ -145,6 +145,32 @@ bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
 
 - 検出結果（failures の strict severity）は PR 本文の `## Findings / Capture候補` セクションに `### docs-integrity` 小見出しで記録する
 - case-update へ連携し、Issue 本文の更新を委譲する（case-run 単独では Issue 本文を書き換えない、REQ-0130-034 準拠）
+
+## verification-only PR（実装差分なし、検証のみ）（REQ-0158-002）
+
+case-run は実行担当サブエージェント委譲の結果、実装差分0件・検証のみで完了する PR（**verification-only PR**）を生成する場合がある。本節は verification-only PR の判定条件、GitHub の空 PR 取り扱い、case-close への引継ぎ注意事项を定める。要件の SSoT は REQ-0158-002。
+
+### 定義
+
+verification-only PR は以下を全て満たす PR とする（REQ-0158-002）。
+
+- PR の変更ファイル数が0件（`gh pr view --json files` で `files: []`）
+- Issue の受け入れ基準が検証のみで充足された（既存実装・既存文書が要件を満たしており、追加実装を要しなかった）
+- 検証結果が PR 本文（`## 変更内容`、`## 完了条件検証` 等）に evidence として記録されている
+
+実行担当サブエージェントは verification-only で完了した場合も `completed-pr` を返し、PR URL を委譲 result に含める（`blocked` / `failed` にはしない）。PR 本文には「実装差分なし（verification-only）」である旨と検証 evidence を記載する。
+
+### GitHub の空 PR 許容
+
+GitHub は空 PR（変更ファイル0件）の squash merge を許可し、空 commit を生成する（commit 2b34f8b0 で実証）。case-run は空 PR の作成・マージを GitHub の挙動に依存して実行する。squash merge で生成された空 commit は履歴に残り、`gh pr merge --squash` の通常フローに従う。
+
+### case-close 引継ぎ注意事项
+
+verification-only PR は case-close Step 3-1 targeted docs guard で files_checked が空になるため、次の注意事项を case-close へ引き継ぐ。
+
+- PR 本文に「verification-only である旨」と「検証 evidence（`## 完了条件検証` 等）」が記録されていること（[case-close.md](case-close.md)「verification-only PR の files_checked 空確認（REQ-0158-002）」参照）
+- case-close は files_checked 空を検出した場合、REQ-0158-002 に基づき verification-only 判定ステップを経て PASS 処理する（false-clean 3層防御との相互作用は case-close SPEC 参照）
+- case-run 側は PR 作成までを責務とし、verification-only 判定自体は case-close が行う（単一書き手: case-close、ADR-0114 完了条件チェックボックス専任責務）
 
 ## 参照する横断 SPEC
 


### PR DESCRIPTION
## 概要

Issue #1567（REQ-0158-002）の Phase 2 case-run 実装。verification-only PR（実装差分0件、検証のみで作成される PR）で files_checked が空になる場合の取り扱いを case-run/case-close SPEC へ明文化する。Phase 1（commit 7b56a737 で REQ-0158-002 APPEND）に続き、SPEC 側の修復を完遂する。

## 変更内容

### docs/specs/commands/case-run.md

「verification-only PR（実装差分なし、検証のみ）（REQ-0158-002）」セクションを新設:

- 定義（変更ファイル0件、検証のみ充足、PR 本文の evidence 記録）
- GitHub の空 PR 許容（squash merge で空 commit 生成、commit 2b34f8b0 で実証）
- case-close 引継ぎ注意事项（PR 本文の evidence 記録、case-close での verification-only 判定）

### docs/specs/commands/case-close.md

「files_checked 空時の取扱い」セクションへ verification-only PR の files_checked 空確認手順を追加:

- case-close 側の確認ステップ（AG-006）へ Step 5 を追加（verification-only 判定への分岐）
- 「verification-only PR の files_checked 空確認（REQ-0158-002）」サブセクションを新設
- 判定基準3項目（PR 変更ファイル空、PR 本文の verification-only 宣言、検証 evidence）
- false-clean 3層防御（REQ-0158「case-close 向け false-clean 予防」節）との相互作用を3層の表で整理

## Files Checked

targeted docs guard（check_changed_docs.ts --workflow case-run）を実行:

| 項目 | 結果 |
|---|---|
| files_checked | docs/specs/commands/case-run.md, docs/specs/commands/case-close.md |
| coupled_files_checked | docs/DOC-MAP.md, docs/README.md, docs/specs/README.md |
| failures | なし |
| warnings | なし |
| spec_readme_update_required | false |
| requirements_readme_update_required | true（REQ-0158 の updated 更新に伴う推奨フラグ、failures/warnings なし） |
| extensions_check_required | true（check_extensions.ts で検証、ok: true, failures 0） |
| full_docs_check_recommended | false |

check_extensions.ts（IR-056）: ok: true, failures 0（command_extensions: 16, skill_extensions: 13, public_commands: 17, public_skills: 28, doc_inputs_residual_files: 0）。

## Test Strategy

- id: TS-001
  target_item: docs/requirements/REQ-0158.md
  verification: REQ-0158-002 エントリの存在確認（Phase 1 commit 7b56a737 で APPEND 済み）
  pass_criteria: REQ-0158-002 エントリが存在し、verification-only PR の定義、files_checked 空確認、false-clean 3層防御との相互作用が記載されていること
  結果: PASS（REQ-0158.md L196-200 に REQ-0158-002 エントリ存在、H3 + table 形式で verification-only PR の files_checked 空確認要件を記載）

- id: TS-002
  target_item: docs/specs/commands/case-run.md
  verification: case-run.md への verification-only PR セクション存在確認
  pass_criteria: verification-only PR の定義（実装差分0件、検証のみ）、空 commit の GitHub 許容、case-close 引継ぎ注意事项が記載されていること
  結果: PASS（L149「verification-only PR（実装差分なし、検証のみ）（REQ-0158-002）」セクション新設、定義・GitHub 空 PR 許容・case-close 引継ぎ注意事项の3サブセクションを記載）

- id: TS-003
  target_item: docs/specs/commands/case-close.md
  verification: case-close.md Step 3-1 への verification-only PR の files_checked 空確認手順の記載確認
  pass_criteria: REQ-0158「case-close 向け false-clean 予防」節の確認事項の適用、verification-only 判定基準、false-clean 3層防御との相互作用が記載されていること
  結果: PASS（L134「verification-only PR の files_checked 空確認（REQ-0158-002）」サブセクション新設、判定基準3項目と3層防御との相互作用表を記載、AG-006 確認ステップに Step 5 追加）

- id: TS-004
  target_item: PR 1527 での実証確認
  verification: PR 1527（Issue 1521/OU-006, Epic 1515 Wave 2）のケースが新 SPEC 手順で verification-only と判定され、files_checked 空が正当化されることを確認
  pass_criteria: 新手順に照らして PR 1527 が verification-only と判定され、files_checked 空が正当化されること
  結果: PASS（PR 1527 は判定基準3項目を全て満たす: (1) files: [] 空配列 (gh pr view --json files で確認)、(2) PR 本文に「実装差分なし (verification-only)」明記、(3) PR 本文に「完了条件検証」セクション + 3件の完了条件検証表を記録。新 SPEC 手順で verification-only と判定され、files_checked 空が正当化される）

## 完了条件

- [x] docs/requirements/REQ-0158.md に REQ-0158-002 エントリが存在（Phase 1 commit 7b56a737 完了）
- [x] docs/specs/commands/case-run.md に verification-only PR セクションが存在（定義、空 commit の GitHub 許容、case-close 引継ぎ注意事项を含む）
- [x] docs/specs/commands/case-close.md Step 3-1 に verification-only PR の files_checked 空確認手順が記載（REQ-0158「case-close 向け false-clean 予防」節との相互作用、verification-only 判定基準を含む）
- [x] PR 1527 のケースが新 SPEC 手順で verification-only と判定され、files_checked 空が正当化されることを実証確認

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| targeted docs guard | failures 0, warnings 0 | strict failure なし | ✅ |
| check_extensions.ts (IR-056) | ok: true, failures 0 | failures 0 | ✅ |
| 変更ファイル数 | 2 (case-run.md, case-close.md) | Issue スコープ内 | ✅ |
| commit message 形式 | feat(specs): ... (Refs: #1567) | agentdev-conventional-commits 準拠 | ✅ |

## Findings / Capture候補

### intake

該当なし

### learning

該当なし

## SPEC確定候補

- case-close.md「verification-only PR の files_checked 空確認」サブセクションの判定基準3項目（PR 変更ファイル空、PR 本文の verification-only 宣言、検証 evidence の存在）は、REQ-0158-002 の要件を SPEC として具体化したもの。case-close Step 3-1 の機械化境界（machine-checkable 範囲）は「PR 変更ファイル空（gh CLI で検証可能）」までで、PR 本文の verification-only 宣言・検証 evidence の存在確認は人間判断を含む heuristic 領域。

## 関連Issue

Closes: #1567