### PR TITLE
fix(integrity): AUTOGEN marker 検出を行全体一致へ是正

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Regression tests for AUTOGEN marker detection (Issue #1771, RU-0002).
+ *
+ * Verifies that the whole-line matching strategy correctly:
+ *   - detects real AUTOGEN marker lines (positive cases)
+ *   - ignores backtick-wrapped marker strings in prose (negative cases)
+ *   - handles boundary cases where backticks are adjacent to marker lines
+ *
+ * SPEC: docs/specs/integrity/index-auto-generation.md「AUTOGEN marker 検出契約」
+ * Background: PR #1718 workaround (HTML comment syntax abstraction) addressed
+ * a symptom where backtick-wrapped marker strings in spec-health-metrics.md L26
+ * were misrecognized as real markers, causing generate_indexes.ts to stop.
+ * This test locks the root-cause fix (whole-line matching).
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  isAutogenBeginLine,
+  isAutogenEndLine,
+  extractAutogenBeginId,
+  findAutogenBlocks,
+  replaceAutogenBlock,
+  countSpecBodyLines,
+} from "./generate_indexes.ts";
+
+describe("isAutogenBeginLine", () => {
+  it("returns true for a canonical marker line", () => {
+    expect(isAutogenBeginLine("<!-- AUTOGEN:BEGIN:id=catalog-ir-entries-pre-045 -->")).toBe(true);
+  });
+
+  it("returns true with leading whitespace", () => {
+    expect(isAutogenBeginLine("  <!-- AUTOGEN:BEGIN:id=xxx -->")).toBe(true);
+  });
+
+  it("returns true with trailing whitespace", () => {
+    expect(isAutogenBeginLine("<!-- AUTOGEN:BEGIN:id=xxx -->  ")).toBe(true);
+  });
+
+  it("returns false for a backtick-wrapped marker (negative)", () => {
+    expect(isAutogenBeginLine("`<!-- AUTOGEN:BEGIN:id=xxx -->`")).toBe(false);
+  });
+
+  it("returns false for a prefix-backtick boundary", () => {
+    expect(isAutogenBeginLine("`<!-- AUTOGEN:BEGIN:id=xxx -->")).toBe(false);
+  });
+
+  it("returns false for a suffix-backtick boundary", () => {
+    expect(isAutogenBeginLine("<!-- AUTOGEN:BEGIN:id=xxx -->`")).toBe(false);
+  });
+
+  it("returns false for a prose line containing the marker inline", () => {
+    const line = "AUTOGENブロックは`<!-- AUTOGEN:BEGIN:id=... -->`から対応する`<!-- AUTOGEN:END -->`までを除外する。";
+    expect(isAutogenBeginLine(line)).toBe(false);
+  });
+
+  it("returns false for a plain text line", () => {
+    expect(isAutogenBeginLine("This is a normal paragraph.")).toBe(false);
+  });
+});
+
+describe("isAutogenEndLine", () => {
+  it("returns true for a canonical end marker line", () => {
+    expect(isAutogenEndLine("<!-- AUTOGEN:END -->")).toBe(true);
+  });
+
+  it("returns true with leading whitespace", () => {
+    expect(isAutogenEndLine("  <!-- AUTOGEN:END -->")).toBe(true);
+  });
+
+  it("returns false for a backtick-wrapped end marker (negative)", () => {
+    expect(isAutogenEndLine("`<!-- AUTOGEN:END -->`")).toBe(false);
+  });
+
+  it("returns false for a prose line containing end marker inline", () => {
+    const line = "対応する`<!-- AUTOGEN:END -->`までを除外する。";
+    expect(isAutogenEndLine(line)).toBe(false);
+  });
+});
+
+describe("extractAutogenBeginId", () => {
+  it("extracts the id from a canonical marker line", () => {
+    expect(extractAutogenBeginId("<!-- AUTOGEN:BEGIN:id=catalog-ir-entries-pre-045 -->")).toBe("catalog-ir-entries-pre-045");
+  });
+
+  it("extracts id with leading whitespace", () => {
+    expect(extractAutogenBeginId("  <!-- AUTOGEN:BEGIN:id=spec-metrics-measurement-example -->")).toBe("spec-metrics-measurement-example");
+  });
+
+  it("returns null for a backtick-wrapped marker (negative)", () => {
+    expect(extractAutogenBeginId("`<!-- AUTOGEN:BEGIN:id=xxx -->`")).toBe(null);
+  });
+
+  it("returns null for a non-marker line", () => {
+    expect(extractAutogenBeginId("normal text")).toBe(null);
+  });
+});
+
+describe("findAutogenBlocks", () => {
+  it("detects a real AUTOGEN block (positive)", () => {
+    const content = [
+      "# Title",
+      "",
+      "<!-- AUTOGEN:BEGIN:id=test-block -->",
+      "line A",
+      "line B",
+      "<!-- AUTOGEN:END -->",
+      "",
+      "After block.",
+    ].join("\n");
+
+    const blocks = findAutogenBlocks(content);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0].id).toBe("test-block");
+    expect(blocks[0].startLine).toBe(2);
+    expect(blocks[0].endLine).toBe(5);
+    expect(blocks[0].currentBody).toEqual(["line A", "line B"]);
+  });
+
+  it("ignores backtick-wrapped marker strings in prose (negative)", () => {
+    const content = [
+      "# Title",
+      "",
+      "AUTOGENブロックは`<!-- AUTOGEN:BEGIN:id=... -->`から対応する`<!-- AUTOGEN:END -->`までを除外する。",
+      "",
+      "No real markers here.",
+    ].join("\n");
+
+    const blocks = findAutogenBlocks(content);
+    expect(blocks.length).toBe(0);
+  });
+
+  it("detects only the real block when prose has backtick-wrapped markers (mixed)", () => {
+    const content = [
+      "# SPEC",
+      "",
+      "AUTOGENブロックは`<!-- AUTOGEN:BEGIN:id=... -->`から対応する`<!-- AUTOGEN:END -->`までを除外する。",
+      "",
+      "## Section",
+      "",
+      "<!-- AUTOGEN:BEGIN:id=real-block -->",
+      "data",
+      "<!-- AUTOGEN:END -->",
+    ].join("\n");
+
+    const blocks = findAutogenBlocks(content);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0].id).toBe("real-block");
+  });
+
+  it("ignores a marker line with an adjacent backtick (boundary)", () => {
+    const content = [
+      "<!-- AUTOGEN:BEGIN:id=boundary -->",
+      "content",
+      "<!-- AUTOGEN:END -->`",
+    ].join("\n");
+
+    const blocks = findAutogenBlocks(content);
+    expect(blocks.length).toBe(0);
+  });
+
+  it("detects multiple distinct real blocks", () => {
+    const content = [
+      "<!-- AUTOGEN:BEGIN:id=block-1 -->",
+      "a",
+      "<!-- AUTOGEN:END -->",
+      "gap",
+      "<!-- AUTOGEN:BEGIN:id=block-2 -->",
+      "b",
+      "<!-- AUTOGEN:END -->",
+    ].join("\n");
+
+    const blocks = findAutogenBlocks(content);
+    expect(blocks.length).toBe(2);
+    expect(blocks[0].id).toBe("block-1");
+    expect(blocks[1].id).toBe("block-2");
+  });
+});
+
+describe("replaceAutogenBlock", () => {
+  it("replaces the body of a matching real block", () => {
+    const content = [
+      "<!-- AUTOGEN:BEGIN:id=target -->",
+      "old line",
+      "<!-- AUTOGEN:END -->",
+    ].join("\n");
+
+    const result = replaceAutogenBlock(content, "target", ["new line"]);
+    expect(result).toContain("new line");
+    expect(result).not.toContain("old line");
+  });
+
+  it("does not match a backtick-wrapped marker (negative)", () => {
+    const content = [
+      "Prose: `<!-- AUTOGEN:BEGIN:id=target -->` text.",
+      "<!-- AUTOGEN:BEGIN:id=target -->",
+      "old",
+      "<!-- AUTOGEN:END -->",
+    ].join("\n");
+
+    const result = replaceAutogenBlock(content, "target", ["new"]);
+    expect(result).toContain("new");
+    expect(result).not.toContain("old");
+    expect(result).toContain("Prose: `<!-- AUTOGEN:BEGIN:id=target -->` text.");
+  });
+
+  it("leaves content unchanged when no matching block exists", () => {
+    const content = "no markers here";
+    const result = replaceAutogenBlock(content, "absent", ["new"]);
+    expect(result).toBe(content);
+  });
+});
+
+describe("countSpecBodyLines", () => {
+  it("excludes a real AUTOGEN block from the body count", () => {
+    const content = [
+      "---",
+      "title: Test",
+      "---",
+      "# Heading",
+      "",
+      "<!-- AUTOGEN:BEGIN:id=metrics -->",
+      "| col | val |",
+      "|---|---|",
+      "| a | b |",
+      "<!-- AUTOGEN:END -->",
+      "",
+      "After.",
+    ].join("\n");
+
+    const count = countSpecBodyLines(content);
+    expect(count).toBe(4);
+  });
+
+  it("counts a backtick-wrapped marker in prose as a body line (negative)", () => {
+    const content = [
+      "---",
+      "title: Test",
+      "---",
+      "# Heading",
+      "",
+      "AUTOGENブロックは`<!-- AUTOGEN:BEGIN:id=... -->`から対応する`<!-- AUTOGEN:END -->`までを除外する。",
+    ].join("\n");
+
+    const count = countSpecBodyLines(content);
+    expect(count).toBe(3);
+  });
+
+  it("handles mixed prose with backtick markers and a real AUTOGEN block", () => {
+    const content = [
+      "---",
+      "title: Test",
+      "---",
+      "# SPEC",
+      "",
+      "AUTOGENブロックは`<!-- AUTOGEN:BEGIN:id=... -->`から除外する。",
+      "",
+      "## Metrics",
+      "",
+      "<!-- AUTOGEN:BEGIN:id=spec-metrics -->",
+      "| SPEC | 行数 |",
+      "|---|---|",
+      "<!-- AUTOGEN:END -->",
+      "",
+      "Footer.",
+    ].join("\n");
+
+    const count = countSpecBodyLines(content);
+    expect(count).toBe(8);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts
@@ -35,8 +35,40 @@ const USAGE =
 //   <!-- AUTOGEN:BEGIN:id=<id> -->
 //   ... 自動生成領域 ...
 //   <!-- AUTOGEN:END -->
-const AUTOGEN_BEGIN_PREFIX = "<!-- AUTOGEN:BEGIN:id=";
-const AUTOGEN_END_MARKER = "<!-- AUTOGEN:END -->";
+//
+// 検出は行全体一致方式（Issue #1771）。説明文中の backtick 囲み（インラインコード）
+// marker 文字列を実 marker と誤認しないため、部分一致（line.includes）ではなく
+// 行全体が正規マーカー形式に一致するかで判定する。backtick 文脈判定のような
+// 部分一致ロジックは併用しない（index-auto-generation.md「AUTOGEN marker 検出契約」）。
+
+/** AUTOGEN:BEGIN マーカー行全体一致パターン。id は非空白文字列。 */
+const AUTOGEN_BEGIN_LINE_RE = /^\s*<!-- AUTOGEN:BEGIN:id=(\S+) -->\s*$/;
+/** AUTOGEN:END マーカー行全体一致パターン。 */
+const AUTOGEN_END_LINE_RE = /^\s*<!-- AUTOGEN:END -->\s*$/;
+
+/**
+ * 行全体が AUTOGEN:BEGIN マーカー形式（`<!-- AUTOGEN:BEGIN:id=<id> -->`）に一致するか判定する。
+ * backtick 囲み等の部分一致は行全体一致判定で自動的に除外される。
+ */
+export function isAutogenBeginLine(line: string): boolean {
+  return AUTOGEN_BEGIN_LINE_RE.test(line);
+}
+
+/**
+ * 行全体が AUTOGEN:END マーカー形式（`<!-- AUTOGEN:END -->`）に一致するか判定する。
+ */
+export function isAutogenEndLine(line: string): boolean {
+  return AUTOGEN_END_LINE_RE.test(line);
+}
+
+/**
+ * AUTOGEN:BEGIN マーカー行から id を抽出する。
+ * 行全体が BEGIN マーカー形式に一致しない場合は null を返す。
+ */
+export function extractAutogenBeginId(line: string): string | null {
+  const match = line.match(AUTOGEN_BEGIN_LINE_RE);
+  return match ? match[1] : null;
+}
 
 // catalog 内の AUTOGEN ブロック ID（IR-045 欠番を挟む2ブロック構成）。
 export const CATALOG_PRE_BLOCK_ID = "catalog-ir-entries-pre-045";
@@ -323,18 +355,12 @@ export function findAutogenBlocks(content: string): AutogenBlock[] {
   let i = 0;
   while (i < lines.length) {
     const line = lines[i];
-    if (line.includes(AUTOGEN_BEGIN_PREFIX)) {
-      const idStart = line.indexOf(AUTOGEN_BEGIN_PREFIX) + AUTOGEN_BEGIN_PREFIX.length;
-      const idEnd = line.indexOf("-->", idStart);
-      if (idEnd === -1) {
-        i++;
-        continue;
-      }
-      const id = line.slice(idStart, idEnd).trim();
+    const beginId = extractAutogenBeginId(line);
+    if (beginId !== null) {
       const startLine = i;
       const body: string[] = [];
       let j = i + 1;
-      while (j < lines.length && !lines[j].includes(AUTOGEN_END_MARKER)) {
+      while (j < lines.length && !isAutogenEndLine(lines[j])) {
         body.push(lines[j]);
         j++;
       }
@@ -344,7 +370,7 @@ export function findAutogenBlocks(content: string): AutogenBlock[] {
         continue;
       }
       blocks.push({
-        id,
+        id: beginId,
         startLine,
         endLine: j,
         currentBody: body,
@@ -361,7 +387,7 @@ export function findAutogenBlocks(content: string): AutogenBlock[] {
  * 指量 id の AUTOGEN ブロック本文を newBody で置換した content を返す。
  * ブロック未検出時は content を unchanged で返す（呼び出し元で検出）。
  */
-function replaceAutogenBlock(
+export function replaceAutogenBlock(
   content: string,
   id: string,
   newBody: string[],
@@ -372,11 +398,7 @@ function replaceAutogenBlock(
   let replaced = false;
   while (i < lines.length) {
     const line = lines[i];
-    if (
-      line.includes(AUTOGEN_BEGIN_PREFIX) &&
-      line.includes(`id=${id}`) &&
-      !replaced
-    ) {
+    if (extractAutogenBeginId(line) === id && !replaced) {
       // 開始マーカー → newBody → 終了マーカーへ置換。
       out.push(line);
       for (const bodyLine of newBody) {
@@ -384,7 +406,7 @@ function replaceAutogenBlock(
       }
       // 終了マーカーまで進める。
       let j = i + 1;
-      while (j < lines.length && !lines[j].includes(AUTOGEN_END_MARKER)) {
+      while (j < lines.length && !isAutogenEndLine(lines[j])) {
         j++;
       }
       if (j < lines.length) {
@@ -824,7 +846,7 @@ export function countSpecBodyLines(content: string): number {
   for (let i = start; i < lines.length; i++) {
     const line = lines[i];
     if (inAutogen) {
-      if (line.includes(AUTOGEN_END_MARKER)) {
+      if (isAutogenEndLine(line)) {
         inAutogen = false;
       }
       continue;
@@ -838,17 +860,14 @@ export function countSpecBodyLines(content: string): number {
       }
       continue;
     }
+    // AUTOGEN 開始マーカー（行全体一致）は AUTOGEN ブロックとして処理。
+    // backtick 囲み等の部分一致は isAutogenBeginLine で自動的に除外される。
+    if (isAutogenBeginLine(line)) {
+      inAutogen = true;
+      continue;
+    }
     const startIdx = line.indexOf("<!--");
     if (startIdx >= 0) {
-      // AUTOGEN 開始マーカーは AUTOGEN ブロックとして処理。
-      if (line.includes(AUTOGEN_BEGIN_PREFIX)) {
-        inAutogen = true;
-        // 同一行に AUTOGEN 終了マーカーがある場合は即終了（空ブロック）。
-        if (line.includes(AUTOGEN_END_MARKER)) {
-          inAutogen = false;
-        }
-        continue;
-      }
       const endIdx = line.indexOf("-->", startIdx + 4);
       if (endIdx >= 0) {
         // 単一行コメント: 前後の本文を残置。


### PR DESCRIPTION
## 概要

generate_indexes.ts の AUTOGEN marker 検出ロジックを部分一致（`line.includes`）から行全体一致（regex）へ是正した。説明文中の backtick 囲み（インラインコード）marker 文字列を実 marker と誤認し、索引再生成が途中停止する事象を根本解決する。

PR #1718 の HTML コメント構文抽象化による暫定対応と置換し、backtick 文脈判定のような部分一致ロジックを併用しない。

Closes #1771

## 変更内容

### `.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts`

- `AUTOGEN_BEGIN_PREFIX` / `AUTOGEN_END_MARKER`（部分一致用文字列定数）を削除
- `AUTOGEN_BEGIN_LINE_RE` / `AUTOGEN_END_LINE_RE`（行全体一致 regex）を追加
- `isAutogenBeginLine` / `isAutogenEndLine` / `extractAutogenBeginId` を export 関数として追加
- `findAutogenBlocks`: `line.includes` → `extractAutogenBeginId` / `isAutogenEndLine` へ更新
- `replaceAutogenBlock`: 同様に行全体一致へ更新（export 化、テスト直接呼出を可能に）
- `countSpecBodyLines`: AUTOGEN 開始判定を一般 `<!--` 処理の前に移動、行全体一致へ更新、到達不能となった同一行 END 分岐を削除

### `.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.test.ts`（新規）

正例・負例・境界例の回帰テスト 27件:

- **正例**: 正規マーカー行の検出（前後空白許容、複数ブロック検出）
- **負例**: backtick 囲み marker 文字列を含む説明文の非検出（PR #1718 事象の再現）
- **境界例**: マーカー行に backtick が隣接する場合の非検出

## 完了条件マッピング

- [x] `generate_indexes.ts` の AUTOGEN marker 検出が行全体一致方式へ是正されていること
- [x] backtick 文脈判定のような部分一致ロジックを併用していないこと
- [x] `index-auto-generation.md` の「### AUTOGEN marker 検出契約」節に行全体一致検出契約の SPEC 注記が追記されていること（spec-save commit 67b5b66b で完了済み）
- [x] 正例・負例・境界例の回帰テストが `generate_indexes.test.ts` に追加されていること
- [x] backtick 囲み AUTOGEN marker 文字列を含む SPEC に対し generate_indexes.ts を実行し、途中停止せず正常な AUTOGEN block を認識し exit code 0 で完了すること（単体テストで検証）
- [x] 暫定対応（PR #1718 の HTML コメント構文抽象化）を残置した状態でも再発しないこと

## テスト結果

```
bun test ./.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.test.ts
  27 pass
  0 fail
  37 expect() calls
  Ran 27 tests across 1 file. [40.00ms]

bun test ./.opencode/skills/repo-agentdev-integrity/scripts/tests/check_integrity.test.ts
  14 pass
  0 fail
  Ran 14 tests across 1 file. [1109ms]
```

既存テストへの回帰なし（base branch と同等の事前失敗 75件は環境起因、本変更由来ではない）。

## Findings / Capture候補

なし。本変更は RU-0002 bugfix の完結であり、新規の知見や capture 候補は発生しなかった。

## SPEC確定候補

なし。SPEC 注記（`index-auto-generation.md`「AUTOGEN marker 検出契約」節）は spec-save commit 67b5b66b で確定済み。
