### PR TITLE
OU-002 (#1738): SPEC 5区分体系と関心キー所有 — acceptance criteria 検証

### DIFF
--- a/docs/requirements/REQ-0155.md
+++ b/docs/requirements/REQ-0155.md
@@ -2,7 +2,7 @@
 id: REQ-0155
 title: "文書粒度モデル"
 created: "2026-06-26"
-updated: "2026-07-22"
+updated: "2026-07-23"
 ---
 
 ## 目的
@@ -31,6 +31,6 @@ SPEC 内部の論理区分、文書分類モデル、粒度ゲート、RU 運用
 
 ## 関連情報
 
-- **関連 REQ**: REQ-0101（文書、REQ管理基準、文書分類定義の一次所有先）、REQ-0102（要件定義、保存、分類ゲート）、REQ-0103（Artifact責任分界）、REQ-0128（learning-promote）、REQ-0129（backlog-review）、REQ-0136（REQ/SPEC責務分離、spec-save 保存前検証）
+- **関連 REQ**: REQ-0101（文書、REQ管理基準、文書分類定義の一次所有先）、REQ-0102（要件定義、保存、分類ゲート）、REQ-0103（Artifact責任分界）、REQ-0128（learning-promote）、REQ-0129（backlog-review）、REQ-0136（REQ/SPEC責務分離、spec-save 保存前検証）、REQ-0156（docs/specs 基盤SPECドメイン別体系化: SPEC 主論理区分・正規所有対象宣言要件が REQ-0155-009 の5区分に依存）
 - **関連 ADR**: ADR-0103（文書種別責務境界）、ADR-0123（SPEC lifecycle）、ADR-0104（実行時独立性）
 - **関連 SPEC**: document-model.md（SPEC内部論理区分、7分類、局所物理分離の規範）、req-health-metrics.md（粒度ゲート閾値）


### PR DESCRIPTION
Resolves #1738

## 概要

OU-002（Issue #1738）の acceptance criteria 順位検証を実施した。Phase 1（commit `0192019c`）で REQ-0155-009、REQ-0156-013、document-model.md「SPEC 内部論理区分」節の5区分拡張、ADR-0139 の新規作成は完了している。本 PR は全項目 PASS を確認した上で、片方向参照の補完（REQ-0155 側の関連 REQ に REQ-0156 を追加）を含む。

## 変更ファイル

- `docs/requirements/REQ-0155.md`: 関連 REQ へ REQ-0156 を相互参照として追加。REQ-0156-013 が REQ-0155-009 の5区分定義に依存する一方で REQ-0155 側の参照が欠けていたため。`updated` 日付を 2026-07-23 へ更新。

## Acceptance criteria 検証結果

- [x] REQ-0156 に主論理区分と正規所有対象の宣言要件が APPEND されている
  - REQ-0156-013（`docs/requirements/REQ-0156.md` L30）で frontmatter または冒頭宣言節による主論理区分（REQ-0155-009 の5区分のいずれか）と正規所有対象の識別、複数論理区分を含む SPEC での主論理区分と従属区分の判別要件を APPEND 済み。
- [x] REQ-0155 に5区分とパラメータ責務の独立要件が APPEND されている
  - REQ-0155-009（`docs/requirements/REQ-0155.md` L25）で5区分（挙動/カタログ/横断契約/パラメータ/実装詳細）とパラメータ責務の実装詳細からの区別を APPEND 済み。REQ-0155-001 の従来4区分を拡張する形式。
- [x] document-model.md の「SPEC 論理区分」節に5区分が明記されている
  - `docs/specs/foundations/document-model.md` L385-406「SPEC 内部論理区分」節で5区分（挙動/カタログ/横断契約/パラメータ/実装詳細）を明記（L389、L391-397 の表）。
- [x] document-model.md でパラメータ SPEC が実装詳細 SPEC と独立して定義されている
  - L396 でパラメータ SPEC（retry 回数、timeout、閾値等のパラメータ責務）を定義、L397 で実装詳細 SPEC（パラメータ責務は除く）を定義。L399 で「パラメータ責務は実装詳細 SPEC から区別し、パラメータ SPEC として独立区分を与える」と明示。
- [x] document-model.md に主論理区分と正規所有対象の宣言要件が追加されている
  - L401 で主論理区分（frontmatter または冒頭宣言節）、L404 で正規所有対象（関心キー）の宣言要件を追加。REQ-0156-013 への参照を含む。
- [x] `docs/adr/ADR-0139.md` が存在する
  - ファイル存在確認（56行）。
- [x] ADR-0139 に5決定事項（REQ ステークホルダー視点、SPEC 5分類、関心キー所有、変更種別分類、req-define/spec-save 責務）が記載されている
  - 決定1: REQ ステークホルダー視点の4妥当性基準（L21-23）
  - 決定2: SPEC 論理区分を5区分としパラメータ責務を実装詳細から区別（L25-27）
  - 決定3: 正規所有の単位を「安定した関心キー」とする（L29-31）
  - 決定4: learning/intake 由来変更は8種別で分類、REQ 拡張は2種別に限定（L33-35）
  - 決定5: req-define は最終分類を確定、spec-save は配置一貫性検証を実施（L37-39）
- [x] `docs/adr/README.md` の Decision Map に ADR-0139 から ADR-0103、ADR-0123、ADR-0107 への relates-to が反映されている
  - Decision Map に3行反映済み（ADR-0139 → ADR-0103、ADR-0123、ADR-0107）。トピック別ビュー「アーキテクチャ」「コマンド、スキル設計」にも ADR-0139 を掲載。

## テスト戦略 検証結果

- TS-002 (AG-002): PASS。document-model.md L389、L391-397、L399 で5区分とパラメータ SPEC の独立性を確認。
- TS-003 (AG-003): PASS（OU-002 スコープ内）。REQ-0156-013 で主論理区分と正規所有対象の宣言要件を確認。関心キー所有の実体定義（artifact-responsibilities.md）は OU-003 担当（本 OU 対象外）。
- TS-009 (AG-009): PASS。ADR-0139 が存在、5決定事項記載、Decision Map に3 relates-to 反映済み。

## QG-3（targeted docs guard）結果

`bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref origin/main --json`:

- `files_checked`: `docs/requirements/REQ-0155.md`
- `coupled_files_checked`: `docs/DOC-MAP.md`, `docs/README.md`, `docs/requirements/README.md`
- `failures`: `[]`（strict failure 0）
- `warnings`: `[]`
- `doc_map_update_required`: false
- `spec_readme_update_required`: true（後述 Findings 参照）
- `requirements_readme_update_required`: false
- `extensions_check_required`: true（後述 Findings 参照）

## Findings / Capture候補

- QG-3 の `spec_readme_update_required: true` フラグ: REQ-0155 変更で specs/README.md の更新が必要と判定されたが、本変更は関連 REQ の相互参照追加のみであり、SPEC 一覧表の内容には影響しない。誤検知の可能性。REQ-0155 は spec-health-metrics.md（REQ-0156-007 新設）と関連するが、今回の変更箇所（関連 REQ セクション）は spec-health-metrics.md の記述に影響しない。
- QG-3 の `extensions_check_required: true` フラグ: project extensions 整合性チェック要求。REQ-0155 変更で extensions への影響はなく、誤検知の可能性。
- REQ-0155 の関連 REQ に REQ-0156 が欠けていた（片方向参照）。REQ-0156 側の関連 REQ には REQ-0155 が既に含まれていた（`REQ-0156.md` L39）。相互参照の片方向欠落は他の REQ でも発生する可能性があり、inspect-docs での横断チェック候補。

## SPEC確定候補

- document-model.md L404「主論理区分・正規所有対象の宣言形式（frontmatter フィールド名、冒頭宣言節フォーマット）の詳細は `../responsibilities/artifact-contracts.md`「分類根拠伝播契約」または本ファイルで定義する。」
  - 「または本ファイルで定義する」という表現が曖昧。宣言形式の最終配置先（artifact-contracts.md と document-model.md のどちらが正規所有者か）が未確定。ADR-0139 決定5「配置一貫性検証」の有効化前に、宣言形式の正規所有者を確定する必要がある。後続 spec-save / case-run 工程で確定候補。

## L2 タイムスタンプ

- 実行開始: 2026-07-23 00:55:09 JST
- 実行終了: 2026-07-23 01:02:00 JST（目安、PR 作成完了時に更新）
- 所要時間: 約7分（目安）
