### PR TITLE
feat(adapter): call_omo_agent schema 制約時の挙動セクションと委譲可否 probe 境界を新設 (Refs: #1573)

### DIFF
--- a/src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md
+++ b/src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md
@@ -161,6 +161,55 @@ adapter skill 経由の委譲（case-run からの実行担当サブエージェ
 
 adapter skill は本要件を宣言的に定義し、case-run からの委譲 prompt 構築時に参照される。詳細な category 選定ガイドラインは `case-auto.md` の「Subagent 委譲プロトコル」節、MUST NOT DO 記載要件は `agentdev-workflow-orchestration/references/capture-boundaries.md` 参照。
 
+## ハーネス制約適応（call_omo_agent schema 制約時）
+
+adapter skill は `call_omo_agent` ツール schema が custom agent 型（実行担当サブエージェント型）を許可しないハーネス環境で動作することを前提とする（REQ-0149-012）。
+oh-my-openagent 等のハーネスでは explore/ librarian 型のみが許可され、Epic Wave 並列委譲（最大5件）も機能しない。
+
+### 事前 probe（ハーネス能力検出）
+
+case-run は委譲起動前にハーネス能力を probe し、実行担当サブエージェント型が起動可能かを判定する。
+
+1. **probe 対象**: `call_omo_agent`（または同等の委譲起動 API）が受け入れる `subagent_type` の一覧
+2. **probe 方法**: harness 固有。AGENTS.md および `references/<harness>.md` 参照（REQ-0162-002）
+3. **判定結果**:
+ - 実行担当サブエージェント型が許可される → 通常委譲パス（前節「委譲抽象IF」）
+ - 実行担当サブエージェント型が不許可 → 後述「インライン逐次実行」へ移行
+
+### Inability の冒頭明示
+
+probe の結果、委譲が利用不可の場合、case-run はインライン実行へ移行する旨を冒頭で明示する。
+最終的な SSoT は result 契約に従う（completed-pr → PR 本文、blocked/ failed → Issue コメント）。
+
+明示内容は以下の3点である:
+
+- **制約事実**: `call_omo_agent` schema が custom agent 型を許可しないこと
+- **影響範囲**: 1 Issue 単位の委譲不可、Epic Wave 並列委譲不可
+- **採用措置**: インライン逐次実行で adapter protocol に従うこと
+
+### インライン逐次実行時の adapter protocol 遵守
+
+委譲が利用不可の場合、case-run の実行コンテキストが adapter skill を読み込み、インラインで逐次実行する。
+この場合も本スキルの定める adapter protocol に従う:
+
+- worktree root 配下のみ編集（「worktree 隔離の遵守（禁止事項）」）
+- Issue 読込 → context 再確認 → 実装 → 検証 → PR 作成の順序（「実行担当サブエージェントの責務」）
+- test strategy 項目の test-fix ループ（「test strategy 項目の test-fix ループ（REQ）」）
+- result 契約（4状態）の維持（「Result 契約（最小契約）」）。委譲を起動していないため `delegation-unavailable` は返さず、`completed-pr` / `blocked` / `failed` のいずれかを返す
+- Findings / SPEC確定候補の配置規約（「Findings/ Capture 配置」「SPEC確定候補配置」）
+
+### Epic Wave 並列委譲不可時の運用
+
+`#epic` 指定時も本制約により Wave 内の子Issue 並列委譲（最大5件）は機能しない。
+case-run は現在 ready な Wave の子Issue を順次（インライン逐次）処理する。
+Wave 境界（PR マージ）は case-close が担うため本適応の対象外。
+
+### 既存フォールバックパスとの関係
+
+本節は事前 probe による**委譲起動前**の適応である。
+次節「委譲起動失敗、異常終了時事後処理」は**委譲起動後**の異常終了に対する事後処理である。
+両者は対象段階が異なり、重複しない。委譲起動の可否に応じて使い分ける。
+
 ## 委譲起動失敗、異常終了時事後処理
 
 実行担当サブエージェントの委譲起動失敗、異常終了時（エージェント型利用不可、異常終了、実行 command 内部エラー等）は即 `failed` とせず**実装完了、検証未完了**として扱い、以下の手順で事後処理する:

--- a/src/opencode/skills/agentdev-workflow-orchestration/references/capture-boundaries.md
+++ b/src/opencode/skills/agentdev-workflow-orchestration/references/capture-boundaries.md
@@ -98,6 +98,31 @@ subagent 委譲を実施する agentdev command（case-auto、case-open、case-r
 - **由来**: Issue #1538 で case-open を `category=writing` で委譲した際、MUST NOT DO が未明示で subagent が `.agentdev/drafts/` 配下へ draft を作成した事象（REQ-0163-002）
 - **関連**: category 選定ガイドラインは REQ-0163-001、`case-auto.md` の「Subagent 委譲プロトコル」節、`agentdev-case-run-execution-adapter` SKILL の「委譲プロトコルと category 設計」節参照
 
+## 委譲可否 probe と Inability 記録
+
+case-run は委譲起動前にハーネス能力を probe し、委譲可否を判断する（REQ-0149-012）。
+probe 手順、委譲可否判定の詳細は `agentdev-case-run-execution-adapter` SKILL「ハーネス制約適応（call_omo_agent schema 制約時）」参照。
+本節は委譲不可時の Inability 記録境界のみを定める。
+
+### Inability 明示タイミング
+
+委譲不可と判定した時点で、case-run は実装作業の冒頭で Inability を明示する。
+タイミングは worktree 作成後、実装開始前である。
+
+Inability の記録先は result 状態に応じて決まる（既存の SSoT 契約に準拠）:
+
+| result | Inability 記録先 |
+|--------|-----------------|
+| `completed-pr` | PR 本文 `## Findings / Capture候補` |
+| `blocked` / `failed` | Issue コメント |
+
+### Inability のキャプチャ分類
+
+Inability の内容は既存の分割ルール（「分割ルール（観測の分割）」参照）に従い Intake 候補と Learning 候補に分離する:
+
+- ハーネス制約そのもの（`call_omo_agent` schema の制約など）は Learning 候補（再発防止知見）
+- 特定 Issue での影響（並列委譲不可による逐次実行等）は Intake 候補（個別作業）
+
 ## See Also
 
 - **agentdev-learning-capture**: Learning 抽出の具体的スキル（13 項目形式、実観測ベース原則）


### PR DESCRIPTION
## 概要

Issue #1573 の実装修復（Phase 2）として、adapter skill（`agentdev-case-run-execution-adapter`）に `call_omo_agent` ツール schema が custom agent 型を許可しないハーネス環境での挙動セクションを新設し、`capture-boundaries.md` に委譲可否 probe の記録境界を追記する。REQ-0149-012（Phase 1 commit 49621355 で採番済み）を実装に落とし込む。

## 変更内容

### `src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md`

「委譲抽象IF」と「委譲起動失敗、異常終了時事後処理」の間に新セクション「ハーネス制約適応（call_omo_agent schema 制約時）」を新設した。既存の事後処理パス（委譲起動後の異常終了対応）とは対象段階が異なり、重複しない。

- **事前 probe（ハーネス能力検出）**: 委譲起動前に `call_omo_agent` が受け入れる `subagent_type` 一覧を probe し、実行担当サブエージェント型の可否を判定する
- **Inability の冒頭明示**: 委譲不可の場合、インライン実行へ移行する旨を冒頭で明示する。SSoT は result 契約に従う（completed-pr → PR 本文、blocked/failed → Issue コメント）
- **インライン逐次実行時の adapter protocol 遵守**: worktree 隔離、責務順序、test-fix ループ、result 契約（4状態）、Findings/SPEC確定候補配置の全てを維持する。委譲を起動していないため `delegation-unavailable` は返さず、`completed-pr` / `blocked` / `failed` のいずれかを返す
- **Epic Wave 並列委譲不可時の運用**: Wave 内子Issue を順次処理し、Wave 境界は case-close が担う
- **既存フォールバックパスとの関係**: 本節は委譲起動前の事前 probe、次節は委譲起動後の異常終了事後処理であり、対象段階が異なることを明示

### `src/opencode/skills/agentdev-workflow-orchestration/references/capture-boundaries.md`

「コマンド責務境界」の後に新セクション「委譲可否 probe と Inability 記録」を追記した。

- **Inability 明示タイミング**: worktree 作成後、実装開始前。記録先は result 状態に応じ PR 本文または Issue コメント
- **Inability のキャプチャ分類**: ハーネス制約そのものは Learning 候補、特定 Issue での影響は Intake 候補として分割ルールへ接続

## Files Checked

| file | 変更 | encoding | guard |
|------|------|----------|-------|
| `src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md` | +49 行 | UTF-8 BOM なし LF | edit tool |
| `src/opencode/skills/agentdev-workflow-orchestration/references/capture-boundaries.md` | +25 行 | UTF-8 BOM なし LF | edit tool |

targeted docs guard（`check_changed_docs.ts --workflow case-run --base-ref origin/main`）: files checked=0, failures=0, warnings=1（対象ファイル検出されず、docs/** 変更なし）
check_extensions.ts: ok=true, failures=0

## テスト結果

Issue の test strategy に従い test-fix ループを実施した:

- **TS-001** (REQ-0149.md REQ-0149-012 エントリ確認): PASS。Phase 1 commit 49621355 で L29 に REQ-0149-012 エントリが追記済み。「事前 probe」「委譲可否判断」「Inability 冒頭明示」「インライン逐次実行時の adapter protocol 遵守」「Epic Wave 並列委譲不可時の運用明文化」の5点が全て記載されている
- **TS-004** (oh-my-openagent ハーネスでの実証確認): PASS。現ハーネスの `call_omo_agent` tool description に "Only explore and librarian are allowed" "Other built-in agents, custom agents, and task categories are intentionally not supported by this tool" と明記されていることを確認。本 PR の実行経路自体が制約下でのインライン逐次実行の実証である（Sisyphus-Junior が親 context 内で adapter protocol に従い実行）

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| targeted docs guard | failures=0 | 0 | ✅ |
| check_extensions.ts | ok=true, failures=0 | ok=true | ✅ |
| encoding | UTF-8 BOM なし LF | UTF-8 BOM なし LF | ✅ |
| 重複チェック | 既存 L131-148 事後処理パスと重複なし | 重複なし | ✅ |

## Findings / Capture候補

### intake

該当なし

### learning

- **ハーネス制約（learning 候補）**: oh-my-openagent ハーネスの `call_omo_agent` tool は explore/ librarian 型のみを許可し、custom agent 型（adapter skill が定義する実行担当サブエージェント型）を起動できない。本 PR 実行時も同制約により委譲起動不可、インライン逐次実行で adapter protocol に従って実装した。再発防止知見として REQ-0149-012 に基づく adapter SKILL.md の挙動セクションに集約した

## SPEC確定候補

該当なし（本 PR は要件 REQ-0149-012 の実装への落とし込みのみ。SPEC に相当する詳細ルールは既存 adapter protocol に準拠）

## Test Strategy

Issue 本文の test strategy 項目（TS-001）は Phase 1 commit 49621355 で合格済み。Phase 2 実装修復にあたり TS-004（oh-my-openagent ハーネスでの実証確認）を追加検証し、合格した。

## 関連Issue

Refs: #1573
