### PR TITLE
fix(integrity): ReferencePath placeholder 判定を <...> 形式へ是正 (#1779)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -3700,9 +3700,12 @@ function isInsideCodeBlock(lines: string[], lineIndex: number): boolean {
  */
 function isTemplatePlaceholder(refPath: string): boolean {
   if (/\{[^}]*\}/.test(refPath)) return true;
-  // REQ-0144-025 / ADR-0136: <harness> 等の angle-bracket placeholder は
-  // 実ファイルを指さない抽象表記のため検査対象外とする。
-  if (/<[a-zA-Z][a-zA-Z0-9_-]*>/.test(refPath)) return true;
+  // REQ-0144-020: <...> 形式の angle-bracket placeholder は具体パスではなく
+  // 置換対象のパラメータ表現であるため実在確認の対象外とする。
+  // REQ-0144-025 / ADR-0136 由来の <harness> 等の抽象表記を含む。
+  // isTemplatePlaceholder は SCRIPT_TEMPLATE_REF_PATTERNS が捕捉した
+  // パス参照文字列のみを受け取るため、<> は placeholder 以外あり得ない。
+  if (/<[^<>]+>/.test(refPath)) return true;
   return false;
 }
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_reference_paths.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_reference_paths.test.ts
@@ -325,6 +325,41 @@ describe("checkScriptTemplateReferencePaths", () => {
     const harnessNg = refNg.filter((r) => r.evidence?.includes("<harness>"));
     expect(harnessNg.length).toBe(0);
   });
+  it("placeholder skipped and concrete missing reported in same fixture (TS-001, REQ-0144-020)", () => {
+    const root = join(TEMP_ROOT, "placeholder-and-missing");
+    buildMinimalFixture(root);
+    copyScripts(root);
+    const cmdDir = join(root, ".opencode", "commands", "agentdev");
+    writeFileSync(
+      join(cmdDir, "test-cmd.md"),
+      [
+        "---",
+        "description: Test",
+        "agent: oracle",
+        "---",
+        "",
+        "起動手段は references/<harness>.md 参照。",
+        "See references/nonexistent.md for the missing logic.",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const result = runScriptJson(root);
+    expect(result.report).not.toBeNull();
+    const refResults = (result.report!.results || []).filter(
+      (r) =>
+        r.category === "ReferencePath" &&
+        r.check === "reference-path-existence",
+    );
+    const placeholderNg = refResults.filter(
+      (r) => r.level === "ng" && r.evidence?.includes("<harness>"),
+    );
+    expect(placeholderNg.length).toBe(0);
+    const missingNg = refResults.filter(
+      (r) => r.level === "ng" && r.evidence?.includes("nonexistent.md"),
+    );
+    expect(missingNg.length).toBeGreaterThanOrEqual(1);
+  });
   it("reports ng for missing repo-root-relative references", () => {
     const root = join(TEMP_ROOT, "root-rel-missing");
     buildMinimalFixture(root);


### PR DESCRIPTION
Closes #1779

Cherry-pick from #1800 (worktree base issue resolved).