### PR TITLE
feat(integrity): NG baseline 集計・由来ラベル・分類を是正 (#1780)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/baselines/ng-baseline.json
+++ b/.opencode/skills/repo-agentdev-integrity/baselines/ng-baseline.json
@@ -8,2345 +8,3015 @@
       "check": "accepted-adr-only-citation",
       "file": "README.md",
       "evidence": "ADR-0134",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "ADR",
       "check": "accepted-adr-only-citation",
       "file": "docs/specs/integrity/rules/IR-058-distribution-untracked-skill-reference.md",
       "evidence": "ADR-0134",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "ADR",
       "check": "accepted-adr-only-citation",
       "file": "docs/specs/local/runtime-package-boundary.md",
       "evidence": "ADR-0134",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "ADR",
       "check": "adr-req-crossref",
       "file": null,
       "evidence": null,
-      "count": 11
+      "count": 11,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "Canonical",
       "check": "req-range-staleness",
       "file": "docs/guides/project-docs-and-specs.md",
       "evidence": "REQ-0101 から REQ-0162",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "CanonicalConflict",
       "check": "gh-direct-invocation",
       "file": "src/opencode/skills/agentdev-quality-gates/references/qg-4-final-acceptance.md",
       "evidence": "gh pr view",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "CanonicalConflict",
       "check": "req-spec-boundary-violation",
       "file": "docs/requirements/REQ-0108.md",
       "evidence": "REQ-0108-268: docs-check 回帰テストの valid fixture は baseline 登録済みの既知違反の影響を受けず、安定して通過するテストデータ構成であること。既知違反と valid fixture の分離が不十分な場合はテストデータ構成を見直すこと（REQ-0108-055、REQ-0108-258 関連）",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "CanonicalConflict",
       "check": "req-spec-boundary-violation",
       "file": "docs/requirements/REQ-0114.md",
       "evidence": "REQ-0114-102: case-auto は、Phase 1 で case-open を順次実行し、Phase 2 で case-run を並列実行し、Phase 3 で case-close を順次実行する Phase 分離モデルを採用すること。各 Phase は前 Phase の対象処理の完了後に開始すること。",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "CanonicalConflict",
       "check": "req-spec-boundary-violation",
       "file": "docs/requirements/REQ-0114.md",
       "evidence": "REQ-0114-103: case-auto は Phase 2 で case-run を bg task として起動し、各 bg task の結果または破棄を収集すること。bg task の起動 API と引数仕様は `references/<harness>.md` に配置し、case-auto は規定しないこと。",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "CanonicalConflict",
       "check": "req-spec-boundary-violation",
       "file": "docs/requirements/REQ-0114.md",
       "evidence": "REQ-0114-104: case-auto は Phase 1 と Phase 3 を直列集約ポイントとし、main push、capture、commit を並列実行区間の外で処理すること。",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "CanonicalConflict",
       "check": "req-spec-boundary-violation",
       "file": "docs/requirements/REQ-0114.md",
       "evidence": "REQ-0114-106: case-auto の Phase 2 における case-run の同時起動数は固定値5とすること。固定値は AgentDevFlow 側で規定し、REQ-0130-026 と同一の実行安全境界として扱うこと。",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "CanonicalConflict",
       "check": "req-spec-boundary-violation",
       "file": "docs/requirements/REQ-0140.md",
       "evidence": "REQ-0140-028: docs/requirements/REQ-*.md の要件行は操作主体（command 名、skill 名、ユーザー、システム）を明示すること。ただし enum 定義、派生ルール、システム側判断ルールなど主体明示が不要な場合はこの限りでないこと",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "CanonicalConflict",
       "check": "req-spec-boundary-violation",
       "file": "docs/requirements/REQ-0144.md",
       "evidence": "REQ-0144-009: システムは copyScripts 本採用環境下で fixture drift を自動検出する仕組みを提供すること",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "CanonicalConflict",
       "check": "req-spec-boundary-violation",
       "file": "docs/requirements/REQ-0148.md",
       "evidence": "REQ-0148-018: case-auto レベルでのグローバル並列上限は設定せず、case-run 単位の並列上限（REQ-0130-026、SPEC `epic-wave-model.md` 参照）のみを制御対象とすること（REQ-0101-069 安定契約例外: 安全境界。並列実行数上限は実行安全境界）。Phase 分離モデル（REQ-0114-102）では、Phase 2 の同時起動数に固定値5を適用すること。",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "CanonicalConflict",
       "check": "req-spec-boundary-violation",
       "file": "docs/requirements/REQ-0149.md",
       "evidence": "REQ-0149-009: agentdev-gh-cli の WRITE 手続きは Windows 環境においてコンソールエンコーディング初期化（standard-procedures Section2 Step0）を必須前置すること。UTF-8 BOM なしファイルの編集結果の mojibake 化を排除すること",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "CanonicalConflict",
       "check": "req-spec-boundary-violation",
       "file": "docs/requirements/REQ-0153.md",
       "evidence": "REQ-0153-001: case-run は機械的テキスト置換または複数ディレクトリ横断の是正を含む PR について、置換対象パターンの再 grep 結果が 0 件であることを完了証拠とすること。ただし「0 件」は意味論的に正しい置換対象範囲（自然言語記述）での 0 件を指し、構造データ（YAML frontmatter、fenced code block 内字句等）への誤付与による 0 件は完了証拠として無効とする（PR #1334 事例）",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "Inventory",
       "check": "adr-readme-index",
       "file": null,
       "evidence": null,
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0101.md",
       "evidence": "ADR-0005",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0101.md",
       "evidence": "ADR-0004",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0102.md",
       "evidence": "ADR-0013",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0103.md",
       "evidence": "ADR-0014",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0103.md",
       "evidence": "ADR-0017",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0104.md",
       "evidence": "ADR-0015",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0104.md",
       "evidence": "ADR-0016",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0104.md",
       "evidence": "ADR-0018",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0105.md",
       "evidence": "ADR-0019",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0106.md",
       "evidence": "ADR-0020",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0107.md",
       "evidence": "ADR-0001",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0108.md",
       "evidence": "ADR-0002",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0109.md",
       "evidence": "ADR-0006",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/adr/ADR-0111.md",
       "evidence": "ADR-0011",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/requirements/REQ-0112.md",
       "evidence": "ADR-0001",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/requirements/REQ-0112.md",
       "evidence": "ADR-0023",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/requirements/REQ-0112.md",
       "evidence": "ADR-0004",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/requirements/REQ-0112.md",
       "evidence": "ADR-0007",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/requirements/REQ-0112.md",
       "evidence": "ADR-0009",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/requirements/REQ-0112.md",
       "evidence": "ADR-0014",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/requirements/REQ-0112.md",
       "evidence": "ADR-0015",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-adr-ref",
       "file": "docs/requirements/REQ-0112.md",
       "evidence": "ADR-0018",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-file-link",
       "file": "docs/specs/quality/quality-gates.md",
       "evidence": "../../src/opencode/skills/agentdev-quality-gates/SKILL.md",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/README.md",
       "evidence": "REQ-0001",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/README.md",
       "evidence": "REQ-0050",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/README.md",
       "evidence": "REQ-0111",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/README.md",
       "evidence": "REQ-0121",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/adr/ADR-0101.md",
       "evidence": "REQ-0115",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/adr/ADR-0113.md",
       "evidence": "REQ-0115",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/REQ-0110.md",
       "evidence": "REQ-0117",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/REQ-0119.md",
       "evidence": "REQ-0111",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/REQ-0124.md",
       "evidence": "REQ-0115",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/REQ-0124.md",
       "evidence": "REQ-0116",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/REQ-0144.md",
       "evidence": "REQ-0122",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/REQ-0161.md",
       "evidence": "REQ-0041",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/REQ-0161.md",
       "evidence": "REQ-0004",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0001",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0050",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0111",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0115",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0116",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0117",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0118",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0120",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0121",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0122",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0002",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0003",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0004",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0005",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0006",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0007",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0008",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0009",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0010",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0011",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0012",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0013",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0014",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0015",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0016",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0017",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0018",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0019",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0020",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0021",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0022",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0023",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0024",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0025",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0026",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0027",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0028",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0029",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0030",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0031",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0032",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0033",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0034",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0035",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0036",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0037",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0038",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0039",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0040",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0041",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0042",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0043",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0044",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0045",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0046",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0047",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0048",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "LinkIntegrity",
       "check": "broken-req-ref",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0049",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0001",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0002",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0003",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0004",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0005",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0006",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0007",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0008",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0009",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0010",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0011",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0012",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0013",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0014",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0015",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0016",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0017",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0018",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0019",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0020",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0021",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0022",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0023",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0024",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0025",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0026",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0027",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0028",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0029",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0030",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0031",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0032",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0033",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0034",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0035",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0036",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0037",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0038",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0039",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0040",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0041",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0042",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0043",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0044",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0045",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0046",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0047",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0048",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0049",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0050",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0111",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0122",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0116",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0118",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0120",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0121",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0115",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "MappingTable",
       "check": "mapping-table-completeness",
       "file": "docs/requirements/mapping-table.md",
       "evidence": "REQ-0117",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114",
-      "count": 30
+      "count": 30,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-064",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-053",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0130-026",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0148-014",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0130",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0148",
-      "count": 3
+      "count": 3,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-065",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-067",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-066",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-088",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-093",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-060",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0162-003",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0162",
-      "count": 5
+      "count": 5,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0162-002",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-073",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-098",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0162-004",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0163",
-      "count": 7
+      "count": 7,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0163-001",
-      "count": 3
+      "count": 3,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0163-002",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0163-003",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-102",
-      "count": 4
+      "count": 4,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "ADR-0138",
-      "count": 4
+      "count": 4,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0151-006",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0151",
-      "count": 10
+      "count": 10,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "ADR-0132",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-082",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0151-008",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-049",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-100",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0151-001",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0151-002",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-095",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0151-003",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0148-015",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0151-004",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0151-005",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "ADR-0137",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-097",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-085",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-106",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-105",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-104",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-101",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-auto.md",
       "evidence": "REQ-0114-107",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-open.md",
       "evidence": "REQ-0132-025",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-open.md",
       "evidence": "REQ-0132",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-run.md",
       "evidence": "REQ-0162-002",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/commands/agentdev/case-run.md",
       "evidence": "REQ-0162",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-adr-file-manager/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-adr-file-manager/SKILL.md",
       "evidence": "REQ-0112-048",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-adr-file-manager/SKILL.md",
       "evidence": "REQ-0112",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-adr-guidelines/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-architecture-advisory/references/architecture-review-delegation.md",
       "evidence": "REQ-0162-002",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-architecture-advisory/references/architecture-review-delegation.md",
       "evidence": "REQ-0162",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-architecture-advisory/references/architecture-review-delegation.md",
       "evidence": "ADR-0136",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-backlog-integration/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
       "evidence": "REQ-0162-002",
-      "count": 3
+      "count": 3,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
       "evidence": "REQ-0162",
-      "count": 4
+      "count": 4,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
       "evidence": "REQ-0162-004",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
       "evidence": "REQ-0163",
-      "count": 5
+      "count": 5,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
       "evidence": "REQ-0163-001",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
       "evidence": "REQ-0163-002",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
       "evidence": "REQ-0163-003",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
       "evidence": "REQ-0149-012",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
       "evidence": "REQ-0149",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/references/harness-delegation.md",
       "evidence": "REQ-0162-002",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/references/harness-delegation.md",
       "evidence": "REQ-0162",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-case-run-execution-adapter/references/harness-delegation.md",
       "evidence": "REQ-0162-004",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-command-authoring/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-command-creator/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-conventional-commits/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-doc-map/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-doc-writing/references/japanese-replacement-dictionary.md",
       "evidence": "REQ-0140-033",
-      "count": 5
+      "count": 5,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-doc-writing/references/japanese-replacement-dictionary.md",
       "evidence": "REQ-0140",
-      "count": 12
+      "count": 12,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-doc-writing/references/japanese-replacement-dictionary.md",
       "evidence": "REQ-0140-026",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-doc-writing/references/japanese-replacement-dictionary.md",
       "evidence": "REQ-0140-034",
-      "count": 4
+      "count": 4,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-doc-writing/references/japanese-replacement-dictionary.md",
       "evidence": "repo-local",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-doc-writing/references/japanese-replacement-dictionary.md",
       "evidence": "REQ-0140-035",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-doc-writing/references/japanese-replacement-dictionary.md",
       "evidence": "REQ-0140-036",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-epic-tracker/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-gh-cli/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-gh-cli/SKILL.md",
       "evidence": "REQ-0149-011",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-gh-cli/references/contracts.md",
       "evidence": "REQ-0149-002",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-gh-cli/references/contracts.md",
       "evidence": "REQ-0149-011",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-gh-cli/references/contracts.md",
       "evidence": "REQ-0149-004",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-gh-cli/references/contracts.md",
       "evidence": "REQ-0149",
-      "count": 3
+      "count": 3,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md",
       "evidence": "REQ-0149-009",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md",
       "evidence": "REQ-0149-011",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md",
       "evidence": "REQ-0149",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-gh-cli/references/verify.md",
       "evidence": "REQ-0149-010",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-gh-cli/references/verify.md",
       "evidence": "REQ-0149",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-git-worktree/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
       "evidence": "src/opencode/",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
       "evidence": "REQ-0125-003",
-      "count": 6
+      "count": 6,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
       "evidence": "REQ-0119-034",
-      "count": 3
+      "count": 3,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
       "evidence": "REQ-0125",
-      "count": 6
+      "count": 6,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
       "evidence": "REQ-0119",
-      "count": 4
+      "count": 4,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
       "evidence": "REQ-0119-033",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
       "evidence": "REQ-0125-005",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
       "evidence": "REQ-0119-033",
-      "count": 7
+      "count": 7,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
       "evidence": "REQ-0119-034",
-      "count": 8
+      "count": 8,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
       "evidence": "REQ-0119",
-      "count": 17
+      "count": 17,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
       "evidence": "REQ-0125-003",
-      "count": 7
+      "count": 7,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
       "evidence": "REQ-0125-004",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
       "evidence": "REQ-0125",
-      "count": 10
+      "count": 10,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
       "evidence": "ADR-0107",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
       "evidence": "src/opencode/",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
       "evidence": "REQ-0125-005",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
       "evidence": "REQ-0119-035",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
       "evidence": "REQ-0119-036",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-intake-pipeline/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-issue-management/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-issue-management/references/issue-operation-safety.md",
       "evidence": "REQ-0132-024",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-learning-capture/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-learning-pipeline/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-project-extensions/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-project-extensions/SKILL.md",
       "evidence": "REQ-0147-001",
-      "count": 5
+      "count": 5,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-project-extensions/SKILL.md",
       "evidence": "REQ-0147",
-      "count": 5
+      "count": 5,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-project-extensions/SKILL.md",
       "evidence": "REQ-0119-034",
-      "count": 5
+      "count": 5,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-project-extensions/SKILL.md",
       "evidence": "REQ-0119",
-      "count": 5
+      "count": 5,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-quality-gates/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-quality-gates/references/qg-2-acceptance-criteria-coverage.md",
       "evidence": "REQ-0131-031",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-quality-gates/references/qg-2-acceptance-criteria-coverage.md",
       "evidence": "REQ-0131",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-quality-gates/references/qg-4-final-acceptance.md",
       "evidence": "REQ-0146-015",
-      "count": 3
+      "count": 3,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-quality-gates/references/qg-4-final-acceptance.md",
       "evidence": "src/opencode/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-quality-gates/references/qg-4-final-acceptance.md",
       "evidence": "REQ-0146-011",
-      "count": 4
+      "count": 4,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-quality-gates/references/qg-4-final-acceptance.md",
       "evidence": "REQ-0146",
-      "count": 6
+      "count": 6,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-analysis/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-analysis/references/investigation-scope-refinement.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-analysis/references/test-strategy-numeric-threshold-guide.md",
       "evidence": "REQ-0131-031",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-analysis/references/test-strategy-numeric-threshold-guide.md",
       "evidence": "REQ-0131",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-analysis/references/test-strategy-numeric-threshold-guide.md",
       "evidence": "src/opencode/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-file-manager/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-file-manager/references/create-append-update-flow.md",
       "evidence": "REQ-0113-010",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-file-manager/references/create-append-update-flow.md",
       "evidence": "REQ-0113",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-file-manager/references/matching-and-merge.md",
       "evidence": "REQ-0113-010",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-file-manager/references/matching-and-merge.md",
       "evidence": "REQ-0113",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-file-manager/references/numbering-and-validation.md",
       "evidence": "REQ-0113-010",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-file-manager/references/numbering-and-validation.md",
       "evidence": "REQ-0113",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-file-manager/references/numbering-and-validation.md",
       "evidence": "src/opencode/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-req-structure-diagnostics/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-skill-authoring/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-skill-authoring/SKILL.md",
       "evidence": "REQ-0113-010",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-skill-authoring/SKILL.md",
       "evidence": "REQ-0113",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-skill-authoring/references/design-principles.md",
       "evidence": "REQ-0113-010",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-skill-authoring/references/design-principles.md",
       "evidence": "REQ-0113",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-skill-authoring/references/development-workflow.md",
       "evidence": "REQ-0113-010",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-skill-authoring/references/development-workflow.md",
       "evidence": "REQ-0113",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-skill-authoring/references/review-protocol.md",
       "evidence": "REQ-0113-010",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-skill-authoring/references/review-protocol.md",
       "evidence": "REQ-0113",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-skill-authoring/references/review-protocol.md",
       "evidence": "src/opencode/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-workflow-lifecycle/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-workflow-orchestration/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-workflow-orchestration/references/capture-boundaries.md",
       "evidence": "REQ-0163-002",
-      "count": 2
+      "count": 2,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-workflow-orchestration/references/capture-boundaries.md",
       "evidence": "REQ-0163",
-      "count": 3
+      "count": 3,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-workflow-orchestration/references/capture-boundaries.md",
       "evidence": "REQ-0163-001",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-workflow-orchestration/references/capture-boundaries.md",
       "evidence": "REQ-0149-012",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-workflow-orchestration/references/capture-boundaries.md",
       "evidence": "REQ-0149",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-workflow-routing/SKILL.md",
       "evidence": "docs/specs/",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-workflow-templates/SKILL.md",
       "evidence": "REQ-0132-025",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
       "category": "RuntimeReference",
       "check": "runtime-unresolved-reference",
       "file": "src/opencode/skills/agentdev-workflow-templates/SKILL.md",
       "evidence": "REQ-0132",
-      "count": 1
+      "count": 1,
+      "provenance": "legacy",
+      "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     }
   ]
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { mkdirSync, writeFileSync, copyFileSync, rmSync, existsSync } from "fs";
+import { mkdirSync, writeFileSync, copyFileSync, rmSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
 
 const SCRIPT_DIR = import.meta.dir;
@@ -2223,5 +2223,387 @@ describe("IR-058 distribution-untracked-skill-reference (REQ-0159-003)", () => {
         (res.message ?? "").includes("ADR-0134"),
     );
     expect(promotionMessage).toBeDefined();
+  });
+});
+
+// ─── NG baseline aggregation / provenance / classification (Issue #1780, REQ-0161-005) ──
+// TS-003: baseline 既知 NG と新規 NG の件数を別々に示し、新規 NG だけが非ゼロ終了の原因になる
+// TS-004: --update-ng-baseline が承認済み由来ラベル付き差分だけを baseline へ追加し、未管理 NG を取り込まない
+// TS-005: baseline 既知 NG、承認済み追加分、新規かつ未管理 NG が報告で区別される
+
+const NGBASELINE_ROOT = join(TEMP_ROOT, "ngbaseline1780");
+const GENERATE_INDEXES_FILE = join(SCRIPT_DIR, "generate_indexes.ts");
+
+function copyScriptsComplete(fixtureRoot: string): void {
+  const dest = join(
+    fixtureRoot,
+    ".opencode",
+    "skills",
+    "repo-agentdev-integrity",
+    "scripts",
+  );
+  mkdirp(dest);
+  copyFileSync(SCRIPT_FILE, join(dest, "check_integrity.ts"));
+  copyFileSync(CLI_UTILS_FILE, join(dest, "cli_utils.ts"));
+  // generate_indexes.ts is imported by check_integrity.ts; copy it so the
+  // fixture is self-contained (the pre-existing copyScripts omits it).
+  if (existsSync(GENERATE_INDEXES_FILE)) {
+    copyFileSync(GENERATE_INDEXES_FILE, join(dest, "generate_indexes.ts"));
+  }
+}
+
+function buildNgBaselineFixture(root: string): void {
+  const reqDir = join(root, "docs", "requirements");
+  mkdirp(reqDir);
+  writeFileSync(
+    join(reqDir, "README.md"),
+    [
+      "# Requirements",
+      "",
+      "| ID | Title |",
+      "|----|-------|",
+      "| REQ-0001 | fixture anchor |",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  writeFileSync(
+    join(reqDir, "REQ-0001.md"),
+    [
+      "---",
+      "id: REQ-0001",
+      "title: fixture anchor",
+      "created: 2025-01-01",
+      "updated: 2025-01-01",
+      "---",
+      "",
+      "Body.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  mkdirp(join(root, "docs", "adr"));
+  writeFileSync(join(root, "docs", "adr", "README.md"), "# ADR\n", "utf-8");
+
+  mkdirp(join(root, "docs", "specs"));
+  writeFileSync(join(root, "docs", "specs", "README.md"), "# SPEC\n", "utf-8");
+
+  // Guide file referencing three non-existent REQ IDs. Each unique ref emits
+  // one broken-req-ref NG with evidence = "REQ-NNNN".
+  const guidesDir = join(root, "docs", "guides");
+  mkdirp(guidesDir);
+  writeFileSync(
+    join(guidesDir, "ng-baseline-test.md"),
+    [
+      "# NG Baseline Test Guide",
+      "",
+      "Reference A: REQ-9001.",
+      "Reference B: REQ-9002.",
+      "Reference C: REQ-9003.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+function writeNgBaselineFile(
+  root: string,
+  entries: Array<{
+    category: string;
+    check: string;
+    file: string | null;
+    evidence: string | null;
+    count: number;
+    provenance: string;
+    reason: string;
+  }>,
+): void {
+  const baselineDir = join(
+    root,
+    ".opencode",
+    "skills",
+    "repo-agentdev-integrity",
+    "baselines",
+  );
+  mkdirp(baselineDir);
+  writeFileSync(
+    join(baselineDir, "ng-baseline.json"),
+    JSON.stringify(
+      {
+        version: 1,
+        rule_id: "NG-BASELINE",
+        generated_at: "2026-07-24",
+        entries,
+      },
+      null,
+      2,
+    ) + "\n",
+    "utf-8",
+  );
+}
+
+function readNgBaselineFile(root: string): {
+  entries: Array<{
+    category: string;
+    check: string;
+    file: string | null;
+    evidence: string | null;
+    count: number;
+    provenance?: string;
+    reason?: string;
+  }>;
+} {
+  const p = join(
+    root,
+    ".opencode",
+    "skills",
+    "repo-agentdev-integrity",
+    "baselines",
+    "ng-baseline.json",
+  );
+  return JSON.parse(readFileSync(p, "utf-8") as string);
+}
+
+const NGBASELINE_GUIDE = "docs/guides/ng-baseline-test.md";
+
+describe("NG baseline aggregation / provenance / classification (Issue #1780, REQ-0161-005)", () => {
+  beforeAll(() => {
+    rmSync(NGBASELINE_ROOT, { recursive: true, force: true });
+    buildNgBaselineFixture(NGBASELINE_ROOT);
+    copyScriptsComplete(NGBASELINE_ROOT);
+    // Seed baseline: REQ-9001 (legacy) + REQ-9002 (approved). REQ-9003 stays
+    // unmanaged so it remains a new-NG driver.
+    writeNgBaselineFile(NGBASELINE_ROOT, [
+      {
+        category: "LinkIntegrity",
+        check: "broken-req-ref",
+        file: NGBASELINE_GUIDE,
+        evidence: "REQ-9001",
+        count: 1,
+        provenance: "legacy",
+        reason: "pre-existing baseline entry (fixture)",
+      },
+      {
+        category: "LinkIntegrity",
+        check: "broken-req-ref",
+        file: NGBASELINE_GUIDE,
+        evidence: "REQ-9002",
+        count: 1,
+        provenance: "approved-fixture",
+        reason: "approved addition (fixture)",
+      },
+    ]);
+  });
+
+  afterAll(() => {
+    rmSync(NGBASELINE_ROOT, { recursive: true, force: true });
+  });
+
+  it("TS-003: separates baseline-known from new NG counts; only new NG drives non-zero exit", () => {
+    const r = runScript(NGBASELINE_ROOT, ["--json"]);
+    expect(r.exitCode).not.toBe(0);
+
+    const parsed = JSON.parse(r.stdout);
+    const brokenReqRefs = parsed.results.filter(
+      (res: { check: string; evidence?: string }) =>
+        res.check === "broken-req-ref",
+    );
+
+    // REQ-9001 (legacy baseline) → demoted to info with [baseline-known] tag.
+    const req9001 = brokenReqRefs.find(
+      (res: { evidence?: string }) => res.evidence === "REQ-9001",
+    );
+    expect(req9001).toBeDefined();
+    expect(req9001.level).toBe("info");
+    expect(req9001.message).toContain("[baseline-known]");
+    expect(req9001.message).not.toContain("provenance=");
+
+    // REQ-9002 (approved baseline) → demoted to info with provenance tag.
+    const req9002 = brokenReqRefs.find(
+      (res: { evidence?: string }) => res.evidence === "REQ-9002",
+    );
+    expect(req9002).toBeDefined();
+    expect(req9002.level).toBe("info");
+    expect(req9002.message).toContain("[baseline-known provenance=approved-fixture]");
+
+    // REQ-9003 (unmanaged) → stays ng; drives non-zero exit.
+    const req9003 = brokenReqRefs.find(
+      (res: { evidence?: string }) => res.evidence === "REQ-9003",
+    );
+    expect(req9003).toBeDefined();
+    expect(req9003.level).toBe("ng");
+  });
+
+  it("TS-005: report distinguishes baseline-known, approved additions, and new unmanaged NG", () => {
+    const r = runScript(NGBASELINE_ROOT, ["--json"]);
+    // The 3-category summary is emitted on stderr.
+    expect(r.stderr).toContain("baseline-known (demoted to info)");
+    expect(r.stderr).toContain("approved additions (provenance-tracked");
+    expect(r.stderr).toContain("new unmanaged NG (delta, exit code driver)");
+
+    // And the three classes are distinguishable in the JSON results.
+    const parsed = JSON.parse(r.stdout);
+    const legacyDemoted = parsed.results.filter(
+      (res: { check: string; level: string; message?: string }) =>
+        res.check === "broken-req-ref" &&
+        res.level === "info" &&
+        (res.message ?? "").startsWith("[baseline-known] ") &&
+        !(res.message ?? "").includes("provenance="),
+    );
+    const approvedDemoted = parsed.results.filter(
+      (res: { check: string; level: string; message?: string }) =>
+        res.check === "broken-req-ref" &&
+        res.level === "info" &&
+        (res.message ?? "").includes("[baseline-known provenance="),
+    );
+    const newNg = parsed.results.filter(
+      (res: { check: string; level: string }) =>
+        res.check === "broken-req-ref" && res.level === "ng",
+    );
+    expect(legacyDemoted.length).toBeGreaterThanOrEqual(1);
+    expect(approvedDemoted.length).toBeGreaterThanOrEqual(1);
+    expect(newNg.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("TS-004: --update-ng-baseline adds only approved deltas with provenance/reason; unmanaged NGs are not absorbed", () => {
+    // Additions manifest: approve REQ-9003 only. Do NOT include the other
+    // fixture NGs (e.g. command-readme-sync, skill-prefix) — those must stay
+    // out of the baseline per SPEC.
+    const manifestPath = join(NGBASELINE_ROOT, "additions-manifest.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify(
+        {
+          additions: [
+            {
+              category: "LinkIntegrity",
+              check: "broken-req-ref",
+              file: NGBASELINE_GUIDE,
+              evidence: "REQ-9003",
+              count: 1,
+              provenance: "ts-004-approval",
+              reason: "TS-004: approving REQ-9003 reference in test fixture",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const updateProc = Bun.spawnSync(
+      [
+        "bun",
+        "run",
+        join(
+          NGBASELINE_ROOT,
+          ".opencode",
+          "skills",
+          "repo-agentdev-integrity",
+          "scripts",
+          "check_integrity.ts",
+        ),
+        "--update-ng-baseline",
+        "--ng-baseline-additions",
+        manifestPath,
+      ],
+      { cwd: NGBASELINE_ROOT, stdout: "pipe", stderr: "pipe" },
+    );
+    expect(updateProc.exitCode).toBe(0);
+
+    // Baseline now has 3 entries; REQ-9003 carries the approved provenance.
+    const baseline = readNgBaselineFile(NGBASELINE_ROOT);
+    const req9003Entry = baseline.entries.find(
+      (e: { evidence?: string }) => e.evidence === "REQ-9003",
+    );
+    expect(req9003Entry).toBeDefined();
+    expect(req9003Entry.provenance).toBe("ts-004-approval");
+    expect(req9003Entry.reason).toContain("TS-004");
+
+    // Unmanaged NG categories were NOT absorbed: the baseline must contain no
+    // entry for command-readme-sync / skill-prefix / etc.
+    const absorbedOtherChecks = baseline.entries.filter(
+      (e: { check: string }) =>
+        e.check !== "broken-req-ref",
+    );
+    expect(absorbedOtherChecks.length).toBe(0);
+
+    // Re-run: REQ-9003 is now demoted as an approved addition.
+    const r = runScript(NGBASELINE_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const req9003After = parsed.results.find(
+      (res: { check: string; evidence?: string }) =>
+        res.check === "broken-req-ref" && res.evidence === "REQ-9003",
+    );
+    expect(req9003After).toBeDefined();
+    expect(req9003After.level).toBe("info");
+    expect(req9003After.message).toContain(
+      "[baseline-known provenance=ts-004-approval]",
+    );
+  });
+
+  it("TS-004 (negative): --update-ng-baseline without additions manifest is rejected", () => {
+    const proc = Bun.spawnSync(
+      [
+        "bun",
+        "run",
+        join(
+          NGBASELINE_ROOT,
+          ".opencode",
+          "skills",
+          "repo-agentdev-integrity",
+          "scripts",
+          "check_integrity.ts",
+        ),
+        "--update-ng-baseline",
+      ],
+      { cwd: NGBASELINE_ROOT, stdout: "pipe", stderr: "pipe" },
+    );
+    expect(proc.exitCode).toBe(2);
+    expect(proc.stderr.toString("utf-8")).toContain(
+      "--ng-baseline-additions",
+    );
+  });
+
+  it("TS-004 (negative): additions manifest missing provenance/reason is rejected", () => {
+    const badManifest = join(NGBASELINE_ROOT, "bad-manifest.json");
+    writeFileSync(
+      badManifest,
+      JSON.stringify({
+        additions: [
+          {
+            category: "LinkIntegrity",
+            check: "broken-req-ref",
+            file: NGBASELINE_GUIDE,
+            evidence: "REQ-9003",
+            count: 1,
+            // provenance and reason intentionally omitted.
+          },
+        ],
+      }),
+      "utf-8",
+    );
+    const proc = Bun.spawnSync(
+      [
+        "bun",
+        "run",
+        join(
+          NGBASELINE_ROOT,
+          ".opencode",
+          "skills",
+          "repo-agentdev-integrity",
+          "scripts",
+          "check_integrity.ts",
+        ),
+        "--update-ng-baseline",
+        "--ng-baseline-additions",
+        badManifest,
+      ],
+      { cwd: NGBASELINE_ROOT, stdout: "pipe", stderr: "pipe" },
+    );
+    expect(proc.exitCode).toBe(2);
+    expect(proc.stderr.toString("utf-8")).toContain("provenance");
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -70,7 +70,7 @@ import {
 const SCRIPT_NAME = "check_integrity.ts";
 const DESCRIPTION = "AgentDevFlow artifact integrity validator";
 const USAGE =
-  "bun run check_integrity.ts [--help] [--json] [--dry-run] [--classification] [--update-ir055-baseline] [--update-ng-baseline]";
+  "bun run check_integrity.ts [--help] [--json] [--dry-run] [--classification] [--update-ir055-baseline] [--update-ng-baseline --ng-baseline-additions <manifest.json>]";
 
 const path = require("path") as typeof import("path");
 const fs = require("fs") as typeof import("fs");
@@ -7154,11 +7154,17 @@ function updateIr055Baseline(root: string): void {
 // unreachable while a known baseline of pre-existing NGs exists. REQ-0161-005
 // redefines the pass criterion as delta-aware: baseline-known NGs are demoted
 // to info (report-only), only NGs exceeding the baseline (new, caused by the
-// change under review) cause failure. The baseline is regenerated explicitly
-// via --update-ng-baseline; it is NOT auto-updated on every run.
+// change under review) cause failure. The baseline is updated explicitly via
+// --update-ng-baseline with an approved additions manifest; it is NOT
+// auto-regenerated on every run, and unmanaged NGs are never absorbed.
 //
 // Bucket key: `${category}\t${check}\t${file||''}\t${evidence||''}`. A bucket
 // with current count <= baseline count is fully baseline-known.
+//
+// SPEC: docs/specs/integrity/integrity-contracts.md「NG baseline 運用手順」.
+// Each entry carries `provenance`（由来ラベル）and `reason`（承認理由）. Demoted
+// findings are classified into three report categories: baseline-known,
+// approved additions (provenance-tracked), new unmanaged NG.
 
 const NG_BASELINE_PATH = path.join(
   ".opencode",
@@ -7174,6 +7180,8 @@ interface NgBaselineEntry {
   file: string | null;
   evidence: string | null;
   count: number;
+  provenance: string;
+  reason: string;
 }
 
 interface NgBaseline {
@@ -7181,6 +7189,31 @@ interface NgBaseline {
   rule_id: "NG-BASELINE";
   generated_at: string;
   entries: NgBaselineEntry[];
+}
+
+// Entry in the additions manifest passed to --update-ng-baseline. Each addition
+// must declare a provenance label and a reason; entries without them are
+// rejected so the baseline cannot silently absorb unmanaged NGs.
+interface NgBaselineAddition {
+  category: string;
+  check: string;
+  file: string | null;
+  evidence: string | null;
+  count: number;
+  provenance: string;
+  reason: string;
+}
+
+interface NgBaselineAdditionsManifest {
+  additions: NgBaselineAddition[];
+}
+
+// Report returned by applyNgBaseline: three NG classification counts per SPEC
+// (baseline-known, approved additions, new unmanaged).
+interface NgBaselineReport {
+  baselineKnown: number;
+  approvedAdditions: number;
+  newNg: number;
 }
 
 function ngBaselineKey(
@@ -7192,12 +7225,38 @@ function ngBaselineKey(
   return `${category}\t${check}\t${file ?? ""}\t${evidence ?? ""}`;
 }
 
+// Normalize a parsed entry to fill provenance/reason for backward compat with
+// baseline files written before REQ-0161-005 introduced the fields. Missing
+// values are treated as "legacy" provenance so existing baseline NGs continue
+// to demote to info without forcing a one-shot migration of the JSON file.
+function normalizeNgBaselineEntry(raw: Partial<NgBaselineEntry>): NgBaselineEntry {
+  return {
+    category: String(raw.category ?? ""),
+    check: String(raw.check ?? ""),
+    file: raw.file === null || raw.file === undefined ? null : String(raw.file),
+    evidence:
+      raw.evidence === null || raw.evidence === undefined
+        ? null
+        : String(raw.evidence),
+    count: typeof raw.count === "number" ? raw.count : 0,
+    provenance: raw.provenance ? String(raw.provenance) : "legacy",
+    reason: raw.reason ? String(raw.reason) : "",
+  };
+}
+
 function loadNgBaseline(root: string): NgBaseline | null {
   const baselineAbs = path.join(root, NG_BASELINE_PATH);
   const content = readText(baselineAbs);
   if (!content) return null;
   try {
-    return JSON.parse(content) as NgBaseline;
+    const parsed = JSON.parse(content) as Partial<NgBaseline>;
+    if (!parsed || !Array.isArray(parsed.entries)) return null;
+    return {
+      version: typeof parsed.version === "number" ? parsed.version : 1,
+      rule_id: "NG-BASELINE",
+      generated_at: parsed.generated_at ?? "",
+      entries: parsed.entries.map(normalizeNgBaselineEntry),
+    };
   } catch {
     return null;
   }
@@ -7208,6 +7267,73 @@ function writeNgBaseline(root: string, baseline: NgBaseline): void {
   const dir = path.dirname(baselineAbs);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(baselineAbs, JSON.stringify(baseline, null, 2) + "\n", "utf-8");
+}
+
+// Load the additions manifest from disk. Validates that every addition carries
+// non-empty provenance and reason; throws on a malformed manifest so the CLI
+// surfaces the error rather than silently absorbing unmanaged NGs.
+function loadNgBaselineAdditions(manifestPath: string): NgBaselineAddition[] {
+  const content = readText(manifestPath);
+  if (!content) {
+    throw new Error(
+      `NG baseline additions manifest not found or unreadable: ${manifestPath}`,
+    );
+  }
+  let parsed: Partial<NgBaselineAdditionsManifest>;
+  try {
+    parsed = JSON.parse(content) as Partial<NgBaselineAdditionsManifest>;
+  } catch (e) {
+    throw new Error(
+      `NG baseline additions manifest is not valid JSON: ${manifestPath} (${
+        e instanceof Error ? e.message : String(e)
+      })`,
+    );
+  }
+  if (!parsed || !Array.isArray(parsed.additions)) {
+    throw new Error(
+      `NG baseline additions manifest must have an "additions" array: ${manifestPath}`,
+    );
+  }
+  const additions: NgBaselineAddition[] = [];
+  for (let i = 0; i < parsed.additions.length; i++) {
+    const raw = parsed.additions[i];
+    if (!raw || typeof raw !== "object") {
+      throw new Error(
+        `NG baseline additions[${i}] is not an object in ${manifestPath}`,
+      );
+    }
+    const category = typeof raw.category === "string" ? raw.category : "";
+    const check = typeof raw.check === "string" ? raw.check : "";
+    if (!category || !check) {
+      throw new Error(
+        `NG baseline additions[${i}] missing required category/check in ${manifestPath}`,
+      );
+    }
+    const provenance =
+      typeof raw.provenance === "string" && raw.provenance.length > 0
+        ? raw.provenance
+        : "";
+    const reason =
+      typeof raw.reason === "string" && raw.reason.length > 0 ? raw.reason : "";
+    if (!provenance || !reason) {
+      throw new Error(
+        `NG baseline additions[${i}] (${category}/${check}) missing required provenance or reason in ${manifestPath}`,
+      );
+    }
+    additions.push({
+      category,
+      check,
+      file: raw.file === null || raw.file === undefined ? null : String(raw.file),
+      evidence:
+        raw.evidence === null || raw.evidence === undefined
+          ? null
+          : String(raw.evidence),
+      count: typeof raw.count === "number" && raw.count > 0 ? raw.count : 1,
+      provenance,
+      reason,
+    });
+  }
+  return additions;
 }
 
 function summarizeNgResults(
@@ -7236,63 +7362,136 @@ function summarizeNgResults(
 }
 
 // Demote baseline-known ng/warning to info so the exit code reflects only the
-// delta (new findings) from the baseline. Returns counts for reporting.
+// delta (new findings) exceeding the baseline. Returns counts split into three
+// SPEC categories: baseline-known (legacy entries, no provenance), approved
+// additions (entries with a non-legacy provenance label), and new unmanaged NG
+// (excess over baseline).
 function applyNgBaseline(
   results: CheckResult[],
   baseline: NgBaseline,
-): { demotedToInfo: number; newNg: number } {
-  const baselineIndex = new Map<string, number>();
+): NgBaselineReport {
+  const baselineIndex = new Map<string, { count: number; provenance: string }>();
   for (const entry of baseline.entries) {
     const key = ngBaselineKey(entry.category, entry.check, entry.file, entry.evidence);
-    baselineIndex.set(key, entry.count);
+    baselineIndex.set(key, { count: entry.count, provenance: entry.provenance });
   }
 
   const currentSummary = summarizeNgResults(results);
   const newBuckets = new Set<string>();
   for (const [key, entry] of currentSummary) {
-    const baselineCount = baselineIndex.get(key) ?? 0;
+    const baselineEntry = baselineIndex.get(key);
+    const baselineCount = baselineEntry?.count ?? 0;
     if (entry.count > baselineCount) newBuckets.add(key);
   }
 
   const emittedPerBucket = new Map<string, number>();
-  let demotedToInfo = 0;
+  let baselineKnown = 0;
+  let approvedAdditions = 0;
   let newNg = 0;
 
   for (const r of results) {
     if (r.level !== "ng" && r.level !== "warning") continue;
     const key = ngBaselineKey(r.category, r.check, r.file ?? null, r.evidence ?? null);
-    const baselineCount = baselineIndex.get(key) ?? 0;
+    const baselineEntry = baselineIndex.get(key);
+    const baselineCount = baselineEntry?.count ?? 0;
+    const provenance = baselineEntry?.provenance ?? "legacy";
     const emitted = emittedPerBucket.get(key) ?? 0;
     emittedPerBucket.set(key, emitted + 1);
     if (emitted < baselineCount && !newBuckets.has(key)) {
       r.level = "info";
       r.finding_level = "observation";
-      r.message = `[baseline-known] ${r.message} (NG baseline, not yet cleaned)`;
-      demotedToInfo++;
+      const tag =
+        provenance === "legacy"
+          ? "[baseline-known]"
+          : `[baseline-known provenance=${provenance}]`;
+      r.message = `${tag} ${r.message} (NG baseline, not yet cleaned)`;
+      if (provenance === "legacy") {
+        baselineKnown++;
+      } else {
+        approvedAdditions++;
+      }
     } else {
       newNg++;
     }
   }
-  return { demotedToInfo, newNg };
+  return { baselineKnown, approvedAdditions, newNg };
 }
 
-function updateNgBaseline(root: string, results: CheckResult[]): void {
-  const summary = summarizeNgResults(results);
-  const baseline: NgBaseline = {
+// Selectively merge approved additions into the baseline. Per SPEC the update
+// does NOT regenerate the whole baseline from current NGs: it merges approved
+// deltas (each carrying provenance + reason) into existing buckets, leaving
+// unmanaged NGs out of the baseline so they remain restoration targets.
+function updateNgBaseline(
+  root: string,
+  results: CheckResult[],
+  additions: NgBaselineAddition[],
+): { addedEntries: number; updatedEntries: number } {
+  const baseline = loadNgBaseline(root) ?? {
     version: 1,
+    rule_id: "NG-BASELINE" as const,
+    generated_at: new Date().toISOString().slice(0, 10),
+    entries: [],
+  };
+
+  const index = new Map<string, NgBaselineEntry>();
+  for (const entry of baseline.entries) {
+    index.set(
+      ngBaselineKey(entry.category, entry.check, entry.file, entry.evidence),
+      entry,
+    );
+  }
+
+  // Current NG counts per bucket — used to cap the merged baseline count so a
+  // provenance label cannot raise the bucket above the observable NG count
+  // (prevents NG隠蔽 via over-counting).
+  const currentCounts = summarizeNgResults(results);
+
+  let addedEntries = 0;
+  let updatedEntries = 0;
+  for (const add of additions) {
+    const key = ngBaselineKey(add.category, add.check, add.file, add.evidence);
+    const current = currentCounts.get(key);
+    const existing = index.get(key);
+    const baseCount = existing ? existing.count : 0;
+    const mergedCount = baseCount + add.count;
+    // Cap at current observable count when current data is available: the
+    // baseline cannot exceed what the checks actually emit.
+    const finalCount = current ? Math.min(mergedCount, current.count) : mergedCount;
+    if (finalCount <= baseCount) {
+      // Nothing to add (current NG count already covered by baseline).
+      continue;
+    }
+    const entry: NgBaselineEntry = {
+      category: add.category,
+      check: add.check,
+      file: add.file,
+      evidence: add.evidence,
+      count: finalCount,
+      provenance: add.provenance,
+      reason: add.reason,
+    };
+    index.set(key, entry);
+    if (existing) updatedEntries++;
+    else addedEntries++;
+  }
+
+  const updated: NgBaseline = {
+    version: baseline.version,
     rule_id: "NG-BASELINE",
     generated_at: new Date().toISOString().slice(0, 10),
-    entries: [...summary.values()].sort((a, b) => {
+    entries: [...index.values()].sort((a, b) => {
       if (a.category !== b.category) return a.category < b.category ? -1 : 1;
       if (a.check !== b.check) return a.check < b.check ? -1 : 1;
-      if ((a.file ?? "") !== (b.file ?? "")) return (a.file ?? "") < (b.file ?? "") ? -1 : 1;
+      if ((a.file ?? "") !== (b.file ?? ""))
+        return (a.file ?? "") < (b.file ?? "") ? -1 : 1;
       return 0;
     }),
   };
-  writeNgBaseline(root, baseline);
+  writeNgBaseline(root, updated);
   console.error(
-    `[integrity] NG baseline regenerated: ${baseline.entries.length} entries (${results.filter((r) => r.level === "ng").length} total NG).`,
+    `[integrity] NG baseline updated: ${addedEntries} added, ${updatedEntries} updated (additions manifest: ${additions.length}).`,
   );
+  return { addedEntries, updatedEntries };
 }
 
 // ===== IR-057: obsolete-spec-path-after-domain-split (REQ-0158-002) =====
@@ -8401,15 +8600,36 @@ async function main(): Promise<void> {
   const processed = processResults(results);
 
   // REQ-0161-005: baseline-aware strict pass. When --update-ng-baseline is
-  // requested, snapshot the current NG set and exit. Otherwise, demote
+  // requested, merge the approved additions manifest into the baseline (the
+  // manifest is required; unmanaged NGs are never absorbed). Otherwise demote
   // baseline-known NGs to info so the exit code reflects only the delta.
   if (args.includes("--update-ng-baseline")) {
-    updateNgBaseline(root, processed);
+    const additionsFlagIdx = args.indexOf("--ng-baseline-additions");
+    const manifestPath =
+      additionsFlagIdx >= 0 ? args[additionsFlagIdx + 1] : undefined;
+    if (!manifestPath) {
+      console.error(
+        "[integrity] --update-ng-baseline requires --ng-baseline-additions <manifest.json> (REQ-0161-005: unmanaged NGs must not be absorbed).",
+      );
+      process.exit(EXIT_ERROR);
+    }
+    let additions: NgBaselineAddition[];
+    try {
+      additions = loadNgBaselineAdditions(manifestPath);
+    } catch (e) {
+      console.error(
+        `[integrity] ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+      process.exit(EXIT_ERROR);
+    }
+    updateNgBaseline(root, processed, additions);
     process.exit(EXIT_OK);
   }
 
   const ngBaseline = loadNgBaseline(root);
-  let ngBaselineInfo: { demotedToInfo: number; newNg: number } | null = null;
+  let ngBaselineInfo: NgBaselineReport | null = null;
   if (ngBaseline) {
     ngBaselineInfo = applyNgBaseline(processed, ngBaseline);
   }
@@ -8434,7 +8654,7 @@ async function main(): Promise<void> {
   console.error(`Report written to: ${reportPath}`);
   if (ngBaselineInfo) {
     console.error(
-      `[integrity] NG baseline applied: ${ngBaselineInfo.demotedToInfo} baseline-known (demoted to info), ${ngBaselineInfo.newNg} new NG (delta).`,
+      `[integrity] NG baseline applied: ${ngBaselineInfo.baselineKnown} baseline-known (demoted to info), ${ngBaselineInfo.approvedAdditions} approved additions (provenance-tracked, demoted to info), ${ngBaselineInfo.newNg} new unmanaged NG (delta, exit code driver).`,
     );
   }
 


### PR DESCRIPTION
## 概要

Issue #1780（OU-003、RU-0012 由来）。`check_integrity.ts` の NG baseline 集計・由来ラベル・分類を REQ-0161-005 および `docs/specs/integrity/integrity-contracts.md`「NG baseline 運用手順」へ整合させる。SPEC（commit a91e211d）は既に配置済みのため、本 PR は実装・baseline データ・回帰テストの是正のみを行う。

## 変更内容

### `check_integrity.ts`

- **`NgBaselineEntry` 型拡張**: `provenance`（由来ラベル）と `reason`（承認理由）を追加。SPEC baseline 形式の `count` / `provenance` / `reason` に整合。
- **`loadNgBaseline` 後方互換**: 旧 baseline ファイルの欠落フィールドを `provenance: "legacy"` で補完し、ワンショット移行を不要にした。
- **`applyNgBaseline` 3分類化**: 戻り値を `{ baselineKnown, approvedAdditions, newNg }` へ拡張。降格 NG の message prefix で由来（`[baseline-known]` or `[baseline-known provenance=...]`）を区別する。
- **`updateNgBaseline` 選択的マージ**: `--update-ng-baseline` は承認済み差分マニフェスト（`--ng-baseline-additions <file>`）から選択的にマージし、現行 NG 全体を無条件再生成しない。未管理 NG は baseline へ取り込まず、NG隠蔽防止のため現在 count を超える count を許容しない cap を付与。
- **報告形式**: stderr の NG baseline summary を3分類（baseline-known / approved additions / new unmanaged NG）で件数表示。

### `ng-baseline.json`

既存 335 エントリに `provenance: "legacy"` と `reason` を一括移行した。

### `check_integrity.test.ts`

TS-003 / TS-004 / TS-005 の回帰テストを追加。自完結型 fixture（`check_integrity.ts` / `cli_utils.ts` / `generate_indexes.ts` をコピー）で既存の `copyScripts` 依存問題を回避する。

## 完了条件

- [x] docs/specs/integrity/integrity-contracts.md「NG baseline 運用手順」節と check_integrity.ts の実装が整合していること
- [x] 実行結果が baseline 既知 NG 件数と新規 NG 件数を別々に示し、新規 NG だけが非ゼロ終了の原因になること
- [x] `--update-ng-baseline` が承認済み由来ラベル付き差分だけを baseline へ追加し、未管理 NG を取り込まないこと
- [x] baseline 既知 NG、承認済み追加分、新規かつ未管理 NG が報告で区別されること
- [x] TS-003、TS-004、TS-005 が合格であること

## テスト戦略検証結果

- **TS-003**: fixture（REQ-9001=legacy baseline / REQ-9002=approved baseline / REQ-9003=unmanaged）で実行し、REQ-9001/9002 が `info`（`[baseline-known]` prefix）へ降格、REQ-9003 が `ng` を維持して非ゼロ終了を駆動することを確認。合格。
- **TS-004**: `--update-ng-baseline --ng-baseline-additions` で REQ-9003 を承認追加し、baseline に REQ-9003 エントリ（provenance/reason 付き）が追加されること、他カテゴリの未管理 NG が baseline へ取り込まれないことを確認。マニフェスト未指定／provenance-reason 欠落のとき exit 2 で拒否されることも確認。合格。
- **TS-005**: stderr 報告が3分類（baseline-known / approved additions / new unmanaged NG）の件数を含み、JSON results で `[baseline-known]` と `[baseline-known provenance=...]` の message prefix が区別されることを確認。合格。

実行コマンド: `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts --test-name-pattern "NG baseline aggregation"` → 5 pass / 0 fail。

## Findings / Capture候補

- **`check_extensions.ts` の NG baseline は対象外**: SPEC「NG baseline 運用手順」は `check_integrity.ts` と `check_extensions.ts` の両方に言及するが、`check_extensions.ts` は独立した `ExtensionsNgBaseline*` 型と `updateExtensionsNgBaseline` 実装（同一の「無条件再生成」パターン）を持つ。本 Issue の対象範囲は `check_integrity.ts` のみであり、`check_extensions.ts` の同様是正は別 Issue で扱う必要がある。
- **既存テストスイートの事前失敗**: `check_integrity.test.ts` の既存67テストは `copyScripts` が `generate_indexes.ts` をコピーしないため実行時に JSON EOF エラーで失敗する（本 PR 以前からの事前問題）。本 PR では新規テストのみ自完結 fixture で対応し、既存インフラの修正は対象外とした。

Closes: #1780