### PR TITLE
docs(adr): ADR README 関連REQ表へ ADR-0137 行を追加

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -255,6 +255,7 @@ Decision Map（ADR 間の supersedes / relates-to / superseded-by 関係）。
 | ADR-0134 | [REQ-0159](../requirements/REQ-0159.md) | 配布物依存スキルの src 昇格方針と未トラックスキル検出 |
 | ADR-0135 | [REQ-0160](../requirements/REQ-0160.md), [REQ-0103](../requirements/REQ-0103.md) | Project Extensions Architecture（doc-inputs から project-extensions への全面置換） |
 | ADR-0136 | [REQ-0162](../requirements/REQ-0162.md), [REQ-0139](../requirements/REQ-0139.md), [REQ-0130](../requirements/REQ-0130.md), [REQ-0114](../requirements/REQ-0114.md), [REQ-0151](../requirements/REQ-0151.md) | 配布物ハーネス境界の浄化（harness 固有詳細の配布物からの除去、4状態結果契約） |
+| ADR-0137 | [REQ-0114](../requirements/REQ-0114.md) | case-auto における case-run インライン実行（多重委譲回避、委譲起点の折りたたみ） |
 | ADR-0138 | [REQ-0114](../requirements/REQ-0114.md), [REQ-0148](../requirements/REQ-0148.md), [REQ-0162](../requirements/REQ-0162.md) | case-auto オーケストレーション制御の AgentDevFlow 側集約（Phase 分離、固定並列数、bg task 状態管理と回復） |
 
 ADR-0001 から ADR-0023 までの23件は、ADR-01XX 現行基盤導入に伴い現行基準から外された歴史的決定記録である（2026-07-20に物理削除）。これらは再編前の判断を保持しており、現行アーキテクチャの基盤は上記 現行基盤ビューの ADR-01XX にある。後継関係（各 ADR-01XX の supersedes 宣言）は Decision Map（関連 ADR 依存関係）の欄を参照。


### PR DESCRIPTION
Closes #1684

## 概要

Epic #1683 Wave 1 OU-014 (Issue #1684) の実装。AG-007 由来。

`docs/specs/integrity/index-auto-generation.md` の3セクション（適用範囲、自動生成の対象領域と生成元、ステータス別ビュー/トピック別ビュー）は spec-save 統合委譲 (`fafe474e` 時点) で既に ACT-SPEC-008/009/010 の内容が反映済み。本 PR は残課題である IMP-006（ADR README 関連REQ表へ ADR-0137 と REQ-0114 の関係を追加）のみを実施する。

## 実装サマリ

- `docs/adr/README.md` の「関連 REQ」表へ ADR-0137 行を追加（ADR-0136 と ADR-0138 の間）
- 関連 REQ は `REQ-0114`（ADR-0137.md Consequences 節「REQ-0114 複数行 UPDATE」に基づく）
- 説明文は ADR-0137 の Decision/Context に従い「case-auto における case-run インライン実行（多重委訲回避、委譲起点の折りたたみ）」
- 変更規模: 1 file changed, 1 insertion(+)

## 完了条件と対応

- [x] `## 適用範囲` セクションが ACT-SPEC-008 内容で更新済み（spec-save 反映済み、TS-007 PASS）
- [x] 現在自動生成・人手管理・混合の3領域区分が明記済み（行17-19）
- [x] 未実装の将来自動生成計画が対象外として明記済み（行20）
- [x] `## 自動生成の対象領域と生成元` セクションが ACT-SPEC-009 内容で更新済み（TS-007 PASS）
- [x] 索引類8種の管理区分と生成元が明記済み（8行の表）
- [x] 管理区分変更時の3文書同時整合が明記済み（行34）
- [x] `### ステータス別ビュー、トピック別ビュー` セクションが ACT-SPEC-010 内容で更新済み（TS-007 PASS）
- [x] Decision Map、トピック別ビュー、関連REQ表が人手管理として明記済み（行51）
- [x] **ADR README 関連REQ表へ ADR-0137 と REQ-0114 の関係が追加**（IMP-006、本 PR で実施）

## 検証

### TS-007 (target_item: AG-007)

- verification: index-auto-generation.md と generate_indexes.ts の実装ブロック照合、ADR README 確認
- pass_criteria: Decision Map等は人手管理、実装済み領域だけが自動生成、ADR-0137 行が存在する → **全項目 PASS**
  - `docs/specs/integrity/index-auto-generation.md` の3セクションが現状実装と整合
  - AUTOGEN ブロック（baseline-count/table, status-accepted, retired-table）には ADR-0137 が既に存在（frontmatter 由来、自動生成）
  - 関連REQ表（人手管理領域）に ADR-0137 行が存在することを本 PR で是正

### docs-check (check_integrity.ts)

- 実行結果: 2 NG 検出、ともに main HEAD (`fafe474e`) 由来の pre-existing であり本 PR 起因ではない
  - `rule-ownership AUTOGEN block out of sync` (docs/specs/integrity/rule-ownership.md:127, IR-056 形式差異)
  - `req-metrics-measurement-example AUTOGEN block out of sync` (docs/specs/quality/req-health-metrics.md:89, REQ-0114 count 98 vs 99)
- いずれも本 PR の変更ファイル (`docs/adr/README.md`) と無関係、スコープ外

### Targeted Docs Guard (check_changed_docs.ts)

- `bun run check_changed_docs.ts --workflow case-run --files docs/adr/README.md`
- 結果: failures=0, warnings=0 → PASS

## Findings / Capture候補

- 2件の pre-existing docs-check NG（rule-ownership IR-056 形式差異、req-metrics REQ-0114 count stale）は main HEAD 由来。Epic #1683 のスコープ外。別途 intake 化を推奨するが本 PR では対処しない。

## SPEC確定候補

- なし（本 PR は既存 SPEC の適用結果に関する ADR README の人手管理表追記のみ）

## 作業ログ (JST)

- case-run #1684 起動: 2026-07-21 08:30:36
- worktree 作成: 2026-07-21 08:32:48
- 完了条件検証 + IMP-006 実装: 2026-07-21 08:34:00
- docs-check 完了: 2026-07-21 08:36:34
- commit: 2026-07-21 08:36:34
- PR 作成: 2026-07-21 (本 commit 直後)
