### PR TITLE
feat(inspect-docs): OU-006 #1724 agentdev-doc-diagnostics skill 新設

### DIFF
--- a/src/opencode/skills/agentdev-doc-diagnostics/SKILL.md
+++ b/src/opencode/skills/agentdev-doc-diagnostics/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: agentdev-doc-diagnostics
+description: docs 横断診断カテゴリ、共通証拠構造、共通 finding 出力契約、文書種別別診断へのルーティングを提供する診断判断 skill。USE FOR: inspect-docs command の診断カテゴリ定義、docs 横断の診断判定規則、共通証拠構造（finding schema、severity、信頼度）、診断結果（finding）の出力契約、診断に必要な reference または script の選択、文書種別別診断（REQ 固有、文意品質、探索順）へのルーティング。DO NOT USE FOR: 診断対象の修正、promote 判断（inspect-promote 担当）、REQ/SPEC/RU 保存（各保存 command 担当）、commit/push（command 担当）、Issue/PR 操作（case-* 担当）、REQ 固有の SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT 診断（agentdev-req-structure-diagnostics 担当）、文意品質診断（agentdev-doc-writing 担当）、探索順（agentdev-doc-map 担当）。
+---
+
+# docs 横断診断知識ベース（doc-diagnostics）
+
+inspect-docs command から呼ばれる docs 横断診断の判断基盤。
+横断診断カテゴリ、共通証拠構造、共通 finding 出力契約、文書種別別診断へのルーティングを一次所有する（AG-008、RU-20260722-01 合意）。
+REQ 固有の SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT 診断、文意品質、探索順は再定義せず、各専門 skill へルーティングする。
+検査対象を直接修正しない診断専用であり、本スキルは判定ロジックとルーティング表の提供のみを行う。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は [`agentdev-doc-diagnostics` SPEC](../../../../docs/specs/skills/agentdev-doc-diagnostics.md) である。
+SPEC を正規原本とし、SKILL.md は実行入口および skill 固有の補完情報を保持する。重複または不一致がある場合は SPEC を正とする。
+extension（`.agentdev/extensions/skills/`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/adr/specs）と DOC-MAP.md のみを前提とし、`docs/specs/**` 内部構成（`foundations`, `responsibilities` 等）は仮定しない
+2. **extension の読込契約**: 呼び出し元コマンドから渡された解決済み文脈を優先し、不足分のみ skill extension（`.agentdev/extensions/skills/agentdev-doc-diagnostics.yaml`）を読む。skill extension はスキル単位で1ファイルに集約し、reference ごとの extension は作らない
+3. **`docs/specs/**` 内部パスの固定知識化の禁止**: extension に列挙されていない `docs/specs/**` 内部パスを固定知識として参照しない。スキル本文・references に具体的な project docs 内部パス（`docs/specs/{foundations,responsibilities,quality,integrity,local,authoring,commands,skills,workflows}/**`）を直接記述しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## 検査対象を直接修正しない制約
+
+- ファイル変更（docs 配下、REQ/ADR/SPEC、Command/Skill/Template/Script）、Issue 作成、PR 作成、RU 保存、branch/worktree 操作を行わない。許可される副作用は `.agentdev/inspect/inbox/inspect-docs-finding-*.md` の生成、および `.agentdev/inspect/` 配下の git 永続化（commit/push）のみ（inspect lifecycle 準拠、REQ-0103-140-151）
+- 診断結果はセッション内テキストで提示する
+- 修正案は route として提示し、実装、保存、自動整形は行わない
+
+## USE FOR
+
+- inspect-docs command の docs 横断診断カテゴリ定義
+  - 廃止 REQ/SPEC 由来記述残置（retired REQ/SPEC ID をソースとした横断スキャン）
+  - REQ/SPEC 境界違反（HOW 詳細の要件行残留、安定契約例外候補の抽出）
+  - REQ 粒度過小（関心対象、成果物種別、command family、lifecycle 段階の混在）
+  - 横断契約矛盾（source-of-truth priority に基づく矛盾）
+  - 文意品質候補（LLM っぽい表現、空虚語、英語混じり、実行主体分類の誤認）
+  - 探索順と索引の不整合（DOC-MAP と基準文書の不整合）
+- docs 横断スキャン観点とルーティング先の定義（専門診断のシグナルカタログ、閾値は再定義しない）
+- 共通証拠構造（finding schema、severity、信頼度）
+- 共通 finding 出力契約（`.agentdev/inspect/inbox/*.md`、severity 分類、信頼度）
+- 診断に必要な reference または script の選択条件
+- 文書種別別診断へのルーティング（REQ 固有、文意品質、探索順の各専門 skill への委譲）
+- source-of-truth priority に基づく矛盾判定（現行 REQ > 承認済み ADR > SPEC > DOC-MAP/guides）
+- NG 分類（false positive / pre-existing / 今回修正対象）の付与
+
+## DO NOT USE FOR
+
+- 診断対象の修正: intake/inspect pipeline 経由でのみ修正を許可する
+- promote 判断: `inspect-promote` の責務
+- REQ/SPEC/RU の保存: 各保存 command（req-save/spec-save 等）の責務
+- commit/push: command の責務（ただし inspect lifecycle に基づく `.agentdev/inspect/` 配下の永続化は許可される副作用）
+- Issue/PR 操作: case-* command の責務
+- REQ 固有の SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT 診断: `agentdev-req-structure-diagnostics` の責務（本スキルはルーティングのみ）
+- 文意品質診断（LLM っぽい表現、空虚な形容/動詞、英語混じり表現）: `agentdev-doc-writing` の責務（本スキルはルーティングのみ）
+- 探索順（DOC-MAP 読み方ガイド、ドキュメント探索順序）: `agentdev-doc-map` の責務（本スキルはルーティングのみ）
+
+## 対象コマンド
+
+| コマンド | 目的 |
+|----------|------|
+| inspect-docs | docs全体の意味整合性診断における横断診断カテゴリ、共通証拠構造、共通 finding 出力契約、文書種別別診断へのルーティングの提供 |
+
+## 責務境界（AC-014、REQ-0109-048、REQ-0124-025）
+
+本スキルは横断編成と結果統合のみを所有し、専門診断の再定義を行わない。
+`diagnostics` 命名は REQ-0124-025 の例外境界に基づき inspect-* 系 command と区別して skill 名でのみ許容される。
+
+| 専門診断 | 正規所有者 skill | 本スキルの役割 |
+|----------|------------------|----------------|
+| REQ 固有 SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT | `agentdev-req-structure-diagnostics` | ルーティングのみ（判定ロジックを再定義しない） |
+| 文意品質（LLM 表現、空虚語、英語混じり、実行主体分類） | `agentdev-doc-writing` | ルーティングのみ |
+| 探索順（DOC-MAP、ドキュメント探索経路） | `agentdev-doc-map` | ルーティングのみ |
+| docs 横断診断カテゴリ、共通証拠構造、共通 finding 出力契約 | `agentdev-doc-diagnostics`（本スキル） | 一次所有 |
+
+## references/ 構成一覧
+
+| ファイル | 内容 |
+|----------|------|
+| `references/diagnostic-categories.md` | docs 横断診断カテゴリ（廃止 REQ/SPEC 由来記述残置、REQ/SPEC 境界違反、REQ 粒度過小、横断契約矛盾、文意品質候補、探索順と索引の不整合）の定義、横断スキャン観点、ルーティング先、安定契約例外候補の抽出方針 |
+| `references/finding-output-contract.md` | 共通証拠構造（finding schema フィールド）、severity 分類、信頼度、出力ファイル契約（`.agentdev/inspect/inbox/`）、NG 分類、source-of-truth priority、許可される副作用 |
+| `references/diagnostic-routing.md` | 文書種別別診断へのルーティング表（REQ 固有、文意品質、探索順、配布物整合性、SPEC 三層構造）、専門 skill 委譲規則、委譲時の入力引き渡し契約、責務重複なしの保証（AC-014） |
+
+## See Also
+
+- **agentdev-req-structure-diagnostics**: REQ 固有 SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT 診断、配布物 ID 汚染検出、配布物統合性検出、SPEC 三層構造検出（ルーティング先）
+- **agentdev-doc-writing**: 文意品質、実行主体分類（ルーティング先）
+- **agentdev-doc-map**: 探索順、DOC-MAP 読み方ガイド（ルーティング先）
+- **agentdev-inspect-skills**: Command/Skill 参照妥当性診断（独立した inspect-* 対象、本スキルのルーティング先ではない）

