### PR TITLE
feat(integrity): check_changed_docs と SPEC README を SPEC 3状態契約へ整合 (#1671)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.test.ts
@@ -142,6 +142,56 @@ function initGitFixture(root: string): void {
   execSync('git commit -q -m "init fixture" --no-verify', { cwd: root });
 }
 
+function addSupersededFixtures(root: string): void {
+  const specsDir = join(root, "docs", "specs");
+  writeFileSync(
+    join(specsDir, "superseded-valid.md"),
+    [
+      "---",
+      "title: superseded valid spec",
+      "status: superseded",
+      "superseded_by: SPEC-0451",
+      "---",
+      "",
+      "# Superseded valid",
+      "",
+      "Fixture content for superseded_by valid test.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  writeFileSync(
+    join(specsDir, "superseded-invalid.md"),
+    [
+      "---",
+      "title: superseded invalid spec",
+      "status: superseded",
+      "---",
+      "",
+      "# Superseded invalid",
+      "",
+      "Missing superseded_by frontmatter.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  writeFileSync(
+    join(specsDir, "unknown-status.md"),
+    [
+      "---",
+      "title: unknown status spec",
+      "status: foobar",
+      "---",
+      "",
+      "# Unknown status",
+      "",
+      "Invalid status value.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
 const FIXTURE_ROOT = join(TEMP_ROOT, "fixture");
 const GIT_FIXTURE_ROOT = join(TEMP_ROOT, "git-fixture");
 
@@ -150,6 +200,7 @@ beforeAll(() => {
   mkdirp(GIT_FIXTURE_ROOT);
   buildMinimalFixture(FIXTURE_ROOT);
   buildMinimalFixture(GIT_FIXTURE_ROOT);
+  addSupersededFixtures(FIXTURE_ROOT);
   copyScripts(FIXTURE_ROOT);
   copyScripts(GIT_FIXTURE_ROOT);
   initGitFixture(GIT_FIXTURE_ROOT);
@@ -557,5 +608,93 @@ describe("Cross-cutting: doc_inputs_check_required must stay removed", () => {
     const extra = [...actualKeys].filter((k) => !expectedKeys.has(k));
     expect(missing).toEqual([]);
     expect(extra).toEqual([]);
+  });
+});
+
+// ─── Issue #1671 TS-004: SPEC status superseded_by handling ─────────────────
+
+describe("Issue #1671 TS-004: SPEC status superseded_by handling (ADR-0123, REQ-0101-076)", () => {
+  it("superseded + superseded_by 設定済み → SPEC-STATUS failure なし (exit 0)", () => {
+    const r = runScript(FIXTURE_ROOT, [
+      "--workflow",
+      "spec-save",
+      "--files",
+      "docs/specs/superseded-valid.md",
+      "--json",
+    ]);
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    const statusFailures = parsed.failures.filter(
+      (f: { rule_id: string }) => f.rule_id === "SPEC-STATUS",
+    );
+    expect(statusFailures).toEqual([]);
+  });
+
+  it("superseded + superseded_by 未設定 → SPEC-STATUS strict failure (exit 非0)", () => {
+    const r = runScript(FIXTURE_ROOT, [
+      "--workflow",
+      "spec-save",
+      "--files",
+      "docs/specs/superseded-invalid.md",
+      "--json",
+    ]);
+    expect(r.exitCode).not.toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    const target = parsed.failures.find(
+      (f: { rule_id: string; severity: string }) =>
+        f.rule_id === "SPEC-STATUS" && f.severity === "strict",
+    );
+    expect(target).toBeDefined();
+    expect(target.message).toContain("superseded_by");
+  });
+
+  it("不正 status → SPEC-STATUS warning", () => {
+    const r = runScript(FIXTURE_ROOT, [
+      "--workflow",
+      "spec-save",
+      "--files",
+      "docs/specs/unknown-status.md",
+      "--json",
+      "--fail-level",
+      "warning",
+    ]);
+    const parsed = JSON.parse(r.stdout);
+    const target = parsed.failures.find(
+      (f: { rule_id: string; severity: string }) =>
+        f.rule_id === "SPEC-STATUS" && f.severity === "warning",
+    );
+    expect(target).toBeDefined();
+    expect(target.message).toContain("foobar");
+  });
+
+  it("status 欠落 → accepted 相当 → SPEC-STATUS failure なし", () => {
+    const specsDir = join(FIXTURE_ROOT, "docs", "specs");
+    writeFileSync(
+      join(specsDir, "status-missing.md"),
+      [
+        "---",
+        "title: status missing spec",
+        "---",
+        "",
+        "# Status missing",
+        "",
+        "status frontmatter is absent (accepted equivalent).",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const r = runScript(FIXTURE_ROOT, [
+      "--workflow",
+      "spec-save",
+      "--files",
+      "docs/specs/status-missing.md",
+      "--json",
+    ]);
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    const statusFailures = parsed.failures.filter(
+      (f: { rule_id: string }) => f.rule_id === "SPEC-STATUS",
+    );
+    expect(statusFailures).toEqual([]);
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts
@@ -549,16 +549,31 @@ function checkSpecFrontmatter(root: string, files: string[]): Failure[] {
     const fm = parseSimpleFrontmatter(content);
     if (!fm) continue;
     const status = fm["status"];
-    if (status && status !== "draft" && status !== "accepted") {
-      failures.push({
-        rule_id: "SPEC-STATUS",
-        severity: "warning",
-        file: path.relative(root, f).replace(/\\/g, "/"),
-        line: 3,
-        message: `SPEC status '${status}' is not 'draft' or 'accepted'`,
-        expected: "draft or accepted (ADR-0123)",
-      });
+    // status 欠落は accepted 相当（document-model.md 設定規則）。
+    if (!status) continue;
+    if (status === "draft" || status === "accepted") continue;
+    if (status === "superseded") {
+      // REQ-0101-076: superseded は superseded_by 必須。保持SPECは通常内容検査対象外。
+      if (!fm["superseded_by"]) {
+        failures.push({
+          rule_id: "SPEC-STATUS",
+          severity: "strict",
+          file: path.relative(root, f).replace(/\\/g, "/"),
+          line: 3,
+          message: `SPEC status 'superseded' requires 'superseded_by' frontmatter`,
+          expected: "superseded_by: <後継SPEC id> (ADR-0123, REQ-0101-076)",
+        });
+      }
+      continue;
     }
+    failures.push({
+      rule_id: "SPEC-STATUS",
+      severity: "warning",
+      file: path.relative(root, f).replace(/\\/g, "/"),
+      line: 3,
+      message: `SPEC status '${status}' is not 'draft', 'accepted', or 'superseded'`,
+      expected: "draft, accepted, or superseded (ADR-0123, REQ-0101-076)",
+    });
   }
   return failures;
 }

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,12 +8,12 @@ SPEC ファイルは現行アーキテクチャの正規文書である（REQ-01
 
 ## SPEC status 追跡情報源（REQ-0154-001, REQ-0154-003）
 
-本ファイルが SPEC の `status`（draft / accepted、ADR-0123 定義）を視認する単一の追跡情報源である（REQ-0154-001）。
+本ファイルが SPEC の `status`（draft / accepted / superseded、ADR-0123 定義）を視認する単一の追跡情報源である（REQ-0154-001）。
 後述の各 SPEC 一覧表の `status` 列で全 SPEC のライフサイクル状態を集約表示する。
 基盤SPEC（REQ-0156 の6ドメイン配下）の status を含め、全 SPEC の status を追跡対象とする（REQ-0154-003）。
 
 - **情報源**: 本ファイル（`docs/specs/README.md`）のみ。`docs/DOC-MAP.md` は SPEC の status を重複管理しない（探索経路の案内のみ）
-- **status 値**: ADR-0123 で定義される `draft` / `accepted` のみ。値の追加、変更は本ファイルの対象外（REQ-0154 対象外）
+- **status 値**: ADR-0123 で定義される `draft` / `accepted` / `superseded` の3つ。値の追加、変更は本ファイルの対象外（REQ-0154 対象外）。`superseded` は `superseded_by` で後継SPECを明示する（REQ-0101-076）
 - **更新タイミング**: spec-save（draft 保存）、case-close（draft から accepted への昇格）の各工程で本ファイルの status 列を更新する。基盤SPEC も同一工程に従う（REQ-0154-003）
 - **欠落扱い**: `status` frontmatter を持たない SPEC は表中で `-` で示す。`-` の SPEC は status 付与を要する（対象 SPEC は spec-save / case-close で順次 status を付与する）
 


### PR DESCRIPTION
Closes #1671

## 概要

Issue #1671 (OU-011 Wave 3) の対応。SPEC `document-model.md` の SPEC lifecycle 3状態契約反映は spec-save 統合委譲で完了済み。本 PR は IMP-003 (`check_changed_docs.ts`) と TS-003 on_failure (SPEC README) の最小修正を実施する。

## 完了条件検証結果

### document-model.md（spec-save 統合委譲で反映済み）

- [x] `### SPEC ライフサイクル（ADR-0123）` セクション（line 169-182）
- [x] 3状態テーブル（draft/accepted/superseded）と status 判定ルール
- [x] superseded_by 保持SPECの通常内容検査対象外（line 177）
- [x] `## 設定規則` セクション（line 215-）
- [x] `### ライフサイクル規則 <!-- REQ-0101 -->` セクション（line 278-）
- [x] SPEC/REQ/ADR/Guide/Report/DOC-MAP 状態遷移テーブル（line 284）

### check_changed_docs.ts（本 PR で実装修正、IMP-003、AG-004、TS-004）

- [x] `checkSpecFrontmatter` が superseded_by 保持SPEC を通常内容検査対象外として扱う

### テスト戦略検証

**TS-003**（AG-003）: document-model.md / REQ-0101-076 / ADR-0123 / patterns.md / SPEC README / DOC-MAP / spec-save で status 列挙を照合

- document-model.md: 3状態 + superseded_by で記載 ✅
- patterns.md line 85: 3状態 + superseded_by + status 欠落時の accepted 相当扱いで記載 ✅
- SPEC README: 本 PR で2状態 → 3状態へ修正（on_failure: fix-and-reverify） ✅
- 全て draft/accepted/superseded で一致し、2状態表現は解消

**TS-004**（AG-004）: check_changed_docs の3状態・superseded_by fixture を実行

- superseded + superseded_by あり → SPEC-STATUS failure なし ✅
- superseded + superseded_by なし → strict failure ✅
- 不正 status（foobar）→ warning ✅
- status 欠落 → accepted 相当 → failure なし ✅
- `bun test` 全30テスト合格

## 変更内容

1. `.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts`: `checkSpecFrontmatter` を SPEC 3状態契約（ADR-0123 / REQ-0101-076）へ対応
   - `superseded` + `superseded_by` 設定済み: 通常内容検査対象外
   - `superseded` + `superseded_by` 未設定: SPEC-STATUS strict failure
   - status 欠落: accepted 相当で対象外（document-model.md 設定規則）
   - draft/accepted/superseded 以外: warning
2. `.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.test.ts`: TS-004 用 `addSupersededFixtures` と4テストケースを追加
3. `docs/specs/README.md`: SPEC status 表現を2状態から3状態へ整合（line 11, 16）

## Findings / Capture候補

- SPEC README の2状態表現は spec-save 統合委譲側で取り残された。REQ-0154（SPEC status 追跡情報源）の更新タイミングで ADR-0123 の status 定義変更を同期する仕組みの検討が別 Issue で望ましい。本 PR で最小修正し TS-003 pass_criteria を満たした。

## SPEC確定候補

（なし）
