### PR TITLE
[#1816] document-model SPEC accepted ADR 節検証 + REQ 参照具体化

### DIFF
--- a/docs/specs/foundations/document-model.md
+++ b/docs/specs/foundations/document-model.md
@@ -282,7 +282,7 @@ SPECはfrontmatter `status`で成熟度と現行性を管理する。状態は `
 
 ## accepted ADR の意味的不変
 
-accepted ADR は意味的に不変とする（REQ-001）。
+accepted ADR は意味的に不変とする（REQ-001-056〜060）。
 詳細プロトコルは agentdev-adr-guidelines「accepted ADR の更新規則」、agentdev-adr-file-manager「accepted ADR 直接編集チェックリスト」を参照。
 
 ### 原則


### PR DESCRIPTION
## 変更概要

Issue #1816（OU-004）の検証を実施。`docs/specs/foundations/document-model.md` の `## accepted ADR の意味的不変` セクション（spec-save commit ed9ceb56 で新設）が Issue の受け入れ基準を満たすことを確認した上で、同セクション冒頭の REQ 参照を `（REQ-001）` から `（REQ-001-056〜060）` へ具体化した。

ファイル内の他節（`（REQ-001-052）`、`（REQ-001-054）`、`（REQ-001-055）` 等）は冒頭参照で出典要件行を明示している。本節も同じ規則へ整え、読者が REQ-001-056..060 の5要件へ直接到達できるようにする。意味の変更は無い。

## 完了条件

- [x] `docs/specs/foundations/document-model.md` の「accepted ADR の意味的不変」セクションへ意味不変原則（accepted ADR は意味的に不変、非意味修正6件/意味変更6件の参照、明示承認記録、過去版無言書換禁止、意味変更の表記修正扱い禁止、Report 移行禁止）が記載されていること → 該当節 `### 原則` に6項目すべて記載済み（document-model.md:288-296）
- [x] 同セクションの「正規所有」へ意味不変原則の正規所有（REQ-001、agentdev-adr-guidelines SPEC）、直接編集チェックリストの正規所有（agentdev-adr-file-manager SPEC）、accepted ADR の扱いの正規所有（document-model）が記載されていること → 該当節 `### 正規所有` に3項目すべて記載済み（document-model.md:297-301）

## テスト戦略検証結果

### TS-007 / AG-001

- verification: document-model.md の「accepted ADR の意味的不変」セクションへ意味不変原則、6+6 分類の参照、正規所有（REQ-001、agentdev-adr-guidelines、agentdev-adr-file-manager、document-model）が記載されているか確認。
- pass_criteria: document-model へ意味不変原則の要約と正規所有参照が記載されていること。
- 結果: **PASS**

検証詳細:

| 項目 | 結果 | 証拠 |
|---|---|---|
| accepted ADR は意味的に不変 | 記載済み | document-model.md:290 |
| 非意味修正6件 / 意味変更6件 の参照 | 記載済み | document-model.md:291「直接更新可能な非意味修正は6件、後継 ADR を必要とする意味変更は6件」 |
| 明示承認記録 | 記載済み | document-model.md:292 |
| 過去版無言書換禁止 | 記載済み | document-model.md:293 |
| 意味変更の表記修正扱い禁止 | 記載済み | document-model.md:294 |
| Report 移行禁止 | 記載済み | document-model.md:295「Report へ規範要件または必達条件を移さない」 |
| 正規所有: REQ-001、agentdev-adr-guidelines | 記載済み | document-model.md:299 |
| 正規所有: agentdev-adr-file-manager（直接編集チェックリスト） | 記載済み | document-model.md:300 |
| 正規所有: accepted ADR の扱い（document-model） | 記載済み | document-model.md:301 |

STEP 4 context 再確認:

- REQ-001-056..060（docs/requirements/REQ-001.md:72-76）の5要件と document-model.md の要約は整合する
- `docs/specs/skills/agentdev-adr-guidelines.md:52`「accepted ADR の更新規則」節が詳細プロトコルを正規所有し、6+6 分類を記載する。document-model.md からの参照先として正しく存在する
- `docs/specs/skills/agentdev-adr-file-manager.md:55`「accepted ADR 直接編集チェックリスト」節が事前確認・事後確認・6件確認を正規所有する。document-model.md からの参照先として正しく存在する

## Findings / Capture候補

document-model.md の `## accepted ADR の意味的不変` 節外（target_area 外）に、commit ed9ceb56 の REQ-001-056..060 APPEND によって意味が変化した REQ ID への参照が2箇所存在する。本 Issue の target_area 外かつ STEP 4 の context 再確認で検出した事項のため、Findings として記録し修正は別 Issue で扱う。

| 行 | 現状 | 問題 | 提案 |
|---|---|---|---|
| document-model.md:27 | `（REQ-001-058）` を「新規ファイル分割は行わず、既存2ファイル間の重複削除で運用する」へ付与 | REQ-001-058 は「後継 ADR を必要とする意味変更は6件」へ再利用された。参照先要件行と文意が不一致 | 別 Issue で正しい REQ ID へ修正（候補: REQ-001-001 周辺、要確認） |
| document-model.md:139 | `廃止（retire）候補の判定基準（REQ-001-056）:` | REQ-001-056 は「accepted ADR を意味的に不変とし…」へ再利用された。参照先要件行と文意が不一致 | 別 Issue で正しい REQ ID へ修正（候補: REQ-001-053 周辺の廃止関連、要確認） |

これらは commit ed9ceb56 より前から存在した dangling 参照（REQ-001-056/058 は当時未割当）が、APPEND によって実体のある別要件へ紐付けられたことで顕在化したもの。target_area（`## accepted ADR の意味的不変`）の検証結果には影響しない。

### その他

- ADR-001.md の横断的確認は実施していない（本 Issue の対象外、Findings 記録にとどめる）
- `## accepted ADR の意味的不変` 節の配置位置（`## ADR 編集制約` の直後、`## 文書分類ポリシー` の直前）は意味的に近接する ADR 関連節へ隣接しており、配置妥当

## SPEC確定候補

本 Issue の検証過程で SPEC レベル（schema、enum、判定表、内部アルゴリズム）で確定すべき新規事項は発生しなかった。document-model.md の「accepted ADR の意味的不変」節は REQ-001-056..060 の要約と正規所有参照のみを正規所有し、詳細プロトコルは agentdev-adr-guidelines、agentdev-adr-file-manager SPEC へ委譲する構造（既存契約通り）を確認した。

Refs: #1816
