### PR TITLE
docs(specs): inspect-extensions SPEC を ADR-006 により superseded へ変更 (OU-003)

### DIFF
--- a/docs/specs/commands/inspect-extensions.md
+++ b/docs/specs/commands/inspect-extensions.md
@@ -1,11 +1,21 @@
 ---
 title: inspect-extensions command SPEC
-status: accepted
+status: superseded
+superseded_by: ADR-006
 created: 2026-07-04
-updated: 2026-07-18
+updated: 2026-07-27
 ---
 
 # inspect-extensions command SPEC
+
+> **Retire notice**: 本 SPEC は [ADR-006](../../adr/ADR-006.md)（inspect 3-command 構成への正規化）により superseded となった。
+> inspect-extensions command は独立公開 command として廃止され、extension 検査責務は次の3層へ移管済みである。
+>
+> - deterministic check（YAML 構文、必須 field、配置規則等）: `/repo/docs-check`（IR-056 と self-hosting full audit、[IR-056 起動契約](../integrity/rules/IR-056-project-extensions-integrity.md) 参照）
+> - semantic diagnosis（extension 責務境界、上書き意図の意味診断）: `/agentdev/inspect-skills`
+> - finding disposition（promote、defer、reject）: `/agentdev/inspect-promote`
+>
+> 後継契約の詳細は ADR-006 と IR-056 SPEC を参照。本文書は歴史的参照として残置する（status: superseded に伴い通常内容検査の対象外）。
 
 ## 目的
 

