### PR TITLE
fix: IR-057 文書レベル履歴注記 exemption の適用統一

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.test.ts
@@ -22,6 +22,7 @@ import { execSync } from "child_process";
 const SCRIPT_DIR = import.meta.dir;
 const SCRIPT_FILE = join(SCRIPT_DIR, "check_changed_docs.ts");
 const CLI_UTILS_FILE = join(SCRIPT_DIR, "cli_utils.ts");
+const IR057_EXEMPTION_FILE = join(SCRIPT_DIR, "ir057_history_exemption.ts");
 const TEMP_BASE = join("C:", "WINDOWS", "TEMP", "opencode");
 const RUN_ID = `changed-docs-test-${crypto.randomUUID().slice(0, 8)}`;
 const TEMP_ROOT = join(TEMP_BASE, RUN_ID);
@@ -68,6 +69,7 @@ function copyScripts(fixtureRoot: string): void {
   mkdirp(dest);
   copyFileSync(SCRIPT_FILE, join(dest, "check_changed_docs.ts"));
   copyFileSync(CLI_UTILS_FILE, join(dest, "cli_utils.ts"));
+  copyFileSync(IR057_EXEMPTION_FILE, join(dest, "ir057_history_exemption.ts"));
 }
 
 // Required TargetedDocsReport fields (REQ-0158 Phase 2 / AG-002 / Epic #1515 OU-005 TS-013).
@@ -192,17 +194,281 @@ function addSupersededFixtures(root: string): void {
   );
 }
 
