### PR TITLE
refactor(commands/skills): learning-promote Step 13-1/2/3 の同一契約再定義を skill reference へ移送 (Refs: #1575)

### DIFF
--- a/src/opencode/commands/agentdev/learning-promote.md
+++ b/src/opencode/commands/agentdev/learning-promote.md
@@ -97,18 +97,7 @@ agent: sisyphus
 
 ### Step 13: deferred 移動（原子的操作）
 
-- **Step 13-1**: inbox.md 全エントリを deferred.md に追記（`**移動日**: YYYY-MM-DD` フィールド追加）
-- **Step 13-2**: deferred.md 書込検証（追記エントリ数をカウント照合）
-- **Step 13-3**: Step 13-2 成功時のみ inbox.md をヘッダーのみにクリア:
- ```markdown
- # 学び、教訓
-
- このドキュメントは、開発過程で得た教訓や失敗から学んだことを記録する。
- まだ整理されていない学びを一時的に保存し、十分な数が溜まったら分類、整理して永続的なドキュメントに移動する。
-
- ---
- ```
-- Step 13-2 失敗 → inbox.md 変更せず、エラー内容を報告
+`agentdev-learning-pipeline` の「deferred 移動原子的操作プロシージャ」（`references/deferred-atomic-move-procedure.md` 参照）に従い、当該プロシージャが定める inbox.md 全エントリの deferred.md 追記、書込検証、inbox.md クリアを実行する。本手順は原子的操作であり、検証失敗時は inbox.md を変更せずエラー内容を報告する（データ喪失防止）。
 
 ### Step 14: 昇華時 prune（deferred.md からの除去）
 

--- a/src/opencode/skills/agentdev-learning-pipeline/references/deferred-atomic-move-procedure.md
+++ b/src/opencode/skills/agentdev-learning-pipeline/references/deferred-atomic-move-procedure.md
@@ -1,0 +1,46 @@
+# deferred 移動原子的操作プロシージャ
+
+<!-- 元コマンド: learning-promote.md (Step 13-1/13-2/13-3) -->
+<!-- 抽出日: 2026-07-19 (Issue #1575, 横断是正残対応) -->
+
+learning-promote コマンドの Step 13 で実行する deferred 移動（inbox.md → deferred.md 原子的移行）の手順を定義する。
+3サブステップ（追記、検証、クリア）を原子的に実行し、中断時のデータ喪失を防止する。
+
+## 前提
+
+- Step 12（採用済み成果物生成）が完了していること
+- inbox.md、deferred.md が `agentdev-learning-pipeline` skill の「Inbox Entry Schema」に従うこと
+
+## 手順
+
+### Step 1: inbox.md 全エントリを deferred.md に追記
+
+inbox.md の全エントリを deferred.md に追記する。各エントリに `**移動日**: YYYY-MM-DD` フィールドを追加する。
+
+### Step 2: deferred.md 書込検証
+
+deferred.md への追記が正しく完了したか、追記エントリ数をカウント照合して検証する。
+
+### Step 3: inbox.md をヘッダーのみにクリア
+
+Step 2 の検証成功時のみ、inbox.md をヘッダーのみにクリアする。クリア後の inbox.md 本文:
+
+```markdown
+# 学び、教訓
+
+このドキュメントは、開発過程で得た教訓や失敗から学んだことを記録する。
+まだ整理されていない学びを一時的に保存し、十分な数が溜まったら分類、整理して永続的なドキュメントに移動する。
+
+---
+```
+
+## 失敗時の扱い
+
+- Step 2（検証）失敗時 → inbox.md を変更せず、エラー内容を報告する。inbox.md のデータは保持されたままとなる
+- Step 3（クリア）は Step 2 成功時のみ実行する。Step 2 失敗時に Step 3 を実行してはならない
+
+## 各 command の参照方法
+
+command 側（learning-promote Step 13）には以下のように参照する:
+
+- 「`agentdev-learning-pipeline` の deferred 移動原子的操作プロシージャ（`references/deferred-atomic-move-procedure.md`）に従い、inbox.md 全エントリの deferred.md 追記、書込検証、inbox.md クリアを実行」


### PR DESCRIPTION
## 概要

Issue #1575 の Phase 2 case-run 成果物（bg task 異常終了からの回復）。

REQ-0119 横断是正残対応のうち、移動可能群（learning-promote Step 13-1/2/3）を skill reference へ移送。公開契約密接群（5件）は REQ-0119-034 例外適用で重複許容を選択。

## 変更内容

- src/opencode/commands/agentdev/learning-promote.md: Step 13-1/13-2/13-3（deferred 移動原子的操作）を gentdev-learning-pipeline/references/deferred-atomic-move-procedure.md への参照に置換。公開契約（Step 13 = deferred 移動原子的操作、停止条件、永続成果物）は不変。
- src/opencode/skills/agentdev-learning-pipeline/references/deferred-atomic-move-procedure.md: 新規作成。deferred 移動の原子的操作手順を詳細化。

## Files Checked

- targeted docs guard: SKIPPED（docs/** 変更なし）
- check_extensions.ts (IR-056): src/opencode/commands/agentdev/learning-promote.md 変更で対象、ok=true 想定

## 完了条件

- [x] REQ-0119-037（段階的対応計画）に基づく移動可能群の特定と移送
- [x] 公開契約密接群（5件）の重複許容判断（REQ-0119-034 例外適用）
- [ ] check_integrity.ts の REQ-0119-036 横断評価減少確認（TS-004 record-in-findings、機械的 IR ルール未整備のため後続 case 依存）

## テスト結果

TS-004（check_integrity.ts の REQ-0119-036 横断評価減少確認）は機械的 IR ルール未整備のため record-in-findings。本 PR で新規違反 0 件、OK +1（新規 reference ファイル）。

## 品質メトリクス

- 変更ファイル: 2件
- insertions: 47
- deletions: 12

## Findings・Capture候補

### docs-integrity
SKIPPED（docs/** 変更なし）

### stale-reference
該当なし

### intake
REQ-0119-036 横断評価減少確認の機械的 IR ルール整備は別 case 依存（本 PR スコープ外）

### learning
bg task 異常終了からの回復パターン: case-run が commit を作成したが PR 作成前に task が破棄された場合、case-auto 親が rebase + push + PR 作成を代行して回復可能。

## SPEC確定候補

該当なし

## Test Strategy

TS-001 (AG-001): learning-promote.md の参照化確認
TS-002 (AG-002): deferred-atomic-move-procedure.md の新規作成確認
TS-003 (AG-003): 公開契約不变性確認
TS-004 (AG-004): record-in-findings（機械的 IR ルール未整備）

## 関連Issue

Refs: #1575