### PR TITLE
docs(specs): ADR-006 接線へ project-extensions SPEC と skill SPEC を更新 (#1834)

### DIFF
--- a/docs/specs/foundations/project-extensions.md
+++ b/docs/specs/foundations/project-extensions.md
@@ -2,12 +2,12 @@
 title: Project Extensions
 status: accepted
 created: 2026-07-04
-updated: 2026-07-18
+updated: 2026-07-27
 ---
 
 # Project Extensions
 
-実行時のプロジェクト固有追加・拡張機構としての project extensions を定義する（ADR-005: Project Extensions Architecture）。
+実行時のプロジェクト固有追加・拡張機構としての project extensions を定義する（ADR-006: inspect 3-command 構成への正規化、ADR-005 を supersede）。
 配布 command/skill 本文をプロジェクト非依存とし、プロジェクト固有の文脈、規約、検査、受け入れゲート、禁止事項を .agentdev/extensions/** 経由で追加・拡張する仕組みを規定する。
 従来の .agentdev/doc-inputs/**（参照リスト機構）に替わる設定層である。
 
@@ -62,7 +62,7 @@ command/skill は実行時に自分に対応する extension だけを読む。
 - 対応 extension が破損している場合はエラーを表示し、当該 extension を無視して標準動作で続行する。
 - extension は標準 command/skill の上書きではなく、追加・拡張としてのみ扱う。
 
-対応 extension が存在しない command/skill は正常動作であり、異常状態ではない。command が project 非依存で単体動作する正当な状態である。例として /agentdev/inspect-extensions は SPEC 直接参照を持たず project 非依存で動作するため extension 不要である。
+対応 extension が存在しない command/skill は正常動作であり、異常状態ではない。command が project 非依存で単体動作する正当な状態である。例として `/agentdev/inspect-skills` は SPEC 直接参照を持たず project 非依存で動作するため extension 不要である。
 
 ## project-local skill 委譲
 
@@ -99,24 +99,22 @@ REQ/ADR/SPEC 本文内の参照も許容する。
 
 ## 検査、診断
 
-/agentdev/inspect-extensions は読み取り専用診断コマンドとして以下を検査する。
+extension 検査は ADR-006（inspect 3-command 構成への正規化）に基づき、deterministic check、semantic diagnosis、finding disposition の3層へ分離される。各層は重複しない。
 
-1. .agentdev/extensions/** の一覧化
-2. extension YAML の構造確認
-3. kind と配置の整合確認
-4. id と対象 command/skill の対応確認
-5. context.paths の実在確認
-6. rules.skill / checks.skill に記述された project-local skill の存在確認
-7. 旧 .agentdev/doc-inputs/** の残存検出
-8. extension が標準 command/skill の上書きとして記述されていないことの確認
+| 層 | 正規所有者 | 検査内容 |
+|---|---|---|
+| deterministic check | IR-056 / `/repo/docs-check`（self-hosting）、`/agentdev/case-run`・`/agentdev/case-close` の changed-path routing（consumer） | extension 一覧化、YAML 構文、必須セクションと field、kind と配置、ID と対象 command/skill の対応、context path 実在、委譲先 skill 実在、旧 `.agentdev/doc-inputs/**` 残存 |
+| semantic diagnosis | `/agentdev/inspect-skills` | extension 責務境界、標準 command/skill を上書きする意図の意味診断 |
+| finding disposition | `/agentdev/inspect-promote` | finding の promote、defer、reject |
 
 AgentDevFlow 標準の inspect 責務は上記構造確認・path 実在確認・skill 存在確認までとする。
 command/skill 本文の ADR/REQ/SPEC 具体参照禁止の持続的検査は、各適用プロジェクトが project-local skill により実装する（AgentDevFlow 標準の対象外）。
 agent-dev-flow リポジトリ自身は適用プロジェクトの1つとして repo-local skill により検査を実装するが、これは標準仕様ではなくローカル運用である。
+`/agentdev/inspect-docs` へ extension の意味診断を追加しない（三層非重複）。
 
 ## ハイブリッド方式
 
-extension 原本は各プロジェクトが所有する。AgentDevFlow 本体は初期テンプレート、schema、検査、/agentdev/inspect-extensions コマンドを提供し、consumer はテンプレートを初期値として取り込みカスタマイズする。AgentDevFlow 本体リポジトリの .agentdev/extensions/** には本体固有 SPEC パスを記述してよい。
+extension 原本は各プロジェクトが所有する。AgentDevFlow 本体は初期テンプレート、schema、検査（`/repo/docs-check`、`/agentdev/inspect-skills`、`/agentdev/inspect-promote` の3層）を提供し、consumer はテンプレートを初期値として取り込みカスタマイズする。AgentDevFlow 本体リポジトリの .agentdev/extensions/** には本体固有 SPEC パスを記述してよい。
 
 ## 配布物参照境界の責務分担
 
@@ -125,6 +123,6 @@ extension 原本は各プロジェクトが所有する。AgentDevFlow 本体は
 配布物参照境界の検出結果はgeneric表記への是正とextensionによるtraceability補完へ接続する。
 ## 関連
 
-- ADR-005: Project Extensions Architecture
+- ADR-006: inspect 3-command 構成への正規化（ADR-005 を supersede、extension 検査の3層責務分離を確定）
 - REQ-001: 実行時独立性（本 SPEC は具体化機構を提供）
 

--- a/docs/specs/quality/spec-health-metrics.md
+++ b/docs/specs/quality/spec-health-metrics.md
@@ -102,8 +102,8 @@ AUTOGENブロックは `AUTOGEN:BEGIN` マーカーから対応する `AUTOGEN:E
 | responsibilities/responsibility-boundary-purification.md | 128 | accepted | responsibilities |
 | quality/req-health-metrics.md | 127 | accepted | quality |
 | commands/req-save.md | 125 | accepted | commands |
-| foundations/project-extensions.md | 125 | accepted | foundations |
 | foundations/harness-separation-model.md | 124 | accepted | foundations |
+| foundations/project-extensions.md | 123 | accepted | foundations |
 | integrity/rules/IR-057-obsolete-spec-path-after-domain-split.md | 118 | accepted | integrity |
 | authoring/command-file-format.md | 115 | accepted | authoring |
 | responsibilities/req-impact-map.md | 115 | accepted | responsibilities |

--- a/docs/specs/skills/agentdev-project-extensions.md
+++ b/docs/specs/skills/agentdev-project-extensions.md
@@ -2,7 +2,7 @@
 title: agentdev-project-extensions SPEC
 status: accepted
 created: 2026-07-04
-updated: 2026-07-18
+updated: 2026-07-27
 ---
 
 # agentdev-project-extensions SPEC
@@ -24,7 +24,7 @@ updated: 2026-07-18
 ### DO NOT USE FOR
 
 - extension schema の定義（基盤 SPEC `foundations/project-extensions.md` の責務）
-- extension 構造の診断、検査（`/agentdev/inspect-extensions` command の責務）
+- extension 構造の診断、検査（`/repo/docs-check`、`/agentdev/inspect-skills`、`/agentdev/inspect-promote` の3層責務、ADR-006）
 - 配布 command/skill 本文の変更
 - project-local skill の実装（各適用プロジェクトの責務）
 
@@ -55,7 +55,7 @@ updated: 2026-07-18
 ## 対象外
 
 - extension schema、配置、命名の定義（基盤 SPEC `foundations/project-extensions.md`）
-- extension 構造の診断（`/agentdev/inspect-extensions`）
+- extension 構造の診断（`/repo/docs-check`、`/agentdev/inspect-skills`、`/agentdev/inspect-promote` の3層、ADR-006）
 - project-local skill の実装（各適用プロジェクトの責務）
 - extension 自体の作成、編集（プロジェクト側の責務）
 
@@ -67,7 +67,7 @@ updated: 2026-07-18
 ## See Also
 
 - [foundations/project-extensions.md](../foundations/project-extensions.md)（project-extensions 機構の基盤 SPEC）
-- [commands/inspect-extensions.md](../commands/inspect-extensions.md)（保守診断 command SPEC）
+- [foundations/system.md](../foundations/system.md)（システム仕様、公開 command 一覧）
 - REQ-002（Project Extensions 機構と配布物参照境界）
-- ADR-005（Project Extensions Architecture）
+- ADR-006（inspect 3-command 構成への正規化、ADR-005 を supersede）
 


### PR DESCRIPTION
## 概要

Issue #1834（OU-002: ADR-006 内容検証 + ADR-005 superseded 確認 + foundation SPEC / skill 参照の ADR-006 更新）の実装。

ADR-006（inspect 3-command 構成への正規化）の acceptance criteria 検証と、agentdev_handoff 対象の foundation SPEC（docs/specs/foundations/project-extensions.md）と skill SPEC（docs/specs/skills/agentdev-project-extensions.md）の ADR-005 → ADR-006 参照更新、inspect-extensions command 参照の後継3層（docs-check、inspect-skills、inspect-promote）への置き換えを実施した。

## 変更点

- `docs/specs/foundations/project-extensions.md`: ADR-005 参照を ADR-006 へ更新。「検査、診断」セクションを inspect-extensions 単一 command から ADR-006 の3層責務分離テーブルへ再構成。inspect-extensions の説明を後継3層（`/repo/docs-check`、`/agentdev/inspect-skills`、`/agentdev/inspect-promote`）へ置き換え。
- `docs/specs/skills/agentdev-project-extensions.md`: USE FOR / DO NOT USE FOR / 対象外 / See Also の ADR-005 と inspect-extensions 参照を ADR-006 と後継3層へ更新。
- `docs/specs/quality/spec-health-metrics.md`: `generate_indexes.ts` による自動再生成（project-extensions.md の行数変化に伴うソート順更新）。

## ADR-006 acceptance criteria 検証結果

| TS | 項目 | 結果 | 根拠 |
|---|---|---|---|
| TS-002 | AG-002（11行責務割当表） | PASS | ADR-006 lines 31-43 に11行の責務割当表あり。8項目 IR-056/docs-check、2項目 inspect-skills、1項目 inspect-promote へ一意割当 |
| TS-004 | AG-005（ADR-005 superseded 記述） | PASS | ADR-006 lines 52-54 に superseded 明示・直接編集禁止を記載。ADR-005 frontmatter が `status: superseded`、`superseded_by: ADR-006` であることを確認 |
| TS-005 | AG-006（IR-059 維持と IR-056 非統合） | PASS | ADR-006 lines 55-56 に IR-059 検出対象・severity・gate level・責務境界の維持と IR-056 非統合を記載 |
| TS-006 | AG-007（三層非重複、inspect-docs 追加禁止） | PASS | ADR-006 lines 47-48 に三層非重複と inspect-docs 追加禁止を記載 |
| TS-007b | AG-004（foundation SPEC / skill 群 参照更新） | PASS | foundation SPEC（project-extensions.md）と skill SPEC（agentdev-project-extensions.md）の inspect-extensions 参照を後継3層へ更新済み |

## 検証

- `check_changed_docs.ts --workflow case-run`: PASS（failures 0件）
- `generate_indexes.ts`: 実行済み（spec-health-metrics.md 自動再生成）
- ADR-006 / ADR-005 frontmatter 整合性: 確認済み
- worktree 隔離: `.worktrees/1834-feature` 配下でのみ編集

## Findings / Capture候補

### docs-integrity

`check_changed_docs.ts --workflow case-run` を実行。failures 0件、warnings 0件。

### stale-reference（ADR-006 適用結果、Sibling Issue 連携候補）

ADR-006 により inspect-extensions は廃止されたが、本 Issue スコープ外（Sibling Issue #1835 / #1836 のスコープまたはそれらとの協調領域）に inspect-extensions 参照が残存する。これらは #1835（command retire + docs/specs/README.md row）および #1836（SPEC retire）の完了に伴い解消される想定である。

- `docs/specs/foundations/system.md` line 62: 公開 command 一覧表の inspect-extensions 行（#1835 連携で更新予定）
- `docs/specs/quality/spec-health-metrics.md` line 126 相当: `commands/inspect-extensions.md` SPEC サイズ行（#1836 SPEC retire 完了後に削除予定）
- `docs/specs/local/runtime-package-boundary.md` line 306: `inspect-extensions` を含む comma list（repo-agentdev-integrity 参照 command の例示）。#1835 完了後に更新が必要
- `src/opencode/commands/agentdev/README.md` line 29, 49: command 一覧表と定義ファイル一覧の inspect-extensions 行（#1835 main scope）
- `docs/specs/README.md`: command SPEC 一覧の inspect-extensions 行（#1835 main scope、明示的に本 Issue スコープ外）

case-update 連携の要否: これらは本 PR 完了後に Sibling Issue 側で処理されるため、本 Issue の完了条件（TS-007b）は foundation SPEC + skill SPEC のみで充足する。Issue 本文の更新は不要。

## SPEC確定候補

特になし。本変更は ADR-006 の適用結果を既存 SPEC へ反映するものであり、新規 SPEC レベルの詳細（schema、enum、判定表、内部アルゴリズム等）の発見はない。

## L2 タイムスタンプ計測

- worktree 設定: case-run Step 5 で作成済み（本委譲時点で完了）
- 実行担当サブエージェント実行: 単一 Issue インライン実行
- worktree クリーンアップ: case-run Step 8 で実施予定

Refs: #1834