--- a/docs/specs/quality/spec-health-metrics.md
+++ b/docs/specs/quality/spec-health-metrics.md
@@ -118,12 +118,12 @@ AUTOGENブロックは `AUTOGEN:BEGIN` マーカーから対応する `AUTOGEN:E
 | skills/agentdev-spec-file-manager.md | 88 | draft | skills |
 | integrity/references/targeted-docs-guard-implementation-details.md | 87 | - | integrity |
 | commands/inspect-docs.md | 85 | accepted | commands |
+| commands/inspect-extensions.md | 84 | superseded | commands |
 | skills/agentdev-doc-diagnostics.md | 83 | draft | skills |
 | skills/agentdev-adr-file-manager.md | 82 | accepted | skills |
 | skills/agentdev-artifact-validation.md | 81 | draft | skills |
 | integrity/rule-ownership.md | 78 | accepted | integrity |
 | commands/inspect-promote.md | 77 | accepted | commands |
-| commands/inspect-extensions.md | 75 | accepted | commands |
 | commands/inspect-skills.md | 75 | accepted | commands |
 | skills/agentdev-skill-authoring.md | 74 | accepted | skills |
 | commands/intake-from-github.md | 70 | accepted | commands |


### PR DESCRIPTION
## 概要

OU-003 対応（Issue #1836）。`docs/specs/commands/inspect-extensions.md` を ADR-006（inspect 3-command 構成への正規化）により superseded へ変更する。inspect-extensions command は ADR-006 で独立公開 command として廃止され、extension 検査責務は docs-check（+IR-056）、inspect-skills、inspect-promote の3層へ移管済みである。本 PR は SPEC ファイルの retire を担う。

## 変更内容

- `docs/specs/commands/inspect-extensions.md`
  - frontmatter: `status: accepted` → `status: superseded`、`superseded_by: ADR-006` 追記、`updated: 2026-07-27`
  - H1 直下に retire notice を追加。後継3層（docs-check / inspect-skills / inspect-promote）への導線と ADR-006、IR-056 起動契約（`IR-056 起動契約（self-hosting と consumer）`）への参照を整備
  - 本文は歴史的参照として残置（`status: superseded` により通常内容検査対象外）
- `docs/specs/quality/spec-health-metrics.md`
  - `generate_indexes.ts` により自動再生成。inspect-extensions 行を更新（accepted → superseded、75 → 84 LOC、順位調整）

## test strategy 検証結果

- **TS-003** (AG-003: IR-056 SPEC への2起動経路記載)
  - verification: `docs/specs/integrity/rules/IR-056-project-extensions-integrity.md` の「## IR-056 起動契約（self-hosting と consumer）」セクション（commit c132ac6f で spec-save 済み）へ3サブセクションが存在することを確認
    - `### self-hosting full audit`: docs-check が .agentdev/extensions/{commands,skills}/*.yaml を走査することを記載
    - `### consumer changed-path routing`: case-run と case-close が .agentdev/extensions/** 変更時に IR-056 を起動することを記載
    - `### 検出事項の処分`: IR-056/docs-check → inspect-skills（意味診断）、inspect-promote（promote/defer/reject）への委譲を記載
  - pass_criteria: 2起動経路と検出事項の処分委譲が IR-056 SPEC に記載されていること → **合格**
  - status: pass
- **TS-007c** (AG-004: inspect-extensions SPEC retire、OU-003 担当分)
  - verification: `docs/specs/commands/inspect-extensions.md` frontmatter を確認
    - `status: superseded` ✓
    - `superseded_by: ADR-006` ✓
    - retire notice に後継3層への導線を明示 ✓
  - pass_criteria: inspect-extensions SPEC が ADR-006 により superseded として明示されていること → **合格**
  - status: pass

## 品質ゲート

- `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow spec-save --files docs/specs/commands/inspect-extensions.md docs/specs/quality/spec-health-metrics.md`
  - files checked: 2
  - coupled files checked: 2（docs/specs/README.md、docs/DOC-MAP.md）
  - failures: 0
  - warnings: 0
  - doc_map_update_required: false
  - spec_readme_update_required: true（後述の協調事項へ）
- `bun run .opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts`
  - `docs/specs/quality/spec-health-metrics.md` を更新（inspect-extensions 行: accepted → superseded、75 → 84 LOC）

## スコープ遵守（MUST NOT DO）

- IR-056 SPEC 本文（`docs/specs/integrity/rules/IR-056-project-extensions-integrity.md`）の編集: 行っていない（commit c132ac6f で spec-save 済み、本 Issue は検証のみ）
- `docs/specs/README.md` の編集: 行っていない（sibling #1835 が主担当、後述の協調事項参照）
- ADR-006 / skill 参照系の編集: 行っていない（#1834 スコープ）
- `src/opencode/commands/agentdev/inspect-extensions.md` command ファイルの retire: 行っていない（#1835 スコープ）
- inspect-extensions SPEC ファイルの削除: 行っていない（retire のみ、歴史参照として残置）
- worktree root（`.worktrees/1836-feature/`）以外のパスでのファイル編集: 行っていない

## Findings / Capture候補

### 協調事項: docs/specs/README.md inspect-extensions 行の status 更新（sibling #1835 担当）

`docs/specs/README.md` L95 の inspect-extensions 行は現状 `accepted` のままである。targeted docs guard は `spec_readme_update_required: true` を検出したが、本 PR の MUST NOT DO 制約により README 編集を sibling Issue #1835 へ委譲する。#1835 は inspect-extensions command の retire と README 更新を主担当するため、同 PR で inspect-extensions 行の status を `superseded` へ更新することが期待される。

該当 README 行（L95、現状）:
```
| [commands/inspect-extensions.md](commands/inspect-extensions.md) | accepted | `/agentdev/inspect-extensions`（...） |
```

期待される更新後（#1835 で実施）:
```
| [commands/inspect-extensions.md](commands/inspect-extensions.md) | superseded | `/agentdev/inspect-extensions`（...） |
```

### 事前不具合（本 PR 由来ではない）

`bun test ./.opencode/skills/repo-agentdev-integrity/scripts/` を実行すると 65 件のテスト fail が発生する。`git stash` して origin/main のクリーン状態で同一コマンドを実行しても同一の 65 件 fail が再現するため、本 PR 由来ではない事前不具合である。主に Skill USE FOR / DO NOT USE FOR section 検査、template file 探索等の環境由来の fail。

## SPEC確定候補

（本 PR で新たに発見された SPEC レベルの詳細事項は無し）

Refs: #1836