### PR TITLE
docs(spec): 宣言率指標セクションの整形補完と受け入れ基準の検証 (#1774)

### DIFF
--- a/docs/specs/quality/spec-health-metrics.md
+++ b/docs/specs/quality/spec-health-metrics.md
@@ -39,6 +39,7 @@ AUTOGENブロックは `AUTOGEN:BEGIN` マーカーから対応する `AUTOGEN:E
 - **再現性**: 同一 commit 状態に対して grep / parse 集計を行えば誰でも同一結果を得られる。集計ロジックは本 SPEC が定義し、実行は `inspect-docs`、`/repo/docs-check` が担う（本 SPEC 自体は計測ロジックを実装しない）
 
 宣言率指標は警告モードで運用し、不合格閾値を設けない（REQ-0136-035 段階適用、ADR-0124 soft-contract）。新規 SPEC から順次宣言付与を適用し、段階的な宣言率向上を追跡する。
+
 ## 閾値とシグナル
 
 ### SPEC 行数


### PR DESCRIPTION
## 概要

Issue #1774 の受け入れ基準（`docs/specs/quality/spec-health-metrics.md` の「測定対象と計測方法」表へ宣言率指標 `spec_logical_division` / `canonical_owner` を追記）は、前工程 spec-save（commit f61664b3）で満たされていることを確認した。本 PR は検証結果の記録と、同 commit で導入された Markdown 整形上の後戻り（見出し前空白行の欠落）の補完を担当する。

## 変更内容

- `docs/specs/quality/spec-health-metrics.md`: 「宣言率指標の定義」節末尾段落と「## 閾値とシグナル」見出しの間に空白行を1行追加（f61664b3 で生じた整形後戻りの補完）

## 受け入れ基準の対応

- [x] 「測定対象と計測方法」表に「宣言率（spec_logical_division）」「宣言率（canonical_owner）」の2指標行が追加されていること
  - 満た済（f61664b3、当該表の末尾2行）
- [x] 各指標の計測方法が frontmatter または冒頭宣言節の宣言有無を機械的に（grep / parse で）集計可能であること
  - 満た済（f61664b3、「宣言率指標の定義」節の「計算方法」項）
- [x] 宣言率指標が警告モード（不合格閾値なし）で運用されることが SPEC 本文に明記されていること
  - 満た済（f61664b3、「閾値」項および節末尾段落）
- [x] 「宣言率指標の定義」節が追加され、分子・分母・unknown 扱い・閾値なし・再現性の各項目が規定されていること
  - 満た済（f61664b3、6項目すべて規定済み: 分子・分母・計算方法・unknown扱い・閾値・再現性）

## テスト戦略（TS-005 / AG-011）の検証

TS-005 が要求する「宣言率が機械的に算出可能（grep / parse で集計可能）であること」を確認するため、`docs/specs/**/*.md`（`_template.md` 除く、143ファイル）に対し frontmatter フィールド有無の grep 集計を実行した:

| 指標 | frontmatter 宣言数 | 宣言率（frontmatter のみ） |
|---|---|---|
| `spec_logical_division` | 0 / 143 | 0.00% |
| `canonical_owner` | 0 / 143 | 0.00% |

- 集計コマンド（PowerShell `Select-String`、`^spec_logical_division:` / `^canonical_owner:` パターン）が正常に動作し、機械的集計が可能であることを確認
- 現在の宣言率 0% は REQ-0136-035「段階適用」（新規 SPEC から順次宣言付与）と整合し、警告モード運用（不合格閾値なし）の前提条件を満たす
- 冒頭宣言節形式での宣言も SPEC が計測対象に含めているため、実運用時には frontmatter + 冒頭宣言節の両方を parse する必要がある（本検証では frontmatter のみで機械化可能性を確認）

## Findings / Capture候補

- なし。本 Issue は spec-save（f61664b3）で受け入れ基準を満たしており、本 PR は検証記録と整形後戻りの補完のみを担当する。計測ロジックの実装（`inspect-docs`、`/repo/docs-check` 側）および既存 SPEC の一括宣言付与（REQ-0136-035 段階適用）は本 Issue の対象外（Issue 本文「実装のスコープ」明記）。

## SPEC確定候補

- なし。

Closes: #1774
