### PR TITLE
feat(integrity): AG-008/009/013 AUTOGEN index generation (SC-002 Phase C Wave 2) Issue #1624

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -32,6 +32,30 @@ import {
   CATALOG_PRE_BLOCK_ID,
   CATALOG_POST_BLOCK_ID,
   RULE_OWNERSHIP_BLOCK_ID,
+  collectAdrFiles,
+  collectRetiredAdrFiles,
+  collectReqFiles,
+  collectRetiredReqFiles,
+  countSpecFiles,
+  generateAdrBaselineCaption,
+  generateAdrBaselineTable,
+  generateAdrStatusList,
+  generateAdrRetiredTable,
+  generateReqActiveCaption,
+  generateReqActiveTable,
+  generateReqRetiredTable,
+  generateDocMapInventory,
+  ADR_BASELINE_COUNT_BLOCK_ID,
+  ADR_BASELINE_TABLE_BLOCK_ID,
+  ADR_STATUS_ACCEPTED_BLOCK_ID,
+  ADR_STATUS_PROPOSED_BLOCK_ID,
+  ADR_STATUS_SUPERSEDED_BLOCK_ID,
+  ADR_STATUS_DEPRECATED_BLOCK_ID,
+  ADR_RETIRED_TABLE_BLOCK_ID,
+  REQ_ACTIVE_COUNT_BLOCK_ID,
+  REQ_ACTIVE_TABLE_BLOCK_ID,
+  REQ_RETIRED_TABLE_BLOCK_ID,
+  DOCMAP_INVENTORY_BLOCK_ID,
 } from "./generate_indexes.ts";
 
 const SCRIPT_NAME = "check_integrity.ts";
@@ -7937,16 +7961,155 @@ function checkIndexGenerationConsistency(root: string): CheckResult[] {
     }
   }
 
+  // AG-008: ADR README (docs/adr/README.md) — 7 AUTOGEN blocks
+  const adrDir = path.join(root, "docs", "adr");
+  const adrRetiredDir = path.join(adrDir, "retired");
+  const adrReadmePath = path.join(adrDir, "README.md");
+  const adrReadmeContent = readText(adrReadmePath);
+  if (adrReadmeContent !== null && fs.existsSync(adrDir)) {
+    const adrInfos = collectAdrFiles(adrDir);
+    const adrRetiredInfos = collectRetiredAdrFiles(adrRetiredDir);
+    const acceptedAdrs = adrInfos.filter((a) => a.status === "accepted");
+    const adrSpecs: AutogenBlockSpec[] = [
+      { blockId: ADR_BASELINE_COUNT_BLOCK_ID, expected: generateAdrBaselineCaption(acceptedAdrs), label: "adr-baseline-count" },
+      { blockId: ADR_BASELINE_TABLE_BLOCK_ID, expected: generateAdrBaselineTable(acceptedAdrs), label: "adr-baseline-table" },
+      { blockId: ADR_STATUS_ACCEPTED_BLOCK_ID, expected: generateAdrStatusList(adrInfos, "accepted"), label: "adr-status-accepted" },
+      { blockId: ADR_STATUS_PROPOSED_BLOCK_ID, expected: generateAdrStatusList(adrInfos, "proposed"), label: "adr-status-proposed" },
+      { blockId: ADR_STATUS_SUPERSEDED_BLOCK_ID, expected: generateAdrStatusList(adrInfos, "superseded"), label: "adr-status-superseded" },
+      { blockId: ADR_STATUS_DEPRECATED_BLOCK_ID, expected: generateAdrStatusList(adrInfos, "deprecated"), label: "adr-status-deprecated" },
+      { blockId: ADR_RETIRED_TABLE_BLOCK_ID, expected: generateAdrRetiredTable(adrRetiredInfos), label: "adr-retired-table" },
+    ];
+    const adrOutcome = verifyAutogenBlocksInFile(
+      adrReadmeContent,
+      adrReadmePath,
+      root,
+      adrSpecs,
+      foundViolation,
+    );
+    results.push(...adrOutcome.results);
+    foundViolation = adrOutcome.foundViolation;
+  }
+
+  // AG-009: REQ README (docs/requirements/README.md) — 3 AUTOGEN blocks
+  const reqDir = path.join(root, "docs", "requirements");
+  const reqRetiredDir = path.join(reqDir, "retired");
+  const reqReadmePath = path.join(reqDir, "README.md");
+  const reqReadmeContent = readText(reqReadmePath);
+  if (reqReadmeContent !== null && fs.existsSync(reqDir)) {
+    const reqInfos = collectReqFiles(reqDir);
+    const reqRetiredInfos = collectRetiredReqFiles(reqRetiredDir);
+    const reqSpecs: AutogenBlockSpec[] = [
+      { blockId: REQ_ACTIVE_COUNT_BLOCK_ID, expected: generateReqActiveCaption(reqInfos), label: "req-active-count" },
+      { blockId: REQ_ACTIVE_TABLE_BLOCK_ID, expected: generateReqActiveTable(reqInfos), label: "req-active-table" },
+      { blockId: REQ_RETIRED_TABLE_BLOCK_ID, expected: generateReqRetiredTable(reqRetiredInfos), label: "req-retired-table" },
+    ];
+    const reqOutcome = verifyAutogenBlocksInFile(
+      reqReadmeContent,
+      reqReadmePath,
+      root,
+      reqSpecs,
+      foundViolation,
+    );
+    results.push(...reqOutcome.results);
+    foundViolation = reqOutcome.foundViolation;
+  }
+
+  // AG-013: DOC-MAP (docs/DOC-MAP.md) — 1 AUTOGEN block
+  const specsDir = path.join(root, "docs", "specs");
+  const docMapPath = path.join(root, "docs", "DOC-MAP.md");
+  const docMapContent = readText(docMapPath);
+  if (docMapContent !== null) {
+    const docMapSpecs: AutogenBlockSpec[] = [
+      {
+        blockId: DOCMAP_INVENTORY_BLOCK_ID,
+        expected: generateDocMapInventory({
+          activeReqCount: fs.existsSync(reqDir) ? collectReqFiles(reqDir).length : 0,
+          retiredReqCount: fs.existsSync(reqRetiredDir) ? collectRetiredReqFiles(reqRetiredDir).length : 0,
+          activeAdrCount: fs.existsSync(adrDir) ? collectAdrFiles(adrDir).length : 0,
+          retiredAdrCount: fs.existsSync(adrRetiredDir) ? collectRetiredAdrFiles(adrRetiredDir).length : 0,
+          specCount: countSpecFiles(specsDir),
+        }),
+        label: "docmap-inventory",
+      },
+    ];
+    const docMapOutcome = verifyAutogenBlocksInFile(
+      docMapContent,
+      docMapPath,
+      root,
+      docMapSpecs,
+      foundViolation,
+    );
+    results.push(...docMapOutcome.results);
+    foundViolation = docMapOutcome.foundViolation;
+  }
+
   if (!foundViolation) {
     results.push(
       ok(
         "IndexGenerationConsistency",
         "index-generation-consistency",
-        `索引類自動生成整合性: All AUTOGEN blocks consistent with IR-* files (catalog pre=${expectedPre.length}, post=${expectedPost.length}; rule-ownership appendix=${expectedRuleOwnership.length} rows) (IR-061, SC-002 Phase C)`,
+        `索引類自動生成整合性: All AUTOGEN blocks consistent (catalog pre=${expectedPre.length}, post=${expectedPost.length}; rule-ownership=${expectedRuleOwnership.length}; ADR README + REQ README + DOC-MAP) (IR-061, SC-002 Phase C)`,
       ),
     );
   }
   return results;
+}
+
+interface AutogenBlockSpec {
+  blockId: string;
+  expected: string[];
+  label: string;
+}
+
+function verifyAutogenBlocksInFile(
+  content: string,
+  filePath: string,
+  root: string,
+  specs: AutogenBlockSpec[],
+  foundViolationIn: boolean,
+): { results: CheckResult[]; foundViolation: boolean } {
+  const results: CheckResult[] = [];
+  let foundViolation = foundViolationIn;
+  const blocks = findAutogenBlocks(content);
+
+  for (const spec of specs) {
+    const block = blocks.find((b) => b.id === spec.blockId);
+    if (!block) {
+      results.push(
+        info(
+          "IndexGenerationConsistency",
+          "index-generation-consistency",
+          `${spec.label} AUTOGEN marker not found; IR-061 ${spec.label} check skipped`,
+          resolveRelative(filePath, root),
+          1,
+        ),
+      );
+      continue;
+    }
+    const mismatchIndex = findFirstMismatch(block.currentBody, spec.expected);
+    if (mismatchIndex !== -1) {
+      foundViolation = true;
+      results.push(
+        ng(
+          "IndexGenerationConsistency",
+          "index-generation-consistency",
+          `${spec.label} AUTOGEN block out of sync. ` +
+            `first mismatch at line ${mismatchIndex + 1} (current=${truncateForLog(
+              block.currentBody[mismatchIndex],
+            )}, expected=${truncateForLog(spec.expected[mismatchIndex])}). ` +
+            `Run: bun run .opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts (IR-061, SC-002)`,
+          resolveRelative(filePath, root),
+          block.startLine + 1 + mismatchIndex,
+          {
+            evidence: `block_id=${spec.blockId}, current_lines=${block.currentBody.length}, expected_lines=${spec.expected.length}`,
+            expected: `AUTOGEN block contents must match source file derivation (${spec.label})`,
+            route: "intake",
+          },
+        ),
+      );
+    }
+  }
+  return { results, foundViolation };
 }
 
 /** 2つの行配列の最初の不一致インデックスを返す（一致時は -1）。 */

--- a/.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts
@@ -404,6 +404,347 @@ function replaceAutogenBlock(
   return out.join("\n");
 }
 
