### PR TITLE
fix(integrity): REQ-0158/REQ-0161 を対応表へ追加し mapping-table-completeness NG を実修復

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 const SCRIPT_DIR = import.meta.dir;
 const SCRIPT_FILE = join(SCRIPT_DIR, "check_integrity.ts");
 const CLI_UTILS_FILE = join(SCRIPT_DIR, "cli_utils.ts");
+const GEN_INDEXES_FILE = join(SCRIPT_DIR, "generate_indexes.ts");
 const TEMP_BASE = join("C:", "WINDOWS", "TEMP", "opencode");
 const RUN_ID = `integrity-test-${crypto.randomUUID().slice(0, 8)}`;
 const TEMP_ROOT = join(TEMP_BASE, RUN_ID);
@@ -49,6 +50,7 @@ function writeFile(p: string, content: string): void {
 // baseline ファイル（baselines/ir-055-baseline.json）はコピーしないことで、
 // valid fixture は本番の baseline 既知違反から独立し、既知違反の変更が
 // valid fixture 系の成否に影響しない。
+// generate_indexes.ts は check_integrity.ts が import するため必須。
 function copyScripts(fixtureRoot: string): void {
   const dest = join(
     fixtureRoot,
@@ -60,6 +62,7 @@ function copyScripts(fixtureRoot: string): void {
   mkdirp(dest);
   copyFileSync(SCRIPT_FILE, join(dest, "check_integrity.ts"));
   copyFileSync(CLI_UTILS_FILE, join(dest, "cli_utils.ts"));
+  copyFileSync(GEN_INDEXES_FILE, join(dest, "generate_indexes.ts"));
 }
 
 function buildValidFixture(root: string): void {
@@ -2223,5 +2226,152 @@ describe("IR-058 distribution-untracked-skill-reference (REQ-0159-003)", () => {
         (res.message ?? "").includes("ADR-0134"),
     );
     expect(promotionMessage).toBeDefined();
+  });
+});
+
+// ─── mapping-table-completeness (Issue #1781 / REQ-0108-084) ────────────────
+// Dedicated fixture with retired REQs covering both polarities:
+//   - REQ-9002 (retired, recorded in mapping-table)  → no NG
+//   - REQ-9003 (retired, missing from mapping-table) → NG
+
+const MTC_ROOT = join(TEMP_ROOT, "mtc");
+
+function buildMappingTableCompletenessFixture(root: string): void {
+  const reqDir = join(root, "docs", "requirements");
+  mkdirp(reqDir);
+
+  writeFileSync(
+    join(reqDir, "REQ-9001.md"),
+    [
+      "---",
+      "id: REQ-9001",
+      "title: mapping-table-completeness active fixture",
+      "created: 2025-01-01",
+      "updated: 2025-01-01",
+      "---",
+      "",
+      "## Body",
+      "",
+      "Active REQ for mapping-table-completeness fixture.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  writeFileSync(
+    join(reqDir, "README.md"),
+    [
+      "# Requirements",
+      "",
+      "| ID | Title |",
+      "|----|-------|",
+      "| REQ-9001 | mapping-table-completeness active fixture |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const retiredDir = join(reqDir, "retired");
+  mkdirp(retiredDir);
+
+  // REQ-9002: retired, recorded in mapping-table (positive case).
+  writeFileSync(
+    join(retiredDir, "REQ-9002.md"),
+    [
+      "---",
+      "id: REQ-9002",
+      "title: mapping-table-completeness recorded retired",
+      "created: 2025-01-01",
+      "updated: 2025-01-01",
+      "---",
+      "",
+      "## retire 宣言",
+      "",
+      "Recorded in mapping-table.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // REQ-9003: retired, NOT recorded in mapping-table (negative case).
+  writeFileSync(
+    join(retiredDir, "REQ-9003.md"),
+    [
+      "---",
+      "id: REQ-9003",
+      "title: mapping-table-completeness missing retired",
+      "created: 2025-01-01",
+      "updated: 2025-01-01",
+      "---",
+      "",
+      "## retire 宣言",
+      "",
+      "Not recorded in mapping-table.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // mapping-table.md lists REQ-9002 only; REQ-9003 omission triggers NG.
+  writeFileSync(
+    join(reqDir, "mapping-table.md"),
+    [
+      "---",
+      "id: mapping-table",
+      "title: mapping-table-completeness fixture",
+      "created: 2025-01-01",
+      "updated: 2025-01-01",
+      "---",
+      "",
+      "## 対応表",
+      "",
+      "| 旧REQ | 判定 | 移行先 | 非移行理由 / 備考 |",
+      "|---|---|---|---|",
+      "| REQ-9002 | retired-no-successor | なし | recorded retired REQ |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  mkdirp(join(root, "docs", "adr"));
+  mkdirp(join(root, "docs", "specs"));
+  writeFileSync(join(root, "docs", "adr", "README.md"), "# ADR\n", "utf-8");
+  writeFileSync(join(root, "docs", "specs", "README.md"), "# SPEC\n", "utf-8");
+}
+
+describe("mapping-table-completeness retired REQ coverage (REQ-0108-084, Issue #1781)", () => {
+  beforeAll(() => {
+    rmSync(MTC_ROOT, { recursive: true, force: true });
+    mkdirp(MTC_ROOT);
+    buildMappingTableCompletenessFixture(MTC_ROOT);
+    copyScripts(MTC_ROOT);
+  });
+
+  afterAll(() => {
+    rmSync(MTC_ROOT, { recursive: true, force: true });
+  });
+
+  it("does NOT flag retired REQ recorded in mapping-table (positive)", () => {
+    const r = runScript(MTC_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const ngFor9002 = parsed.results.filter(
+      (res: { check: string; level: string; message?: string }) =>
+        res.check === "mapping-table-completeness" &&
+        res.level === "ng" &&
+        (res.message ?? "").includes("REQ-9002"),
+    );
+    expect(ngFor9002.length).toBe(0);
+  });
+
+  it("flags retired REQ missing from mapping-table (negative)", () => {
+    const r = runScript(MTC_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const ngFor9003 = parsed.results.filter(
+      (res: { check: string; level: string; message?: string }) =>
+        res.check === "mapping-table-completeness" &&
+        res.level === "ng" &&
+        (res.message ?? "").includes("REQ-9003"),
+    );
+    expect(ngFor9003.length).toBe(1);
   });
 });

--- a/docs/requirements/mapping-table.md
+++ b/docs/requirements/mapping-table.md
@@ -2,7 +2,7 @@
 id: mapping-table
 title: "旧REQから新active REQへの移行表"
 created: "2026-05-30"
-updated: "2026-07-21"
+updated: "2026-07-24"
 ---
 
 ## 目的
@@ -79,3 +79,5 @@ REQ-0001〜REQ-0050 をすべて retired とし、REQ-0101〜REQ-0133（REQ-0111
 | REQ-0121 | migrated | REQ-0103, REQ-0108 | Runtime Command 規範語構成を REQ-0103 に吸収（REQ-0103-152）、Integrity 検査定義（規範語検査の責務境界違反検査への再定義、規範語残存前提の除去）を REQ-0108 に吸収（REQ-0108-242, REQ-0108-243）。語彙ポリシー整合は REQ-0103/REQ-0108/REQ-0119 で一貫管理するため独立REQは不要と判断（`agentdev-system-reorganization` OU-04）。旧REQ、削除済み（2026-07-20物理削除） |
 | REQ-0115 | migrated | REQ-0108, REQ-0109, REQ-0124 | 恒久要件を REQ-0108（docs-check 検査責務）、REQ-0109（inspect-docs）、REQ-0124（inspect 命名恒久制約）へ移行し retire（2026-06-16）。タイトル「docs-* command suite」が移行主題であり REQ-0124-021 に抵触。旧REQ、削除済み（2026-07-20物理削除） |
 | REQ-0117 | migrated | REQ-0110 | Git worktree ジャンクションクリーンアップフォールバック手順を REQ-0110 に統合（REQ-0110-008: Windows + ジャンクション環境の "Not a directory" エラーフォールバック）。worktree 削除信頼性を一元管理するため独立REQは不要と判断（`agentdev-system-reorganization` OU-06）。旧REQ、削除済み（2026-07-20物理削除） |
+| REQ-0158 | migrated | REQ-0108 | targeted docs guard（check_changed_docs.ts）の恒久契約を REQ-0108 へ統合（REQ-0108-279: verification-only PR PASS、REQ-0108-280〜282: changed docs guard 統合候補評価）。実装詳細は SPEC（targeted-docs-guard-implementation.md、validator-split-criteria.md、integrity-contracts.md、IR-057、obsolete-path-map.yaml）へ移管。RU-20260721-03 由来（Issue #1713、Epic #1711 Wave 2 OU-002）。独立REQは不要と判断し retired/REQ-0158.md へ移動（2026-07-21） |
+| REQ-0161 | retired-no-successor | なし | config.yaml および旧 doc-inputs 機構の完全削除という完結済み作業記録であり、現行の安定契約を含まないため retire（RU-20260721-03 由来）。恒久契約残存なし、後継REQなし。retired/REQ-0161.md へ移動（2026-07-21） |


### PR DESCRIPTION
## 概要

mapping-table-completeness 検査（REQ-0108-084）で報告されていた既存未管理 NG を実修復した。`docs/requirements/retired/` に存在する REQ-0158 と REQ-0161 が `mapping-table.md` に未記載のため新規 NG となっていた。両 RETREQ の対応表エントリを追加し、新規 NG を解消した。baseline 更新ではなく実修復で対処している。

## 変更内容

- `docs/requirements/mapping-table.md`
  - REQ-0158 エントリ追加（migrated → REQ-0108）。targeted docs guard の恒久契約は REQ-0108（REQ-0108-279/280〜282）へ統合済み。RU-20260721-03 由来。
  - REQ-0161 エントリ追加（retired-no-successor）。config.yaml/旧 doc-inputs 機構の完全削除という完結済み作業記録であり、現行の安定契約を含まない。
  - frontmatter `updated` を 2026-07-24 へ更新。
- `.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts`
  - mapping-table-completeness 実修復の回帰テストを追加（陽性・陰性）。
  - `copyScripts` が `generate_indexes.ts` をコピーするよう修正。`check_integrity.ts` が `./generate_indexes.ts` を import する依存関係があり、コピー対象から漏れていたためテスト全体が実行不能だった前提を復旧した。

## 検証結果

- `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts --check mapping-table`：mapping-table-completeness の新規 NG は 0 件（baseline-known INFO のみ）。
- `bun test check_integrity.test.ts`：70/70 pass（既存68 + 追加2）。
- TS-006 pass_criteria「既存未管理の mapping-table-completeness NG が実修復により報告されない」「baseline 更新だけで結果を抑止していない」を満たす。

## Findings / Capture候補

### intake

- `copyScripts`（check_integrity.test.ts）が `generate_indexes.ts` のコピーを漏らしていた件は、`check_integrity.ts` が同ファイルを import する依存を取得した際のテストインフラ追従忘れと見られる。本 PR で併せて修正したが、同種の import 追加時のテストインフラ追従漏れを検出する仕組み（lint 等の検出）があるか確認推奨。

## SPEC確定候補

（なし。AG-006 は是正対象のみであり恒久契約は追加しない）

Closes #1781