--- a/src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-categories.md
+++ b/src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-categories.md
@@ -1,0 +1,140 @@
+# docs 横断診断カテゴリ
+
+inspect-docs command が実行する docs 横断診断のカテゴリ定義と、各専門 skill へのルーティング対象を定義する。
+本スキルは「横断的に複数文書をスキャンして専門診断の対象を特定する」役割のみを持ち、各カテゴリの判定シグナル、閾値、出力 schema の詳細は専門 skill が所有する（`diagnostic-routing.md` 参照）。
+専門診断の判定ロジックを本カテゴリで再定義しない（AC-014、REQ-0109-048）。
+
+## カテゴリ一覧
+
+| カテゴリ | 横断スキャン観点 | ルーティング先 |
+|----------|------------------|----------------|
+| 廃止 REQ/SPEC 由来記述残置 | retired REQ/SPEC ID をソースとした記述が活性文書に残置していないか | `agentdev-req-structure-diagnostics`（REQ 体系境界、配布物 ID 汚染） |
+| REQ/SPEC 境界違反 | HOW 詳細が現行 REQ 要件行に残留しているか（document-model SPEC Separation Criteria 準拠） | `agentdev-req-structure-diagnostics`（MOVE 観点） |
+| REQ 粒度過小 | 1 REQ に複数関心、成果物種別、command family、lifecycle 段階が混在しているか | `agentdev-req-structure-diagnostics`（SPLIT 観点） |
+| 横断契約矛盾 | REQ/ADR/SPEC/guides/DOC-MAP 間で source-of-truth priority に基づく矛盾があるか | `agentdev-req-structure-diagnostics`（DRIFT 等）、`agentdev-doc-writing`（文意品質） |
+| 文意品質候補 | LLM っぽい表現、空虚語、英語混じり表現、実行主体分類の誤認が残存しているか | `agentdev-doc-writing` |
+| 探索順と索引の不整合 | DOC-MAP 記載と実際の基準文書構造が不整合でないか | `agentdev-doc-map` |
+
+各カテゴリの検出シグナル、シグナル閾値、判定ルールの詳細はルーティング先の専門 skill が所有する。
+本スキルは「どのカテゴリを横断的にスキャンするか」「どの専門 skill へルーティングするか」のみを定義する。
+
+## 廃止 REQ/SPEC 由来記述残置
+
+活性文書（現行 docs/、配布物）に retired REQ/SPEC ID をソースとした記述が残置していないかを横断的にスキャンする（REQ-0124-024）。
+活性 REQ/SPEC（現行セット）への言及は対象外とする。
+
+### 横断スキャン対象
+
+| 対象 | 理由 |
+|------|------|
+| `docs/requirements/**/*.md`（retired/ 配下は除く） | 現行要件の参照整合性保持 |
+| `docs/adr/**/*.md` | 現行 ADR の参照整合性保持 |
+| `docs/specs/**/*.md` | 現行 SPEC の参照整合性保持 |
+| `docs/guides/**/*.md` | ガイドの参照整合性保持 |
+| `docs/DOC-MAP.md` | 探索経路インデックスの整合性保持 |
+| `src/opencode/commands/**/*.md` | 配布物の ID 汚染検出（利用者向け） |
+| `src/opencode/skills/**/*.md` | 配布物の ID 汚染検出（利用者向け） |
+
+`docs/requirements/retired/` 配下、`docs/requirements/mapping-table.md` は履歴保持のため対象外とする。
+
+### 横断スキャン観点
+
+- retired REQ/SPEC ID の一覧を `docs/requirements/retired/`、`docs/specs/retired/` 等から収集する
+- 収集した ID をキーに活性文書を横断検索する
+- 「現行判断の根拠」として使われている言及を high severity 候補としてルーティングする
+- 履歴参照、移行履歴説明目的の言及は対象外とする（文脈で判定）
+
+詳細な検出パターン、配布物 ID 汚染の判定ルール、配布物統合性検査は `agentdev-req-structure-diagnostics` が所有する。本スキルはルーティング対象の特定のみを行う。
+
+## REQ/SPEC 境界違反
+
+現行 REQ の要件行に SPEC 分離基準違反（HOW 詳細、内部パラメータ）が残留していないかを横断的にスキャンする（REQ-0109-047、document-model SPEC Separation Criteria 準拠）。
+
+### 横断スキャン観点
+
+- 現行 REQ の要件テーブル行を優先して確認する
+- 要件行が SPEC、rule catalog、command reference、skill reference、test docs に置くべき詳細（HOW）を主たる文意としているかを判定する
+- 安定契約例外候補（公開 command 名、ドメイン状態の位置づけ、外部接続契約、安全境界、停止条件の大枠）に該当する可能性がある場合は確信度を下げる
+
+### 安定契約例外候補
+
+次の要素は安定契約（外部公開が必要）に該当する可能性があり、例外として扱う。確信度を medium/low に下げ、根拠に例外候補を明記する。
+
+- 公開 command 名（`/agentdev/*`）
+- ドメイン状態の位置づけ（`.agentdev/` 配下の構造要素）
+- 外部接続契約（委譲、入出力、ライフサイクル境界）
+- 安全境界、停止条件の大枠
+
+例外判定の SSoT は document-model SPEC（extension 経由で参照）。本スキルは例外候補の抽出と確信度調整のみを行う。
+
+### ルーティング先
+
+検出シグナルの詳細カタログ（schema field、enum 値一覧、route 判定表、file pattern、template variant、report format、内部アルゴリズム、作業履歴、実装パラメータ等）、判定ルール、出力 schema は `agentdev-req-structure-diagnostics`（MOVE 観点）が所有する。本スキルは横断スキャンでシグナル候補を抽出し、ルーティングする。
+
+## REQ 粒度過小
+
+1 つの現行 REQ に複数の独立した関心が混在し、分割が適切かを横断的に診断する（SPLIT 観点の横断適用）。
+
+### 横断スキャン観点
+
+- 複数 REQ を横断比較し、関心の重複、境界の曖昧さを検出する
+- 1 REQ に複数の関心対象、複数成果物種別、複数 command family、複数 lifecycle 段階が混在していないかを走査する
+- 要件行数、関心分類数、成果物種別数の定量閾値は req-health-metrics SPEC が所有する
+
+### ルーティング先
+
+SPLIT 観点の判定ロジック、シグナル閾値（1シグナルは觀察メモ、2シグナル以上は検出事項 等）、出力 schema（7フィールド）は `agentdev-req-structure-diagnostics` が所有する。本スキルは横断比較によるシグナル候補抽出とルーティングのみを行う。
+
+## 横断契約矛盾
+
+REQ/ADR/SPEC/guides/DOC-MAP 間で、source-of-truth priority に基づく矛盾の有無を検出する。
+source-of-truth priority: 現行 REQ > 承認済み ADR > SPEC > DOC-MAP/guides（REQ-0109-013 準拠）。
+
+### 横断スキャン観点
+
+| シグナル | 内容 |
+|----------|------|
+| 下位文書の上位文書への矛盾 | DOC-MAP/guides の記述が現行 REQ/承認済み ADR と矛盾する |
+| SPEC と REQ の責務説明矛盾 | SPEC の責務記述が現行 REQ の要件と矛盾する |
+| 旧名称、旧概念の残存 | 改名、廃止済みの概念が活性文書に残存している（DRIFT 的観点の横断適用） |
+
+### 判定ルール
+
+- 矛盾判定は source-of-truth priority に従う。上位文書を正とし、下位文書の矛盾を検出事項とする
+- 旧名称、旧概念の残存は DRIFT 観点として `agentdev-req-structure-diagnostics` へルーティングする
+- 文意品質に起因する矛盾（表現揺れ、曖昧語）は `agentdev-doc-writing` へルーティングする
+- 履歴説明目的の言及は対象外とする（文脈で判定）
+
+## 文意品質候補
+
+LLM っぽい表現、空虚な形容/動詞、英語混じり表現、実行主体分類の誤認（command を skill と呼ぶ等）が活性文書に残存していないかを横断的にスキャンする。
+
+### 横断スキャン観点
+
+- 対象は `docs/**`、配布物（`src/opencode/commands/`、`src/opencode/skills/`）の自然言語記述
+- 横断的に出現パターンを走査し、文意品質問題の候補を抽出する
+
+### ルーティング先
+
+判定辞書（置換辞書、LLM 表現辞書、英語抽象語書き換え辞書）、機械的置換ルール、査読出力形式は `agentdev-doc-writing` が所有する。本スキルは横断スキャンで候補を抽出し、ルーティングする。
+
+## 探索順と索引の不整合
+
+DOC-MAP 記載と実際の基準文書（REQ/ADR/SPEC）の構造が不整合でないかを横断的にスキャンする。
+
+### 横断スキャン観点
+
+- DOC-MAP の対象領域セクションに列挙された基準文書パスが実在するか
+- DOC-MAP の要約と基準文書の内容が矛盾していないか
+- 索引の範囲を超えて DOC-MAP が要件、判断、仕様を記述していないか
+
+### ルーティング先
+
+DOC-MAP の読み方ガイド、ドキュメント探索順序、影響確認ルールは `agentdev-doc-map` が所有する。本スキルは横断スキャンで不整合候補を抽出し、ルーティングする。
+
+## 安定契約例外の総合判定
+
+複数カテゴリにまたがる安定契約例外候補は、個別カテゴリで確信度を調整した上で横断的に再評価する。
+例外確定の場合は検出事項から外し、例外でない場合は該当カテゴリの severity で出力する。
+
+例外判定の SSoT は document-model SPEC（extension 経由で参照）。本 reference では例外候補の抽出と確信度調整のみを行う。

