### PR TITLE
docs: OU-003 4用語反映とPhase残渣整理 (#1824)

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -142,7 +142,7 @@ SPEC は commands / skills / workflows の 3 層ディレクトリ構造と、�
 | [workflows/workflow-contracts.md](workflows/workflow-contracts.md) | accepted | ワークフロー契約（横断） | パイプライン概要、共通フェーズ、SSoT 遷移、実装分類、case-auto と case-run の委譲モデル、result 4状態契約 |
 | [workflows/delegation-contracts.md](workflows/delegation-contracts.md) | accepted | サブエージェント委譲契約 | 委譲時最小契約、委譲種別、制約、manager-orchestrator 分離 |
 | [workflows/capture-boundaries.md](workflows/capture-boundaries.md) | accepted | キャプチャ境界 | intake / learning 境界、Split Rule、PR 本文永続チャネル |
-| [workflows/epic-wave-model.md](workflows/epic-wave-model.md) | accepted | Epic / Wave / Issue 実行モデル | OU 階層、子Issue 状態 enum、Wave スケジューリング、execution_unit 構成契約、Phase 分離モデル、per-Epic 単一書き手 |
+| [workflows/epic-wave-model.md](workflows/epic-wave-model.md) | accepted | Epic / Wave / Issue 実行モデル | OU 階層、子Issue 状態 enum、Wave スケジューリング、execution_unit 構成契約、orchestration stage モデル、per-Epic 単一書き手 |
 | [workflows/backlog-artifact-lifecycle.md](workflows/backlog-artifact-lifecycle.md) | accepted | RU / 採用済み成果物 / draft lifecycle | artifact lifecycle、検出事項プロトコル、artifact_actions 工程分岐 |
 | [workflows/references/execution-unit-construction.md](workflows/references/execution-unit-construction.md) | accepted | execution_unit 構成アルゴリズム参照 | epic-wave-model.md から参照される連結成分アルゴリズム、3軸判断モデルの機械的判定手順 |
 

--- a/docs/specs/foundations/harness-separation-model.md
+++ b/docs/specs/foundations/harness-separation-model.md
@@ -2,7 +2,7 @@
 title: harness 分離モデル
 status: accepted
 created: 2026-07-12
-updated: 2026-07-26
+updated: 2026-07-27
 ---
 
 # harness 分離モデル
@@ -60,6 +60,8 @@ AgentDevFlow 配布物と harness 実行制御の責務分離モデルを定義�
 - プロジェクトルート `AGENTS.md`: harness 選定、エージェント型指定
 - 各 skill の `references/<topic>.md`: skill 固有の実行制御具体（エージェント型名、起動方法、timeout、並列度、再試行等）
 
+上記 harness 側の実行制御は、`responsibility-boundary-purification.md` が定義する「harness execution mechanism」（agent 起動、background task、並列実行、context 管理）として ADF 規範所有対象外である（REQ-011-018）。本 SPEC は harness execution mechanism の境界宣言のみを所有し、起動 API、並列数、timeout 等の具体は各 skill の `references/` へ集約する。external execution boundary（外部バックエンド接続）は REQ-011 が正規所有する（REQ-011-017）。
+
 ## 実行結果契約
 
 case-run、case-auto の実行結果契約は次の4状態を区別する。
@@ -72,13 +74,13 @@ case-run、case-auto の実行結果契約は次の4状態を区別する。
 `failed` と `delegation-unavailable` は異なる回復アクションを要する独立の結果状態として扱う。
 結果状態の遷移機械、委譲契約、ラベル構造の詳細は `docs/specs/workflows/delegation-contracts.md` を正規所有者とし、本 SPEC は境界宣言へ縮約する。
 
-## case-auto の Phase 分離と bg task 管理
+## case-auto の orchestration stage と bg task 管理
 
-case-auto の Phase 分離、Phase 2 の固定並列数、bg task の状態管理、破棄検知時の状態別回復（commit 済み PR 未作成、未コミット変更残存の区別）は AgentDevFlow 側の業務ワークフロー契約として所有する。
+case-auto の orchestration stage（stage 1 case-open 順次、stage 2 case-run 並列、stage 3 case-close 順次）、stage 2 の固定並列数、bg task の状態管理、破棄検知時の状態別回復（commit 済み PR 未作成、未コミット変更残存の区別）は AgentDevFlow 側の業務ワークフロー契約として所有する。
 これらは後続工程が依存する安全境界と回復契約であり、配布物で共有する。
 
-bg task API、実行エージェント選定、実行担当サブエージェント内部の推論、context 管理、retry、heartbeat、エラー解析は harness 側の所有とする。
-Phase 1 と Phase 3 の直列集約ポイントは main push、capture、commit を並列実行区間の外で処理する AgentDevFlow 側の契約とし、bg task API 経由の実行制御は harness 側の責務として維持する。
+bg task API、実行エージェント選定、実行担当サブエージェント内部の推論、context 管理、retry、heartbeat、エラー解析は harness 側の所有とする（harness execution mechanism、ADF 規範所有対象外、REQ-011-018）。
+stage 1 と stage 3 の直列集約ポイントは main push、capture、commit を並列実行区間の外で処理する AgentDevFlow 側の契約とし、bg task API 経由の実行制御は harness 側の責務として維持する。
 
 工程別の所有対象、非所有対象の詳細リストは `docs/specs/responsibilities/responsibility-boundary-purification.md` を正規所有者とする。
 

--- a/docs/specs/quality/spec-health-metrics.md
+++ b/docs/specs/quality/spec-health-metrics.md
@@ -103,7 +103,7 @@ AUTOGENブロックは `AUTOGEN:BEGIN` マーカーから対応する `AUTOGEN:E
 | quality/req-health-metrics.md | 127 | accepted | quality |
 | commands/req-save.md | 125 | accepted | commands |
 | foundations/project-extensions.md | 125 | accepted | foundations |
-| foundations/harness-separation-model.md | 122 | accepted | foundations |
+| foundations/harness-separation-model.md | 124 | accepted | foundations |
 | integrity/rules/IR-057-obsolete-spec-path-after-domain-split.md | 118 | accepted | integrity |
 | authoring/command-file-format.md | 115 | accepted | authoring |
 | responsibilities/req-impact-map.md | 115 | accepted | responsibilities |

--- a/docs/specs/responsibilities/responsibility-boundary-purification.md
+++ b/docs/specs/responsibilities/responsibility-boundary-purification.md
@@ -34,12 +34,12 @@ AgentDevFlow 配布物と harness 実行制御の責務境界を、所有対象�
 - plan task監査ログ
 
 ### case-auto所有/非所有リスト
-**所有**: 入力解決、auto_gate確認、artifact_actions基準工程決定、入力引き渡し、永続状態再読込、継続停止再開判定、完了進行未実行報告、壁時計時間計測、orchestration stage 分離（stage 1 case-open 順次実行、stage 2 case-run 並列実行、stage 3 case-close 順次実行、REQ-006-102）、orchestration stage 2 の固定並列数5（REQ-006-106）、bg task の状態管理、破棄検知（REQ-006-105）、状態別回復（commit 済み PR 未作成 / 未コミット変更残存の区別）、orchestration stage 1 と 3 の直列集約ポイント（main push / capture / commit、REQ-006-104）
+**所有**: 入力解決、auto_gate確認、artifact_actions基準工程決定、入力引き渡し、永続状態再読込、継続停止再開判定、完了進行未実行報告、壁時計時間計測、orchestration stage（stage 1 case-open 順次実行、stage 2 case-run 並列実行、stage 3 case-close 順次実行、REQ-006-089）、stage 2 の固定並列数5（REQ-006-091）、bg task の状態管理、破棄検知（REQ-006-093）、状態別回復（commit 済み PR 未作成 / 未コミット変更残存の区別）、stage 1 と stage 3 の直列集約ポイント（main push / capture / commit、REQ-006-090）
 **非所有**: 工程内部手順再実装、エージェント選定、スケジューリング、エラー解析、context圧縮、retry、QG再評価、capture再実装、bg task API、実行担当サブエージェント内部の実行制御（推論、context 管理、retry、エラー解析等）、heartbeat、plan task監査ログ
 
 > **用語注記**: 「実行担当サブエージェント内部の実行制御」は、推論、context 管理、retry、エラー解析等を含む上位概念として扱う。line 38 限定注記内の表記と一致させる（語彙揺れ是正）。
 
-> **v2:ADR-0138 による v2:ADR-0136 決定2の限定範囲（REQ-006-102〜107）**: v2:ADR-0136 決定2「配布物は業務ワークフロー契約のみを記述し、実行制御は harness 責務」に対し、case-auto の orchestration stage 分離、orchestration stage 2 の固定並列数、bg task の状態管理と状態別回復、orchestration stage 1 と 3 の直列集約だけを AgentDevFlow 側の業務ワークフロー契約として規定する。bg task API と実行担当サブエージェント内部の実行制御は harness 側に維持し、決定2の本体を変更しない。
+> **v2:ADR-0138 による v2:ADR-0136 決定2の限定範囲（REQ-006-089〜093）**: v2:ADR-0136 決定2「配布物は業務ワークフロー契約のみを記述し、実行制御は harness 責務」に対し、case-auto の orchestration stage（stage 1〜3）、stage 2 の固定並列数、bg task の状態管理と状態別回復、stage 1 と stage 3 の直列集約だけを AgentDevFlow 側の業務ワークフロー契約として規定する。bg task API と実行担当サブエージェント内部の実行制御は harness 側に維持し、決定2の本体を変更しない。
 
 ### case-run所有/分離対象リスト
 **所有**: Issue/実行単位解決、worktree branch準備、Issue+worktree root+branch引き渡し、結果受領状態処理、PR停止情報確認、Findings PR本文引き継ぎ、再開可能状態維持、壁時計時間計測

--- a/docs/specs/workflows/epic-wave-model.md
+++ b/docs/specs/workflows/epic-wave-model.md
@@ -2,7 +2,7 @@
 title: Epic / Wave / Issue 実行モデル
 status: accepted
 created: 2026-06-21
-updated: 2026-07-25
+updated: 2026-07-27
 ---
 
 # Epic / Wave / Issue 実行モデル
@@ -228,7 +228,7 @@ case-open、case-auto、case-run で参照される並列上限と停止条件�
 | 文脈 | 上限 | 根拠 |
 |---|---|---|
 | case-run Wave 内子 Issue 並列 | 5件 | REQ-006-026（同一 Wave 内の case-run サブエージェント並列起動上限） |
-| case-auto Phase 2 同時起動数 | 5件 | REQ-006-106（Phase 分離モデルにおける case-run bg task 同時起動数） |
+| case-auto orchestration stage 2 同時起動数 | 5件 | REQ-006-091（orchestration stage における case-run bg task 同時起動数） |
 | execution_unit 全体並列 | 上限なし | REQ-006-018（必須依存がない execution_unit 群は全て並列実行可能） |
 
 3つの「5件」は別文脈であり、混同しない。
@@ -255,13 +255,13 @@ case-auto は停止時に停止理由を以下の分類で報告する（REQ-006
 
 分類は再開コマンド選択とユーザー通知の精度向上が目的であり、HITL 境界の変更ではない。
 
-## ドラフト間並列実行モデル（REQ-006-102〜107）
+## ドラフト間並列実行モデル（REQ-006-089〜093）
 
-case-auto が複数の対象を処理する場合、Phase 分離モデルを適用する。Phase 1 は case-open を順次実行し、Phase 2 は case-run を bg task として最大5件ずつ並列実行し、Phase 3 は case-close を順次実行する。Phase 1 と Phase 3 を main push と capture の直列集約ポイントとし、commit も並列実行区間の外で処理する。
+case-auto が複数の対象を処理する場合、orchestration stage モデルを適用する。stage 1 は case-open を順次実行し、stage 2 は case-run を bg task として最大5件ずつ並列実行し、stage 3 は case-close を順次実行する。stage 1 と stage 3 を main push と capture の直列集約ポイントとし、commit も並列実行区間の外で処理する。
 
-Phase 分離、Phase 2 の同時起動数固定値5、bg task の状態管理、破棄検知時の状態別回復、Phase 1 と Phase 3 の直列集約は AgentDevFlow 側の制御点である。bg task API、実行エージェント選定、実行担当サブエージェント内部の推論、context 管理、retry、heartbeat、エラー解析は harness 側に維持する。
+orchestration stage（stage 1〜3）、stage 2 の同時起動数固定値5、bg task の状態管理、破棄検知時の状態別回復、stage 1 と stage 3 の直列集約は AgentDevFlow 側の制御点である。bg task API、実行エージェント選定、実行担当サブエージェント内部の推論、context 管理、retry、heartbeat、エラー解析は harness 側に維持する（harness execution mechanism、ADF 規範所有対象外、REQ-011-018）。
 
-Phase 2 の bg task がシステムにより破棄されたことを検知した場合、commit 済みで PR 未作成の状態と未コミット変更が残る状態を区別し、それぞれの状態に対応する回復パターンを適用する。並列実行が利用できない場合だけ順次フォールバックを使用し、理由を完了報告に残す。
+stage 2 の bg task がシステムにより破棄されたことを検知した場合、commit 済みで PR 未作成の状態と未コミット変更が残る状態を区別し、それぞれの状態に対応する回復パターンを適用する。並列実行が利用できない場合だけ順次フォールバックを使用し、理由を完了報告に残す。
 
 ## 前工程完了度3段階分類（REQ-003-010）
 

--- a/src/opencode/skills/agentdev-workflow-orchestration/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-orchestration/SKILL.md
@@ -28,7 +28,9 @@ extension（`.agentdev/extensions/skills/`）は標準 SKILL.md を前提とし�
 case-run は単一 Issue または単一 Wave（`#epic` 指定時: 現在 ready な Wave の子Issue を 実行担当サブエージェント（adapter skill 経由、委譲 prompt 内で実行 command を指定）に並列委譲、最大5件）を処理し、Epic 全体（複数 Wave）の一括実行、Wave 境界（PR マージ）は扱わない（Wave 構成生成は case-open、Wave 境界クローズは case-close の責務）。
 Epic 全体の進行は case-auto が case-run(#epic) → case-close(#epic) の反復制御を担い、Wave 内の子Issue 選択、並列委譲は case-run(#epic) が、Wave 境界クローズ、Epic Issue 本文ステータス追跡テーブル更新は case-close(#epic) が担う（単一書き手: ADR、epic-wave-model SPEC、ADR）。
 
-### フェーズ構成
+### case-run internal lifecycle フェーズ構成
+
+case-run は orchestration stage（case-auto が管理する command 間進行、REQ-006 / case-auto 所有）と区別し、単一 Issue または Wave 内の case-run internal lifecycle（REQ-006 / case-run 所有）として次のフェーズを管理する。本節のフェーズは case-run internal lifecycle に属し、orchestration stage とは混同しない（`docs/specs/responsibilities/responsibility-boundary-purification.md`「case 実行責務の 4 用語と所有者」参照）。
 
 | フェーズ | Steps | 再開条件 |
 |----------|-------|----------|


### PR DESCRIPTION
## 概要

OU-003 responsibility-boundary-purification SPEC 新設セクション（case 実行責務の 4 用語と所有者）の acceptance criteria 検証と、agentdev_handoff 対象の配布 SPEC / SKILL 反映、既存 Phase 残渣と dangling REQ-006-105/106/102〜107 参照整理を実施。

Refs: #1824
Parent: #1821

## 変更内容

### agentdev_handoff（4 用語反映）

- `src/opencode/skills/agentdev-workflow-orchestration/SKILL.md`
  - 「### フェーズ構成」→「### case-run internal lifecycle フェーズ構成」へ改名
  - orchestration stage（REQ-006 / case-auto 所有）と case-run internal lifecycle（REQ-006 / case-run 所有）の区別を導入節へ明記
  - responsibility-boundary-purification SPEC「case 実行責務の 4 用語と所有者」セクションへ参照導線を明記
- `docs/specs/foundations/harness-separation-model.md`
  - 「### harness 側（実行制御）」節へ harness execution mechanism の ADF 規範所有対象外（REQ-011-018）と external execution boundary の REQ-011 正規所有（REQ-011-017）を明記
  - 「## case-auto の Phase 分離と bg task 管理」→「## case-auto の orchestration stage と bg task 管理」へ改名し Phase 残渣を整理

### pre-existing（Phase 残渣・dangling REQ 整理）

- `docs/specs/responsibilities/responsibility-boundary-purification.md` L37-42
  - 既存 case-auto 所有リストの Phase 1/2/3 表記を orchestration stage（stage 1/2/3）へ置換
  - dangling REQ-006-102/104/105/106 参照を正規 REQ-006-089/090/091/093 へ修正
  - v2:ADR-0138 注記の REQ-006-102〜107 範囲表記を REQ-006-089〜093 へ修正
  - 根拠: REQ-006 の最大 ID は REQ-006-104（105/106/107 は未存在）。正規マッピングは REQ-006-089（orchestration stage モデル）、REQ-006-090（stage 1/3 直列集約）、REQ-006-091（stage 2 並列数）、REQ-006-093（bg task 破棄時回復）
- `docs/specs/workflows/epic-wave-model.md` L231, L258, L260, L262, L264
  - 並列上限表の "case-auto Phase 2 同時起動数 / REQ-006-106" を "case-auto orchestration stage 2 同時起動数 / REQ-006-091" へ修正
  - 「## ドラフト間並列実行モデル（REQ-006-102〜107）」→「（REQ-006-089〜093）」へ修正
  - Phase 1/2/3 記述を orchestration stage（stage 1/2/3）へ置換
- `docs/specs/README.md`
  - epic-wave-model.md 責務列の「Phase 分離モデル」を「orchestration stage モデル」へ更新

### 自動生成

- `docs/specs/quality/req-health-metrics.md`, `docs/specs/quality/spec-health-metrics.md`
  - generate_indexes.ts により再生成（measure date 2026-07-27）

## 完了条件

- [x] SPEC 新設セクション追加（spec-save commit 1f004de7 で完了済み、本 PR では検証のみ）
- [x] 同セクション所有者表が 4 用語と正規所有者を固定（orchestration stage=REQ-006/case-auto、case-run internal lifecycle=REQ-006/case-run、harness execution mechanism=harness 責務 ADF 対象外、external execution boundary=REQ-011）
- [x] 責務分離原則サブセクション（case-auto / case-run 複製禁止、harness execution mechanism の references/ 集約、external execution boundary の REQ-011 一意解決）
- [x] 修飾なし Phase の除去サブセクション
- [x] agentdev_handoff: workflow-orchestration SKILL.md が orchestration stage と case-run internal lifecycle の区別を使用
- [x] agentdev_handoff: harness-separation-model.md が harness execution mechanism の ADF 規範所有対象外を明記
- [x] pre-existing: responsibility-boundary-purification.md L35-40 付近の Phase 残渣と dangling REQ-006-105/106 参照が整理済み

## テスト戦略

- TS-002 (AG-001 orchestration stage 所有者): PASS — SPEC L71「orchestration stage | ... | REQ-006 / case-auto」
- TS-003 (AG-003 harness execution mechanism 所有者): PASS — SPEC L73「harness execution mechanism | ... | harness 責務（ADF 規範所有対象外）」
- TS-004 (AG-004 external execution boundary 所有者): PASS — SPEC L74「external execution boundary | ... | REQ-011」
- TS-001 (Phase 残渣 grep, task inferred): PASS — docs/specs/ 配下で Phase 1 case-open / Phase 分離モデル パターンは SPEC 規範記述（L87 置換ルール）のみ残存、意図的
- TS-005 (REQ-006 関連 REQ 維持, task inferred): PASS — REQ-006-089/090/091/093 は全て REQ-006.md に存在（L109, L110, L111, L113）、dangling REQ-006-105/106/107 は docs/specs/ から完全除去済み

## Findings / Capture候補

### intake 候補

- 既存 `docs/specs/commands/case-open.md` L239-240 に「REQ-006-089」「REQ-006-093」参照があるが、文脈（子Issue 本文案作成・検査・Issue 作成の並列化、Epic Issue 作成の直列集約）が REQ-006-089（orchestration stage モデル）/ REQ-006-093（bg task 破棄時回復）の正規定義と一部ズレる。req-save / spec-save 工程の並列化契約は REQ-006-089〜093 とは別文脈の可能性あり。本 PR スコープ外（case-open.md SPEC は別 Issue で精査すべき）。

### learning 候補

- 該当なし。

## SPEC確定候補

該当なし。本 PR は既存 SPEC（responsibility-boundary-purification、harness-separation-model、epic-wave-model）への用語反映と Phase 残渣整理のみで、新規 SPEC 定義は含まない。