### PR TITLE
Verify #1667: req-save command Step 3-3 を REQ-0102-039/040/041 へ整合 (OU-002, Wave 1)

### DIFF
--- a/src/opencode/commands/agentdev/req-save.md
+++ b/src/opencode/commands/agentdev/req-save.md
@@ -65,10 +65,9 @@ REQ/ADR 保存前に対象ドキュメント種別を確認する。
 
 **Step 3-3**: REQ/ADR artifact_actions 処理ゲート。ドラフトの `artifact_actions` から `artifact: req`/ `artifact: adr` の entry を処理対象とする（draft 全体の REQ/ADR artifact_actions を処理し、OU ごとに分割しない）:
 - `artifact_actions` に REQ/ADR entry がない場合 → no-op 完了（Step 1 で判定済み）
-- `operation_units` が存在する場合 → 処理対象 OU を決定する:
- - OU ID が指定されている場合 → 指定された OU を処理対象とする
- - OU ID 指定なし、OU 1 件 → その OU を自動選択して処理する
- - OU ID 指定なし、OU 2 件以上 → OU 一覧（`ou_id`, `target_req`, `target_spec`, `operation`）を表示して停止する。ユーザーに OU ID の指定を求める
+- `operation_units` が存在する場合 → 処理対象 `artifact_actions` を決定する（REQ-0102-039/040/041）:
+ - OU ID が指定されている場合 → 指定された OU に属する REQ/ADR 対象 `artifact_actions` だけを処理対象とする
+ - OU ID 未指定時 → draft 全体の REQ/ADR 対象 `artifact_actions` を処理対象とする（OU 件数によらず、OU が複数存在することだけを理由に停止しない）
 - `artifact_actions` フィールドがない（旧形式 draft）の場合 → 従来どおり全 req-operation を処理する（後方互換）
 - **SPEC artifact_actions の取扱い**: `artifact: spec` の entry は spec-save コマンドの対象であり、req-save は処理しない（スキップする）
 


### PR DESCRIPTION
Closes #1667

## 概要

Issue #1667 (OU-002, Wave 1) の検証と最小修正を実施した。
Epic #1665 (SPEC lifecycle・保存コマンド整合) の子 Issue。

REQ-0102 への REQ-0102-039/040/041/046/047/070 反映は req-save 統合委譲 (`fa992e0b`, `06ee2c76`) で完了済み。本 PR は完了条件の最終項「`src/opencode/commands/agentdev/req-save.md` と `docs/specs/commands/req-save.md` が上記契約へ整合していること」に対する IMP-004 実施（OU-020 と連動）。

## 完了条件の検証結果

| # | 完了条件 | 結果 | 根拠 |
|---|---------|------|------|
| 1 | REQ-0102 に 039/040/041/046/047/070 が ACT-REQ-002 の内容で反映 | PASS | `docs/requirements/REQ-0102.md` L45/46/47/52/53/71 に Issue 指定文言と完全一致 |
| 2 | REQ-0102-039 で OU ID 指定時の限定処理が明記 | PASS | REQ-0102.md L45「OU ID指定時に、指定OUに属するREQ/ADR対象`artifact_actions`だけを処理」 |
| 3 | REQ-0102-040 で OU ID 未指定時の draft 全体処理が明記 | PASS | REQ-0102.md L46「OU ID未指定時に、draft全体のREQ/ADR対象`artifact_actions`を処理」 |
| 4 | REQ-0102-041 で OU 複数件だけを理由とする停止が禁止 | PASS | REQ-0102.md L47「OUが複数存在することだけを理由に停止せず」 |
| 5 | REQ-0102-046 で work_type 固定分岐が禁止、artifact_actions 種別判定が明記 | PASS | REQ-0102.md L52「`work_type`固定分岐ではなく、`artifact_actions`の有無と`artifact`種別で決定」 |
| 6 | req-save command/SPEC が上記契約へ整合 | PASS (修正済) | 本 PR で command を修正、SPEC は既存の整合状態を確認 |

## 修正内容

### `src/opencode/commands/agentdev/req-save.md` Step 3-3（4 行削除/3 行追加）

OU 件数ベース分岐を廃止し、REQ-0102-039/040/041 への整合を明示。

before:
```
- `operation_units` が存在する場合 → 処理対象 OU を決定する:
 - OU ID が指定されている場合 → 指定された OU を処理対象とする
 - OU ID 指定なし、OU 1 件 → その OU を自動選択して処理する
 - OU ID 指定なし、OU 2 件以上 → OU 一覧を表示して停止する。ユーザーに OU ID の指定を求める
```

after:
```
- `operation_units` が存在する場合 → 処理対象 `artifact_actions` を決定する（REQ-0102-039/040/041）:
 - OU ID が指定されている場合 → 指定された OU に属する REQ/ADR 対象 `artifact_actions` だけを処理対象とする
 - OU ID 未指定時 → draft 全体の REQ/ADR 対象 `artifact_actions` を処理対象とする（OU 件数によらず、OU が複数存在することだけを理由に停止しない）
```

Step 3-3 の冒頭文「draft全体の REQ/ADR artifact_actions を処理し、OU ごとに分割しない」と Step 4 L77「OU ごとの消費は行わない」とも整合。後段の既存記述は修正不要。

## SPEC 整合確認（`docs/specs/commands/req-save.md`）

既存の以下行が REQ-0102-039/040/041 と整合済み（修正不要）:
- L39: artifact_actions に REQ/ADR 対象 action がない場合は no-op 完了
- L42: OU ID 指定時は指定 OU に属する REQ/ADR 対象 action だけを処理
- L43: OU ID 未指定時は draft 全体の REQ/ADR 対象 action を処理
- L44: OU が複数存在することだけを理由に停止しない

## テスト戦略 TS-005

- id: TS-005
  - verification: req-save の OU 0件・1件・複数件・ID指定テスト
  - pass_criteria: OU未指定は全REQ/ADR action処理、ID指定は指定範囲だけ処理、対象なしはno-op
  - on_failure: fix-and-reverify

command/SPEC は markdown 定義であり自動テスト実行不可。構造検証で契約反映を確認:
- REQ-0102-039/040/041 の 3 条件が command L68-70 と SPEC L42-44 の双方へ過不足なく反映
- 旧形式後方互換 (command L71) と SPEC artifact_actions スキップ (command L72) は温存

## Findings / Capture候補

- なし。本 PR は完結した IMP-004 最小修正。

## SPEC確定候補

- なし。

## worktree 情報

- worktree root: `.worktrees/1667-maintenance/`
- branch: `maintenance/issue-1667`
- base: `origin/main` (9b6fca57)