--- a/src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-routing.md
+++ b/src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-routing.md
@@ -1,0 +1,77 @@
+# 文書種別別診断へのルーティング
+
+inspect-docs command が実行する docs 横断診断のうち、専門診断を要する事項を適切な専門 skill へルーティングするための規則を定義する。
+本スキル（`agentdev-doc-diagnostics`）は横断編成と結果統合のみを所有し、専門診断の判定ロジックを再定義しない（AC-014、REQ-0109-048）。
+
+## ルーティング対象と委譲先
+
+| 診断観点 | 委譲先 skill | 本スキルの役割 | 委譲しない情形 |
+|----------|--------------|----------------|----------------|
+| REQ 固有 SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT | `agentdev-req-structure-diagnostics` | 横断的に複数 REQ を比較し、シグナルを抽出してルーティング | 該当なし（常に委譲） |
+| REQ 参照 ID 整合性、第一参照導線、現行/廃止/世代境界 | `agentdev-req-structure-diagnostics` | 横断スキャンで対象を特定し、ルーティング | 該当なし（常に委譲） |
+| SPEC 分離基準違反（HOW 詳細残留） | `agentdev-req-structure-diagnostics`（MOVE 観点） | 要件行のシグナル抽出（`diagnostic-categories.md` 参照）、安定契約例外判定の補助 | 該当なし（常に委譲） |
+| 配布物 ID 汚染（`src/opencode/` の内部 ID 残留） | `agentdev-req-structure-diagnostics` | 横断スキャンで検出、ルーティング | 該当なし（常に委譲） |
+| 配布物統合性（構文健全性、文意保持、責務整合） | `agentdev-req-structure-diagnostics` | 対象範囲の特定、ルーティング | 該当なし（常に委譲） |
+| SPEC 三層構造違反（commands/skills/workflows 層分離） | `agentdev-req-structure-diagnostics` | 横断的に SPEC を比較、シグナル抽出、ルーティング | 該当なし（常に委譲） |
+| 文意品質（LLM っぽい表現、空虚な形容/動詞、英語混じり表現） | `agentdev-doc-writing` | 横断スキャンで検出、ルーティング | 該当なし（常に委譲） |
+| 実行主体分類の誤認（command を skill と呼ぶ等） | `agentdev-doc-writing`（doc-writing 査読観点） | 横断スキャンで検出、ルーティング | 該当なし（常に委譲） |
+| DOC-MAP 探索順、関連文書探索 | `agentdev-doc-map` | 横断スキャンで DOC-MAP 記載との整合性を確認、ルーティング | 該当なし（常に委譲） |
+| Command/Skill 参照妥当性、Skill 構造 | `agentdev-inspect-skills`（独立 inspect-* 対象） | ルーティングしない（独立コマンド `inspect-skills` の対象） | inspect-docs からはルーティングせず、独立実行を促す |
+
+## 委譲規則
+
+### 1. 横断編成は本スキルが所有
+
+複数文書種別にまたがる診断カテゴリ（廃止 REQ/SPEC 由来記述残置、REQ/SPEC 境界違反、REQ 粒度過小、横断契約矛盾）は本スキルが横断的にスキャンし、シグナルを抽出する（`diagnostic-categories.md` 参照）。
+個別 REQ/ADR/SPEC の内部診断は専門 skill へルーティングする。
+
+### 2. 専門診断の再定義禁止
+
+本スキルの references には専門診断の判定ロジック（SPLIT シグナル閾値、REQ 参照 ID 整合性の具体的検出手順、文意品質判定辞書 等）を再定義しない。
+必要な情報は委譲先 skill の reference を参照するか、委譲時に必要な入力（対象ファイル、シグナル概要）を引き渡す。
+
+### 3. 委譲時の入力引き渡し
+
+専門 skill へルーティングする際、以下を引き渡す。
+
+| 項目 | 内容 |
+|------|------|
+| 対象範囲 | ファイルパス、REQ ID、セクション 等 |
+| 抽出シグナル | 横断スキャンで検出したシグナルの概要 |
+| 横断文脈 | 他文書との関係、source-of-truth 判定結果 |
+| 期待される専門診断 | SPLIT/MOVE 等、委譲先が担当する観点 |
+
+### 4. ルーティング結果の統合
+
+専門 skill から返却された検出事項（finding）は、本スキルが定める共通 finding 出力契約（`finding-output-contract.md`）へ適合させて統合する。
+severity、confidence、NG 分類は本スキルの共通契約へ正規化する。
+
+## ルーティング表と inspect-docs Step の対応
+
+inspect-docs command の各 Step は次のように本スキルと専門 skill を組み合わせる。
+
+| inspect-docs Step | 本スキルの役割 | ルーティング先 |
+|--------------------|----------------|----------------|
+| Step 2: REQ 参照 ID 整合性確認 | 横断スキャンで対象特定 | `agentdev-req-structure-diagnostics` |
+| Step 3: 第一参照導線確認 | 横断スキャンで対象特定 | `agentdev-req-structure-diagnostics` |
+| Step 4: 現行/廃止/世代境界確認 | 横断スキャンで対象特定 | `agentdev-req-structure-diagnostics` |
+| Step 5: SPEC 意味診断 | 横断契約矛盾の抽出（本スキル直接判定） | `agentdev-req-structure-diagnostics`（詳細は委譲） |
+| Step 6: ADR 意味診断 | 横断契約矛盾の抽出（本スキル直接判定） | `agentdev-req-structure-diagnostics`（詳細は委譲） |
+| Step 7: guides 意味診断 | 横断契約矛盾の抽出（本スキル直接判定） | `agentdev-doc-writing`（文意品質）、`agentdev-doc-map`（探索順） |
+| Step 8: DOC-MAP 意味診断 | 索引の範囲超過の抽出（本スキル直接判定） | `agentdev-doc-map` |
+| Step 9: REQ structure review（6観点） | 横断比較でシグナル抽出 | `agentdev-req-structure-diagnostics` |
+| Step 10: 文書分類一貫性検査 | 横断スキャンで SPEC 分離基準違反シグナル抽出 | `agentdev-req-structure-diagnostics`（MOVE 観点） |
+| Step 11: 配布物整合性検査 | 対象範囲特定、ルーティング | `agentdev-req-structure-diagnostics` |
+| Step 13: 未処理 artifact 確認 | 横断スキャン（本スキル直接判定） | 該当なし |
+
+## 責務重複なしの保証（AC-014）
+
+本スキルと 3 専門 skill との責務重複がないことを、以下の境界で保証する。
+
+| skill | 専門領域 | 本スキルとの境界 |
+|-------|----------|------------------|
+| `agentdev-req-structure-diagnostics` | REQ 固有 SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT 診断、REQ 参照 ID 整合性、配布物統合性、SPEC 三層構造 | 本スキルは横断スキャン、シグナル抽出、ルーティングのみ。判定ロジック、シグナル閾値、出力 schema（7フィールド）は再定義しない |
+| `agentdev-doc-writing` | 文意品質（LLM 表現、空虚語、英語混じり）、実行主体分類、機械的置換辞書 | 本スキルは横断スキャンで検出、ルーティングのみ。判定辞書、書き換え辞書は再定義しない |
+| `agentdev-doc-map` | DOC-MAP 読み方ガイド、ドキュメント探索順序、影響確認ルール | 本スキルは横断スキャンで DOC-MAP との整合性を確認、ルーティングのみ。探索順、影響確認フローは再定義しない |
+
+境界違反を検出した場合（本スキルが専門診断を再定義している、専門 skill が横断編成を所有している等）は stop-and-fix で即時修正する。

