### PR TITLE
fix(commands): OU-007 #1725 CaptureBoundary チェック違反4件修復 + 全件回帰検査

### DIFF
--- a/src/opencode/commands/agentdev/case-close.md
+++ b/src/opencode/commands/agentdev/case-close.md
@@ -276,7 +276,7 @@ Issue close 手続き（理由: completed、`agentdev-gh-cli`）
 - G18: learning と intake を同一 commit に含める
 - G19: Step 12 は結果状態を分離して報告。`.agentdev` push失敗時は完了扱いにしない
 - G20: 完了条件チェックボックスの評価、更新は case-close の専任責務。case-run/ driver/ 外部実行バックエンドは更新しない。case-close は別コンテキストで Issue 本文を再読込して最終完了判定し、更新後に再読込 VERIFY を必ず実施する
-- G21: case-close の capture 責務は「回収・保存」（recover and save）。PR 本文から intake/ learning を分離回収しドメイン状態に保存する。境界の詳細は `agentdev-workflow-orchestration` 参照
+- G21: case-close の capture 責務は「回収・保存」（recover and save）。PR 本文から intake/ learning を分離回収しドメイン状態に保存する。capture 境界（capture-boundaries）の詳細は `agentdev-workflow-orchestration` 参照
 - G22: SPEC status 昇格（draft → accepted）は case-close の責務。昇格は対象 SPEC が `draft` かつ今回の実装が SPEC 内容を検証済みの場合のみ実施する。spec-save は accepted を付与しない
 - G23: SPEC確定候補の処理（Step 3-2）は PR 本文の `## SPEC確定候補` セクションを入力とし、`## Findings / Capture候補` とは区別して扱う
 - G24: Epic Issue 本文ステータス追跡テーブルの更新は case-close のみが実施する（単一書き手制約）。case-run は Epic Issue 本文を読み取るのみで書き込まない。case-auto は Wave 反復制御のみ行い Epic Issue 本文に直接書き込まない。last-write-wins 競合防止は case-close の単一書き手で維持される

--- a/src/opencode/commands/agentdev/case-open.md
+++ b/src/opencode/commands/agentdev/case-open.md
@@ -264,7 +264,7 @@ push 失敗時は構造化エラーメッセージを表示して停止する
 - G17: 成果物本文（Issue本文、PR本文、commit message、保存対象ファイル本文、テンプレート成果物）はverbatimで返す。「verbatim」とはLF・空行・インデントを含む行構造をbyte単位で保持することを指し、文字列の正規化、改行圧縮、空白挿入・削除をすべて禁止する。委譲接続点（Step 2/6/8/9）と最終 gh CLI 渡し（Step 12/13）の双方に適用する。判定結果、調査過程、中間ログ、読解メモは要約、成果物パス、根拠、親判断事項、capture候補へ圧縮して返す（REQ-0132-026）
 
  ### Capture 非関与制約
-- G18: case-open は intake/ learning capture を行わない。capture 境界の詳細は `agentdev-workflow-orchestration` を参照
+- G18: case-open は intake/ learning capture を行わない。capture 境界（capture-boundaries）の詳細は `agentdev-workflow-orchestration` を参照
 
 ### OU 処理制約
 - G19: case-open は自律的な要件分析に基づいて Epic Issue を作成すること。ただし機能要件、非機能要件、対象外、受け入れ条件を新規に作成しないこと

--- a/src/opencode/commands/agentdev/case-run.md
+++ b/src/opencode/commands/agentdev/case-run.md
@@ -269,7 +269,7 @@ intake/ learning 境界は `agentdev-workflow-orchestration` を参照する。
 - G14: スコープ拡大禁止。発見は記録し修正は後続処理に委ねる
 - G15: intake 候補を PR 本文の `## Findings / Capture候補` に記録。`.agentdev/intake/inbox/` の直接変更禁止
 - G16: learning 候補を intake 候補と区別して記録
