### PR TITLE
feat(case-close): AUTOGEN block 索引再生成差分検出を project extension checks へ導入

### DIFF
--- a/.agentdev/extensions/commands/case-close.yaml
+++ b/.agentdev/extensions/commands/case-close.yaml
@@ -17,6 +17,11 @@ context:
     paths:
       - "docs/specs/commands/case-close.md"
     purpose: "case-close の完了ゲートと QG-4 達成判定の確認"
+  - id: index-auto-generation-spec
+    when: "Step 3-3 AUTOGEN block 索引再生成差分検出（単一 Issue / Epic Wave E5b 前段）参照時"
+    paths:
+      - "docs/specs/integrity/index-auto-generation.md"
+    purpose: "AUTOGEN block 自動生成機構と generate_indexes.ts の契約確認"
   - id: discovery-1
     purpose: "docs/DOC-MAP.md 経由で SPEC 確定対象と整合性ルールを探索してよい"
   - id: discovery-2
@@ -26,7 +31,10 @@ context:
 
 rules: []
 
-checks: []
+checks:
+  - id: autogen-index-regeneration-diff
+    when: "Step 3-3（単一 Issue クローズ）および Step E5b 前段（Epic Wave クローズ）。generate_indexes.ts --dry-run で AUTOGEN block 再生成差分を検出する。差分あり（WOULD UPDATE 行を含む）場合は case-close を停止し case-run へ差戻す（再生成の実 commit は case-run が行う）。差分なしの場合のみ case-close を完了する。case-close 自身は索引ファイルを直接編集・commit しない。契約の詳細は case-close SPEC Step 3-3 参照"
+    skill: repo-agentdev-integrity
 
 acceptance_gates:
   - 完了した Issue/PR の成果物が docs/requirements/, docs/adr/, docs/specs/ のいずれかに存在すること


### PR DESCRIPTION
## 概要

case-close SPEC Step 3-3（spec-save commit 67b5b66b で確定済み）が宣言する AUTOGEN block 索引再生成差分検出を、project extension 機構（ADR-0135）の checks セクション経由で case-close へ導入する。

case-close command 本体（`src/opencode/commands/agentdev/case-close.md`）の手順を直接編集せず、既存の project extension 機構（`.agentdev/extensions/commands/case-close.yaml`、project-extensions SPEC、ADR-0135）の checks セクション経由で導入する契約とする。実行主体は `repo-agentdev-integrity` skill が所有する `generate_indexes.ts` である。

Closes #1772

## 変更内容

### `.agentdev/extensions/commands/case-close.yaml`

#### context セクション（1エントリ追加）

- `index-auto-generation-spec`: `docs/specs/integrity/index-auto-generation.md`（SC-002 索引自動生成 SPEC）への参照エントリを追加。AUTOGEN block 自動生成機構と `generate_indexes.ts` の契約を case-close 実行時参照可能にする。

#### checks セクション（1エントリ追加、空配列から具現化）

- `autogen-index-regeneration-diff`: AUTOGEN block 索引再生成差分検出エントリ。`skill: repo-agentdev-integrity` へ委譲し、Step 3-3（単一 Issue クローズ）および Step E5b 前段（Epic Wave クローズ）で `generate_indexes.ts --dry-run` を実行する。
  - 差分あり（`WOULD UPDATE` 行を含む）: case-close を停止し case-run へ差戻す（再生成の実 commit は case-run が行う）
  - 差分なし: case-close を完了する
  - case-close 自身は索引ファイルを直接編集・commit しない

## 完了条件マッピング

- [x] case-close SPEC（`docs/specs/commands/case-close.md`）の「### 単一 Issue クローズ（従来フロー、後方互換）」節に Step 3-3 が追記されていること — spec-save commit 67b5b66b で完了済み
- [x] case-close が直接編集・commit せず dry-run/差分検査で停止し、再生成（実 commit）は case-run へ委譲する契約が SPEC へ明示されていること — spec-save commit 67b5b66b で完了済み
- [x] 差分がある場合は case-run へ差戻しされ、差分なしの場合のみ case-close が完了する契約が SPEC へ明示されていること — spec-save commit 67b5b66b で完了済み
- [x] 索引検証が case-close command 本体（`src/opencode/commands/agentdev/case-close.md`）の手順を直接編集せず、project extension（`.agentdev/extensions/commands/case-close.yaml`）の checks セクション経由で導入されていること — **本 PR で完了**
- [x] case-close SPEC に「extension/checks 経由で実行される契約」と「command 本体への手順ハードコードを行わない」が明記されていること — spec-save commit 67b5b66b で完了済み
- [x] Epic Wave クローズ経路の Step E5b 前段にも同等の dry-run/diff による索引健全性検証を適用することが SPEC（または case_open_hints、Epic 完了条件）へ明記されていること — spec-save commit 67b5b66b で完了済み

## テスト結果

```
# 拡張構造検証（IR-056）
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts --json
→ ok: true, failures: 0

# targeted docs guard（case-close workflow）
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-close --files ".agentdev/extensions/commands/case-close.yaml"
→ failures: 0, warnings: 0

# generate_indexes.ts dry-run 動作確認（依存 #1771 marker 検出是正の確認）
bun run .opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts --dry-run
→ EXIT: 0（WOULD UPDATE 行で差分検出可能、marker 誤認識なし）

# 関連テスト
bun test ./.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.test.ts
→ 2 pass

bun test ./.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.test.ts
→ 27 pass（依存 #1771 の回帰テスト含む）
```

前提依存 #1771（generate_indexes.ts AUTOGEN marker 検出を行全体一致へ是正、PR #1792 でマージ済み）により、dry-run/diff 検証が成立する。

## Findings / Capture候補

`generate_indexes.ts --dry-run` は常に `req-health-metrics.md` / `spec-health-metrics.md` の2件を WOULD UPDATE として報告する（計測日 `YYYY-MM-DD` が日次で変動するため）。本挙動は既存の仕様であり、本 PR の対象外。case-close から case-run への差戻し頻度に影響するが、SPEC Step 3-3 の差分→差戻し契約通りに運用される。別 Issue で計測日の日次変動を抑制するか（例: 計測日を AUTOGEN 対象外へ分離）、metrics のみ dry-run 対象外とするかを検討可能。

## SPEC確定候補

なし。case-close SPEC Step 3-3（spec-save commit 67b5b66b）で契約は確定済み。本 PR は当該契約の project extension 実装である。