+// ─── ADR / REQ collector (AG-008 / AG-009 / AG-013) ──────────────────────────
+
+/**
+ * ADR メタデータ（AG-008 ADR README 自動生成の_source）。
+ * frontmatter から id/title/status/created を抽出する。
+ */
+export interface AdrInfo {
+  /** ADR ID（例: "ADR-0101"）。 */
+  id: string;
+  /** ADR 数値部（例: 101）。ソート用。 */
+  num: number;
+  /** frontmatter title（例: "AgentDevFlow プラグイン名前空間の統一"）。 */
+  title: string;
+  /** frontmatter status（例: "accepted"）。 */
+  status: string;
+  /** frontmatter created（例: "2026-06-08"）。 */
+  created: string;
+  /** ファイル名（例: "ADR-0101.md"）。 */
+  filename: string;
+  /**
+   * README からの相対リンクパス。
+   * active ADR: "ADR-0101.md"
+   * retired ADR: "retired/ADR-0001.md"（adrDir からの相対）
+   */
+  relPath: string;
+}
+
+/**
+ * REQ メタデータ（AG-009 REQ README / AG-013 DOC-MAP 自動生成の source）。
+ */
+export interface ReqInfo {
+  /** REQ ID（例: "REQ-0101"）。 */
+  id: string;
+  /** REQ 数値部（例: 101）。 */
+  num: number;
+  /** frontmatter title。 */
+  title: string;
+  /** ファイル名（例: "REQ-0101.md"）。 */
+  filename: string;
+  /** README からの相対リンクパス。 */
+  relPath: string;
+}
+
+/**
+ * ADR-*.md からメタデータを抽出する。
+ * retiredDirFromAdr: retired ファイルの場合 "retired/" prefix を付与（active は空文字）。
+ */
+function extractAdrInfo(
+  fullPath: string,
+  relPath: string,
+): AdrInfo | null {
+  const content = readText(fullPath);
+  if (!content) return null;
+
+  const filename = path.basename(fullPath);
+  const idMatch = filename.match(/^ADR-(\d+)\.md$/);
+  if (!idMatch) return null;
+  const num = Number(idMatch[1]);
+  const id = `ADR-${String(num).padStart(4, "0")}`;
+
+  const fm = parseFrontmatter(content);
+  let title = "";
+  let status = "";
+  let created = "";
+  if (fm) {
+    if (typeof fm["title"] === "string") title = fm["title"];
+    if (typeof fm["status"] === "string") status = fm["status"];
+    if (typeof fm["created"] === "string") created = fm["created"];
+  }
+  // title が frontmatter に無い場合は H1 から抽出（フォールバック）。
+  if (!title) {
+    const h1Match = content.match(/^#\s+(.+)$/m);
+    if (h1Match) {
+      const h1 = h1Match[1].trim();
+      const colonIdx = h1.indexOf(":");
+      title = colonIdx !== -1 ? h1.slice(colonIdx + 1).trim() : h1;
+    }
+  }
+
+  return { id, num, title, status, created, filename, relPath };
+}
+
+/**
+ * docs/adr/ 配下の ADR-*.md を収集し、番号順に返す（retired/ 除く）。
+ */
+export function collectAdrFiles(adrDir: string): AdrInfo[] {
+  const files = listFiles(adrDir).filter((f) => /^ADR-\d+\.md$/.test(f));
+  const infos: AdrInfo[] = [];
+  for (const f of files) {
+    const fullPath = path.join(adrDir, f);
+    const info = extractAdrInfo(fullPath, f);
+    if (info) infos.push(info);
+  }
+  infos.sort((a, b) => a.num - b.num);
+  return infos;
+}
+
+/**
+ * docs/adr/retired/ 配下の ADR-*.md を収集し、番号順に返す。
+ */
+export function collectRetiredAdrFiles(retiredDir: string): AdrInfo[] {
+  const files = listFiles(retiredDir).filter((f) => /^ADR-\d+\.md$/.test(f));
+  const infos: AdrInfo[] = [];
+  for (const f of files) {
+    const fullPath = path.join(retiredDir, f);
+    const info = extractAdrInfo(fullPath, `retired/${f}`);
+    if (info) infos.push(info);
+  }
+  infos.sort((a, b) => a.num - b.num);
+  return infos;
+}
+
+function extractReqInfo(
+  fullPath: string,
+  relPath: string,
+): ReqInfo | null {
+  const content = readText(fullPath);
+  if (!content) return null;
+
+  const filename = path.basename(fullPath);
+  const idMatch = filename.match(/^REQ-(\d+)\.md$/);
+  if (!idMatch) return null;
+  const num = Number(idMatch[1]);
+  const id = `REQ-${String(num).padStart(4, "0")}`;
+
+  const fm = parseFrontmatter(content);
+  let title = "";
+  if (fm) {
+    if (typeof fm["title"] === "string") title = fm["title"];
+  }
+  if (!title) {
+    const h1Match = content.match(/^#\s+(.+)$/m);
+    if (h1Match) title = h1Match[1].trim();
+  }
+
+  return { id, num, title, filename, relPath };
+}
+
+/**
+ * docs/requirements/ 配下の REQ-*.md を収集し、番号順に返す（retired/ 除く）。
+ */
+export function collectReqFiles(reqDir: string): ReqInfo[] {
+  const files = listFiles(reqDir).filter((f) => /^REQ-\d+\.md$/.test(f));
+  const infos: ReqInfo[] = [];
+  for (const f of files) {
+    const fullPath = path.join(reqDir, f);
+    const info = extractReqInfo(fullPath, f);
+    if (info) infos.push(info);
+  }
+  infos.sort((a, b) => a.num - b.num);
+  return infos;
+}
+
+/**
+ * docs/requirements/retired/ 配下の REQ-*.md を収集し、番号順に返す。
+ */
+export function collectRetiredReqFiles(retiredDir: string): ReqInfo[] {
+  const files = listFiles(retiredDir).filter((f) => /^REQ-\d+\.md$/.test(f));
+  const infos: ReqInfo[] = [];
+  for (const f of files) {
+    const fullPath = path.join(retiredDir, f);
+    const info = extractReqInfo(fullPath, `retired/${f}`);
+    if (info) infos.push(info);
+  }
+  infos.sort((a, b) => a.num - b.num);
+  return infos;
+}
+
+// ─── AG-008: ADR README 生成 ─────────────────────────────────────────────────
+
+// ADR README 内の AUTOGEN ブロック ID。
+export const ADR_BASELINE_COUNT_BLOCK_ID = "adr-baseline-count";
+export const ADR_BASELINE_TABLE_BLOCK_ID = "adr-baseline-table";
+export const ADR_STATUS_ACCEPTED_BLOCK_ID = "adr-status-accepted";
+export const ADR_STATUS_PROPOSED_BLOCK_ID = "adr-status-proposed";
+export const ADR_STATUS_SUPERSEDED_BLOCK_ID = "adr-status-superseded";
+export const ADR_STATUS_DEPRECATED_BLOCK_ID = "adr-status-deprecated";
+export const ADR_RETIRED_TABLE_BLOCK_ID = "adr-retired-table";
+
+/**
+ * 表セル内のパイプ・改行を回避する（catalog/rule-ownership 形式と同一）。
+ */
+function sanitizeTableCell(text: string): string {
+  return text.replace(/\|/g, "/").replace(/\n/g, " ");
+}
+
+/**
+ * 現行基盤ビューの件数表明キャプション（1行）。
+ * 形式: "承認済みステータス（accepted）の ADR-01XX N件が、現在のアーキテクチャ判断の基盤である。"
+ */
+export function generateAdrBaselineCaption(
+  acceptedAdrs: AdrInfo[],
+): string[] {
+  return [
+    `承認済みステータス（accepted）の ADR-01XX ${acceptedAdrs.length}件が、現在のアーキテクチャ判断の基盤である。`,
+  ];
+}
+
+/**
+ * 現行基盤ビュー表（ヘッダー + accepted ADR 行）。
+ */
+export function generateAdrBaselineTable(
+  acceptedAdrs: AdrInfo[],
+): string[] {
+  const lines: string[] = [];
+  lines.push("| ADR番号 | タイトル | ステータス | 作成日 |");
+  lines.push("|---------|---------|-----------|--------|");
+  for (const info of acceptedAdrs) {
+    lines.push(
+      `| ${info.id} | ${sanitizeTableCell(info.title)} | ${info.status} | ${info.created} |`,
+    );
+  }
+  return lines;
+}
+
+/**
+ * ステータス別リスト（bullet 形式）。
+ * 形式: "- [ADR-0101](ADR-0101.md)（title）"
+ */
+export function generateAdrStatusList(
+  infos: AdrInfo[],
+  status: string,
+): string[] {
+  return infos
+    .filter((a) => a.status === status)
+    .map(
+      (info) => `- [${info.id}](${info.relPath})（${info.title}）`,
+    );
+}
+
+/**
+ * 廃止済み履歴ビュー表（ヘッダー + retired ADR 行）。
+ * 引き継ぎ先列は active ADR 側の supersedes 宣言から導出可能だが、
+ * retired ADR frontmatter に該当フィールドが無いため本 PR では 3 列生成とする。
+ */
+export function generateAdrRetiredTable(
+  retiredAdrs: AdrInfo[],
+): string[] {
+  const lines: string[] = [];
+  lines.push("| ADR番号 | タイトル | retired時ステータス |");
+  lines.push("|---------|---------|-------------------|");
+  for (const info of retiredAdrs) {
+    lines.push(
+      `| [${info.id}](${info.relPath}) | ${sanitizeTableCell(info.title)} | ${info.status} |`,
+    );
+  }
+  return lines;
+}
+
+// ─── AG-009: REQ README 生成 ─────────────────────────────────────────────────
+
+export const REQ_ACTIVE_COUNT_BLOCK_ID = "req-active-count";
+export const REQ_ACTIVE_TABLE_BLOCK_ID = "req-active-table";
+export const REQ_RETIRED_TABLE_BLOCK_ID = "req-retired-table";
+
+/**
+ * 現行要件の件数表明キャプション（1行）。
+ * 形式: "現在の要件判断では、以下N件を第一参照先とする。"
+ */
+export function generateReqActiveCaption(activeReqs: ReqInfo[]): string[] {
+  return [
+    `現在の要件判断では、以下${activeReqs.length}件を第一参照先とする。`,
+  ];
+}
+
+/**
+ * 現行要件一覧表（ヘッダー + active REQ 行）。関心対象列は hand-curated のため
+ * AG-009 では REQ ID + タイトルの 2 列自動生成とする（SC-002 混合領域許容）。
+ */
+export function generateReqActiveTable(activeReqs: ReqInfo[]): string[] {
+  const lines: string[] = [];
+  lines.push("| REQ ID | タイトル |");
+  lines.push("|---|---|");
+  for (const info of activeReqs) {
+    lines.push(
+      `| [${info.id}](${info.relPath}) | ${sanitizeTableCell(info.title)} |`,
+    );
+  }
+  return lines;
+}
+
+/**
+ * 廃止済み要件一覧表（ヘッダー + retired REQ 行）。
+ */
+export function generateReqRetiredTable(retiredReqs: ReqInfo[]): string[] {
+  const lines: string[] = [];
+  lines.push("| REQ ID | タイトル |");
+  lines.push("|---|---|");
+  for (const info of retiredReqs) {
+    lines.push(
+      `| [${info.id}](${info.relPath}) | ${sanitizeTableCell(info.title)} |`,
+    );
+  }
+  return lines;
+}
+
+// ─── AG-013: DOC-MAP 生成 ────────────────────────────────────────────────────
+
+export const DOCMAP_INVENTORY_BLOCK_ID = "docmap-inventory";
+
+/**
+ * DOC-MAP インベントリブロック（件数 + ファイル群参照）。
+ * docs/requirements/REQ-*.md, docs/requirements/retired/REQ-*.md,
+ * docs/adr/ADR-*.md, docs/adr/retired/ADR-*.md, docs/specs/ 配下 .md から再生成。
+ */
+export function generateDocMapInventory(args: {
+  activeReqCount: number;
+  retiredReqCount: number;
+  activeAdrCount: number;
+  retiredAdrCount: number;
+  specCount: number;
+}): string[] {
+  return [
+    `- 現行 REQ: ${args.activeReqCount}件（\`docs/requirements/REQ-*.md\`）`,
+    `- 廃止済み REQ: ${args.retiredReqCount}件（\`docs/requirements/retired/REQ-*.md\`）`,
+    `- ADR: ${args.activeAdrCount}件（\`docs/adr/ADR-*.md\`）、retired: ${args.retiredAdrCount}件（\`docs/adr/retired/ADR-*.md\`）`,
+    `- SPEC: ${args.specCount}件（\`docs/specs/**/*.md\`）`,
+  ];
+}
+
+/**
+ * docs/specs/ 配下の .md を再帰収集して件数を返える（check_integrity.ts と同ロジック）。
+ */
+export function countSpecFiles(specsDir: string): number {
+  if (!fs.existsSync(specsDir)) return 0;
+  let count = 0;
+  const walk = (dir: string): void => {
+    const entries = fs.readdirSync(dir, { withFileTypes: true }) as import("fs").Dirent[];
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.name.endsWith(".md")) {
+        count++;
+      }
+    }
+  };
+  walk(specsDir);
+  return count;
+}
+
 // ─── main ──────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