--- a/src/opencode/skills/agentdev-doc-diagnostics/references/finding-output-contract.md
+++ b/src/opencode/skills/agentdev-doc-diagnostics/references/finding-output-contract.md
@@ -1,0 +1,132 @@
+# 共通 finding 出力契約
+
+inspect-docs command が出力する docs 横断診断の検出事項（finding）に共通する証拠構造、severity、信頼度、出力ファイル契約を定義する。
+REQ 固有診断、文意品質診断等の専門診断からルーティングされてきた検出事項も本契約へ適合させる（共通証拠構造の統一）。
+
+本契約は inspect-docs command が出力する最終的な共通証拠構造である。専門 skill が内部で保持する診断観点別の出力形式（例: `agentdev-req-structure-diagnostics` の問題候補出力スキーマ7フィールド）は各専門 skill の内部スキーマであり、本契約へ正規化して統合する。専門 skill の内部スキーマを再定義せず、変換契約のみを本節で定義する。
+
+## 専門 skill 内部スキーマとの関係
+
+| 専門 skill | 内部スキーマ | 本契約への正規化 |
+|------------|--------------|------------------|
+| `agentdev-req-structure-diagnostics` | 問題候補出力スキーマ7フィールド（観点、対象、根拠、シグナル数、確信度、推奨アクション、req-define入力案） | 観点→category、対象→target、根拠→evidence、シグナル数→notes、確信度→confidence、推奨アクション→recommended_route、req-define入力案→notes へマッピング。severity、source_of_truth、ng_classification は本スキルが横断的に付与 |
+| `agentdev-doc-writing` | 査読出力形式（`references/review-output.md`） | 本契約の target、evidence、recommended_route へ正規化 |
+| `agentdev-doc-map` | 影響確認フロー結果 | 本契約の target、evidence、recommended_route へ正規化 |
+
+## finding schema（共通証拠構造）
+
+各検出事項は以下のフィールドを持つ。inspect-docs command は本スキルが定める schema に従い検出事項を出力する。
+
+| フィールド | 内容 | 必須 |
+|-----------|------|------|
+| id | 検出事項の一意識別子（セッション内連番または `{category}-{n}` 形式） | 必須 |
+| category | 横断診断カテゴリ（`diagnostic-categories.md` 参照）またはルーティング元の専門診断観点 | 必須 |
+| target | 対象ファイルパス、REQ ID、ADR ID、SPEC パス等の識別子 | 必須 |
+| evidence | 根拠となる参照、本文要約、検出シグナルの具体的内容 | 必須 |
+| severity | 重要度（後述 severity 分類） | 必須 |
+| confidence | 確信度（後述 信頼度） | 必須 |
+| source_of_truth | source-of-truth priority に基づく判定結果（どの文書を正としたか） | 必須 |
+| recommended_route | 推奨される委譲先または後続処理（`diagnostic-routing.md` 参照） | 必須 |
+| ng_classification | NG 分類（false positive / pre-existing / 今回修正対象、後述） | 必須 |
+| notes | 補足、安定契約例外候補、要ヒューマンレビュー等の付随情報 | 任意 |
+
+## severity 分類
+
+| severity | 意味 | 即時対応目安 |
+|----------|------|--------------|
+| high | 現行判断に直接影響する矛盾、ID 不整合、配布物汚染 | 次リリース前に対応推奨 |
+| medium | 文書品質、参照整合性の局所的破綻 | 計画的対応 |
+| low | 觀察メモ、改善提案、安定契約例外候補 | 機会ある時に対応 |
+
+### severity 決定ルール
+
+- retired REQ/SPEC 由来記述が「現行判断の根拠」として使われている場合は high
+- REQ/SPEC 境界違反（SPEC 分離基準違反シグナル）は high-specificity signal につき、1シグナルでも原則 high（安定契約例外候補の場合は medium に下げる）
+- 横断契約矛盾で上位文書（REQ、承認済み ADR）を正として下位文書が矛盾する場合は high
+- 文意品質、「旧名称残存」等の局所的問題は medium または low
+
+## 信頼度（confidence）
+
+| confidence | 意味 |
+|------------|------|
+| high | 機械的シグナル、明確なパターンマッチで確定判定可能 |
+| medium | 文脈確認で確定判定可能、安定契約例外候補を含む |
+| low | ヒューマンレビューが必要、複数解釈が可能 |
+
+### confidence 決定ルール
+
+- 機械的に一意に判定できるパターン（例: retired ID の直接参照）は high
+- 文脈依存の判定（例: 履歴参照 vs 現行判断の区別）は medium 以下
+- 安定契約例外候補、複数解釈が可能な場合は low または medium
+
+## 出力ファイル契約
+
+### 出力先
+
+`.agentdev/inspect/inbox/inspect-docs-finding-{timestamp}.md`（REQ-0124-004、REQ-0124-015、REQ-0103-140 準拠）。
+ファイル名の `{timestamp}` は ISO 8601 形式（`YYYYMMDDTHHMMSSZ` 等のタイムゾーン付き）。
+
+### 出力構成
+
+検出事項ファイルは以下の構成を持つ。
+
+```
+# inspect-docs finding {timestamp}
+
+## サマリ
+- スキャン対象の件数
+- 各カテゴリの検出件数
+- high severity の件数
+
+## 検出事項リスト
+（finding schema に従う各検出事項）
+
+## 推奨アクション
+- 各検出事項に対する推奨対応（route 先、req-define 再壁打ち候補 等）
+
+## 対象外（Out of Scope）
+- 本スキャンで明示的に対象外とした事項
+```
+
+### inspect lifecycle との協調
+
+- 検出事項ファイルは `.agentdev/inspect/inbox/` に配置し、`inspect-promote` への入力となる（REQ-0124-004）
+- reject された検出事項は即時削除する（REQ-0103-140、REQ-0103-146）
+- promote された検出事項は `.agentdev/inspect/promoted/` へ保存し、`backlog-review` の入力となる（REQ-0103-146、REQ-0103-147）
+- 検出事項の source_type は `inspect`（REQ-0124-014、REQ-0103-149）
+
+## NG 分類
+
+検出事項には以下の NG 分類を付ける（docs-spec-rebuild-integrity SPEC NG 分類表に準拠、`agentdev-req-structure-diagnostics` 配布物統合性検出と共通）。
+
+| 分類 | 定義 | 後続対象 |
+|------|------|----------|
+| false positive | 検査ルールの誤検知 | 検査ルールの修正 |
+| pre-existing | 今回の変更以前から存在する既知の問題 | 別途要件化 |
+| 今回修正対象 | 今回の変更で導入、残存した問題 | 今回の Issue で修正 |
+
+NG 分類は recommended_route とは別軸で付ける。
+検出事項が属する分類が不明な場合は「要ヒューマンレビュー」と明記する。
+
+## source-of-truth priority
+
+矛盾判定時の優先順位（REQ-0109-013 準拠）。
+
+1. 現行 REQ（`docs/requirements/REQ-*.md`、retired/ 配下を除く）
+2. 承認済み ADR（`status: accepted` の ADR）
+3. SPEC（`docs/specs/**/*.md`）
+4. DOC-MAP / guides（補助文書）
+
+下位文書が上位文書と矛盾する場合、下位文書の記述を検出事項とする。
+
+## 許可される副作用
+
+本スキルが関与する診断結果の副作用は以下のみを許可する（REQ-0103-140-151、inspect lifecycle 準拠）。
+
+| 副作用 | 許可 |
+|--------|------|
+| `.agentdev/inspect/inbox/inspect-docs-finding-*.md` の生成 | 許可 |
+| `.agentdev/inspect/` 配下の git 永続化（commit/push） | 許可（commit message: `chore(agentdev): capture inspect-docs finding`） |
+| 検査対象（docs/、src/opencode/）のファイル編集 | 禁止 |
+| Issue/PR 作成、worktree 作成、branch 操作 | 禁止 |
+| intake/learning/RU の処理 | 禁止 |