-- G17: intake/learning 候補を混ぜた単一成果物にしない。capture 境界の詳細は `agentdev-workflow-orchestration` 参照（case-run の capture 責務は記録のみ）
+- G17: intake/learning 候補を混ぜた単一成果物にしない。capture 境界（capture-boundaries）の詳細は `agentdev-workflow-orchestration` 参照（case-run の capture 責務は記録のみ）
 - G21: `.agentdev/learning/inbox.md` の直接変更禁止。capture 情報は PR 本文経由のみ case-close に引き継ぐ
 - G27: SPEC確定候補（実装で発見された SPEC レベル詳細）は PR 本文の `## SPEC確定候補` セクションに記録し、`## Findings / Capture候補` とは混在させない。SPEC確定候補の確定、SPEC ファイルへの反映判断は case-close の責務
 

--- a/src/opencode/commands/agentdev/req-save.md
+++ b/src/opencode/commands/agentdev/req-save.md
@@ -312,7 +312,7 @@ ADR保存の直前に、以下の妥当性を再検証すること:
 - G10: 成果物本文（Issue本文、PR本文、commit message、保存対象ファイル本文、テンプレート成果物）はverbatimで返す。判定結果、調査過程、中間ログ、読解メモは要約、成果物パス、根拠、親判断事項、capture候補へ圧縮して返す
 
 ### Capture 非関与制約
-- G12: req-save の capture 責務は原則非関与。intake/ learning capture を行わない。例外: REQ 再構成 intake（`.agentdev/intake/inbox/req-restructure/**`）のみ生成可能。capture 境界の詳細は `agentdev-workflow-orchestration` 参照
+- G12: req-save の capture 責務は原則非関与。intake/ learning capture を行わない。例外: REQ 再構成 intake（`.agentdev/intake/inbox/req-restructure/**`）のみ生成可能。capture 境界（capture-boundaries）の詳細は `agentdev-workflow-orchestration` 参照
 
 ### Issue作成制約
 - G11: req-saveはIssueを作成してはならない。Issue作成はcase-openの責任範囲である


### PR DESCRIPTION
## 概要

OU-007: REQ-0108/0144/0145 UPDATE + 全件回帰検査（Epic #1719 Wave 4 最終検証フェーズ）。Phase 1 で完了済みの REQ/SPEC 更新を検証確認し、全件回帰検査（docs-check、integrity rule catalog、script test）を実施した。検査で発見された src/opencode/ 配下の修正可能な不具合（CaptureBoundary 4件）を修正した。

Parent: #1719

## 変更内容

全件回帰検査で発見された CaptureBoundary 違反 4件を修正。PR #1728（Wave 1, OU-001）で skill 内部参照 `agentdev-workflow-orchestration/references/capture-boundaries.md` を `agentdev-workflow-orchestration` へ抽象化した際、文字列 `capture-boundaries` が除去され、check_integrity.ts の `checkCommandCaptureDuties` チェック（`content.includes("capture-boundaries")`）が崩れていた。コンクリートパスを使わず概念名 `capture-boundaries` を括弧書きで追加し、チェックを復元した。

- `src/opencode/commands/agentdev/case-run.md` G17: `capture 境界（capture-boundaries）の詳細は…`
- `src/opencode/commands/agentdev/case-close.md` G21: `capture 境界（capture-boundaries）の詳細は…`
- `src/opencode/commands/agentdev/req-save.md` G12: `capture 境界（capture-boundaries）の詳細は…`
- `src/opencode/commands/agentdev/case-open.md` G18: `capture 境界（capture-boundaries）の詳細は…`

## 全件回帰検査結果

### TS-007: 固定件数の是正（PASS）

`docs/specs/responsibilities/document-type-responsibilities.md` を確認。固定件数「全27ファイル」等は廃止済み（line 142, 164）。動的追従方針（AG-011、RU-20260722-01 合意）へ是正されている。

### TS-009: 文書整合性検査と script test

#### check_integrity.ts（docs-check Step 1）

