### PR TITLE
fix(integrity): ReferencePath placeholder 判定是正 + 回帰テスト (#1779)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { mkdirSync, writeFileSync, copyFileSync, rmSync, existsSync } from "fs";
+import { mkdirSync, writeFileSync, copyFileSync, rmSync, existsSync, readdirSync } from "fs";
 import { join } from "path";
 
 const SCRIPT_DIR = import.meta.dir;
@@ -49,6 +49,8 @@ function writeFile(p: string, content: string): void {
 // baseline ファイル（baselines/ir-055-baseline.json）はコピーしないことで、
 // valid fixture は本番の baseline 既知違反から独立し、既知違反の変更が
 // valid fixture 系の成否に影響しない。
+// check_integrity.ts は generate_indexes.ts 等 scripts/ 配下の他の .ts を
+// 静的 import するため、テスト対象の .ts（.test.ts 除く）は全てコピーする。
 function copyScripts(fixtureRoot: string): void {
   const dest = join(
     fixtureRoot,
@@ -58,8 +60,11 @@ function copyScripts(fixtureRoot: string): void {
     "scripts",
   );
   mkdirp(dest);
-  copyFileSync(SCRIPT_FILE, join(dest, "check_integrity.ts"));
-  copyFileSync(CLI_UTILS_FILE, join(dest, "cli_utils.ts"));
+  for (const f of readdirSync(SCRIPT_DIR)) {
+    if (f.endsWith(".ts") && !f.endsWith(".test.ts")) {
+      copyFileSync(join(SCRIPT_DIR, f), join(dest, f));
+    }
+  }
 }
 
 function buildValidFixture(root: string): void {
@@ -2223,5 +2228,110 @@ describe("IR-058 distribution-untracked-skill-reference (REQ-0159-003)", () => {
         (res.message ?? "").includes("ADR-0134"),
     );
     expect(promotionMessage).toBeDefined();
+  });
+});
+
+const REFPATH_ROOT = join(TEMP_ROOT, "refpath-placeholder");
+
+function buildRefPathFixture(root: string): void {
+  const reqDir = join(root, "docs", "requirements");
+  mkdirp(reqDir);
+  writeFileSync(
+    join(reqDir, "REQ-9401.md"),
+    [
+      "---",
+      "id: REQ-9401",
+      "title: ReferencePath placeholder fixture",
+      "created: 2025-01-01",
+      "updated: 2025-01-01",
+      "---",
+      "",
+      "Body.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  writeFileSync(
+    join(reqDir, "README.md"),
+    [
+      "# Requirements",
+      "",
+      "| ID | Title |",
+      "|----|-------|",
+      "| REQ-9401 | ReferencePath placeholder fixture |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  mkdirp(join(root, "docs", "adr"));
+  writeFileSync(join(root, "docs", "adr", "README.md"), "# ADR\n", "utf-8");
+  mkdirp(join(root, "docs", "specs"));
+  writeFileSync(join(root, "docs", "specs", "README.md"), "# SPEC\n", "utf-8");
+  writeFileSync(
+    join(root, "docs", "DOC-MAP.md"),
+    "# DOC-MAP\n\n| 分類 | パス |\n|------|------|\n| REQ | docs/requirements/REQ-9401.md |\n",
+    "utf-8",
+  );
+
+  const cmdDir = join(root, ".opencode", "commands", "agentdev");
+  mkdirp(cmdDir);
+  writeFileSync(
+    join(cmdDir, "placeholder-cmd.md"),
+    [
+      "---",
+      "description: placeholder regression command",
+      "agent: oracle",
+      "---",
+      "",
+      "起動手段は references/<harness>.md 参照。",
+      "See references/concrete-missing.md for the missing logic.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+describe("ReferencePath placeholder regression (REQ-0144-020, Issue #1779)", () => {
+  beforeAll(() => {
+    rmSync(REFPATH_ROOT, { recursive: true, force: true });
+    mkdirp(REFPATH_ROOT);
+    buildRefPathFixture(REFPATH_ROOT);
+    copyScripts(REFPATH_ROOT);
+  });
+
+  afterAll(() => {
+    rmSync(REFPATH_ROOT, { recursive: true, force: true });
+  });
+
+  it("does not flag <...> placeholder path as ReferencePath NG (正例)", () => {
+    const r = runScript(REFPATH_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const placeholderNg = parsed.results.filter(
+      (res: {
+        category: string;
+        level: string;
+        evidence?: string;
+      }) =>
+        res.category === "ReferencePath" &&
+        res.level === "ng" &&
+        (res.evidence ?? "").includes("<harness>"),
+    );
+    expect(placeholderNg.length).toBe(0);
+  });
+
+  it("reports ReferencePath NG for concrete unresolved path (負例)", () => {
+    const r = runScript(REFPATH_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const missingNg = parsed.results.filter(
+      (res: {
+        category: string;
+        level: string;
+        evidence?: string;
+      }) =>
+        res.category === "ReferencePath" &&
+        res.level === "ng" &&
+        (res.evidence ?? "").includes("concrete-missing.md"),
+    );
+    expect(missingNg.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -3696,9 +3696,12 @@ function isInsideCodeBlock(lines: string[], lineIndex: number): boolean {
  */
 function isTemplatePlaceholder(refPath: string): boolean {
   if (/\{[^}]*\}/.test(refPath)) return true;
-  // REQ-0144-025 / ADR-0136: <harness> 等の angle-bracket placeholder は
-  // 実ファイルを指さない抽象表記のため検査対象外とする。
-  if (/<[a-zA-Z][a-zA-Z0-9_-]*>/.test(refPath)) return true;
+  // REQ-0144-020: <...> 形式の angle-bracket placeholder は具体パスではなく
+  // 置換対象のパラメータ表現であるため実在確認の対象外とする。
+  // REQ-0144-025 / ADR-0136 由来の <harness> 等の抽象表記を含む。
+  // isTemplatePlaceholder は SCRIPT_TEMPLATE_REF_PATTERNS が捕捉した
+  // パス参照文字列のみを受け取るため、<> は placeholder 以外あり得ない。
+  if (/<[^<>]+>/.test(refPath)) return true;
   return false;
 }
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_reference_paths.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_reference_paths.test.ts
@@ -325,6 +325,41 @@ describe("checkScriptTemplateReferencePaths", () => {
     const harnessNg = refNg.filter((r) => r.evidence?.includes("<harness>"));
     expect(harnessNg.length).toBe(0);
   });
+  it("placeholder skipped and concrete missing reported in same fixture (TS-001, REQ-0144-020)", () => {
+    const root = join(TEMP_ROOT, "placeholder-and-missing");
+    buildMinimalFixture(root);
+    copyScripts(root);
+    const cmdDir = join(root, ".opencode", "commands", "agentdev");
+    writeFileSync(
+      join(cmdDir, "test-cmd.md"),
+      [
+        "---",
+        "description: Test",
+        "agent: oracle",
+        "---",
+        "",
+        "起動手段は references/<harness>.md 参照。",
+        "See references/nonexistent.md for the missing logic.",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const result = runScriptJson(root);
+    expect(result.report).not.toBeNull();
+    const refResults = (result.report!.results || []).filter(
+      (r) =>
+        r.category === "ReferencePath" &&
+        r.check === "reference-path-existence",
+    );
+    const placeholderNg = refResults.filter(
+      (r) => r.level === "ng" && r.evidence?.includes("<harness>"),
+    );
+    expect(placeholderNg.length).toBe(0);
+    const missingNg = refResults.filter(
+      (r) => r.level === "ng" && r.evidence?.includes("nonexistent.md"),
+    );
+    expect(missingNg.length).toBeGreaterThanOrEqual(1);
+  });
   it("reports ng for missing repo-root-relative references", () => {
     const root = join(TEMP_ROOT, "root-rel-missing");
     buildMinimalFixture(root);


### PR DESCRIPTION
## 概要

Issue #1779 (OU-001, RU-0011 由来)。ReferencePath 検査の placeholder 判定を是正し、回帰テストを追加する。`<...>` 形式の placeholder を含むパス参照を実在確認対象外とし、placeholder を含まない具体パスには実在確認を行い未解決の場合は NG を報告する。

## 対象範囲

- `docs/specs/integrity/integrity-contracts.md`（REQ-0144-020 節）: commit a91e211d で配置済み（本 PR では変更なし）
- `.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts`（`isTemplatePlaceholder` 分岐）
- `.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts`
- `.opencode/skills/repo-agentdev-integrity/scripts/check_reference_paths.test.ts`

## 実装内容

### 1. isTemplatePlaceholder regex 拡張（REQ-0144-020）

`checkScriptTemplateReferencePaths` から呼ばれる `isTemplatePlaceholder` の angle-bracket placeholder 判定 regex を拡張した。

- 変更前: `/<[a-zA-Z][a-zA-Z0-9_-]*>/`（letter-first の word token のみ）
- 変更後: `/<[^<>]+>/`（`<>` 内の任意の非空文字列）

SPEC（REQ-0144-020）の `<...>` 形式を完全網羅する。`isTemplatePlaceholder` は `SCRIPT_TEMPLATE_REF_PATTERNS` が捕捉したパス参照文字列のみを受け取るため、入力に `<>` が含まれる場合は placeholder 以外あり得ない。既存の `<harness>` 除外（REQ-0144-025 / ADR-0136）を包含し、挙動は後方互換。

実在確認の分岐順序（placeholder skip → glob skip → runtime-generated skip → 実在確認）は維持。placeholder を含まない具体パスが未解決の場合は従来どおり ReferencePath NG を報告する。

### 2. 回帰テスト追加

#### check_reference_paths.test.ts（TS-001 combined fixture）

同一 fixture 内に `<harness>` placeholder 参照（正例）と具体未解決パス（負例）を両方配置し、placeholder は NG を出さず、具体未解決パスは NG を報告することを検証する。

#### check_integrity.test.ts（正例・負例）

新規 describe block `ReferencePath placeholder regression (REQ-0144-020, Issue #1779)` を追加。`<harness>` placeholder が NG とならないこと（正例）と、具体未解決パスが NG として報告されること（負例）を検証する。

### 3. copyScripts インフラ修正（pre-existing 解消）

`check_integrity.test.ts` の `copyScripts` が `check_integrity.ts` と `cli_utils.ts` のみコピーし、`generate_indexes.ts` 等の静的 import 依存ファイルをコピーしていなかった。このため fixture 内でスクリプトが import error でクラッシュし、同ファイルの全テスト（68件）が pre-existing で失敗していた。`check_reference_paths.test.ts` と同等に `.test.ts` を除く全 `.ts` ファイルをコピーするよう修正し、既存テスト含む全70件が合格する状態へ復旧した。

## 検証結果

- `bun test check_reference_paths.test.ts`: 22 pass / 0 fail（+1 新規）
- `bun test check_integrity.test.ts`: 70 pass / 0 fail（+2 新規、既存68件の pre-existing 失敗も解消）
- 実 repo への `check_integrity.ts --json` 実行: ReferencePath 35件中 NG 0件、`<harness>` 参照は全て適切にスキップ
- TS-001（AG-001）: placeholder 参照は ReferencePath NG を出さず、具体的な未解決パスは ReferencePath NG として報告されることを確認

## 完了条件

- [x] `docs/specs/integrity/integrity-contracts.md` REQ-0144-020 節と check_integrity.ts の実装が整合していること（SPEC は commit a91e211d で配置済み、本 PR で実装を是正）
- [x] `checkScriptTemplateReferencePaths` が `<...>` 形式 placeholder を含む参照を実在確認対象外とすること
- [x] placeholder を含まない具体パスが未解決の場合 ReferencePath NG を報告すること
- [x] `check_integrity.test.ts` と `check_reference_paths.test.ts` に placeholder 正例・負例の回帰テストが追加されていること
- [x] TS-001 が合格であること

## Findings / Capture候補

- `check_integrity.test.ts` の `copyScripts` が依存 `.ts` をコピーしていなかった問題（pre-existing、本 PR で解消）。#1780 と check_integrity.ts を共有するが、本 PR の論理（placeholder 判定）は #1780 の NG baseline 集計論理とは独立。merge conflict は case-close Level 1 で解消予定（Issue 補足情報どおり）。

Closes #1779
