### PR TITLE
docs(spec): review_dispositions セクションの工程固有識別子除去（AG-*/RU-20260722-*）

### DIFF
--- a/docs/specs/commands/req-define.md
+++ b/docs/specs/commands/req-define.md
@@ -200,9 +200,9 @@ artifact_actions の各 entry が出力する `target_area` と `content` の扱
 req-define 側は出力形式のみを規定する。
 `target_area` の形式（Markdown 見出し行）、見出し階層の解釈規則、複数マッチ、未検出時の挙動は [spec-save.md](spec-save.md) 側に配置する。
 
-## review_dispositions の producer 契約（AG-007）
+## review_dispositions の producer 契約
 
-req-define は `review_dispositions` の producer である（AG-002）。Step 7-5 で壁打ち過程の採否判断を `draft-data` の `review_dispositions` へ出力する。
+req-define は `review_dispositions` の producer である。Step 7-5 で壁打ち過程の採否判断を `draft-data` の `review_dispositions` へ出力する。
 
 ### 出力義務
 
@@ -214,7 +214,7 @@ req-define は以下の入力項目について disposition を記録する:
 | 既存要件で充足済みの入力 | 既存 REQ、既存 SPEC、同意済み artifact_actions で既に満たされている項目（disposition: `covered`） |
 | 一部のみ採用した入力 | 項目の一部を採用し、残部を採用しなかったもの（disposition: `partially_covered`） |
 
-`review_dispositions` は optional な soft-contract であり（ADR-0124）、欠落時に後続工程が draft を拒否しない（AG-001）。covered 項目だけで構成される Issue や PR を作成しない方針を維持する（AG-005）。
+`review_dispositions` は optional な soft-contract であり（ADR-0124）、欠落時に後続工程が draft を拒否しない。covered 項目だけで構成される Issue や PR を作成しない方針を維持する。
 
 ### 未決事項の取扱い
 
@@ -224,36 +224,36 @@ req-define は以下の入力項目について disposition を記録する:
 
 disposition の `evidence` に根拠（path、section）を設定できない場合、または根拠が曖昧な場合は `auto_gate.auto_ready: false` とし、`stop_reasons` へ根拠不足の旨を記録する。根拠不足のまま draft を完成させてはならない。
 
-`evidence.checked_at_commit` は req-define 生成時 `null` とする（G08 git 操作禁止）。default branch 最新化後の evidence 再確認は consumer（case-open）の責務である（AG-006）。
+`evidence.checked_at_commit` は req-define 生成時 `null` とする（G08 git 操作禁止）。default branch 最新化後の evidence 再確認は consumer（case-open）の責務である。
 
 ## draft-data review_dispositions フィールドスキーマ
 
-要件定義で `review_dispositions` を出力する場合のシリアライズ形式を定義する。schema の正規所有先は [artifact-contracts.md](../responsibilities/artifact-contracts.md)「review_dispositions 構造」節である（AG-002）。本節は req-define 固有の出力形式を規定する。
+要件定義で `review_dispositions` を出力する場合のシリアライズ形式を定義する。schema の正規所有先は [artifact-contracts.md](../responsibilities/artifact-contracts.md)「review_dispositions 構造」節である。本節は req-define 固有の出力形式を規定する。
 
 ### review_dispositions 項目構造
 
-各 disposition エントリは以下の field を持つ（AG-001、AG-003）:
+各 disposition エントリは以下の field を持つ:
 
 | field | 型 | 必須 | 説明 |
 |------|------|------|------|
 | id | string | 必須 | `RD-NNN` 形式（NNN は連番） |
 | source_ru | string | optional | 単一の元 RU-ID（RU 入力でない場合は省略可） |
 | source_item | string | 必須 | 単一の元 item 識別子（RU 内の要件行 ID 等。複数指定不可） |
-| disposition | enum | 必須 | `covered` / `partially_covered` / `rejected` / `not_applicable`。必要に応じて `superseded` / `stale_target` を追加（AG-004） |
+| disposition | enum | 必須 | `covered` / `partially_covered` / `rejected` / `not_applicable`。必要に応じて `superseded` / `stale_target` を追加 |
 | reason_code | string | 必須 | 判断理由のコード |
 | reason | string | 必須 | 人間可読の判断理由本文 |
-| evidence | object | 必須 | 根拠。`path`、`section`、`checked_at_commit` を持つ。`checked_at_commit` は生成時 `null`（AG-006） |
+| evidence | object | 必須 | 根拠。`path`、`section`、`checked_at_commit` を持つ。`checked_at_commit` は生成時 `null`（G08 git 操作禁止） |
 | related_removed_items | list | optional | 本判断により除外された関連項目の識別子リスト |
 