- 初回実行: OK=439, NG=212, Warning=22, Info=815
- 修正後実行: OK=443, NG=208, Warning=22, Info=815（CaptureBoundary 4件解消）
- 残り NG 208件の内訳:
  - RuntimeReference: 202件（全て IR-055 baseline-known、route: intake）
  - IndexGenerationConsistency: 3件（docs/ AUTOGEN block out of sync、docs/ 配下のため対象外）
  - MappingTable: 2件（REQ-0158/0161 retired だが mapping-table 未登録、docs/ 配下のため対象外）
  - Inventory: 1件（REQ-0158 が DOC-MAP 参照だがファイル不存在、docs/ 配下のため対象外）
- CaptureBoundary 4件（case-run/close/open, req-save）: **修正済み**（本 PR）

#### その他 integrity スクリプト（全て PASS）

- check_distribution_boundary.ts: 本 PR の編集ファイルは検出対象外（既存 SKILL.md 由来の baseline 検出のみ）
- check_extensions.ts: exit 0, 0 failures
- check_command_format.ts: exit 0
- check_templates.ts: exit 0, 全カテゴリ 0 NG
- lint_skills.ts: exit 0
- check_changed_docs.ts（--workflow docs-check）: exit 0, 0 failures

#### script test (bun test)

- `agentdev-artifact-validation/scripts`: 22 pass, 0 fail
- `agentdev-spec-file-manager/scripts`: 8 pass, 0 fail
- `agentdev-req-file-manager/scripts`: 20 pass, 0 fail
- `repo-agentdev-integrity/scripts`: 635 pass, **67 fail**（既存の worktree 環境問題、詳細は Findings 参照）

### TS-012: 対象一覧の完全性（PASS）

全 149 対象を列挙・分類。カウント全て一致: 17 command / 32 skill / 17 command SPEC / 31 skill SPEC / 52 REQ。

#### Commands (17)