@@ -435,12 +776,20 @@ EXIT CODES:
   1  Unused (kept for compatibility with EXIT_NG)
   2  Input error or execution failure
 
-TARGET FILES (SC-002 Phase C, Wave 1):
-  - docs/specs/integrity/integrity-rule-catalog.md (catalog IR entries, 2 blocks around IR-045 gap)
-  - docs/specs/integrity/rule-ownership.md (IR cross-reference appendix)
+TARGET FILES (SC-002 Phase C):
+  Wave 1:
+    - docs/specs/integrity/integrity-rule-catalog.md (catalog IR entries, 2 blocks around IR-045 gap)
+    - docs/specs/integrity/rule-ownership.md (IR cross-reference appendix)
+  Wave 2 (AG-008/009/013):
+    - docs/adr/README.md (baseline view, status views, retired history)
+    - docs/requirements/README.md (active/retired REQ tables)
+    - docs/DOC-MAP.md (inventory stats)
 
 GENERATION SOURCE:
   - docs/specs/integrity/rules/IR-*.md (frontmatter + body Field/Value table)
+  - docs/adr/ADR-*.md, docs/adr/retired/ADR-*.md (frontmatter)
+  - docs/requirements/REQ-*.md, docs/requirements/retired/REQ-*.md (frontmatter)
+  - docs/specs/**/*.md (file count)
 
 RELATED:
   - SPEC: docs/specs/integrity/index-auto-generation.md (SC-002)
@@ -478,6 +827,14 @@ RELATED:
     "integrity",
     "rule-ownership.md",
   );
+  const adrDir = path.join(root, "docs", "adr");
+  const adrRetiredDir = path.join(adrDir, "retired");
+  const reqDir = path.join(root, "docs", "requirements");
+  const reqRetiredDir = path.join(reqDir, "retired");
+  const specsDir = path.join(root, "docs", "specs");
+  const adrReadmePath = path.join(adrDir, "README.md");
+  const reqReadmePath = path.join(reqDir, "README.md");
+  const docMapPath = path.join(root, "docs", "DOC-MAP.md");
 
   if (!fs.existsSync(rulesDir)) {
     console.error(`[generate_indexes] rules dir not found: ${rulesDir}`);
@@ -489,6 +846,31 @@ RELATED:
     console.error(`[generate_indexes] no IR-*.md files found in ${rulesDir}`);
     process.exit(EXIT_ERROR);
   }
+
+  const adrInfos = collectAdrFiles(adrDir);
+  const adrRetiredInfos = collectRetiredAdrFiles(adrRetiredDir);
+  const reqInfos = collectReqFiles(reqDir);
+  const reqRetiredInfos = collectRetiredReqFiles(reqRetiredDir);
+  const specCount = countSpecFiles(specsDir);
+  const acceptedAdrs = adrInfos.filter((a) => a.status === "accepted");
+
+  const adrBaselineCaption = generateAdrBaselineCaption(acceptedAdrs);
+  const adrBaselineTable = generateAdrBaselineTable(acceptedAdrs);
+  const adrStatusAccepted = generateAdrStatusList(adrInfos, "accepted");
+  const adrStatusProposed = generateAdrStatusList(adrInfos, "proposed");
+  const adrStatusSuperseded = generateAdrStatusList(adrInfos, "superseded");
+  const adrStatusDeprecated = generateAdrStatusList(adrInfos, "deprecated");
+  const adrRetiredTable = generateAdrRetiredTable(adrRetiredInfos);
+  const reqActiveCaption = generateReqActiveCaption(reqInfos);
+  const reqActiveTable = generateReqActiveTable(reqInfos);
+  const reqRetiredTable = generateReqRetiredTable(reqRetiredInfos);
+  const docMapInventory = generateDocMapInventory({
+    activeReqCount: reqInfos.length,
+    retiredReqCount: reqRetiredInfos.length,
+    activeAdrCount: adrInfos.length,
+    retiredAdrCount: adrRetiredInfos.length,
+    specCount,
+  });
 
   const { pre: catalogPre, post: catalogPost } = generateCatalogBlocks(infos);
   const ruleOwnershipLines = generateRuleOwnershipAppendix(infos);
@@ -560,6 +942,114 @@ RELATED:
     updates.push({ file: ruleOwnershipPath, content: ruleOwnershipUpdated });
   }
 