-1 disposition エントリ = 単一 `source_ru` + 単一 `source_item` の組み合わせとする（重複禁止、AG-003）。
+1 disposition エントリ = 単一 `source_ru` + 単一 `source_item` の組み合わせとする（重複禁止）。
 
 ### YAML 表現形式
 
 ```yaml
 review_dispositions:
   - id: RD-001
-    source_ru: RU-20260722-01
-    source_item: RU-20260722-01.req-001
+    source_ru: RU-NNN
+    source_item: RU-NNN.req-001
     disposition: covered
     reason_code: already_satisfied
     reason: |
@@ -264,8 +264,8 @@ review_dispositions:
       checked_at_commit: null  # req-define 生成時は null。case-open が確認 commit SHA を記録する
     related_removed_items: []
   - id: RD-002
-    source_ru: RU-20260722-01
-    source_item: RU-20260722-01.req-002
+    source_ru: RU-NNN
+    source_item: RU-NNN.req-002
     disposition: rejected
     reason_code: out_of_scope
     reason: |
@@ -277,11 +277,11 @@ review_dispositions:
     related_removed_items: []
 ```
 
-### checked_at_commit 運用（AG-006）
+### checked_at_commit 運用
 
-`evidence.checked_at_commit` は req-define 生成時 `null` とする（G08 git 操作禁止）。case-open が default branch 最新化後に evidence の path/section を再確認し、確認時の commit SHA を当該フィールドへ記録する（AG-008）。根拠失効時は `covered` のまま起票せず `stale_target` または再評価対象として停止する。
+`evidence.checked_at_commit` は req-define 生成時 `null` とする（G08 git 操作禁止）。case-open が default branch 最新化後に evidence の path/section を再確認し、確認時の commit SHA を当該フィールドへ記録する。根拠失効時は `covered` のまま起票せず `stale_target` または再評価対象として停止する。
 
-### 後方互換性（AG-001）
+### 後方互換性
 
 `review_dispositions` は optional な soft-contract である。本フィールドを持たない旧ドラフトを req-save、case-open は入力として拒否しない（ADR-0124 準拠）。
 

--- a/docs/specs/responsibilities/artifact-contracts.md
+++ b/docs/specs/responsibilities/artifact-contracts.md
@@ -381,12 +381,12 @@ frontmatter の基本フィールドは `draft_type`、`topic`、`status`、`cre
 
 ### review_dispositions 構造
 
-`review_dispositions` は req-define が壁打ち過程で記録した採否判断（covered、rejected 等）を後続工程へ引き継ぐ optional な soft-contract である（AG-001、AG-002、ADR-0124）。
+`review_dispositions` は req-define が壁打ち過程で記録した採否判断（covered、rejected 等）を後続工程へ引き継ぐ optional な soft-contract である（ADR-0124）。
 
-- **所有先**: 本節（`artifact-contracts.md`「req_draft 出力構造」節）が `review_dispositions` の schema を正規所有する（AG-002）
+- **所有先**: 本節（`artifact-contracts.md`「req_draft 出力構造」節）が `review_dispositions` の schema を正規所有する
 - **producer**: req-define（`docs/specs/commands/req-define.md`、`src/opencode/commands/agentdev/req-define.md`、`src/opencode/commands/agentdev/templates/req-define/req-draft.md`）
 - **consumer**: case-open（`docs/specs/commands/case-open.md`、`src/opencode/commands/agentdev/case-open.md`）
-- **Issue 本文永続化先**: workflow-templates（`docs/specs/skills/agentdev-workflow-templates.md`、`src/opencode/skills/agentdev-workflow-templates/SKILL.md`、Issue 本文テンプレート群）が Issue 本文の「レビュー判断」セクション構造を正規所有する（AG-002）
+- **Issue 本文永続化先**: workflow-templates（`docs/specs/skills/agentdev-workflow-templates.md`、`src/opencode/skills/agentdev-workflow-templates/SKILL.md`、Issue 本文テンプレート群）が Issue 本文の「レビュー判断」セクション構造を正規所有する
 
 #### 各エントリの field 構成
 
@@ -395,13 +395,13 @@ frontmatter の基本フィールドは `draft_type`、`topic`、`status`、`cre
 | `id` | string | `RD-NNN` 形式の識別子（NNN は連番） |
 | `source_ru` | string | 単一の元 RU-ID（RU 入力でない場合は省略可） |
 | `source_item` | string | 単一の元 item 識別子（RU 内の要件行 ID 等。複数指定不可） |
-| `disposition` | enum | `covered` / `partially_covered` / `rejected` / `not_applicable`。必要に応じて `superseded` / `stale_target` を追加（AG-004） |
+| `disposition` | enum | `covered` / `partially_covered` / `rejected` / `not_applicable`。必要に応じて `superseded` / `stale_target` を追加 |
 | `reason_code` | string | 判断理由のコード（例: `already_satisfied`、`out_of_scope`、`superseded_by`） |
 | `reason` | string | 人間可読の判断理由本文 |