+// Issue #1768 TS-001: IR-057 文書レベル履歴注記 exemption の回帰テスト用 fixture。
+// 正例（文書レベル履歴注記を持つ ADR）・負例（exemption 表未登録で現行機能の記述）・
+// 境界例（frontmatter 後本文の短い/長い、明示的注記ブロックあり/なし）を網羅する。
+function buildIr057ExemptionFixture(root: string): void {
+  const integrityDir = join(root, "docs", "specs", "integrity");
+  mkdirp(integrityDir);
+  writeFileSync(
+    join(integrityDir, "obsolete-path-map.yaml"),
+    [
+      'version: "1"',
+      "",
+      "scope:",
+      "  include:",
+      '    - "docs/**"',
+      '    - "src/**"',
+      "  exclude: []",
+      "",
+      "entries:",
+      '  - old: "docs/specs/system.md"',
+      '    new: "docs/specs/foundations/system.md"',
+      '    severity: "ng"',
+      "",
+      "legacy_local_generation_vocabulary:",
+      '  - term: "直接生成方式"',
+      '    severity: "ng"',
+      '  - term: "transform/generate.md"',
+      '    severity: "ng"',
+      '  - term: "local-opencode-transform"',
+      '    severity: "ng"',
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const adrDir = join(root, "docs", "adr");
+  mkdirp(adrDir);
+
+  // 正例1: 条件1（frontmatter 後本文）。旧語彙を含むが文書レベル免除される。
+  writeFileSync(
+    join(adrDir, "ADR-09001.md"),
+    [
+      "---",
+      "id: ADR-09001",
+      "title: frontmatter 後本文パターン",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "本 ADR は直接生成方式から link mode への移行を記録する。transform/generate.md は廃止した。",
+      "",
+      "# 移行判断",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 正例2: 条件2（> 注記ブロック）。frontmatter 後は見出しへ飛び、> 本文書は歴史的経緯... が続く。
+  writeFileSync(
+    join(adrDir, "ADR-09002.md"),
+    [
+      "---",
+      "id: ADR-09002",
+      "title: blockquote 注記パターン",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "# 移行判断",
+      "",
+      "> 本文書は歴史的経緯を記録する。直接生成方式、transform/generate.md は旧資産の引用である。",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 正例3: ADR-0131 相当。> 旧語彙の引用について ブロックで Issue #1768 の3件を含む。
+  writeFileSync(
+    join(adrDir, "ADR-09003.md"),
+    [
+      "---",
+      "id: ADR-09003",
+      "title: ADR-0131 相当",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "# ADR-09003: link mode 移行",
+      "",
+      "> **旧語彙の引用について**: 本 ADR は ADR-0090（superseded）から link mode（decision #1）への移行判断を記録する歴史文書である。以下の背景、決定、結果影響において、直接生成方式、transform/generate.md は移行前の状態説明のための引用として使用する。",
+      "",
+      "## 背景",
+      "",
+      "旧直接生成方式と transform/generate.md を廃止した。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 正例4: superseded ADR（条件1）。
+  writeFileSync(
+    join(adrDir, "ADR-09004.md"),
+    [
+      "---",
+      "id: ADR-09004",
+      "title: superseded ADR",
+      'status: "superseded"',
+      "superseded_by: ADR-09999",
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "本 ADR は直接生成方式を採用していた。transform/generate.md を使用していた。",
+      "",
+      "# タイトル",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 負例1: status=draft。文書レベル免除なし、行レベル marker なし → failure 報告される。
+  writeFileSync(
+    join(adrDir, "ADR-09005.md"),
+    [
+      "---",
+      "id: ADR-09005",
+      "title: draft ADR（exemption 対象外）",
+      'status: "draft"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "本 ADR は直接生成方式を採用している。",
+      "",
+      "# タイトル",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 負例2: command 本文（exemption 表未登録）。旧語彙を現行機能の用語として使用 → failure 報告される。
+  const cmdDir = join(root, "src", "opencode", "commands", "agentdev");
+  mkdirp(cmdDir);
+  writeFileSync(
+    join(cmdDir, "dummy-cmd.md"),
+    [
+      "---",
+      "description: dummy command",
+      "agent: build",
+      "---",
+      "",
+      "# dummy-cmd",
+      "",
+      "直接生成方式で処理する。transform/generate.md を呼び出す。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 境界例1: frontmatter 後本文が短い（1行）。
+  writeFileSync(
+    join(adrDir, "ADR-09006.md"),
+    [
+      "---",
+      "id: ADR-09006",
+      "title: 短い本文パターン",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "直接生成方式の歴史メモ。",
+      "",
+      "# タイトル",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 境界例2: frontmatter 後本文が長い（複数段落）。
+  writeFileSync(
+    join(adrDir, "ADR-09007.md"),
+    [
+      "---",
+      "id: ADR-09007",
+      "title: 長い本文パターン",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "本 ADR は直接生成方式の歴史経緯を記録する。",
+      "",
+      "前段落。直接生成方式は廃止された。",
+      "",
+      "後段落。transform/generate.md も廃止された。",
+      "",
+      "# タイトル",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 境界例3: 明示的 > 注記ブロックあり、frontmatter 後本文なし。
+  writeFileSync(
+    join(adrDir, "ADR-09008.md"),
+    [
+      "---",
+      "id: ADR-09008",
+      "title: blockquote のみ（frontmatter 後本文なし）",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "# タイトル",
+      "",
+      "> 本 ADR は移行履歴を保持する。直接生成方式と transform/generate.md を含む。",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 境界例4: 注記なし、frontmatter 後本文なし（frontmatter 後即見出し）。failure 報告される。
+  writeFileSync(
+    join(adrDir, "ADR-09009.md"),
+    [
+      "---",
+      "id: ADR-09009",
+      "title: 注記なし",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "# タイトル",
+      "",
+      "直接生成方式で処理する。transform/generate.md を呼び出す。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
 const FIXTURE_ROOT = join(TEMP_ROOT, "fixture");
 const GIT_FIXTURE_ROOT = join(TEMP_ROOT, "git-fixture");
+const IR057_FIXTURE_ROOT = join(TEMP_ROOT, "ir057-fixture");
 
 beforeAll(() => {
   mkdirp(FIXTURE_ROOT);
   mkdirp(GIT_FIXTURE_ROOT);
+  mkdirp(IR057_FIXTURE_ROOT);
   buildMinimalFixture(FIXTURE_ROOT);
   buildMinimalFixture(GIT_FIXTURE_ROOT);
   addSupersededFixtures(FIXTURE_ROOT);
+  buildIr057ExemptionFixture(IR057_FIXTURE_ROOT);
   copyScripts(FIXTURE_ROOT);
   copyScripts(GIT_FIXTURE_ROOT);
+  copyScripts(IR057_FIXTURE_ROOT);
   initGitFixture(GIT_FIXTURE_ROOT);
 });
 
@@ -696,5 +962,78 @@ describe("Issue #1671 TS-004: SPEC status superseded_by handling (ADR-0123, REQ-
       (f: { rule_id: string }) => f.rule_id === "SPEC-STATUS",
     );
     expect(statusFailures).toEqual([]);
+  });
+});
+
+// ─── Issue #1768 TS-001: IR-057 文書レベル履歴注記 exemption (targeted guard) ──
+//
+// SPEC IR-057「例外登録（現行ADRの履歴記載）」セクション準拠。targeted guard
+// （check_changed_docs.ts）は full audit（check_integrity.ts）と同じ例外規則を
+// 使用する（REQ-0144-024）。正例は旧語彙を含む文書レベル履歴注記 ADR、負例は
+// exemption 表未登録で現行機能の記述、境界例は注記の長短・有無を検証する。
+
+describe("Issue #1768 TS-001: IR-057 文書レベル履歴注記 exemption (targeted guard)", () => {
+  function ir057FailuresOf(file: string): { rule_id: string; file: string; line: number; message: string }[] {
+    const r = runScript(IR057_FIXTURE_ROOT, [
+      "--workflow", "case-close",
+      "--files", file,
+      "--json",
+    ]);
+    const parsed = JSON.parse(r.stdout);
+    return parsed.failures.filter((f: { rule_id: string }) => f.rule_id === "IR-057");
+  }
+
+  it("正例1: frontmatter 後本文（条件1）→ IR-057 failure なし", () => {
+    const failures = ir057FailuresOf("docs/adr/ADR-09001.md");
+    expect(failures).toEqual([]);
+  });
+
+  it("正例2: 明示的 > 注記ブロック（条件2）→ IR-057 failure なし", () => {
+    const failures = ir057FailuresOf("docs/adr/ADR-09002.md");
+    expect(failures).toEqual([]);
+  });
+
+  it("正例3: ADR-0131 相当（> 旧語彙の引用について）→ IR-057 failure なし（Issue #1768 主訴求事項）", () => {
+    const failures = ir057FailuresOf("docs/adr/ADR-09003.md");
+    expect(failures).toEqual([]);
+  });
+
+  it("正例4: superseded ADR（条件1）→ IR-057 failure なし", () => {
+    const failures = ir057FailuresOf("docs/adr/ADR-09004.md");
+    expect(failures).toEqual([]);
+  });
+
+  it("負例1: status=draft ADR（文書レベル免除対象外）→ IR-057 strict failure 報告", () => {
+    const failures = ir057FailuresOf("docs/adr/ADR-09005.md");
+    expect(failures.length).toBeGreaterThan(0);
+    expect(failures.some((f) => f.message.includes("直接生成方式"))).toBe(true);
+  });
+
+  it("負例2: command 本文（exemption 表未登録）→ IR-057 strict failure 報告", () => {
+    const failures = ir057FailuresOf("src/opencode/commands/agentdev/dummy-cmd.md");
+    expect(failures.length).toBeGreaterThan(0);
+    expect(failures.some((f) => f.message.includes("直接生成方式"))).toBe(true);
+    expect(failures.some((f) => f.message.includes("transform/generate.md"))).toBe(true);
+  });
+
+  it("境界例1: frontmatter 後本文が短い（1行）→ 文書レベル注記として認識し IR-057 failure なし", () => {
+    const failures = ir057FailuresOf("docs/adr/ADR-09006.md");
+    expect(failures).toEqual([]);
+  });
+
+  it("境界例2: frontmatter 後本文が長い（複数段落）→ 文書レベル注記として認識し IR-057 failure なし", () => {
+    const failures = ir057FailuresOf("docs/adr/ADR-09007.md");
+    expect(failures).toEqual([]);
+  });
+
+  it("境界例3: 明示的 > 注記ブロックのみ（frontmatter 後本文なし）→ 条件2で IR-057 failure なし", () => {
+    const failures = ir057FailuresOf("docs/adr/ADR-09008.md");
+    expect(failures).toEqual([]);
+  });
+
+  it("境界例4: 注記なし・frontmatter 後本文なし → 文書レベル免除なし、IR-057 strict failure 報告", () => {
+    const failures = ir057FailuresOf("docs/adr/ADR-09009.md");
+    expect(failures.length).toBeGreaterThan(0);
+    expect(failures.some((f) => f.message.includes("直接生成方式"))).toBe(true);
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts
@@ -32,6 +32,10 @@ import {
   type FindingCategory,
   findRepoRoot,
 } from "./cli_utils.ts";
+import {
+  isFileLevelHistoryExempt,
+  hasLineLevelHistoryMarker,
+} from "./ir057_history_exemption.ts";
 
 const path = require("path") as typeof import("path");
 const fs = require("fs") as typeof import("fs");
@@ -419,11 +423,13 @@ function checkObsoleteSpecPath(
     if (/docs\/requirements\/REQ-010[12]\.md$/.test(rel)) continue;
     const content = readText(f);
     if (!content) continue;
+    if (isFileLevelHistoryExempt(rel, content)) continue;
     const lines = content.split("\n");
     for (const old of oldPaths) {
       for (let i = 0; i < lines.length; i++) {
         if (!lines[i].includes(old)) continue;
         if (isInsideCodeBlock(lines, i)) continue;
+        if (hasLineLevelHistoryMarker(lines[i])) continue;
         failures.push({
           rule_id: "IR-057",
           severity: "strict",
@@ -463,11 +469,13 @@ function checkLegacyVocab(
     if (/repo-agentdev-integrity\/scripts\/check_integrity\.ts$/.test(rel)) continue;
     const content = readText(f);
     if (!content) continue;
+    if (isFileLevelHistoryExempt(rel, content)) continue;
     const lines = content.split("\n");
     for (const term of vocab) {
       for (let i = 0; i < lines.length; i++) {
         if (!lines[i].includes(term)) continue;
         if (isInsideCodeBlock(lines, i)) continue;
+        if (hasLineLevelHistoryMarker(lines[i])) continue;
         failures.push({
           rule_id: "IR-057",
           severity: "strict",

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -5,6 +5,8 @@ import { join } from "path";
 const SCRIPT_DIR = import.meta.dir;
 const SCRIPT_FILE = join(SCRIPT_DIR, "check_integrity.ts");
 const CLI_UTILS_FILE = join(SCRIPT_DIR, "cli_utils.ts");
+const GENERATE_INDEXES_FILE = join(SCRIPT_DIR, "generate_indexes.ts");
+const IR057_EXEMPTION_FILE = join(SCRIPT_DIR, "ir057_history_exemption.ts");
 const TEMP_BASE = join("C:", "WINDOWS", "TEMP", "opencode");
 const RUN_ID = `integrity-test-${crypto.randomUUID().slice(0, 8)}`;
 const TEMP_ROOT = join(TEMP_BASE, RUN_ID);
@@ -60,6 +62,8 @@ function copyScripts(fixtureRoot: string): void {
   mkdirp(dest);
   copyFileSync(SCRIPT_FILE, join(dest, "check_integrity.ts"));
   copyFileSync(CLI_UTILS_FILE, join(dest, "cli_utils.ts"));
+  copyFileSync(GENERATE_INDEXES_FILE, join(dest, "generate_indexes.ts"));
+  copyFileSync(IR057_EXEMPTION_FILE, join(dest, "ir057_history_exemption.ts"));
 }
 
 function buildValidFixture(root: string): void {
@@ -2223,5 +2227,380 @@ describe("IR-058 distribution-untracked-skill-reference (REQ-0159-003)", () => {
         (res.message ?? "").includes("ADR-0134"),
     );
     expect(promotionMessage).toBeDefined();
+  });
+});
+
+// ─── Issue #1768 TS-001: IR-057 文書レベル履歴注記 exemption (full audit) ──
+//
+// SPEC IR-057「例外登録（現行ADRの履歴記載）」セクション準拠。full audit
+// （check_integrity.ts）は targeted guard（check_changed_docs.ts）と同じ例外規則を
+// 使用する（REQ-0144-024）。同一 fixture データで両スクリプトを検証する。
+
+const IR057_ROOT = join(TEMP_ROOT, "ir057");
+
+function buildIr057Fixture(root: string): void {
+  const reqDir = join(root, "docs", "requirements");
+  mkdirp(reqDir);
+  writeFileSync(
+    join(reqDir, "REQ-9401.md"),
+    [
+      "---",
+      "id: REQ-9401",
+      "title: IR-057 fixture",
+      "created: 2025-01-01",
+      "updated: 2025-01-01",
+      "---",
+      "",
+      "Body.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  writeFileSync(
+    join(reqDir, "README.md"),
+    [
+      "# Requirements",
+      "",
+      "| ID | Title |",
+      "|----|-------|",
+      "| REQ-9401 | IR-057 fixture |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  mkdirp(join(root, "docs", "adr"));
+  writeFileSync(join(root, "docs", "adr", "README.md"), "# ADR\n", "utf-8");
+  mkdirp(join(root, "docs", "specs"));
+  writeFileSync(join(root, "docs", "specs", "README.md"), "# SPEC\n", "utf-8");
+  writeFileSync(
+    join(root, "docs", "DOC-MAP.md"),
+    "# DOC-MAP\n\n| 分類 | パス |\n|------|------|\n| REQ | docs/requirements/REQ-9401.md |\n",
+    "utf-8",
+  );
+
+  // obsolete-path-map.yaml（IR-057 検査の前提データ）
+  const integrityDir = join(root, "docs", "specs", "integrity");
+  mkdirp(integrityDir);
+  writeFileSync(
+    join(integrityDir, "obsolete-path-map.yaml"),
+    [
+      'version: "1"',
+      "",
+      "scope:",
+      "  include:",
+      '    - "docs/**"',
+      '    - "src/**"',
+      "  exclude: []",
+      "",
+      "entries:",
+      '  - old: "docs/specs/system.md"',
+      '    new: "docs/specs/foundations/system.md"',
+      '    severity: "ng"',
+      "",
+      "legacy_local_generation_vocabulary:",
+      '  - term: "直接生成方式"',
+      '    severity: "ng"',
+      '  - term: "transform/generate.md"',
+      '    severity: "ng"',
+      '  - term: "local-opencode-transform"',
+      '    severity: "ng"',
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const adrDir = join(root, "docs", "adr");
+
+  // 正例1: 条件1（frontmatter 後本文）。
+  writeFileSync(
+    join(adrDir, "ADR-9001.md"),
+    [
+      "---",
+      "id: ADR-9001",
+      "title: frontmatter 後本文パターン",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "本 ADR は直接生成方式から link mode への移行を記録する。transform/generate.md は廃止した。",
+      "",
+      "# 移行判断",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 正例2: 条件2（> 注記ブロック）。
+  writeFileSync(
+    join(adrDir, "ADR-9002.md"),
+    [
+      "---",
+      "id: ADR-9002",
+      "title: blockquote 注記パターン",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "# 移行判断",
+      "",
+      "> 本文書は歴史的経緯を記録する。直接生成方式、transform/generate.md は旧資産の引用である。",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 正例3: ADR-0131 相当（> 旧語彙の引用について ブロック）。
+  writeFileSync(
+    join(adrDir, "ADR-9003.md"),
+    [
+      "---",
+      "id: ADR-9003",
+      "title: ADR-0131 相当",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "# ADR-9003: link mode 移行",
+      "",
+      "> **旧語彙の引用について**: 本 ADR は ADR-0090（superseded）から link mode（decision #1）への移行判断を記録する歴史文書である。以下の背景、決定、結果影響において、直接生成方式、transform/generate.md は移行前の状態説明のための引用として使用する。",
+      "",
+      "## 背景",
+      "",
+      "旧直接生成方式と transform/generate.md を廃止した。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 正例4: superseded ADR（条件1）。
+  writeFileSync(
+    join(adrDir, "ADR-9004.md"),
+    [
+      "---",
+      "id: ADR-9004",
+      "title: superseded ADR",
+      'status: "superseded"',
+      "superseded_by: ADR-9999",
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "本 ADR は直接生成方式を採用していた。transform/generate.md を使用していた。",
+      "",
+      "# タイトル",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 負例1: status=draft ADR（文書レベル免除対象外）。
+  writeFileSync(
+    join(adrDir, "ADR-9005.md"),
+    [
+      "---",
+      "id: ADR-9005",
+      "title: draft ADR（exemption 対象外）",
+      'status: "draft"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "本 ADR は直接生成方式を採用している。",
+      "",
+      "# タイトル",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 負例2: command 本文（exemption 表未登録、現行機能の用語として使用）。
+  const cmdDir = join(root, "src", "opencode", "commands", "agentdev");
+  mkdirp(cmdDir);
+  writeFileSync(
+    join(cmdDir, "dummy-cmd.md"),
+    [
+      "---",
+      "description: dummy command",
+      "agent: build",
+      "---",
+      "",
+      "# dummy-cmd",
+      "",
+      "直接生成方式で処理する。transform/generate.md を呼び出す。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 境界例1: frontmatter 後本文が短い（1行）。
+  writeFileSync(
+    join(adrDir, "ADR-9006.md"),
+    [
+      "---",
+      "id: ADR-9006",
+      "title: 短い本文パターン",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "直接生成方式の歴史メモ。",
+      "",
+      "# タイトル",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 境界例2: frontmatter 後本文が長い（複数段落）。
+  writeFileSync(
+    join(adrDir, "ADR-9007.md"),
+    [
+      "---",
+      "id: ADR-9007",
+      "title: 長い本文パターン",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "本 ADR は直接生成方式の歴史経緯を記録する。",
+      "",
+      "前段落。直接生成方式は廃止された。",
+      "",
+      "後段落。transform/generate.md も廃止された。",
+      "",
+      "# タイトル",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 境界例3: 明示的 > 注記ブロックのみ（frontmatter 後本文なし）。
+  writeFileSync(
+    join(adrDir, "ADR-9008.md"),
+    [
+      "---",
+      "id: ADR-9008",
+      "title: blockquote のみ（frontmatter 後本文なし）",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "# タイトル",
+      "",
+      "> 本 ADR は移行履歴を保持する。直接生成方式と transform/generate.md を含む。",
+      "",
+      "本文。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 境界例4: 注記なし・frontmatter 後本文なし。
+  writeFileSync(
+    join(adrDir, "ADR-9009.md"),
+    [
+      "---",
+      "id: ADR-9009",
+      "title: 注記なし",
+      'status: "accepted"',
+      'created: "2026-07-24"',
+      'updated: "2026-07-24"',
+      "---",
+      "",
+      "# タイトル",
+      "",
+      "直接生成方式で処理する。transform/generate.md を呼び出す。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+describe("Issue #1768 TS-001: IR-057 文書レベル履歴注記 exemption (full audit)", () => {
+  beforeAll(() => {
+    rmSync(IR057_ROOT, { recursive: true, force: true });
+    mkdirp(IR057_ROOT);
+    buildIr057Fixture(IR057_ROOT);
+    copyScripts(IR057_ROOT);
+  });
+
+  afterAll(() => {
+    rmSync(IR057_ROOT, { recursive: true, force: true });
+  });
+
+  function ir057ResultsForFile(fileRel: string): { level: string; message: string }[] {
+    const r = runScript(IR057_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    return parsed.results.filter(
+      (res: { check: string; level: string; file?: string; message: string }) =>
+        res.check === "obsolete-spec-path" &&
+        res.level === "ng" &&
+        (res.file ?? "").endsWith(fileRel),
+    );
+  }
+
+  it("正例1: frontmatter 後本文（条件1）→ IR-057 ng なし", () => {
+    expect(ir057ResultsForFile("docs/adr/ADR-9001.md")).toEqual([]);
+  });
+
+  it("正例2: 明示的 > 注記ブロック（条件2）→ IR-057 ng なし", () => {
+    expect(ir057ResultsForFile("docs/adr/ADR-9002.md")).toEqual([]);
+  });
+
+  it("正例3: ADR-0131 相当（> 旧語彙の引用について）→ IR-057 ng なし（Issue #1768 主訴求事項）", () => {
+    expect(ir057ResultsForFile("docs/adr/ADR-9003.md")).toEqual([]);
+  });
+
+  it("正例4: superseded ADR（条件1）→ IR-057 ng なし", () => {
+    expect(ir057ResultsForFile("docs/adr/ADR-9004.md")).toEqual([]);
+  });
+
+  it("負例1: status=draft ADR（文書レベル免除対象外）→ IR-057 ng 報告", () => {
+    const results = ir057ResultsForFile("docs/adr/ADR-9005.md");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((r) => r.message.includes("直接生成方式"))).toBe(true);
+  });
+
+  it("負例2: command 本文（exemption 表未登録）→ IR-057 ng 報告", () => {
+    const results = ir057ResultsForFile("src/opencode/commands/agentdev/dummy-cmd.md");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((r) => r.message.includes("直接生成方式"))).toBe(true);
+    expect(results.some((r) => r.message.includes("transform/generate.md"))).toBe(true);
+  });
+
+  it("境界例1: frontmatter 後本文が短い（1行）→ IR-057 ng なし", () => {
+    expect(ir057ResultsForFile("docs/adr/ADR-9006.md")).toEqual([]);
+  });
+
+  it("境界例2: frontmatter 後本文が長い（複数段落）→ IR-057 ng なし", () => {
+    expect(ir057ResultsForFile("docs/adr/ADR-9007.md")).toEqual([]);
+  });
+
+  it("境界例3: 明示的 > 注記ブロックのみ（frontmatter 後本文なし）→ 条件2で IR-057 ng なし", () => {
+    expect(ir057ResultsForFile("docs/adr/ADR-9008.md")).toEqual([]);
+  });
+
+  it("境界例4: 注記なし・frontmatter 後本文なし → IR-057 ng 報告", () => {
+    const results = ir057ResultsForFile("docs/adr/ADR-9009.md");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((r) => r.message.includes("直接生成方式"))).toBe(true);
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -66,6 +66,10 @@ import {
   README_REQ_SUMMARY_COUNT_BLOCK_ID,
   generateReadmeReqSummaryCount,
 } from "./generate_indexes.ts";
+import {
+  isFileLevelHistoryExempt,
+  hasLineLevelHistoryMarker,
+} from "./ir057_history_exemption.ts";
 
 const SCRIPT_NAME = "check_integrity.ts";
 const DESCRIPTION = "AgentDevFlow artifact integrity validator";
@@ -7530,12 +7534,8 @@ function isIr057InCodeBlock(lines: string[], lineIdx: number): boolean {
   return inCode;
 }
 
-// REQ-0144-024: 歴史経緯説明文脈の汎用判定（ADR-0131/0126 等）。
-// isIr057HistoricalAdrContext を汎用化し、ADR 以外のドキュメント
-// （glossary.md 等）にも適用する。以下のいずれかが成立する行を除外する:
-//   1. ファイルが「旧語彙の引用について」宣言を含む歴史文書（ファイル単位）
-//   2. 行が歴史経緯マーカーを含む（行単位）
-// 「廃止」は時制判定する（「廃止された」「廃止済み」は歴史、「廃止する」は現行）。
+// IR-057 文書レベル履歴注記 exemption（Issue #1768、IR-057 SPEC「例外登録」セクション、REQ-0144-024）。
+// targeted guard（check_changed_docs.ts）と共通の純粋関数へ集約し、exemption 判定を一致させる。
 const ir057HistoricalFileCache = new Map<string, boolean>();
 
 function isIr057HistoricalContext(
@@ -7545,41 +7545,16 @@ function isIr057HistoricalContext(
 ): boolean {
   const relPath = resolveRelative(fullPath, root);
 
-  // 1. ファイル単位: 「旧語彙の引用について」等の明示的歴史宣言を持つ文書は全体を歴史扱い
-  //    （ADR-0131/0126 のブロック引用宣言。著者が意図的に付与したアノテーション）
   let fileIsHistorical = ir057HistoricalFileCache.get(relPath);
   if (fileIsHistorical === undefined) {
     const content = readText(fullPath);
     fileIsHistorical =
-      content !== null &&
-      /旧語彙の引用について|歴史文書である|旧概念.*引用/.test(content);
+      content !== null && isFileLevelHistoryExempt(relPath, content);
     ir057HistoricalFileCache.set(relPath, fileIsHistorical);
   }
   if (fileIsHistorical) return true;
 
-  // 2. 行単位: 歴史経緯マーカー
-  const lineMarkers = [
-    "旧",
-    "移行前",
-    "移行後",
-    "前提",
-    "時代",
-    "履歴",
-    "historical",
-    "legacy",
-    "deprecated",
-    "歴史",
-    "経緯",
-    "過去",
-    "以前",
-    "従来",
-  ];
-  if (lineMarkers.some((m) => line.includes(m))) return true;
-
-  // 3. 「廃止」の時制判定: 過去形・完了形は歴史、能望形は現行
-  if (/廃止(された|済み|確定)/.test(line)) return true;
-
-  return false;
+  return hasLineLevelHistoryMarker(line);
 }
 
 function checkObsoleteSpecPath(root: string): CheckResult[] {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/ir057_history_exemption.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/ir057_history_exemption.ts
@@ -1,0 +1,215 @@
+/**
+ * ir057_history_exemption.ts — IR-057 文書レベル履歴注記 exemption（Issue #1768）
+ *
+ * IR-057 SPEC「例外登録（現行ADRの履歴記載）」セクション（docs/specs/integrity/
+ * rules/IR-057-obsolete-spec-path-after-domain-split.md）に基づく免除判定の
+ * 純粋関数群。targeted guard（check_changed_docs.ts）と full audit
+ * （check_integrity.ts）で同じ例外規則を使用する（REQ-0144-024）。
+ *
+ * 依存: なし（純粋関数のみ）。fs, path への依存を持たない。
+ */
+
+/**
+ * ADR ファイルパス判定。`docs/adr/ADR-*.md` 形式（retired 配下を除く）。
+ */
+export function isAdrFile(relPath: string): boolean {
+  if (relPath.startsWith("docs/adr/retired/")) return false;
+  return /^docs\/adr\/ADR-\d+.*\.md$/.test(relPath);
+}
+
+/**
+ * frontmatter から指定キーの値を抽出する。
+ * frontmatter がない、またはキーが存在しない場合は null を返す。
+ *
+ * frontmatter 形式:
+ *   ---
+ *   key1: value1
+ *   key2: "value2"
+ *   ---
+ */
+export function extractFrontmatterValue(
+  content: string,
+  key: string,
+): string | null {
+  const lines = content.split("\n");
+  if (lines.length === 0 || lines[0].trim() !== "---") return null;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") break;
+    const line = lines[i];
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const k = line.slice(0, idx).trim();
+    if (k === key) {
+      return line.slice(idx + 1).trim().replace(/^["']|["']$/g, "");
+    }
+  }
+  return null;
+}
+
+/**
+ * frontmatter 終了直後から最初の見出し（`#` 〜 `######`）までの本文を抽出する。
+ * frontmatter がない場合はファイル先頭から。本文がない（最初の行が見出し）場合は空文字。
+ */
+export function extractBodyBeforeFirstHeading(content: string): string {
+  const lines = content.split("\n");
+  let start = 0;
+  if (lines.length > 0 && lines[0].trim() === "---") {
+    let i = 1;
+    for (; i < lines.length; i++) {
+      if (lines[i].trim() === "---") {
+        start = i + 1;
+        break;
+      }
+    }
+    if (start === 0) return ""; // frontmatter 閉じなし
+  }
+  const body: string[] = [];
+  for (let i = start; i < lines.length; i++) {
+    if (/^#{1,6}\s/.test(lines[i])) break;
+    body.push(lines[i]);
+  }
+  return body.join("\n").trim();
+}
+
+/**
+ * 文書レベル履歴注記の条件1: frontmatter 終了直後から最初の見出しまでの本文が存在するか。
+ * 空でないテキストがある場合に true。
+ *
+ * SPEC IR-057「例外登録」第一条件: frontmatter 終了直後から最初の見出し（`#` または
+ * `##`）までの本文が存在すること。当該本文は文書レベル履歴注記として扱い、文書全体が
+ * 歴史経緯の記録であるとみなす。
+ */
+export function hasDocumentLevelHistoryNoteBody(content: string): boolean {
+  return extractBodyBeforeFirstHeading(content).length > 0;
+}
+
+// 文書レベル履歴注記ブロックとして認識する定型フレーズ。
+// SPEC「例外登録」第二条件が例示する表現に加え、ADR-0131 で使用中の表現を含む。
+const HISTORY_BLOCKQUOTE_PHRASES = [
+  "本文書は歴史的経緯を記録する",
+  "本 ADR は移行履歴を保持する",
+  "本ADRは移行履歴を保持する",
+  "歴史文書である",
+  "旧語彙の引用について",
+  "歴史的経緯を記録する",
+  "移行履歴を保持する",
+  "歴史的経緯を記録する歴史文書",
+];
+
+/**
+ * 文書レベル履歴注記の条件2: 明示的な引用ブロック（`>` 起点行）による履歴注記が存在するか。
+ *
+ * SPEC IR-057「例外登録」第二条件: `> 本文書は歴史的経緯を記録する`、
+ * `> 本 ADR は移行履歴を保持する` 等の引用ブロック形式で、文書全体が歴史経緯の
+ * 記録であることを示す注記を認識する。
+ */
+export function hasExplicitHistoryBlockQuote(content: string): boolean {
+  const lines = content.split("\n");
+  for (const raw of lines) {
+    const trimmed = raw.trim();
+    if (!trimmed.startsWith(">")) continue;
+    if (HISTORY_BLOCKQUOTE_PHRASES.some((p) => trimmed.includes(p))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * ADR ファイルが文書レベル履歴注記条件を満たすか（ファイル全体が歴史経緯の記録であるか）。
+ *
+ * SPEC IR-057「例外登録」: frontmatter `status` が `accepted` または `superseded`
+ * であり、かつ次のいずれかの文書レベル履歴注記条件を満たす ADR ファイルである。
+ *   - 条件1: frontmatter 終了直後から最初の見出しまでの本文が存在
+ *   - 条件2: 明示的な `>` 引用ブロック形式の履歴注記が存在
+ *
+ * 満たす場合、検出行への履歴マーカー付与を要求せず免除する。
+ */
+export function isAdrWithDocumentLevelHistoryNote(content: string): boolean {
+  const status = extractFrontmatterValue(content, "status");
+  if (status !== "accepted" && status !== "superseded") return false;
+  return (
+    hasDocumentLevelHistoryNoteBody(content) ||
+    hasExplicitHistoryBlockQuote(content)
+  );
+}
+
+// SPEC「例外登録」セクションが列挙する行レベル marker（「廃止」以外は単独で歴史扱い）。
+const PRIMARY_LINE_MARKERS = [
+  "旧",
+  "移行前",
+  "前提",
+  "historical",
+  "legacy",
+  "deprecated",
+];
+
+// 周辺文脈判定で補助的に使用する歴史経緯語彙。SPEC は「固定の語彙リストのみに依存せず、
+// 文書レベル注記、行レベル marker、周辺文脈で行う」と宣言するため、補助語彙を保持する。
+const CONTEXTUAL_LINE_MARKERS = [
+  "移行後",
+  "時代",
+  "履歴",
+  "歴史",
+  "経緯",
+  "過去",
+  "以前",
+  "従来",
+];
+
+/**
+ * 行が履歴経緯マーカーを含むか（文書レベル注記を満たさない ADR ファイル向け）。
+ *
+ * SPEC IR-057「例外登録」: 文書レベル履歴注記条件を満たさない ADR ファイルは、
+ * 検出行が履歴マーカー（`旧`、`移行前`、`廃止`、`前提`、`historical`、`legacy`、
+ * `deprecated`）を含む場合のみ免除する。現行機能の記述は検出対象とする。
+ *
+ * 「廃止」は時制判定する: 過去形・完了形（廃止された/済み/確定）は歴史、
+ * 能望形（廃止する）は現行。
+ */
+export function hasLineLevelHistoryMarker(line: string): boolean {
+  if (PRIMARY_LINE_MARKERS.some((m) => line.includes(m))) return true;
+  if (/廃止(された|済み|確定|済)/.test(line)) return true;
+  if (CONTEXTUAL_LINE_MARKERS.some((m) => line.includes(m))) return true;
+  return false;
+}
+
+/**
+ * ファイル全体が歴史経緯の記録であるか（ファイル単位免除）。
+ *
+ * targeted guard（check_changed_docs.ts）と full audit（check_integrity.ts）で
+ * 共通使用する。SPEC IR-057「例外登録（現行ADRの履歴記載）」セクション準拠。
+ *
+ * ADR ファイル（`docs/adr/ADR-*.md`、retired 配下を除く）について文書レベル履歴注記
+ * 条件を判定する。条件は frontmatter `status` が `accepted` または `superseded` であり、
+ * かつ次のいずれかを満たすこと。
+ *   - 条件1: frontmatter 終了直後から最初の見出しまでの本文が存在
+ *   - 条件2: 明示的な `>` 引用ブロック形式の履歴注記が存在
+ *
+ * これらを満たす ADR ファイルは検出行への履歴マーカー付与を要求せず免除する。
+ * ADR 以外のファイルは本関数では免除しない（行レベル marker を別途適用）。
+ */
+export function isFileLevelHistoryExempt(
+  relPath: string,
+  content: string,
+): boolean {
+  if (!isAdrFile(relPath)) return false;
+  return isAdrWithDocumentLevelHistoryNote(content);
+}
+
+/**
+ * IR-057 の行単位・ファイル単位 exemption を統合判定する。
+ * targeted guard と full audit で同じ例外規則を使用する（REQ-0144-024）。
+ *
+ * `relPath`: repo-relative path（`docs/adr/ADR-0131.md` 形式）
+ * `content`: ファイル全体の内容。ファイル単位免除判定に使用
+ * `line`: 検出対象行のテキスト。行レベル marker 判定に使用
+ */
+export function isIr057LineExempt(
+  relPath: string,
+  content: string,
+  line: string,
+): boolean {
+  if (isFileLevelHistoryExempt(relPath, content)) return true;
+  return hasLineLevelHistoryMarker(line);
+}


### PR DESCRIPTION
## 概要

Issue #1768 (OU-001, source RU: RU-0020, Parent: #1767) の実装。
IR-057 検査（`check_changed_docs.ts`, `check_integrity.ts`）における文書レベル履歴注記 exemption の適用統一。ADR-0131 の frontmatter 直後の明示的履歴注記（`> 旧語彙の引用について` ブロック）で文書全体が歴史経緯の記録であることを示しているが、IR-057 検査は文書レベル履歴注記を認識せず、3件を strict failure として報告していた false positive を解消する。

## 変更内容

### 新規ファイル: `ir057_history_exemption.ts`

文書レベル履歴注記 exemption の純粋関数群（fs, path への依存なし）。targeted guard（`check_changed_docs.ts`）と full audit（`check_integrity.ts`）で同じ例外規則を使用するため、共通モジュールへ集約。

提供関数:
- `isAdrFile(relPath)`: ADR ファイルパス判定
- `extractFrontmatterValue(content, key)`: frontmatter 値抽出
- `extractBodyBeforeFirstHeading(content)`: frontmatter 終了直後〜最初の見出しまでの本文
- `hasDocumentLevelHistoryNoteBody(content)`: SPEC 条件1
- `hasExplicitHistoryBlockQuote(content)`: SPEC 条件2（`>` 注記ブロック）
- `isAdrWithDocumentLevelHistoryNote(content)`: 文書レベル免除判定（status accepted/superseded + 条件1 or 2）
- `hasLineLevelHistoryMarker(line)`: 行レベル marker（SPEC 語彙リスト + 周辺文脈）
- `isFileLevelHistoryExempt(relPath, content)`: ファイル単位免除統合判定
- `isIr057LineExempt(relPath, content, line)`: 行単位・ファイル単位 exemption 統合

### `check_integrity.ts` (full audit)

`isIr057HistoricalContext` を共通ヘルパー（`isFileLevelHistoryExempt`, `hasLineLevelHistoryMarker`）で判定するよう書換。ファイルキャッシュは維持。

### `check_changed_docs.ts` (targeted guard)

`checkObsoleteSpecPath`, `checkLegacyVocab` へ文書レベル履歴注記認識と行レベル marker exemption を導入。`check_integrity.ts` と同じ例外規則（共通ヘルパー経由）を使用。

### テスト（Issue #1768 TS-001）

`check_changed_docs.test.ts` と `check_integrity.test.ts` の両方に回帰テストを追加。正例・負例・境界例の同一 fixture データで両スクリプトを検証する。

- 正例1: frontmatter 後本文パターン（条件1）
- 正例2: 明示的 `>` 注記ブロックパターン（条件2）
- 正例3: ADR-0131 相当（`> 旧語彙の引用について` ブロック）
- 正例4: superseded ADR（条件1）
- 負例1: status=draft ADR（文書レベル免除対象外）
- 負例2: command 本文（exemption 表未登録で現行機能の用語として使用）
- 境界例1: frontmatter 後本文が短い（1行）
- 境界例2: frontmatter 後本文が長い（複数段落）
- 境界例3: 明示的 `>` 注記ブロックのみ（frontmatter 後本文なし）
- 境界例4: 注記なし・frontmatter 後本文なし（frontmatter 後即見出し）

### 副次的修正: `check_integrity.test.ts` の copyScripts

`check_integrity.ts` が import する `generate_indexes.ts` が copyScripts のコピー対象から漏れていた既存の不具合を修正。本 PR で `ir057_history_exemption.ts` を新たに import したことで表面化したため、併せて修正。

## 完了条件のマッピング

- [x] `docs/specs/integrity/rules/IR-057-obsolete-spec-path-after-domain-split.md` の「## 例外登録（現行ADRの履歴記載）」セクションに文書レベル履歴注記の2条件、行レベル marker による免除規則が定義されていること → **SPEC 側は spec-save (commit c8dcafeb) で完了済み**
- [x] `check_changed_docs.ts` と `check_integrity.ts` が文書レベル履歴注記認識を含む同じ例外規則を使用していること → **共通ヘルパー `ir057_history_exemption.ts` 経由で統一**
- [x] ADR-0131 の3件が strict failure として報告されないこと → **正例3 テスト（ADR-0131 相当）で検証**
- [x] `docs/adr/ADR-0131.md` が変更されていないこと（AG-001、CR-001）→ **当 PR の diff に ADR-0131.md は含まれない**
- [x] `check_changed_docs.test.ts` と `check_integrity.test.ts` に正例・負例・境界例の回帰テストが追加されていること → **TS-001 テスト群を追加**

## テスト結果

- `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.test.ts`: **40 pass / 0 fail** (108 expect calls)
- `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts`: **78 pass / 0 fail** (191 expect calls)
- `bunx tsc --noEmit` (strict, skipLibCheck): 追加コード由来の型エラーなし（既存の制約による `@types/node` 未導入、Bun 固有拡張由来のエラーのみ）

## Findings / Capture候補

### intake

- なし

### learning

- `check_integrity.test.ts` の `copyScripts` が `generate_indexes.ts` をコピー対象から漏れていた（既存の不具合）。本 PR で修正したが、同種の import 解決漏れが他のテスト fixture にないか、学習 capture 候補。テスト fixture へのスクリプトコピーは、被テストスクリプトの import を網羅する必要がある。

## SPEC確定候補

- なし（SPEC 側は spec-save で確定済み、本 PR は実装のみ）

## レビュー判断

親 Epic Issue #1767 の「レビュー判断」セクションを参照。

Closes #1768