+  // ADR README 更新 (AG-008)
+  const adrReadmeOriginal = readText(adrReadmePath);
+  if (adrReadmeOriginal === null) {
+    console.error(`[generate_indexes] ADR README not found: ${adrReadmePath}`);
+    process.exit(EXIT_ERROR);
+  }
+  const adrReadmeBlocks = findAutogenBlocks(adrReadmeOriginal);
+  const adrReadmeExpectedIds = [
+    ADR_BASELINE_COUNT_BLOCK_ID,
+    ADR_BASELINE_TABLE_BLOCK_ID,
+    ADR_STATUS_ACCEPTED_BLOCK_ID,
+    ADR_STATUS_PROPOSED_BLOCK_ID,
+    ADR_STATUS_SUPERSEDED_BLOCK_ID,
+    ADR_STATUS_DEPRECATED_BLOCK_ID,
+    ADR_RETIRED_TABLE_BLOCK_ID,
+  ];
+  const adrReadmeFoundIds = new Set(adrReadmeBlocks.map((b) => b.id));
+  const adrReadmeMissing = adrReadmeExpectedIds.filter(
+    (id) => !adrReadmeFoundIds.has(id),
+  );
+  if (adrReadmeMissing.length > 0) {
+    console.error(
+      `[generate_indexes] ADR README AUTOGEN markers not found: ${adrReadmeMissing.join(", ")}`,
+    );
+    process.exit(EXIT_ERROR);
+  }
+  let adrReadmeUpdated = adrReadmeOriginal;
+  const adrReadmeReplacements: Record<string, string[]> = {
+    [ADR_BASELINE_COUNT_BLOCK_ID]: adrBaselineCaption,
+    [ADR_BASELINE_TABLE_BLOCK_ID]: adrBaselineTable,
+    [ADR_STATUS_ACCEPTED_BLOCK_ID]: adrStatusAccepted,
+    [ADR_STATUS_PROPOSED_BLOCK_ID]: adrStatusProposed,
+    [ADR_STATUS_SUPERSEDED_BLOCK_ID]: adrStatusSuperseded,
+    [ADR_STATUS_DEPRECATED_BLOCK_ID]: adrStatusDeprecated,
+    [ADR_RETIRED_TABLE_BLOCK_ID]: adrRetiredTable,
+  };
+  for (const blockId of adrReadmeExpectedIds) {
+    adrReadmeUpdated = replaceAutogenBlock(
+      adrReadmeUpdated,
+      blockId,
+      adrReadmeReplacements[blockId],
+    );
+  }
+  if (adrReadmeUpdated !== adrReadmeOriginal) {
+    updates.push({ file: adrReadmePath, content: adrReadmeUpdated });
+  }
+
+  // REQ README 更新 (AG-009)
+  const reqReadmeOriginal = readText(reqReadmePath);
+  if (reqReadmeOriginal === null) {
+    console.error(`[generate_indexes] REQ README not found: ${reqReadmePath}`);
+    process.exit(EXIT_ERROR);
+  }
+  const reqReadmeBlocks = findAutogenBlocks(reqReadmeOriginal);
+  const reqReadmeExpectedIds = [
+    REQ_ACTIVE_COUNT_BLOCK_ID,
+    REQ_ACTIVE_TABLE_BLOCK_ID,
+    REQ_RETIRED_TABLE_BLOCK_ID,
+  ];
+  const reqReadmeFoundIds = new Set(reqReadmeBlocks.map((b) => b.id));
+  const reqReadmeMissing = reqReadmeExpectedIds.filter(
+    (id) => !reqReadmeFoundIds.has(id),
+  );
+  if (reqReadmeMissing.length > 0) {
+    console.error(
+      `[generate_indexes] REQ README AUTOGEN markers not found: ${reqReadmeMissing.join(", ")}`,
+    );
+    process.exit(EXIT_ERROR);
+  }
+  let reqReadmeUpdated = reqReadmeOriginal;
+  const reqReadmeReplacements: Record<string, string[]> = {
+    [REQ_ACTIVE_COUNT_BLOCK_ID]: reqActiveCaption,
+    [REQ_ACTIVE_TABLE_BLOCK_ID]: reqActiveTable,
+    [REQ_RETIRED_TABLE_BLOCK_ID]: reqRetiredTable,
+  };
+  for (const blockId of reqReadmeExpectedIds) {
+    reqReadmeUpdated = replaceAutogenBlock(
+      reqReadmeUpdated,
+      blockId,
+      reqReadmeReplacements[blockId],
+    );
+  }
+  if (reqReadmeUpdated !== reqReadmeOriginal) {
+    updates.push({ file: reqReadmePath, content: reqReadmeUpdated });
+  }
+
+  // DOC-MAP 更新 (AG-013)
+  const docMapOriginal = readText(docMapPath);
+  if (docMapOriginal === null) {
+    console.error(`[generate_indexes] DOC-MAP not found: ${docMapPath}`);
+    process.exit(EXIT_ERROR);
+  }
+  const docMapBlocks = findAutogenBlocks(docMapOriginal);
+  if (!docMapBlocks.some((b) => b.id === DOCMAP_INVENTORY_BLOCK_ID)) {
+    console.error(
+      `[generate_indexes] DOC-MAP AUTOGEN marker not found. Expected id: ${DOCMAP_INVENTORY_BLOCK_ID}`,
+    );
+    process.exit(EXIT_ERROR);
+  }
+  const docMapUpdated = replaceAutogenBlock(
+    docMapOriginal,
+    DOCMAP_INVENTORY_BLOCK_ID,
+    docMapInventory,
+  );
+  if (docMapUpdated !== docMapOriginal) {
+    updates.push({ file: docMapPath, content: docMapUpdated });
+  }
+
   if (options.dryRun) {
     console.log(
       `[generate_indexes] dry-run: ${infos.length} IR files collected`,
@@ -572,6 +1062,15 @@ RELATED:
     );
     console.log(
       `[generate_indexes] rule-ownership appendix: ${ruleOwnershipLines.length} rows (incl. header)`,
+    );
+    console.log(
+      `[generate_indexes] ADR README: ${adrInfos.length} active (${acceptedAdrs.length} accepted), ${adrRetiredInfos.length} retired`,
+    );
+    console.log(
+      `[generate_indexes] REQ README: ${reqInfos.length} active, ${reqRetiredInfos.length} retired`,
+    );
+    console.log(
+      `[generate_indexes] DOC-MAP inventory: SPEC ${specCount} files`,
     );
     for (const u of updates) {
       console.log(`[generate_indexes] WOULD UPDATE: ${u.file}`);

--- a/docs/DOC-MAP.md
+++ b/docs/DOC-MAP.md
@@ -14,6 +14,15 @@
 | Guides | `guides/*.md` | 人間向けの案内層。規範的権限を持たない（ADR-0103） |
 | DOC-MAP | このファイル | 文書探索入口 |
 
+## インデックス統計（自動生成）
+
+<!-- AUTOGEN:BEGIN:id=docmap-inventory -->
+- 現行 REQ: 54件（`docs/requirements/REQ-*.md`）
+- 廃止済み REQ: 58件（`docs/requirements/retired/REQ-*.md`）
+- ADR: 29件（`docs/adr/ADR-*.md`）、retired: 23件（`docs/adr/retired/ADR-*.md`）
+- SPEC: 142件（`docs/specs/**/*.md`）
+<!-- AUTOGEN:END -->
+
 ## 現行 REQ
 
 | REQ | タイトル | 概要 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,37 +4,41 @@
 
 ## 現行基盤ビュー
 
+<!-- AUTOGEN:BEGIN:id=adr-baseline-count -->
 承認済みステータス（accepted）の ADR-01XX 25件が、現在のアーキテクチャ判断の基盤である。
+<!-- AUTOGEN:END -->
 各 ADR は基準再編により旧 ADR の内容を統合、再定義している。
 現行基盤ビューは承認済み ADR のみを現行根拠として含み、置き換え済み（superseded）、非推奨（deprecated）の ADR は別セクション（ステータス別ビュー）に分離する。
 
+<!-- AUTOGEN:BEGIN:id=adr-baseline-table -->
 | ADR番号 | タイトル | ステータス | 作成日 |
 |---------|---------|-----------|--------|
 | ADR-0101 | AgentDevFlow プラグイン名前空間の統一 | accepted | 2026-06-08 |
 | ADR-0102 | 実行時 / 編集時 関心分離 | accepted | 2026-06-08 |
-| ADR-0103 | 文書種別責務境界、記述対象境界 | accepted | 2026-06-08 |
+| ADR-0103 | 文書種別責務境界 | accepted | 2026-06-08 |
 | ADR-0104 | 実行時独立性 | accepted | 2026-06-08 |
-| ADR-0105 | OpenCode ソース、プロジェクション分離 | accepted | 2026-06-08 |
-| ADR-0106 | /repo/* Namespace for Repo-Local Tooling | accepted | 2026-06-08 |
+| ADR-0105 | OpenCode ソース・プロジェクション分離 | accepted | 2026-06-08 |
+| ADR-0106 | リポジトリローカルツールのための /repo/* 名前空間 | accepted | 2026-06-08 |
 | ADR-0107 | コマンド・スキル・テンプレート・スクリプト責任分界の正式定義 | accepted | 2026-06-08 |
 | ADR-0108 | オーケストレーションスキル作成基準の導入 | accepted | 2026-06-08 |
 | ADR-0109 | Epic Issue 本文を実行順序 SSoT とする設計 | accepted | 2026-06-08 |
 | ADR-0110 | DOC-MAP 採用判断 | accepted | 2026-06-08 |
 | ADR-0112 | サブエージェント委譲の一般化と委譲時最小契約 | accepted | 2026-06-10 |
 | ADR-0114 | case-run 実行責務の外部実行バックエンド委譲 | accepted | 2026-06-16 |
-| ADR-0123 | SPEC lifecycle と spec-save の導入 | accepted | 2026-06-18 |
-| ADR-0124 | req_draft soft-contract 原則: LLM推論消費、厳格schemaなし | accepted | 2026-06-19 |
+| ADR-0123 | SPEC ライフサイクルと spec-save の導入 | accepted | 2026-06-18 |
+| ADR-0124 | req_draft ソフトコントラクト原則: LLM推論消費・厳格スキーマなし | accepted | 2026-06-19 |
 | ADR-0125 | case-auto Wave 内並列子Issue実行モデル | accepted | 2026-06-20 |
 | ADR-0127 | case-auto 構成工程の委譲によるスケーラビリティ確立 | accepted | 2026-06-21 |
 | ADR-0128 | case-run の実行モデル: 実行担当サブエージェント委譲 | accepted | 2026-06-21 |
-| ADR-0129 | 複数 execution_unit 並列実行モデル（複数 SSoT 並立と Epic 間並列 orchestration）| accepted | 2026-06-23 |
+| ADR-0129 | 複数 execution_unit 並列実行モデル（複数 SSoT 並立と Epic 間並列 orchestration"） | accepted | 2026-06-23 |
 | ADR-0130 | `agentdev-gh-cli` を差し替え可能な I/O 境界として確立 | accepted | 2026-06-23 |
 | ADR-0131 | ローカル版導入方式を link mode へ統一し生成方式を廃止 | accepted | 2026-06-23 |
-| ADR-0132 | コンフリクト解消モデル（3レベルエスカレーションと責務割当）| accepted | 2026-06-24 |
+| ADR-0132 | コンフリクト解消モデル（3レベルエスカレーションと責務割当） | accepted | 2026-06-24 |
 | ADR-0135 | Project Extensions Architecture | accepted | 2026-07-04 |
-| ADR-0136 | 配布物ハーネス境界の浄化 | accepted | 2026-07-12 |
+| ADR-0136 | 配布物の harness 実行制御分離 | accepted | 2026-07-12 |
 | ADR-0137 | case-auto における case-run インライン実行（多重委譲回避） | accepted | 2026-07-16 |
 | ADR-0138 | case-auto オーケストレーション制御の AgentDevFlow 側集約 | accepted | 2026-07-19 |
+<!-- AUTOGEN:END -->
 
 > この README は分類ビューであり、ADR本文のSSoTではない。
 > 基準は各 `ADR-{NNNN}.md` ファイルである（REQ-0101）。
@@ -43,44 +47,52 @@
 
 ### 承認済み（accepted）
 
+<!-- AUTOGEN:BEGIN:id=adr-status-accepted -->
 - [ADR-0101](ADR-0101.md)（AgentDevFlow プラグイン名前空間の統一）
 - [ADR-0102](ADR-0102.md)（実行時 / 編集時 関心分離）
-- [ADR-0103](ADR-0103.md)（文書種別責務境界、記述対象境界）
+- [ADR-0103](ADR-0103.md)（文書種別責務境界）
 - [ADR-0104](ADR-0104.md)（実行時独立性）
-- [ADR-0105](ADR-0105.md)（OpenCode ソース、プロジェクション分離）
-- [ADR-0106](ADR-0106.md)（/repo/* Namespace for Repo-Local Tooling）
+- [ADR-0105](ADR-0105.md)（OpenCode ソース・プロジェクション分離）
+- [ADR-0106](ADR-0106.md)（リポジトリローカルツールのための /repo/* 名前空間）
 - [ADR-0107](ADR-0107.md)（コマンド・スキル・テンプレート・スクリプト責任分界の正式定義）
 - [ADR-0108](ADR-0108.md)（オーケストレーションスキル作成基準の導入）
 - [ADR-0109](ADR-0109.md)（Epic Issue 本文を実行順序 SSoT とする設計）
 - [ADR-0110](ADR-0110.md)（DOC-MAP 採用判断）
 - [ADR-0112](ADR-0112.md)（サブエージェント委譲の一般化と委譲時最小契約）
 - [ADR-0114](ADR-0114.md)（case-run 実行責務の外部実行バックエンド委譲）
-- [ADR-0123](ADR-0123.md)（SPEC lifecycle と spec-save の導入）
-- [ADR-0124](ADR-0124.md)（req_draft soft-contract 原則: LLM推論消費、厳格schemaなし）
+- [ADR-0123](ADR-0123.md)（SPEC ライフサイクルと spec-save の導入）
+- [ADR-0124](ADR-0124.md)（req_draft ソフトコントラクト原則: LLM推論消費・厳格スキーマなし）
 - [ADR-0125](ADR-0125.md)（case-auto Wave 内並列子Issue実行モデル）
 - [ADR-0127](ADR-0127.md)（case-auto 構成工程の委譲によるスケーラビリティ確立）
 - [ADR-0128](ADR-0128.md)（case-run の実行モデル: 実行担当サブエージェント委譲）
-- [ADR-0129](ADR-0129.md)（複数 execution_unit 並列実行モデル）（複数 SSoT 並立と Epic 間並列 orchestration）
+- [ADR-0129](ADR-0129.md)（複数 execution_unit 並列実行モデル（複数 SSoT 並立と Epic 間並列 orchestration"））
 - [ADR-0130](ADR-0130.md)（`agentdev-gh-cli` を差し替え可能な I/O 境界として確立）
 - [ADR-0131](ADR-0131.md)（ローカル版導入方式を link mode へ統一し生成方式を廃止）
 - [ADR-0132](ADR-0132.md)（コンフリクト解消モデル（3レベルエスカレーションと責務割当））
 - [ADR-0135](ADR-0135.md)（Project Extensions Architecture）
-- [ADR-0136](ADR-0136.md)（配布物ハーネス境界の浄化）
+- [ADR-0136](ADR-0136.md)（配布物の harness 実行制御分離）
 - [ADR-0137](ADR-0137.md)（case-auto における case-run インライン実行（多重委譲回避））
 - [ADR-0138](ADR-0138.md)（case-auto オーケストレーション制御の AgentDevFlow 側集約）
+<!-- AUTOGEN:END -->
 
 ### 提案中（proposed）
 
+<!-- AUTOGEN:BEGIN:id=adr-status-proposed -->
 - [ADR-0134](ADR-0134.md)（配布物依存スキルの src 昇格方針）
+<!-- AUTOGEN:END -->
 
 ### 置き換え済み（superseded）
 
-- [ADR-0111](ADR-0111.md)（マネージャー、オーケストレータパターンの限定採用（superseded by ADR-0112））
-- [ADR-0126](ADR-0126.md)（ローカル版 OpenCode 生成基盤: source model 拡張と生成安全性制約（superseded by ADR-0131））
+<!-- AUTOGEN:BEGIN:id=adr-status-superseded -->
+- [ADR-0111](ADR-0111.md)（マネージャー・オーケストレータパターンの限定採用）
+- [ADR-0126](ADR-0126.md)（ローカル版 OpenCode 生成基盤: ソースモデル拡張と生成安全性制約）
+<!-- AUTOGEN:END -->
 
 ### 非推奨（deprecated）
 
-- [ADR-0113](ADR-0113.md)（診断ワークフロー導入とレビュー系コマンド完全削除（diagnostics → inspect 改名により現行根拠として非適用）。現行状態は REQ-0124 / SPEC 参照）
+<!-- AUTOGEN:BEGIN:id=adr-status-deprecated -->
+- [ADR-0113](ADR-0113.md)（診断ワークフロー導入とレビュー系コマンド完全削除）
+<!-- AUTOGEN:END -->
 
 ## トピック別ビュー
 
@@ -249,28 +261,32 @@ Decision Map（ADR 間の supersedes / relates-to / superseded-by 関係）。
 ADR-0001 から ADR-0023 までの23件は、ADR-01XX 現行基盤導入に伴い `retired/` ディレクトリに移動された歴史的決定記録である。
 これらは再編前の判断を保持しており、現行アーキテクチャの基盤は上記 現行基盤ビューの ADR-01XX にある。
 
-| ADR番号 | タイトル | retired時ステータス | 引き継ぎ先 |
-|---------|---------|-------------------|-----------|
-| [ADR-0001](retired/ADR-0001.md) | Command/Skill/Template/Script責任分界の正式定義 | proposed | ADR-0107 |
-| [ADR-0002](retired/ADR-0002.md) | Orchestration skill作成基準の導入 | proposed | ADR-0108 |
-| [ADR-0003](retired/ADR-0003.md) | issue-req入力の抽象化 | deprecated | なし（再編前から非現行） |
-| [ADR-0004](retired/ADR-0004.md) | 要件管理構造の area-based 移行方針 | superseded | なし（再編前から非現行） |
-| [ADR-0005](retired/ADR-0005.md) | AgentDevFlow を配布 plugin 名として採用し、公開 command namespace を /agentdev/*、domain state を .agentdev/、skill prefix を agentdev-* に統一する | accepted | ADR-0101 |
-| [ADR-0006](retired/ADR-0006.md) | Epic Issue 本文を実行順序 SSoT とする設計 | proposed | ADR-0109 |
-| [ADR-0007](retired/ADR-0007.md) | REQ/ADR基準構造と分類ビュー運用の再定義 | superseded | なし（再編前から非現行） |
-| [ADR-0008](retired/ADR-0008.md) | DOC-MAP導入と requirements/views 廃止 | proposed | ADR-0110 |
-| [ADR-0009](retired/ADR-0009.md) | REQ体系再基準化（旧REQ分類モデル、対応表、分類ゲート導入）| deprecated | なし（再編前から非現行） |
-| [ADR-0010](retired/ADR-0010.md) | HITL boundary（全 agentdev command の Human-in-the-Loop 境界原則）| deprecated | なし（再編前から非現行） |
-| [ADR-0011](retired/ADR-0011.md) | マネージャー、オーケストレータパターンの限定採用（標準構造とはしない）| proposed | ADR-0111 |
-| [ADR-0012](retired/ADR-0012.md) | Requirement Source pipeline の正式定義（promoted→RU→req-define の一貫流）| deprecated | なし（再編前から非現行） |
-| [ADR-0013](retired/ADR-0013.md) | runtime / authoring 関心分離 | accepted | ADR-0102 |
-| [ADR-0014](retired/ADR-0014.md) | ADR / SPEC 再分類基準 | superseded | なし（再編前から非現行） |
-| [ADR-0015](retired/ADR-0015.md) | docs/specs 非runtime依存宣言 | superseded | なし（再編前から非現行） |
-| [ADR-0016](retired/ADR-0016.md) | skill references runtime-only 制約 | superseded | なし（再編前から非現行） |
-| [ADR-0017](retired/ADR-0017.md) | 文書種別責務境界 | accepted | ADR-0103 |
-| [ADR-0018](retired/ADR-0018.md) | runtime 独立性 | accepted | ADR-0104 |
-| [ADR-0019](retired/ADR-0019.md) | OpenCode ソース、プロジェクション分離 | accepted | ADR-0105 |
-| [ADR-0020](retired/ADR-0020.md) | Adopt /repo/* Namespace for Repo-Local Tooling | accepted | ADR-0106 |
-| [ADR-0021](retired/ADR-0021.md) | Upstream Handoff Metadata Convention | deprecated | なし（再編前から非現行） |
-| [ADR-0022](retired/ADR-0022.md) | review/refine 系中間コマンドを promote 内フェーズへ統合 | deprecated | なし（再編前から非現行） |
-| [ADR-0023](retired/ADR-0023.md) | backlog-save 廃止とパイプライン再構築 | deprecated | なし（再編前から非現行） |
+<!-- AUTOGEN:BEGIN:id=adr-retired-table -->
+| ADR番号 | タイトル | retired時ステータス |
+|---------|---------|-------------------|
+| [ADR-0001](retired/ADR-0001.md) | Command/Skill/Template/Script責任分界の正式定義 | proposed |
+| [ADR-0002](retired/ADR-0002.md) | Orchestration skill作成基準の導入 | proposed |
+| [ADR-0003](retired/ADR-0003.md) | issue-req入力の抽象化 | deprecated |
+| [ADR-0004](retired/ADR-0004.md) | 要件管理構造の area-based 移行方針 | superseded |
+| [ADR-0005](retired/ADR-0005.md) | AgentDevFlow を配布 plugin 名として採用し、公開 command namespace を /agentdev/*、domain state を .agentdev/、skill prefix を agentdev-* に統一する | accepted |
+| [ADR-0006](retired/ADR-0006.md) | Epic Issue 本文を実行順序 SSoT とする設計 | proposed |
+| [ADR-0007](retired/ADR-0007.md) | REQ/ADR基準構造と分類ビュー運用の再定義 | superseded |
+| [ADR-0008](retired/ADR-0008.md) | DOC-MAP導入と requirements/views 廃止 | proposed |
+| [ADR-0009](retired/ADR-0009.md) | REQ体系再基準化：旧REQ分類モデル・対応表・分類ゲート導入 | deprecated |
+| [ADR-0010](retired/ADR-0010.md) | HITL boundary：全 agentdev command の Human-in-the-Loop 境界原則 | deprecated |
+| [ADR-0011](retired/ADR-0011.md) | Manager/orchestrator パターンの限定採用：標準構造とはしない | proposed |
+| [ADR-0012](retired/ADR-0012.md) | Requirement Source pipeline の正式定義：promoted→RU→req-define の一貫流 | deprecated |
+| [ADR-0013](retired/ADR-0013.md) | runtime / authoring 関心分離 | accepted |
+| [ADR-0014](retired/ADR-0014.md) | ADR / SPEC 再分類基準 | superseded |
+| [ADR-0015](retired/ADR-0015.md) | docs/specs 非runtime依存宣言 | superseded |
+| [ADR-0016](retired/ADR-0016.md) | skill references runtime-only 制約 | superseded |
+| [ADR-0017](retired/ADR-0017.md) | 文書種別責務境界 | accepted |
+| [ADR-0018](retired/ADR-0018.md) | runtime 独立性 | accepted |
+| [ADR-0019](retired/ADR-0019.md) | OpenCode Source / Projection 分離 | accepted |
+| [ADR-0020](retired/ADR-0020.md) | Adopt /repo/* Namespace for Repo-Local Tooling | accepted |
+| [ADR-0021](retired/ADR-0021.md) | Upstream Handoff Metadata Convention | deprecated |
+| [ADR-0022](retired/ADR-0022.md) | review/refine 系中間コマンドを promote 内フェーズへ統合 | deprecated |
+| [ADR-0023](retired/ADR-0023.md) | backlog-save 廃止とパイプライン再構築 | deprecated |
+<!-- AUTOGEN:END -->
+
+> 引き継ぎ先（各 ADR-01XX の supersedes 宣言）は Decision Map（関連 ADR 依存関係）の欄を参照。

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -2,68 +2,72 @@
 
 ## 現行要件
 
-現在の要件判断では、以下54件（REQ-0111, REQ-0115, REQ-0116, REQ-0117, REQ-0118, REQ-0120, REQ-0121, REQ-0122 は廃止）を第一参照先とする。
+<!-- AUTOGEN:BEGIN:id=req-active-count -->
+現在の要件判断では、以下54件を第一参照先とする。
+<!-- AUTOGEN:END -->
 旧REQ 50件はすべて廃止済みであり、履歴参照に限定する。
 
 各 REQ の詳細関心は各 REQ ファイル本文を参照のこと。
 本表の「関心対象」列は核心契約の要約に留める。
 
-| REQ ID | タイトル | 関心対象 |
-|---|---|---|
-| [REQ-0101](REQ-0101.md) | 文書、REQ管理基準 | 文書種別の基準境界と ADR 記述対象 |
-| [REQ-0102](REQ-0102.md) | 要件定義、保存 | req-define、req-save、分類ゲート |
-| [REQ-0103](REQ-0103.md) | Artifact責任分界 | command/skill/template/script の責務境界 |
-| [REQ-0104](REQ-0104.md) | Workflow / Command Protocol | ワークフロー、work_type/scale 分類、SSoT |
-| [REQ-0105](REQ-0105.md) | RU lifecycle / Requirement Unit 管理 | RU lifecycle と RU メタデータ |
-| [REQ-0106](REQ-0106.md) | Case実行オーケストレーション / Epic、Wave | Epic/Wave 並列実行と子Issue 状態整合 |
-| [REQ-0107](REQ-0107.md) | Reporting / Writing Quality | 完了報告と自然言語成果物品質 |
-| [REQ-0108](REQ-0108.md) | docs-check / Validation / Tests | 整合性検査と検出事項ライフサイクル |
-| [REQ-0109](REQ-0109.md) | inspect-docs / REQ体系整合性 | retired archive と REQ 再構成運用 |
-| [REQ-0110](REQ-0110.md) | Git worktree cleanup 信頼性 | git worktree cleanup 信頼性 |
-| [REQ-0112](REQ-0112.md) | ADRライフサイクル、文書体系基盤、実行時独立性 | ADR lifecycle 基盤と文書体系正規化 |
-| [REQ-0113](REQ-0113.md) | Skill References SPEC分離 | skill references の SPEC 分離基準 |
-| [REQ-0114](REQ-0114.md) | /agentdev/case-auto 最大自走モード | case-auto 最大自走と複数 execution_unit |
-| [REQ-0119](REQ-0119.md) | コマンド、スキル、サブエージェント責務分界 | command/skill/サブエージェント責務分界 |
-| [REQ-0123](REQ-0123.md) | workflow-lifecycle 宣言的定義責務とコマンド固有手順のスキル分担 | workflow-lifecycle 宣言的責務とスキル移管 |
-| [REQ-0124](REQ-0124.md) | AgentDevFlow inspect-* 検出コマンド群と inspect lifecycle | inspect-* コマンド群と lifecycle |
-| [REQ-0125](REQ-0125.md) | inspect-skills / Command/Skill参照妥当性検出 | inspect-skills 参照妥当性検出 |
-| [REQ-0126](REQ-0126.md) | inspect-promote / 検出事項分類、昇格 | inspect 検出事項の分類、昇格 |
-| [REQ-0127](REQ-0127.md) | Intake command群 (capture / from-github / promote) | intake コマンド群とドメイン状態 |
-| [REQ-0128](REQ-0128.md) | Learning-promote | learning-promote と 8-axis 評価 |
-| [REQ-0129](REQ-0129.md) | Backlog-review | backlog-review と RU 生成 |
-| [REQ-0130](REQ-0130.md) | case-run / 実装パイプライン | case-run 実装パイプラインと QG-3 |
-| [REQ-0131](REQ-0131.md) | case-close / 完了処理 | case-close 完了処理と branch cleanup |
-| [REQ-0132](REQ-0132.md) | case-open / Issue作成 | case-open Issue 作成と flow routing |
-| [REQ-0133](REQ-0133.md) | case-update / Issue更新 | case-update Issue/REQ 更新 |
-| [REQ-0134](REQ-0134.md) | 配布基盤: source/projection、sync、repo type、consumer install | 配布基盤の source/projection と consumer install |
-| [REQ-0135](REQ-0135.md) | Drafts配置、Draft Type Registry | drafts 配置と type registry |
-| [REQ-0136](REQ-0136.md) | REQ/SPEC 責務分離の徹底と新ワークフロー（spec-save 新設、req-define 強化） | spec-save 新設と REQ/SPEC 責務分離 |
-| [REQ-0137](REQ-0137.md) | 並列実行安全 git 操作規律 | 並列実行安全 git 操作規律 |
-| [REQ-0138](REQ-0138.md) | 構造化req_draft契約 | 構造化 req_draft 契約 |
-| [REQ-0139](REQ-0139.md) | 外部エージェント統合契約 | 外部エージェント統合契約 |
-| [REQ-0140](REQ-0140.md) | 文書品質ゲート | 文書品質ゲートと SSoT 分割 |
-| [REQ-0141](REQ-0141.md) | ローカル版 OpenCode 導入方式とローカルCaseファイル運用 | link mode と Case ファイル運用 |
-| [REQ-0142](REQ-0142.md) | 配布物ID除去後の文意保持、構文健全性、責務整合 | 配布物 ID 除去後の品質保持 |
-| [REQ-0143](REQ-0143.md) | Command 定義ファイルフォーマット標準化 | command 定義ファイルフォーマット標準 |
-| [REQ-0144](REQ-0144.md) | docs-check/integrity 運用是正 | docs-check/integrity 運用是正の完了条件 |
-| [REQ-0145](REQ-0145.md) | docs-check/integrity 検出設計改善 | docs-check/integrity 検出設計改善 |
-| [REQ-0146](REQ-0146.md) | 実行契約、委譲、プロセス設計 | 実行契約、委譲、プロセス設計 |
-| [REQ-0147](REQ-0147.md) | 文書化規律、HITL境界 | 文書化規律と HITL 境界 |
-| [REQ-0148](REQ-0148.md) | RU群バッチ処理と複数 execution_unit 並列実行 | RU 群バッチと複数 execution_unit 並列 |
-| [REQ-0149](REQ-0149.md) | `agentdev-gh-cli` 手続き委譲基盤 | gh-cli 手続き委譲基盤と I/O 責務分離 |
-| [REQ-0150](REQ-0150.md) | ローカル版 `agentdev-gh-cli` 実装 | ローカル版 `agentdev-gh-cli` と Case ファイル差し替え |
-| [REQ-0151](REQ-0151.md) | コンフリクト解消モデルと実行時間観測 | 3レベルコンフリクト解消モデルと工程別タイムスタンプ計測 |
-| [REQ-0152](REQ-0152.md) | gh 直接記述機械検出（IR-053） | gh CLI 直接呼出しの機械検出ルール（IR-053）と inspect-skills 診断観点との協調 |
-| [REQ-0153](REQ-0153.md) | 機械横断是正の完了証明 | 機械横断是正 PR の再 grep 0 件証拠の完了条件化と PR 本文記載 |
-| [REQ-0154](REQ-0154.md) | SPEC status 追跡と draft 放置検出 | SPEC status 単一情報源化と draft 放置機械検出 |
-| [REQ-0155](REQ-0155.md) | 文書粒度モデル | SPEC内部4論理区分、文書7分類モデル、粒度ゲート2点必須化、局所物理分離許容 |
-| [REQ-0156](REQ-0156.md) | docs/specs 基盤SPECドメイン別体系化 | docs/specs 直下基盤SPECの6ドメイン分類と段階移送方針 |
-| [REQ-0158](REQ-0158.md) | Targeted Docs Integrity Guard | 変更ファイル限定文書整合性ガードと旧パス検出機構 |
-| [REQ-0159](REQ-0159.md) | 配布物依存スキルの src 昇格方針と未トラックスキル検出 | 配布物依存スキルの src 昇格、repo-local 境界、docs-check 未トラック検出 |
-| [REQ-0160](REQ-0160.md) | Project Extensions 機構と配布物参照境界 | .agentdev/extensions/** によるプロジェクト固有追加・拡張機構と配布物具体参照禁止 |
-| [REQ-0161](REQ-0161.md) | config.yaml および旧 doc-inputs 機構定義の完全削除 | config.yaml 削除と旧 doc-inputs 機構定義文書の完全削除 |
-| [REQ-0162](REQ-0162.md) | 配布物ハーネス境界浄化 | AgentDevFlow と harness の責務境界、4状態結果契約 |
-| [REQ-0163](REQ-0163.md) | subagent 委譲プロトコル要件 | category 選定ガイドライン、MUST NOT DO セクション必須化、委譲プロンプトテンプレート |
+<!-- AUTOGEN:BEGIN:id=req-active-table -->
+| REQ ID | タイトル |
+|---|---|
+| [REQ-0101](REQ-0101.md) | 文書・REQ管理基準 |
+| [REQ-0102](REQ-0102.md) | 要件定義・保存 |
+| [REQ-0103](REQ-0103.md) | アーティファクト責任分界 |
+| [REQ-0104](REQ-0104.md) | ワークフロー・コマンドプロトコル |
+| [REQ-0105](REQ-0105.md) | RU ライフサイクル・RU 管理 |
+| [REQ-0106](REQ-0106.md) | Case実行オーケストレーション / Epic・Wave |
+| [REQ-0107](REQ-0107.md) | 完了報告・文書品質 |
+| [REQ-0108](REQ-0108.md) | docs-check / 検証・テスト |
+| [REQ-0109](REQ-0109.md) | inspect-docs / REQ体系整合性 |
+| [REQ-0110](REQ-0110.md) | Git worktree 削除の信頼性 |
+| [REQ-0112](REQ-0112.md) | ADRライフサイクル・文書体系基盤・実行時独立性 |
+| [REQ-0113](REQ-0113.md) | Skill References SPEC分離 |
+| [REQ-0114](REQ-0114.md) | /agentdev/case-auto 最大自走モード |
+| [REQ-0119](REQ-0119.md) | コマンド・スキル・サブエージェント責務分界 |
+| [REQ-0123](REQ-0123.md) | workflow-lifecycle 宣言的定義責務とコマンド固有手順のスキル分担 |
+| [REQ-0124](REQ-0124.md) | AgentDevFlow inspect-* 検出コマンド群と inspect lifecycle |
+| [REQ-0125](REQ-0125.md) | inspect-skills / Command/Skill参照妥当性検出 |
+| [REQ-0126](REQ-0126.md) | inspect-promote / 検出事項分類・昇格 |
+| [REQ-0127](REQ-0127.md) | Intake command群 (capture / from-github / promote) |
+| [REQ-0128](REQ-0128.md) | Learning-promote |
+| [REQ-0129](REQ-0129.md) | Backlog-review |
+| [REQ-0130](REQ-0130.md) | case-run / 実装パイプライン |
+| [REQ-0131](REQ-0131.md) | case-close / 完了処理 |
+| [REQ-0132](REQ-0132.md) | case-open / Issue作成 |
+| [REQ-0133](REQ-0133.md) | case-update / Issue更新 |
+| [REQ-0134](REQ-0134.md) | 配布基盤: 原本/配置先・同期・リポジトリ種別・導入先インストール |
+| [REQ-0135](REQ-0135.md) | Drafts配置・Draft Type Registry |
+| [REQ-0136](REQ-0136.md) | REQ/SPEC 責務分離の徹底と新ワークフロー（spec-save 新設・req-define 強化） |
+| [REQ-0137](REQ-0137.md) | 並列実行安全 git 操作規律（共有作業ツリーでの case-auto 並行実行支援） |
+| [REQ-0138](REQ-0138.md) | 構造化req_draft契約 |
+| [REQ-0139](REQ-0139.md) | 外部エージェント統合契約 |
+| [REQ-0140](REQ-0140.md) | 文書品質ゲート |
+| [REQ-0141](REQ-0141.md) | ローカル版 OpenCode 導入方式とローカルCaseファイル運用 |
+| [REQ-0142](REQ-0142.md) | 配布物ID除去後の文意保持・構文健全性・責務整合 |
+| [REQ-0143](REQ-0143.md) | Command 定義ファイルフォーマット標準化 |
+| [REQ-0144](REQ-0144.md) | docs-check/integrity 運用是正 |
+| [REQ-0145](REQ-0145.md) | docs-check/integrity 検出設計改善 |
+| [REQ-0146](REQ-0146.md) | 実行契約・委譲・プロセス設計 |
+| [REQ-0147](REQ-0147.md) | 文書化規律・HITL境界 |
+| [REQ-0148](REQ-0148.md) | RU群バッチ処理と複数 execution_unit 並列実行 |
+| [REQ-0149](REQ-0149.md) | `agentdev-gh-cli` 手続き委譲基盤 |
+| [REQ-0150](REQ-0150.md) | ローカル版 `agentdev-gh-cli` 実装 |
+| [REQ-0151](REQ-0151.md) | コンフリクト解消モデルと実行時間観測 |
+| [REQ-0152](REQ-0152.md) | gh 直接記述機械検出（IR-053） |
+| [REQ-0153](REQ-0153.md) | 機械横断是正の完了証明 |
+| [REQ-0154](REQ-0154.md) | SPEC status 追跡と draft 放置検出 |
+| [REQ-0155](REQ-0155.md) | 文書粒度モデル |
+| [REQ-0156](REQ-0156.md) | docs/specs 基盤SPECドメイン別体系化 |
+| [REQ-0158](REQ-0158.md) | Targeted Docs Integrity Guard |
+| [REQ-0159](REQ-0159.md) | 配布物依存スキルの src 昇格方針と未トラックスキル検出 |
+| [REQ-0160](REQ-0160.md) | Project Extensions 機構と配布物参照境界 |
+| [REQ-0161](REQ-0161.md) | config.yaml および旧 doc-inputs 機構定義の完全削除 |
+| [REQ-0162](REQ-0162.md) | 配布物の harness 実行制御分離 |
+| [REQ-0163](REQ-0163.md) | subagent 委譲プロトコル要件（category 選定、MUST NOT DO） |
+<!-- AUTOGEN:END -->
 
 ## 廃止済み要件
 
@@ -81,6 +85,69 @@
 | REQ-0121 | 移行→廃止済み | 実行時コマンド規範語を REQ-0103（REQ-0103-152）、整合性検査を REQ-0108（REQ-0108-242/243）に吸収。OU-04 再編成で廃止（2026-06-16）。`retired/REQ-0121.md` 参照 |
 | REQ-0115 | 移行→廃止済み | docs-* command suite の恒久要件を REQ-0108（docs-check 検査責務）、REQ-0109（inspect-docs）、REQ-0124（inspect 命名恒久制約）へ移行。タイトルが移行主題であり REQ-0124-021 に抵触。OU-05 再編成で廃止（2026-06-16）。`retired/REQ-0115.md` 参照 |
 | REQ-0117 | 移行→廃止済み | Git worktree ジャンクション cleanup フォールバック手順を REQ-0110 に統合（REQ-0110-008）。OU-06 再編成で廃止（2026-06-16）。`retired/REQ-0117.md` 参照 |
+
+<!-- AUTOGEN:BEGIN:id=req-retired-table -->
+| REQ ID | タイトル |
+|---|---|
+| [REQ-0001](retired/REQ-0001.md) | AgentDevFlow ワークフローアーキテクチャ |
+| [REQ-0002](retired/REQ-0002.md) | AgentDevFlow コマンドプロトコル |
+| [REQ-0003](retired/REQ-0003.md) | Case 並列実行 |
+| [REQ-0004](retired/REQ-0004.md) | 要件・ADRドキュメントシステム |
+| [REQ-0005](retired/REQ-0005.md) | Epic Issue 管理 |
+| [REQ-0006](retired/REQ-0006.md) | Sisyphus プラン基盤 |
+| [REQ-0007](retired/REQ-0007.md) | ナレッジパイプライン高度化 |
+| [REQ-0008](retired/REQ-0008.md) | スキル品質フレームワーク |
+| [REQ-0009](retired/REQ-0009.md) | テンプレートシステム |
+| [REQ-0010](retired/REQ-0010.md) | AgentDevFlow Command実装改善：安全性・品質・状態管理 |
+| [REQ-0011](retired/REQ-0011.md) | Issue/PR書き込み後の内容品質自動検証 |
+| [REQ-0012](retired/REQ-0012.md) | AI-slop 執筆品質基準 |
+| [REQ-0013](retired/REQ-0013.md) | intake 承認フロー分割と解消済み確認機能 |
+| [REQ-0014](retired/REQ-0014.md) | case-run 自律修正ループと責務分離の明確化 |
+| [REQ-0015](retired/REQ-0015.md) | 関連ドキュメントの要件達成対象化 |
+| [REQ-0016](retired/REQ-0016.md) | Command/Skill/Template/Script責任分界とlearning要件ソース化 |
+| [REQ-0017](retired/REQ-0017.md) | AgentDevFlow plugin namespace 統一と learning / intake / integrity の正式化 |
+| [REQ-0018](retired/REQ-0018.md) | agentdev-req-analysis 未決分岐解消メソドロジー |
+| [REQ-0019](retired/REQ-0019.md) | intake / learning の責任境界明確化と workflow 組み込み |
+| [REQ-0020](retired/REQ-0020.md) | Epic Issue 実行順序 SSoT と case-run Epic Orchestrator 化 |
+| [REQ-0021](retired/REQ-0021.md) | AgentDevFlow ガードレールのスクリプト化と skill-local scripts 配置方針 |
+| [REQ-0022](retired/REQ-0022.md) | .agentdev domain state 更新後の git 永続化 |
+| [REQ-0023](retired/REQ-0023.md) | learning staging stub の取り込み追跡と取り込み後アーカイブ |
+| [REQ-0024](retired/REQ-0024.md) | 全 agentdev コマンドの完了報告フォーマット統一 |
+| [REQ-0025](retired/REQ-0025.md) | intake 系コマンドの .agentdev/intake 更新後の git 永続化 |
+| [REQ-0026](retired/REQ-0026.md) | intake lifecycle の queue/archive 再定義 |
+| [REQ-0027](retired/REQ-0027.md) | learning artifact lifecycle の責任範囲明確化 |
+| [REQ-0028](retired/REQ-0028.md) | Documentation granularity and responsibility restructuring |
+| [REQ-0029](retired/REQ-0029.md) | intake-open promoted artifact 一括処理 |
+| [REQ-0030](retired/REQ-0030.md) | agentdev コマンド群の体系的テスト実装 |
+| [REQ-0031](retired/REQ-0031.md) | GitHub本文内リポジトリ参照リンクの正規化 |
+| [REQ-0032](retired/REQ-0032.md) | case-close 未チェック項目達成判定 |
+| [REQ-0033](retired/REQ-0033.md) | AgentDevFlow command / skill 定義の二次整合性是正 |
+| [REQ-0034](retired/REQ-0034.md) | req-define 関連ドキュメント更新候補抽出と後続工程への伝播 |
+| [REQ-0035](retired/REQ-0035.md) | DOC-MAP導入と requirements/views 廃止による文書探索・維持管理再設計 |
+| [REQ-0036](retired/REQ-0036.md) | agentdev-no-ai-slop-writing Skill 追加 |
+| [REQ-0037](retired/REQ-0037.md) | worktree 削除時の残存ファイル対策強化 |
+| [REQ-0038](retired/REQ-0038.md) | case実行信頼性向上（チェックボックス確認・pull前チェック・docs整合性grep） |
+| [REQ-0039](retired/REQ-0039.md) | req-backlog コマンドと Requirement Unit パイプライン |
+| [REQ-0040](retired/REQ-0040.md) | 子Issue PRに Findings / Intake候補を永続化し、case-closeで回収する |
+| [REQ-0041](retired/REQ-0041.md) | REQ体系再基準化：旧REQ分類・新基準REQ群・分類ゲート |
+| [REQ-0042](retired/REQ-0042.md) | REQ/ADR/SPEC/DOC-MAP 基準構造 |
+| [REQ-0043](retired/REQ-0043.md) | req-define / req-save / REQ分類ゲート |
+| [REQ-0044](retired/REQ-0044.md) | Command / Skill / Template / Script 責任分界 |
+| [REQ-0045](retired/REQ-0045.md) | AgentDevFlow command protocol |
+| [REQ-0046](retired/REQ-0046.md) | intake / learning / req-backlog / RU lifecycle |
+| [REQ-0047](retired/REQ-0047.md) | case-run / case-close / post-run capture |
+| [REQ-0048](retired/REQ-0048.md) | reporting / GitHub body / link / writing quality |
+| [REQ-0049](retired/REQ-0049.md) | integrity / validation / tests |
+| [REQ-0050](retired/REQ-0050.md) | REQ再構成intakeの分離保存と回収導線 |
+| [REQ-0111](retired/REQ-0111.md) | Command authoring 後方互換性維持原則 |
+| [REQ-0115](retired/REQ-0115.md) | docs-* command suite 構成 |
+| [REQ-0116](retired/REQ-0116.md) | 文書分類ポリシー |
+| [REQ-0117](retired/REQ-0117.md) | Git worktree junction cleanup フォールバック |
+| [REQ-0118](retired/REQ-0118.md) | Subagent edit safety ガイドライン |
+| [REQ-0120](retired/REQ-0120.md) | Runtime Command 最小参照構成 |
+| [REQ-0121](retired/REQ-0121.md) | Runtime Command 規範語構成と Integrity 検査定義 |
+| [REQ-0122](retired/REQ-0122.md) | RFC2119 ルールおよび記載の完全削除 |
+<!-- AUTOGEN:END -->
 
 ## 移行表
 


### PR DESCRIPTION
## 概要

SC-002 Phase C Wave 2 として、Wave 1 で確立した `generate_indexes.ts`（catalog/rule-ownership AUTOGEN 対応済み）へ3つの索引自動生成領域を追加した。

- **AG-008**: ADR README (`docs/adr/README.md`) — 現行基盤ビュー、ステータス別ビュー、廃止済み履歴ビュー
- **AG-009**: REQ README (`docs/requirements/README.md`) — 現行要件一覧表、廃止済み要件一覧表
- **AG-013**: DOC-MAP (`docs/DOC-MAP.md`) — インデックス統計（REQ/ADR/SPEC 件数）

各ファイルの AUTOGEN マーカー領域（`<!-- AUTOGEN:BEGIN:id=xxx --> ... <!-- AUTOGEN:END -->`）を実ファイル frontmatter から再生成する。`check_integrity.ts` の IR-061 検査（`checkIndexGenerationConsistency`）を拡張し、3新領域の整合性を検証する。

## 変更ファイル

| file | +/- | 内容 |
|------|-----|------|
| `.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts` | +505/-27 | AG-008/009/013 生成関数、main() 拡張 |
| `.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts` | +165/-7 | IR-061 checkIndexGenerationConsistency 拡張、verifyAutogenBlocksInFile 共通ヘルパー |
| `docs/adr/README.md` | +75/-27 | 7 AUTOGEN blocks 挿入 + 生成済み |
| `docs/requirements/README.md` | +95/-86 | 3 AUTOGEN blocks 挿入 + 生成済み |
| `docs/DOC-MAP.md` | +9/-0 | 1 AUTOGEN block 挿入 + 生成済み |

Total: 5 files changed, +858 insertions, -104 deletions

## 実装詳細

### AG-008: ADR README（7 AUTOGEN blocks）

| block ID | 対象領域 | 生成元 |
|----------|---------|--------|
| `adr-baseline-count` | 現行基盤ビュー件数表明（1行） | accepted ADR count |
| `adr-baseline-table` | 現行基盤ビュー表（4列: ADR番号/タイトル/ステータス/作成日） | `docs/adr/ADR-*.md` frontmatter (`status: accepted`) |
| `adr-status-accepted` | ステータス別: 承認済みリスト | 同上 |
| `adr-status-proposed` | ステータス別: 提案中リスト | 同上 |
| `adr-status-superseded` | ステータス別: 置き換え済みリスト | 同上 |
| `adr-status-deprecated` | ステータス別: 非推奨リスト | 同上 |
| `adr-retired-table` | 廃止済み履歴ビュー表（3列: ADR番号/タイトル/retired時ステータス） | `docs/adr/retired/ADR-*.md` frontmatter |

### AG-009: REQ README（3 AUTOGEN blocks）

| block ID | 対象領域 | 生成元 |
|----------|---------|--------|
| `req-active-count` | 現行要件件数表明（1行） | active REQ count |
| `req-active-table` | 現行要件一覧表（2列: REQ ID/タイトル） | `docs/requirements/REQ-*.md` frontmatter |
| `req-retired-table` | 廃止済み要件一覧表（2列: REQ ID/タイトル） | `docs/requirements/retired/REQ-*.md` frontmatter |

### AG-013: DOC-MAP（1 AUTOGEN block）

| block ID | 対象領域 | 生成元 |
|----------|---------|--------|
| `docmap-inventory` | インデックス統計（REQ/retired REQ/ADR/retired ADR/SPEC 件数） | 各ディレクトリの実ファイル数 |

### check_integrity.ts 拡張

`checkIndexGenerationConsistency`（IR-061）へ3新領域の整合性検証を追加。共通ヘルパー `verifyAutogenBlocksInFile` を新設し、11ブロック（7+3+1）の検証コードの重複を排除した。各ブロックは `findFirstMismatch` で現行内容と期待内容を比較し、不整合時は `ng` を報告する。

## Test Strategy 検証結果

### TS-008 (AG-008: ADR README) — PASS

- verification: `docs/adr/README.md` の各自動生成対象領域に AUTOGEN マーカー存在確認（7 blocks: baseline-count, baseline-table, status-{accepted,proposed,superseded,deprecated}, retired-table）
- verification: 生成スクリプトを実行し、各ビューが `docs/adr/ADR-*.md` の frontmatter と一致（IR-061 check OK で機械検証済み）
- pass_criteria: 件数表明「承認済みステータス（accepted）の ADR-01XX 25件」の 25 が実測と一致（accepted ADR count = 25）

### TS-009 (AG-009: REQ README) — PASS

- verification: `docs/requirements/README.md` の現行要件一覧表/廃止済み要件一覧表に AUTOGEN マーカー存在確認（3 blocks: active-count, active-table, retired-table）
- verification: 生成スクリプトを実行し、各一覧が `docs/requirements/REQ-*.md` の frontmatter と一致（IR-061 check OK で機械検証済み）
- pass_criteria: 件数表明「以下54件」の 54 が実測と一致（active REQ count = 54）

### TS-013 (AG-013: DOC-MAP) — PASS

- verification: `docs/DOC-MAP.md` の件数・一覧表に AUTOGEN マーカー存在確認（1 block: docmap-inventory）
- verification: 生成スクリプトを実行し、件数・一覧が `docs/requirements/REQ-*.md`, `docs/specs/**/*.md`, `docs/adr/ADR-*.md` の実ファイル配置と一致（IR-061 check OK で機械検証済み）
  - 現行 REQ: 54件、廃止済み REQ: 58件、ADR: 29件、retired ADR: 23件、SPEC: 142件
- pass_criteria: DOC-MAP に AUTOGEN マーカー存在 + 件数・一覧が実ファイル配置と一致

## 品質ゲート結果

### check_integrity.ts (IR-061 含む全文書検査)

```
| IndexGenerationConsistency | 1 | 0 | 0 | - |
```

IR-061 拡張領域（ADR README 7 blocks + REQ README 3 blocks + DOC-MAP 1 block）全て OK。既存 catalog/rule-ownership も維持 OK。

### check_changed_docs.ts --workflow case-run

```
files checked: 3 (docs/DOC-MAP.md, docs/adr/README.md, docs/requirements/README.md)
coupled files checked: 3
failures: 0
warnings: 0
exit: 0
```

targeted docs guard PASS。

### 型安全性

- `as any` / `@ts-ignore` / `@ts-expect-error`: 新規コードには0件（grep で確認済み）
- 既存の `(import.meta as any).dir`（Wave 1, line 804）は Bun runtime workaround として維持

### べき等性

`generate_indexes.ts` の2回目実行で "no changes (already up-to-date)" を出力し、べき等性を確認。

## Findings / Capture候補

### 廃止済み履歴ビューの引き継ぎ先列削除

ADR README の廃止済み履歴ビュー表（`adr-retired-table`）は、retired ADR frontmatter に後継 ADR を示すフィールドが存在しないため、3列（ADR番号/タイトル/retired時ステータス）生成とした。従来の4列目「引き継ぎ先」は削除した。当該情報は現行基盤 ADR 側の Decision Map（supersedes 宣言）から導出可能である。README 末尾に「引き継ぎ先は Decision Map を参照」の案内を追記した。

### REQ README 関心対象列の削除

REQ README の現行要件一覧表（`req-active-table`）は、SC-002 SPEC が生成元を frontmatter `id` + `title` と指定しているため、2列（REQ ID/タイトル）生成とした。従来の3列目「関心対象」は hand-curated 内容であり frontmatter から導出できないため削除した。詳細関心は各 REQ ファイル本文を参照する構造維持。

### Topic View / Decision Map / Related REQ 表の AUTOGEN 未適用

SC-002 SPEC が「トピック分類など frontmatter に存在しないメタデータは、各 ADR 本文のセクション構造から導出する規則を定めるか、frontmatter への分類フィールド追加を別途検討する」と明記している通り、トピック別ビュー・Decision Map・関連 REQ 表は frontmatter から導出できない。Wave 2 ではこれらを人手編集領域として残置し、SC-002 SPEC の「混合領域」許容に従う。別途 frontmatter 拡張（topic tags 等）を要する case で導入を検討する。

### DOC-MAP 詳細 REQ 表の保持

DOC-MAP の既存「現行 REQ」詳細表（3列: REQ/タイトル/概要）は hand-curated 概要列が付加価値を持つため、AUTOGEN 対象から除外し人手編集領域として保持した。代わりに「インデックス統計（自動生成）」セクション（`docmap-inventory` block）を新設し、件数表明とファイル群参照を機械検証可能とした。既存の詳細表は `checkDocMapReqSync`（IR-017 関連）が継続検証する。

## SPEC確定候補

### AG-008/009/013 AUTOGEN block ID 命名規則

本 PR で確立した block ID 命名パターン（`{target}-{section}-{subsection}` 形式、例: `adr-status-accepted`, `req-active-table`）を SC-002 SPEC の具体例として追記可能。Wave 1 の catalog/rule-ownership と同様に、ファイル種別 + セクション名の組み合わせで一意性を確保する規則である。

### verifyAutogenBlocksInFile 共通ヘルパー

`check_integrity.ts` の IR-061 検査で、複数 AUTOGEN ブロックの検証を共通化する `verifyAutogenBlocksInFile` 関数を確立した。Wave 1 の catalog/rule-ownership 個別検証コードも本関数へリファクタリング可能だが、スコープ外として別 case で検討する。