### PR DESCRIPTION
Parent: #1719

## 概要

inspect-docs command が呼ぶ docs 横断診断の判断基盤として `agentdev-doc-diagnostics` skill を新設する（AG-008、RU-20260722-01 合意、REQ-0109-048、REQ-0124-025）。

OU-006 Wave 2 子 Issue #1724 の実装。Phase 1（REQ-0109/0124 UPDATE、SPEC create）は req-save/spec-save 完了済みであり、本 PR は `src/opencode/skills/agentdev-doc-diagnostics/` の実装を対象とする。

## 変更内容

### 追加ファイル

- `src/opencode/skills/agentdev-doc-diagnostics/SKILL.md`
  横断診断カテゴリ、共通証拠構造、共通 finding 出力契約、文書種別別診断へのルーティングを一次所有する skill の実行入口。原本は `docs/specs/skills/agentdev-doc-diagnostics.md`（SPEC）。
- `src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-categories.md`
  廃止 REQ/SPEC 由来記述残置、REQ/SPEC 境界違反、REQ 粒度過小、横断契約矛盾、文意品質候補、探索順と索引の不整合の6カテゴリについて横断スキャン観点とルーティング先、安定契約例外候補の抽出方針を定義。
- `src/opencode/skills/agentdev-doc-diagnostics/references/finding-output-contract.md`
  共通 finding schema（10フィールド）、severity、信頼度、出力ファイル契約（`.agentdev/inspect/inbox/`）、NG 分類、source-of-truth priority、専門 skill 内部スキーマ（req-structure-diagnostics の7フィールド等）との正規化関係を定義。