| command | 分類 | 判定根拠 |
|---------|------|----------|
| backlog-review | 変更不要 | Wave 1-3 で変更なし。skill 内部参照を含まず抽象化対象外 |
| case-auto | 本文更新/reference移送 | Wave 1-3 (#1728-1734) で skill 内部参照抽象化・Step番号依存除去 |
| case-close | 本文更新/reference移送 | Wave 1-3 (#1728-1734) で skill 内部参照抽象化・Step番号依存除去 |
| case-open | 本文更新/reference移送 | Wave 1-3 (#1728-1734) で skill 内部参照抽象化・Step番号依存除去 |
| case-run | 本文更新/reference移送 | Wave 1-3 (#1728-1734) で skill 内部参照抽象化・Step番号依存除去 |
| case-update | 変更不要 | Wave 1-3 で変更なし。skill 内部参照を含まず抽象化対象外 |
| inspect-docs | 本文更新/reference移送 | Wave 1-3 (#1728-1734) で skill 内部参照抽象化・Step番号依存除去 |
| inspect-extensions | 変更不要 | Wave 1-3 で変更なし。skill 内部参照を含まず抽象化対象外 |
| inspect-promote | 変更不要 | Wave 1-3 で変更なし。skill 内部参照を含まず抽象化対象外 |
| inspect-skills | 本文更新/reference移送 | Wave 1-3 (#1728-1734) で skill 内部参照抽象化・Step番号依存除去 |
| intake-capture | 本文更新/reference移送 | Wave 1-3 (#1728-1734) で skill 内部参照抽象化・Step番号依存除去 |
| intake-from-github | 本文更新/reference移送 | Wave 1-3 (#1728-1734) で skill 内部参照抽象化・Step番号依存除去 |
| intake-promote | 変更不要 | Wave 1-3 で変更なし。skill 内部参照を含まず抽象化対象外 |
| learning-promote | 本文更新/reference移送 | Wave 1-3 (#1728-1734) で skill 内部参照抽象化・Step番号依存除去 |
| req-define | 本文更新/reference移送 | Wave 1-3 (#1728-1734) で skill 内部参照抽象化・Step番号依存除去 |
| req-save | 本文更新/reference移送 | Wave 1-3 (#1728-1734) で skill 内部参照抽象化・Step番号依存除去 |
| spec-save | 本文更新/reference移送 | Wave 1-3 (#1728-1734) で skill 内部参照抽象化・Step番号依存除去 |

#### Skills (32)

| skill | 分類 | 判定根拠 |
|-------|------|----------|
| agentdev-adr-file-manager | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-adr-guidelines | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-architecture-advisory | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-artifact-validation | 新規所有者移管 | Wave 2 (#1733) で新設。既存 skill から検証 script 所有を分離 |
| agentdev-backlog-integration | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-case-run-execution-adapter | 本文更新/reference移送 | Wave 1-3 で skill 内部参照抽象化・参照パス分離 |
| agentdev-command-authoring | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-command-creator | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-conventional-commits | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-doc-diagnostics | 新規所有者移管 | Wave 2 (#1731) で新設。docs 横断診断カテゴリを分離 |
| agentdev-doc-map | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-doc-writing | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-epic-tracker | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-gh-cli | script移送 | Wave 1-3 で共通/SPEC固有 script を agentdev-artifact-validation/spec-file-manager へ移管、SKILL.md 本文更新 |
| agentdev-git-worktree | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-inspect-skills | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-intake-pipeline | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-issue-management | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-learning-capture | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-learning-pipeline | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-project-extensions | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-quality-gates | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-req-analysis | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-req-file-manager | script移送 | Wave 1-3 で共通/SPEC固有 script を agentdev-artifact-validation/spec-file-manager へ移管、SKILL.md 本文更新 |
| agentdev-req-structure-diagnostics | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-skill-authoring | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-spec-file-manager | 新規所有者移管 | Wave 2 (#1732) で新設。SPEC 固有 script 所有を分離 |
| agentdev-workflow-lifecycle | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-workflow-orchestration | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-workflow-routing | 変更不要 | Wave 1-3 で変更なし。対象外の skill 内部参照・script 所有変更なし |
| agentdev-workflow-templates | 本文更新/reference移送 | Wave 1-3 で skill 内部参照抽象化・参照パス分離 |
| japanese-tech-writing | 変更不要 | Wave 1-3 で変更なし。配布物依存スキル、対象外 |

#### Command SPECs (17)

| SPEC | 分類 | 判定根拠 |
|------|------|----------|
| backlog-review | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| case-auto | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| case-close | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| case-open | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| case-run | 本文更新 | Wave 1-3 (#1729) で command 変更に追従する SPEC 更新 |
| case-update | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| inspect-docs | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| inspect-extensions | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| inspect-promote | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| inspect-skills | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| intake-capture | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| intake-from-github | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| intake-promote | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| learning-promote | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| req-define | 本文更新 | Wave 1-3 (#1734) で command 変更に追従する SPEC 更新 |
| req-save | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |
| spec-save | 変更不要 | Phase 1/Wave 1-3 で変更不要。対応 command は変更不要または SPEC 影響なし |

#### Skill SPECs (31)

| SPEC | 分類 | 判定根拠 |
|------|------|----------|
| agentdev-adr-file-manager | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-adr-guidelines | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-architecture-advisory | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-artifact-validation | 新規所有者移管 | Phase 1 (spec-save) で新設。新 skill の正規原本 SPEC |
| agentdev-backlog-integration | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-case-run-execution-adapter | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-command-authoring | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-command-creator | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-conventional-commits | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-doc-diagnostics | 新規所有者移管 | Phase 1 (spec-save) で新設。新 skill の正規原本 SPEC |
| agentdev-doc-map | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-doc-writing | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-epic-tracker | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-gh-cli | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-git-worktree | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-inspect-skills | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-intake-pipeline | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-issue-management | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-learning-capture | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-learning-pipeline | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-project-extensions | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-quality-gates | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-req-analysis | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-req-file-manager | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-req-structure-diagnostics | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-skill-authoring | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-spec-file-manager | 新規所有者移管 | Phase 1 (spec-save) で新設。新 skill の正規原本 SPEC |
| agentdev-workflow-lifecycle | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-workflow-orchestration | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-workflow-routing | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |
| agentdev-workflow-templates | 変更不要 | Phase 1/Wave 1-3 で変更不要。既存 SPEC は維持 |

#### REQs (52)

本文更新（13）: REQ-0102, 0103, 0108, 0109, 0119, 0124, 0130, 0131, 0136, 0143, 0144, 0145, 0149（Phase 1 commit b2941935 で今回の変更内容を反映）

変更不要（39）: REQ-0101, 0104, 0105, 0106, 0107, 0110, 0112, 0113, 0114, 0123, 0125, 0126, 0127, 0128, 0129, 0132, 0133, 0134, 0135, 0137, 0138, 0139, 0140, 0141, 0142, 0146, 0147, 0148, 0150, 0151, 0152, 0153, 0154, 0155, 0156, 0159, 0160, 0162, 0163（Phase 1 で変更不要。今回の変更の影響対象外）

## Findings / Capture候補

### intake

- **CaptureBoundary チェック違反（4件、修正済み）**: PR #1728（Wave 1, OU-001）の skill 内部参照抽象化で `capture-boundaries` 文字列が除去され、`checkCommandCaptureDuties` チェックが崩れていた。概念名 `capture-boundaries` を括弧書きで追加し復元。コンクリートパス（docs/specs/workflows/capture-boundaries.md）は使わず、配布物参照境界（IR-059）違反なし。
- **IndexGenerationConsistency 違反（3件、対象外）**: docs/DOC-MAP.md（SPEC 件数 142→145）、docs/specs/quality/req-health-metrics.md、docs/specs/quality/spec-health-metrics.md の AUTOGEN block out of sync。Phase 1 + Wave 1-3 の構成変更に伴う件数ドリフト。`bun run generate_indexes.ts` で再生可能だが docs/ 配下のため本 Issue 対象外。別 Issue（docs-check/intake）での対応推奨。
- **MappingTable 違反（2件、対象外）**: REQ-0158, REQ-0161 が retired だが docs/requirements/mapping-table.md へ未登録。docs/requirements/ 配下のため本 Issue 対象外。別 Issue（req-save）での対応推奨。
- **Inventory 違反（1件、対象外）**: REQ-0158 が docs/DOC-MAP.md で参照されているがファイル不存在（retire 済み）。docs/ 配下のため本 Issue 対象外。
- **REQ-0149-009 Phase 1 incompleteness（Wave 3 #1734 から継承）**: docs/requirements/REQ-0149-009 が「standard-procedures Section2 Step0」参照を含み REQ-0149-013 違反。docs/requirements/ 変更禁止のため本 Issue では対応不可。req-save/req-define での修正推奨。
- **repo-agentdev-integrity test 67件失敗（既存環境問題）**: worktree 環境で check_integrity.ts の subprocess JSON 出力が空となり `JSON.parse(r.stdout)` が "Unexpected EOF" で失敗。git stash で本 PR 変更を退避しても同一に失敗することを確認済み（pre-existing）。Windows worktree の stdout エンコーディング・バッファリング問題が原因と推定。main 環境では再現しない可能性が高い。

### learning

特記事項なし。

## SPEC確定候補

- **CaptureBoundary チェックと配布物参照境界の相互作用**: `checkCommandCaptureDuties` は `content.includes("capture-boundaries")` で文字列一致を要求するが、配布物参照境界（IR-059）はコンクリートパス `docs/specs/workflows/capture-boundaries.md` を禁止する。両者を両立させるには概念名 `capture-boundaries` を括弧書き等で本文へ含める運用が必要。この相互作用を SPEC（integrity-contracts.md または capture-boundaries.md）へ明記することを推奨する。case-auto.md は現状コンクリートパス参照（baseline-known NG）を含んでおり、将来のクリーンアップで本 PR と同様の概念名参照へ統一すべきである。

## テスト戦略処理結果

- TS-009（文書整合性検査と script test）: 合格。スコープ内の CaptureBoundary 4件は fix-and-reverify で修復済み。残り NG は全て baseline-known または docs/ 配下（対象外）。67件の test 失敗は pre-existing 環境問題（record-in-findings）。
- TS-012（対象一覧の完全性）: 合格。149 対象を列挙・分類、欠落・重複・未判定なし。変更不要行にも根拠を記録。
- TS-007（固定件数の是正）: 合格。固定件数は動的追従方針へ是正済み（Phase 1 完了）。

## 関連 Issue

- Closes #1725
- Parent: #1719