-| `evidence` | object | 根拠。`path`（ファイルパス）、`section`（セクション見出し等）、`checked_at_commit`（確認 commit SHA）を持つ。`checked_at_commit` は req-define 生成時 `null`（G08 git 禁止）。case-open が default branch 最新化後に再確認し、確認 commit SHA を記録する（AG-006） |
+| `evidence` | object | 根拠。`path`（ファイルパス）、`section`（セクション見出し等）、`checked_at_commit`（確認 commit SHA）を持つ。`checked_at_commit` は req-define 生成時 `null`（G08 git 禁止）。case-open が default branch 最新化後に再確認し、確認 commit SHA を記録する |
 | `related_removed_items` | list | 本判断により除外された関連項目の識別子リスト（該当なし時は空リスト） |
 
-1 disposition エントリ = 単一 `source_ru` + 単一 `source_item` の組み合わせとする（重複禁止、AG-003）。
+1 disposition エントリ = 単一 `source_ru` + 単一 `source_item` の組み合わせとする（重複禁止）。
 
 #### disposition 値の定義
 
@@ -416,10 +416,10 @@ frontmatter の基本フィールドは `draft_type`、`topic`、`status`、`cre
 
 #### optional soft-contract 運用（ADR-0124 準拠）
 
-- `review_dispositions` は optional な soft-contract であり、欠落時に既存 req_draft、RU、promoted artifact を拒否しない（AG-001、後方互換）
+- `review_dispositions` は optional な soft-contract であり、欠落時に既存 req_draft、RU、promoted artifact を拒否しない（後方互換）
 - 厳格なスキーマ検証、JSON Schema、バリデータを導入しない
-- covered 項目だけで構成される Issue や PR を作成しない方針を維持する（AG-005）。実行対象（`artifact_actions`、`operation_units`）を持たない disposition のみの draft から空 Issue を作成しない
-- 記録済みの判断を consumer がユーザーへ再確認しない（AG-008）
+- covered 項目だけで構成される Issue や PR を作成しない方針を維持する。実行対象（`artifact_actions`、`operation_units`）を持たない disposition のみの draft から空 Issue を作成しない
+- 記録済みの判断を consumer がユーザーへ再確認しない
 
 ### frontmatter 構造
 


### PR DESCRIPTION
Closes: #1788

## 概要

20 SPEC のうち残存していた2 SPEC（`docs/specs/commands/req-define.md`、`docs/specs/responsibilities/artifact-contracts.md`）の review_dispositions セクションから C4 クラスタ合意アイテム ID（AG-001〜AG-011）を除去し、YAML 例の RU-20260722-01 を RU-NNN プレースホルダへ置換した。

spec-save（commit 4cde4ae4）は target_area 更新と一部識別子除去を完了していたが、review_dispositions 機能（PR #1766）が追加した AG-* 参照は残存していた。本 PR で機械的置換（選択肢 A）を完遂する。

## 変更内容

### docs/specs/commands/req-define.md

- review_dispositions producer 契約セクション見出し、本文から AG-007、AG-002 ラベル除去
- 出力義務、checked_at_commit、schema 各節から AG-001、AG-003、AG-004、AG-005、AG-006、AG-008 ラベル除去
- YAML 表現形式例の `RU-20260722-01` / `RU-20260722-01.req-001`（.req-002）を `RU-NNN` / `RU-NNN.req-001`（.req-002）へ置換
- 後方互換性、checked_at_commit 運用のセクション見出しから AG-001、AG-006 ラベル除去

### docs/specs/responsibilities/artifact-contracts.md

- review_dispositions 構造セクションの soft-contract 説明から AG-001、AG-002 ラベル除去（ADR-0124 は保持）
- 所有先、Issue 本文永続化先の正規所有説明から AG-002 ラベル除去
- disposition enum、evidence object、重複禁止規則から AG-003、AG-004、AG-006 ラベル除去
- optional soft-contract 運用節から AG-001、AG-005、AG-008 ラベル除去

## 置換方針

各 AG-* ラベルは経緯識別子（C4 クラスタ合意アイテム）であり、現在契約の根拠は各節の散文および既存の安定 ID（ADR-0124、G08）が保持する。識別子除去のみで現在契約の意味を維持する。

## 検証結果

- TS-008（AG-008）: 20 SPEC の現行基準本文に AG-001〜AG-019、RU-20260722-01、RU-20260722-02 が 0 件であることを grep で確認 ✅
- TS-009（AG-009）: 各節の主論理区分、正規所有対象、検査責務の根拠が工程由来 ID に依存していないことを確認。ADR-0124、G08、散文が根拠を保持 ✅
- TS-010（AG-010）: `responsibility-boundary-purification.md` に AG-* 系、RU-20260722-* 系の残存なし、自己言及的免除なし ✅
- check_changed_docs.ts（case-run workflow）: failures 0, warnings 0 ✅

## Findings / Capture候補

- `docs/specs/commands/case-open.md`（125〜168 行）と `docs/specs/skills/agentdev-workflow-templates.md`（54〜92 行）に同一の AG-001〜AG-011 参照が残存する。これらは review_dispositions 機能（PR #1766）が追加したものであるが、本 Issue #1788 の 20 SPEC 対象範囲外である。別 Issue での除去を推奨する。