- `src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-routing.md`
  文書種別別診断へのルーティング表、専門 skill 委譲規則、委譲時の入力引き渡し契約、責務重複なし保証（AC-014）、inspect-docs Step との対応表を定義。

### 完了条件の検証

| 完了条件 | 検証結果 |
|----------|----------|
| REQ-0109 に agentdev-doc-diagnostics 新設が反映されていること（検証のみ） | REQ-0109-048（行41）で反映済み |
| REQ-0124 に diagnostics 許容の例外境界が明記されていること（検証のみ） | REQ-0124-025（行54）で明記済み |
| docs/specs/skills/agentdev-doc-diagnostics.md が存在すること（検証のみ） | 存在確認済み（spec-save 完了済み） |
| src/opencode/skills/agentdev-doc-diagnostics/SKILL.md が存在すること（要実装） | 本 PR で作成 |
| src/opencode/skills/agentdev-doc-diagnostics/references/ が適切に構成されていること（要実装） | 本 PR で3ファイル作成（diagnostic-categories, finding-output-contract, diagnostic-routing） |
| agentdev-doc-diagnostics の責務が doc-writing, doc-map, req-structure-diagnostics と重複しないこと（AC-014、TS-014） | TS-014 PASS（後述） |

## テスト戦略検証

### TS-014: AG-008 責務分離

