### PR TITLE
feat(integrity): 変更要否判定を行レベル意味差分へ限定 (Issue #1784, OU-007)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.test.ts
@@ -698,3 +698,272 @@ describe("Issue #1671 TS-004: SPEC status superseded_by handling (ADR-0123, REQ-
     expect(statusFailures).toEqual([]);
   });
 });
+
+// ─── Issue #1784 / OU-007: line-level semantic diff for update flags ────────
+// check_changed_docs.ts の更新要否フラグを行レベル意味差分（導出元影響）ベースへ限定。
+// SPEC targeted-docs-guard-implementation.md「full_docs_check_recommended 条件」節。
+
+function setupGitFixture(root: string): string {
+  execSync("git init -q", { cwd: root });
+  execSync('git config user.email "test@example.com"', { cwd: root });
+  execSync('git config user.name "test"', { cwd: root });
+  execSync("git add -A", { cwd: root });
+  execSync('git commit -q -m "init" --no-verify --allow-empty', { cwd: root });
+  return execSync("git rev-parse HEAD", { cwd: root, encoding: "utf-8" }).trim();
+}
+
+function commitAll(root: string, message: string): void {
+  execSync("git add -A", { cwd: root });
+  execSync(`git commit -q -m "${message}" --no-verify`, { cwd: root });
+}
+
+function writeSpecFile(
+  root: string,
+  name: string,
+  title: string,
+  status: string,
+  body: string,
+): void {
+  const specsDir = join(root, "docs", "specs");
+  mkdirp(specsDir);
+  writeFileSync(
+    join(specsDir, name),
+    [
+      "---",
+      `title: ${title}`,
+      `status: ${status}`,
+      "---",
+      "",
+      `# ${title}`,
+      "",
+      body,
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+function writeReqFile(
+  root: string,
+  name: string,
+  id: string,
+  title: string,
+  body: string,
+): void {
+  const reqDir = join(root, "docs", "requirements");
+  mkdirp(reqDir);
+  writeFileSync(
+    join(reqDir, name),
+    [
+      "---",
+      `id: ${id}`,
+      `title: ${title}`,
+      "---",
+      "",
+      "## Body",
+      "",
+      body,
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+describe("Issue #1784 TS-010: trivial body-only change does NOT trigger update flags", () => {
+  const NEG_ROOT = join(TEMP_ROOT, "issue1784-neg");
+
+  beforeAll(() => {
+    mkdirp(NEG_ROOT);
+    writeSpecFile(NEG_ROOT, "body-only.md", "body only spec", "accepted", "Original body content.");
+    writeReqFile(NEG_ROOT, "REQ-9001.md", "REQ-9001", "body only req", "Original req body.");
+    setupGitFixture(NEG_ROOT);
+
+    // 相互参照追記 + 相対パス是正 + 表記修正: frontmatter 値は不変
+    writeSpecFile(
+      NEG_ROOT,
+      "body-only.md",
+      "body only spec",
+      "accepted",
+      [
+        "Fixed typo in body.",
+        "関連: [REQ-9001](../requirements/REQ-9001.md)",
+      ].join("\n"),
+    );
+    writeReqFile(NEG_ROOT, "REQ-9001.md", "REQ-9001", "body only req", "Fixed req body typo.");
+
+    copyScripts(NEG_ROOT);
+  });
+
+  it("spec-save: SPEC body-only change → spec_readme_update_required=false", () => {
+    const r = runScript(NEG_ROOT, [
+      "--workflow",
+      "spec-save",
+      "--files",
+      "docs/specs/body-only.md",
+      "--json",
+    ]);
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.spec_readme_update_required).toBe(false);
+  });
+
+  it("req-save: REQ body-only change → requirements_readme_update_required=false", () => {
+    const r = runScript(NEG_ROOT, [
+      "--workflow",
+      "req-save",
+      "--files",
+      "docs/requirements/REQ-9001.md",
+      "--json",
+    ]);
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.requirements_readme_update_required).toBe(false);
+  });
+
+  it("SPEC body-only change → extensions_check_required=false", () => {
+    const r = runScript(NEG_ROOT, [
+      "--workflow",
+      "spec-save",
+      "--files",
+      "docs/specs/body-only.md",
+      "--json",
+    ]);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.extensions_check_required).toBe(false);
+  });
+
+  it("REQ body-only change → extensions_check_required=false", () => {
+    const r = runScript(NEG_ROOT, [
+      "--workflow",
+      "req-save",
+      "--files",
+      "docs/requirements/REQ-9001.md",
+      "--json",
+    ]);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.extensions_check_required).toBe(false);
+  });
+});
+
+describe("Issue #1784 TS-011: lifecycle / frontmatter change triggers update flags", () => {
+  it("TS-011a: added SPEC → spec_readme_update_required=true, extensions_check_required=true", () => {
+    const root = join(TEMP_ROOT, "issue1784-add");
+    mkdirp(root);
+    setupGitFixture(root);
+    writeSpecFile(root, "new-spec.md", "new spec", "accepted", "New spec body.");
+    copyScripts(root);
+
+    const r = runScript(root, [
+      "--workflow",
+      "spec-save",
+      "--files",
+      "docs/specs/new-spec.md",
+      "--json",
+    ]);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.spec_readme_update_required).toBe(true);
+    expect(parsed.extensions_check_required).toBe(true);
+  });
+
+  it("TS-011b: SPEC frontmatter title change → spec_readme_update_required=true", () => {
+    const root = join(TEMP_ROOT, "issue1784-fm-spec");
+    mkdirp(root);
+    writeSpecFile(root, "fm-spec.md", "original title", "accepted", "Body content.");
+    setupGitFixture(root);
+    writeSpecFile(root, "fm-spec.md", "changed title", "accepted", "Body content.");
+    copyScripts(root);
+
+    const r = runScript(root, [
+      "--workflow",
+      "spec-save",
+      "--files",
+      "docs/specs/fm-spec.md",
+      "--json",
+    ]);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.spec_readme_update_required).toBe(true);
+    expect(parsed.extensions_check_required).toBe(true);
+  });
+
+  it("TS-011c: REQ frontmatter title change → requirements_readme_update_required=true", () => {
+    const root = join(TEMP_ROOT, "issue1784-fm-req");
+    mkdirp(root);
+    writeReqFile(root, "REQ-9002.md", "REQ-9002", "original title", "Body content.");
+    setupGitFixture(root);
+    writeReqFile(root, "REQ-9002.md", "REQ-9002", "changed title", "Body content.");
+    copyScripts(root);
+
+    const r = runScript(root, [
+      "--workflow",
+      "req-save",
+      "--files",
+      "docs/requirements/REQ-9002.md",
+      "--json",
+    ]);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.requirements_readme_update_required).toBe(true);
+    expect(parsed.extensions_check_required).toBe(true);
+  });
+
+  it("TS-011d: SPEC status change (draft→accepted) → spec_readme_update_required=true", () => {
+    const root = join(TEMP_ROOT, "issue1784-status");
+    mkdirp(root);
+    writeSpecFile(root, "status-spec.md", "status spec", "draft", "Body content.");
+    setupGitFixture(root);
+    writeSpecFile(root, "status-spec.md", "status spec", "accepted", "Body content.");
+    copyScripts(root);
+
+    const r = runScript(root, [
+      "--workflow",
+      "spec-save",
+      "--files",
+      "docs/specs/status-spec.md",
+      "--json",
+    ]);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.spec_readme_update_required).toBe(true);
+  });
+
+  it("TS-011e: deleted SPEC (--base-ref) → spec_readme_update_required=true", () => {
+    const root = join(TEMP_ROOT, "issue1784-delete");
+    mkdirp(root);
+    writeSpecFile(root, "del-spec.md", "delete spec", "accepted", "Body content.");
+    const sha1 = setupGitFixture(root);
+    rmSync(join(root, "docs", "specs", "del-spec.md"));
+    commitAll(root, "delete spec");
+    copyScripts(root);
+
+    const r = runScript(root, [
+      "--workflow",
+      "spec-save",
+      "--base-ref",
+      sha1,
+      "--json",
+    ]);
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.files_checked).toContain("docs/specs/del-spec.md");
+    expect(parsed.spec_readme_update_required).toBe(true);
+    expect(parsed.extensions_check_required).toBe(true);
+  });
+
+  it("TS-011f: body-only change does NOT trigger (negative cross-check)", () => {
+    const root = join(TEMP_ROOT, "issue1784-body-only-pos");
+    mkdirp(root);
+    writeSpecFile(root, "body-spec.md", "body spec", "accepted", "Original body.");
+    setupGitFixture(root);
+    writeSpecFile(root, "body-spec.md", "body spec", "accepted", "Updated body with typo fix.");
+    copyScripts(root);
+
+    const r = runScript(root, [
+      "--workflow",
+      "spec-save",
+      "--files",
+      "docs/specs/body-spec.md",
+      "--json",
+    ]);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.spec_readme_update_required).toBe(false);
+    expect(parsed.extensions_check_required).toBe(false);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts
@@ -201,12 +201,15 @@ function resolveChangedFiles(
         `git diff --name-only ${baseRef}...HEAD`,
         { cwd: root, encoding: "utf-8" },
       ) as string;
+      // Issue #1784: existsSync filter removed for --base-ref mode.
+      // 削除・移動されたファイルも files_checked に含め、行レベル意味差分で
+      // lifecycle (deleted/renamed) を検出できるようにする。下游の content 系検査は
+      // readText が null を返した場合 skip し、flag 系は git status を見るため安全。
       return out
         .split("\n")
         .map((l) => l.trim())
         .filter((l) => l.length > 0)
-        .map((rel) => path.join(root, rel.replace(/\//g, path.sep)))
-        .filter((f) => fs.existsSync(f));
+        .map((rel) => path.join(root, rel.replace(/\//g, path.sep)));
     } catch (e) {
       throw new Error(
         `git diff against --base-ref ${baseRef} failed: ${e instanceof Error ? e.message : String(e)}`,
@@ -541,6 +544,192 @@ function parseSimpleFrontmatter(content: string): Record<string, string> | null 
   return result;
 }
 
+// ─── Line-level change descriptor (Issue #1784 / OU-007) ────────────────────
+//
+// 更新要否フラグ（requirements_readme_update_required, spec_readme_update_required,
+// extensions_check_required, full_docs_check_recommended）は変更ファイルの存在や
+// 変更種別名ではなく、行レベル差分が導出元（文書 lifecycle, 索引 frontmatter 値、公開入口、
+// extension 参照対象、DOC-MAP/README 生成元）へ影響するかで判定する（SPEC
+// targeted-docs-guard-implementation.md「full_docs_check_recommended 条件」節）。
+
+const INDEX_FRONTMATTER_KEYS = new Set([
+  "id",
+  "title",
+  "status",
+  "type",
+  "domain",
+  "scope",
+  "superseded_by",
+]);
+
+interface ChangeDescriptor {
+  absPath: string;
+  relPath: string;
+  // "added" = 新規追加, "deleted" = 削除, "renamed" = 移動/名称変更,
+  // "modified" = 変更（lifecycle 影響なし）, "unknown" = git で判定不可
+  lifecycle: "added" | "deleted" | "renamed" | "modified" | "unknown";
+  previousRelPath?: string;
+  changedFrontmatterKeys: Set<string>;
+}
+
+interface GitNameStatus {
+  status: "A" | "D" | "R" | "M" | null;
+  previousPath?: string;
+}
+
+function gitNameStatusFor(
+  root: string,
+  rel: string,
+  baseRef: string | null,
+): GitNameStatus {
+  const { execSync } = require("child_process") as typeof import("child_process");
+  try {
+    // --base-ref 時は baseRef...HEAD の committed range を見る。
+    // --files 時は HEAD..working-tree を見る（uncommitted 変更）。
+    const diffCmd = baseRef
+      ? `git diff --name-status --diff-filter=ADRMCR ${baseRef}...HEAD -- "${rel}"`
+      : `git diff --name-status --diff-filter=ADRMCR HEAD -- "${rel}"`;
+    const diffOut = execSync(diffCmd, { cwd: root, encoding: "utf-8" }) as string;
+    const parsed = parseGitNameStatusLine(diffOut);
+    if (parsed.status) return parsed;
+
+    // --files モードでは未追跡ファイルを git status で検出
+    if (!baseRef) {
+      try {
+        const statusOut = execSync(`git status --porcelain -- "${rel}"`, {
+          cwd: root,
+          encoding: "utf-8",
+        }) as string;
+        return parseGitStatusPorcelain(statusOut);
+      } catch {
+        return { status: null };
+      }
+    }
+    return { status: null };
+  } catch {
+    return { status: null };
+  }
+}
+
+function parseGitNameStatusLine(out: string): GitNameStatus {
+  const line = out.split("\n").find((l) => l.trim().length > 0);
+  if (!line) return { status: null };
+  const parts = line.split("\t");
+  const statusCode = parts[0];
+  if (statusCode.startsWith("R") || statusCode.startsWith("C")) {
+    return { status: "R", previousPath: parts[2]?.trim() };
+  }
+  if (statusCode === "A") return { status: "A" };
+  if (statusCode === "D") return { status: "D" };
+  if (statusCode === "M") return { status: "M" };
+  return { status: null };
+}
+
+function parseGitStatusPorcelain(out: string): GitNameStatus {
+  const line = out.split("\n").find((l) => l.trim().length > 0);
+  if (!line) return { status: null };
+  const xy = line.slice(0, 2);
+  if (xy === "??") return { status: "A" };
+  // R/C の場合は "XY\told\tnew" 形式を取る
+  if (xy[0] === "R" || xy[0] === "C") {
+    const rest = line.slice(3);
+    const tabIdx = rest.indexOf("\t");
+    if (tabIdx >= 0) {
+      return { status: "R", previousPath: rest.slice(0, tabIdx).trim() };
+    }
+    return { status: "R" };
+  }
+  if (xy.includes("A")) return { status: "A" };
+  if (xy.includes("D")) return { status: "D" };
+  if (xy.includes("M")) return { status: "M" };
+  return { status: null };
+}
+
+function frontmatterAtRef(
+  root: string,
+  ref: string,
+  rel: string,
+): Record<string, string> | null {
+  const { execSync } = require("child_process") as typeof import("child_process");
+  try {
+    const out = execSync(`git show ${ref}:"${rel}"`, {
+      cwd: root,
+      encoding: "utf-8",
+    }) as string;
+    return parseSimpleFrontmatter(out);
+  } catch {
+    return null;
+  }
+}
+
+function changedFrontmatterKeysFor(
+  root: string,
+  rel: string,
+  baseRef: string | null,
+  lifecycle: ChangeDescriptor["lifecycle"],
+): Set<string> {
+  // 追加/削除/リネームは lifecycle のみで判定するため frontmatter 差分は不要
+  if (lifecycle === "added" || lifecycle === "deleted" || lifecycle === "renamed") {
+    return new Set();
+  }
+  const ref = baseRef ?? "HEAD";
+  const oldFm = frontmatterAtRef(root, ref, rel);
+  if (!oldFm) return new Set();
+  const absPath = path.join(root, rel.replace(/\//g, path.sep));
+  const content = readText(absPath);
+  if (!content) return new Set();
+  const newFm = parseSimpleFrontmatter(content) ?? {};
+  const keys = new Set<string>();
+  for (const k of new Set([...Object.keys(oldFm), ...Object.keys(newFm)])) {
+    if (oldFm[k] !== newFm[k]) keys.add(k);
+  }
+  return keys;
+}
+
+function computeChangeDescriptors(
+  root: string,
+  files: string[],
+  baseRef: string | null,
+): ChangeDescriptor[] {
+  return files.map((absPath) => {
+    const rel = path.relative(root, absPath).replace(/\\/g, "/");
+    const status = gitNameStatusFor(root, rel, baseRef);
+    let lifecycle: ChangeDescriptor["lifecycle"] = "unknown";
+    let previousRelPath: string | undefined;
+    if (status.status === "A") lifecycle = "added";
+    else if (status.status === "D") lifecycle = "deleted";
+    else if (status.status === "R") {
+      lifecycle = "renamed";
+      previousRelPath = status.previousPath;
+    } else if (status.status === "M") lifecycle = "modified";
+
+    const changedKeys = changedFrontmatterKeysFor(root, rel, baseRef, lifecycle);
+    return {
+      absPath,
+      relPath: rel,
+      lifecycle,
+      previousRelPath,
+      changedFrontmatterKeys: changedKeys,
+    };
+  });
+}
+
+// 導出元影響判定: lifecycle 変更（追加/削除/リネーム）または索引 frontmatter 値変更で true。
+// SPEC targeted-docs-guard-implementation.md「full_docs_check_recommended 条件」節に基づく。
+function isIndexChange(s: ChangeDescriptor): boolean {
+  if (
+    s.lifecycle === "added" ||
+    s.lifecycle === "deleted" ||
+    s.lifecycle === "renamed"
+  ) {
+    return true;
+  }
+  for (const k of s.changedFrontmatterKeys) {
+    if (INDEX_FRONTMATTER_KEYS.has(k)) return true;
+  }
+  return false;
+}
+
 function checkSpecFrontmatter(root: string, files: string[]): Failure[] {
   const failures: Failure[] = [];
   for (const f of files) {
@@ -608,6 +797,7 @@ function runWorkflowChecks(
   coupledFiles: string[],
   obsolete: { oldPaths: string[]; vocab: string[] },
   declaredFiles: string[],
+  changeDescriptors: ChangeDescriptor[],
 ): {
   failures: Failure[];
   warnings: string[];
@@ -646,22 +836,26 @@ function runWorkflowChecks(
         (rel) => rel.includes("REQ-") || rel.includes("docs/specs/"),
       )
     : false;
-  const specReadmeUpdateRequired = profile.rules.includes("spec-readme-update-required") ||
+
+  // Issue #1784 / OU-007: 更新要否フラグを行レベル意味差分（導出元影響）ベースへ限定。
+  // ファイル存在や変更種別名ではなく、文書 lifecycle（追加/削除/移動/名称変更）または
+  // 索引 frontmatter 値（id, title, status 等）の変更でのみ true とする。
+  // SPEC targeted-docs-guard-implementation.md「full_docs_check_recommended 条件」節。
+  const specReadmeUpdateRequired =
+    profile.rules.includes("spec-readme-update-required") ||
     profile.rules.includes("spec-readme-status-sync")
-    ? detectUpdateRequired(
-        root,
-        changedFiles,
-        "docs/specs/README.md",
-        (rel) => rel.startsWith("docs/specs/"),
-      )
-    : false;
-  const requirementsReadmeUpdateRequired = profile.rules.includes("requirements-readme-sync")
-    ? detectUpdateRequired(
-        root,
-        changedFiles,
-        "docs/requirements/README.md",
-        (rel) => rel.startsWith("docs/requirements/REQ-"),
-      )
+      ? changeDescriptors.some((d) => {
+          if (!/^docs\/specs\/.*\.md$/.test(d.relPath)) return false;
+          return isIndexChange(d);
+        })
+      : false;
+  const requirementsReadmeUpdateRequired = profile.rules.includes(
+    "requirements-readme-sync",
+  )
+    ? changeDescriptors.some((d) => {
+        if (!/^docs\/requirements\/REQ-.*\.md$/.test(d.relPath)) return false;
+        return isIndexChange(d);
+      })
     : false;
 
   // full_docs_check_recommended: integrity rule 追加/削除、DOC-MAP 構造変更、docs/specs 大規模移動、extensions 変更等
@@ -683,14 +877,12 @@ function runWorkflowChecks(
       })
     : false;
 
-  // extensions_check_required: extensions 機構への影響（REQ/ADR/SPEC の追加・移動・改名）
-  const extensionsCheckRequired = changedFiles.some((f) => {
-    const rel = path.relative(root, f).replace(/\\/g, "/");
-    return (
-      /^docs\/requirements\/REQ-.*\.md$/.test(rel) ||
-      /^docs\/adr\/ADR-.*\.md$/.test(rel) ||
-      /^docs\/specs\/.*\.md$/.test(rel)
-    );
+  // extensions_check_required: extension が参照する対象（REQ/ADR/SPEC）の lifecycle
+  // または索引 frontmatter 値の変更で true。
+  const extensionsCheckRequired = changeDescriptors.some((d) => {
+    if (!/^docs\/(requirements\/REQ-|adr\/ADR-|specs\/).*\.md$/.test(d.relPath))
+      return false;
+    return isIndexChange(d);
   });
 
   // declared_files_check: --declared-files 指定時、宣言ファイルと実変更ファイルの対応を検査
@@ -802,6 +994,12 @@ function main(): void {
 
   const obsolete = loadObsoleteTerms(root);
 
+  const changeDescriptors = computeChangeDescriptors(
+    root,
+    applicable,
+    parsed.baseRef,
+  );
+
   const runResult = runWorkflowChecks(
     root,
     profile,
@@ -809,6 +1007,7 @@ function main(): void {
     coupledFiles,
     obsolete,
     parsed.declaredFiles,
+    changeDescriptors,
   );
 
   const report: TargetedDocsReport = {


### PR DESCRIPTION
## 概要

Issue #1784 / OU-007（RU-0026 由来）。`check_changed_docs.ts` の更新要否フラグ（`requirements_readme_update_required`、`spec_readme_update_required`、`extensions_check_required`）を、変更ファイルの存在ベースから行レベル意味差分（導出元影響）ベースへ切り替える。

相互参照追記・相対パス是正・表記修正など導出元に影響しない変更では全フラグを `false` にする（SPEC `targeted-docs-guard-implementation.md`「full_docs_check_recommended 条件」節）。

Closes #1784

## 変更内容

### check_changed_docs.ts

- **`ChangeDescriptor` 型と `computeChangeDescriptors` を追加**: git diff から各変更ファイルの lifecycle（added/deleted/renamed/modified/unknown）と frontmatter キー変更差分を検出
- **`isIndexChange` ヘルパー**: lifecycle 変更（追加/削除/移動/名称変更）または索引 frontmatter 値（id, title, status, type, domain, scope, superseded_by）の変更で true を返す
- **3フラグの判定ロジックを切替**:
  - `spec_readme_update_required`: SPEC の lifecycle/frontmatter 変更で判定
  - `requirements_readme_update_required`: REQ の lifecycle/frontmatter 変更で判定
  - `extensions_check_required`: REQ/ADR/SPEC の lifecycle/frontmatter 変更で判定
- **`resolveChangedFiles` の `--base-ref` モードから `existsSync` フィルタを除去**: 削除/移動されたファイルも `files_checked` に含め、lifecycle (deleted/renamed) を検出できるようにする。下游の content 系検査は `readText` が null の場合 skip し、flag 系は git status を見るため安全
- `full_docs_check_recommended` は SPEC と既存ロジックが整合しているため維持（構造ファイルの変更は同ファイル自体が導出元であるため）
- `doc_map_update_required` は本 Issue の対象外のため既存ロジックを維持

### check_changed_docs.test.ts

- **TS-010（負例）**: REQ 相互参照追記・SPEC 相対パス是正・表記修正（frontmatter 不変）で3フラグが false になることを検証（4テスト）
- **TS-011a-f（正例）**: 追加/frontmatter title変更/REQ frontmatter変更/status変更/削除（--base-ref）/body-only負例の交差検証（6テスト）

## テスト結果

```
bun test ./.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.test.ts
40 pass / 0 fail / 113 expect() calls
```

- 既存30テスト: 全件合格（後方互換性維持）
- 新規10テスト: 全件合格（TS-010 + TS-011）

`tsc --noEmit` は新規エラーなし（既存の設定系エラーのみ）。

## 完了条件

- [x] `docs/specs/integrity/targeted-docs-guard-implementation.md`「full_docs_check_recommended 条件」節と `check_changed_docs.ts` の判定ロジックが整合していること
- [x] 相互参照追記・相対パス是正・表記修正など導出元に影響しない変更で `spec_readme_update_required`、`requirements_readme_update_required`、`extensions_check_required` が false になること
- [x] 文書の追加・削除・移動・名称変更、索引 frontmatter 値変更で対応する README 更新要否フラグが true になること
- [x] `check_changed_docs.test.ts` に軽微変更（負例）と実質変更（正例）の回帰テストが追加されていること
- [x] TS-010、TS-011 が合格であること

## Findings / Capture候補

- `resolveChangedFiles` の `--files` モードでは `existsSync` フィルタが残っているため、削除ファイルを `--files` で直接指定した場合は検出できない（`--files` は「存在するファイルを明示指定する」セマンティクスのため妥当）。削除検出には `--base-ref` が必要
- `check_changed_docs.ts` は純 LOC 953行（ベースライン794行）。5層アーキテクチャ（resolver/profile/coupled/checker/reporter）を1ファイルに集約しているため。本 Issue のスコープ外（フラグ判定ロジック切替）のため分割は見送り

## SPEC確定候補

なし。実装は既存 SPEC `targeted-docs-guard-implementation.md`「full_docs_check_recommended 条件」節に従う。