- **verification**: agentdev-doc-diagnostics の診断カテゴリ、証拠、finding 形式、route を agentdev-req-structure-diagnostics、agentdev-doc-writing、agentdev-doc-map と比較
- **pass_criteria**: 横断編成と結果統合だけを所有し、REQ 固有診断、文章品質、探索順を再定義しないこと
- **結果**: **PASS**

検証内容:
- SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT の判定ロジック、シグナル閾値（1シグナル/2シグナル/3シグナル）、出力 schema（7フィールド）は `agentdev-req-structure-diagnostics` が所有し、本 skill は再定義しない（`diagnostic-categories.md`、「ルーティング先」セクションで明示）
- 文意品質判定辞書（置換辞書、LLM 表現辞書、英語抽象語書き換え辞書）、機械的置換ルールは `agentdev-doc-writing` が所有し、本 skill はルーティングのみ
- DOC-MAP 読み方ガイド、ドキュメント探索順序、影響確認ルールは `agentdev-doc-map` が所有し、本 skill はルーティングのみ
- 本 skill が一次所有するのは「共通 finding 出力契約」「横断スキャン観点」「ルーティング表」「source-of-truth priority 適用」「NG 分類」のみ

## Findings / Capture候補

特になし。実装は SPEC（`docs/specs/skills/agentdev-doc-diagnostics.md`）、REQ-0109-048、REQ-0124-025、artifact-responsibilities SPEC AG-008 台帳に従い、責務境界違反なし。

## SPEC確定候補

- `docs/specs/skills/agentdev-doc-diagnostics.md` の status は `draft` のままである。case-close Step 3 の SPEC 確定チェックにて `accepted` 昇格を判断予定。
- 共通 finding schema（10フィールド）と req-structure-diagnostics 問題候補出力 schema（7フィールド）の正規化マッピングは `finding-output-contract.md` に定義した。このマッピングが SPEC に記載されるべき詳細かどうかは case-close で判断予定。

## Parent Issue

Parent: #1719
