### PR TITLE
feat(case-auto): REQ-006-083 orchestration pre-reader 契約を配布 command へ反映

### DIFF
--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -87,6 +87,8 @@ case-open 委譲の完了後、出力を確認して以下のいずれかに分�
 - **Standard flow（単一 Issue）**: case-open 委譲が共通終了処理（コメント追加、ドラフト削除、RU削除、完了報告）を完了していることを確認 → クリーンアップ検証ゲート（後述）→ 既存の直列フロー（case-run → case-close）
 - **Epic Issue flow（マルチREQ または 単一REQ Epic flow）**: 同上の確認 → クリーンアップ検証ゲート → Wave 反復制御（後述）
 
+**req_draft reader lifecycle（REQ-006-083）**: case-auto は orchestration pre-reader として case-open 完了前のみ req_draft を読み込む。case-open 成功後は invalid post-case reader として req_draft を読まず、停止、再開、完了処理は Issue と Epic だけで成立させる（G19）。クリーンアップ検証ゲートでドラフト削除を検証するのもこの lifecycle に由来する。
+
 #### Wave 反復制御（case-auto 直接制御、AG-003）
 
 Epic Issue 番号を記録。Epic Issue 本文（SSoT）から Wave 構成・各子Issue ステータスを読み取る（**読み取りのみ、Epic Issue 本文の書き込みは case-close の単一書き手責務**、G16）。case-run(#epic) への委譲は行わない。各子Issue ごとにインライン case-run を実行。以下の反復ループを実行:
@@ -331,7 +333,7 @@ Level 1（case-close rebase）→ Level 2（case-auto インライン case-run �
 - G15: case-auto は Epic Wave 実行時、Wave 反復制御、現在 Wave の ready 子Issue 選択、子Issue 並列委譲（最大5件）を直接担当する（AG-003）。case-run(#epic) への委譲は行わない。各子Issue ごとにインライン case-run を実行する。Wave 境界のクローズは case-close(#epic) に委譲する
 - G16: case-auto は独自の操作単位ステータス追跡を持ってはならない。Epic Issue のステータス追跡テーブルを使用する。**Epic Issue 本文の書き込みは case-close の単一書き手責務。case-auto は読み取るのみで書き込まない**
 - G18: case-auto は操作単位キューの管理、制御のみを担い、OU 本文の抽出、変換、REQ 操作解釈を行わないこと
-- G19: case-auto は req-save 段階（case-open 完了前）のみ draft を OU 情報の SSoT として扱うこと。case-open 完了後は子Issue（Epic Issue のステータス追跡テーブル含む）が SSoT となること。クリーンアップ検証ゲート（ドラフト削除検証）は case-open 完了後に実行すること。独自の OU 状態管理を持たないこと
+- G19: case-auto は orchestration pre-reader として case-open 完了前のみ req_draft を読み込み、case-open 成功後は invalid post-case reader として req_draft を読まないこと（REQ-006-083）。case-open 成功後の停止、再開、完了処理は Issue と Epic（Epic Issue のステータス追跡テーブル含む）だけで成立させること。クリーンアップ検証ゲート（ドラフト削除検証）は case-open 完了後に実行すること。独自の OU 状態管理を持たないこと
 - G20: OU 間依存は queue dependency として扱い、依存関係があるだけでは Epic Issue 化しないこと
 - G21: case-auto は Epic Issue 化の判定に関与しないこと。case-open の判定結果に従うこと
 - G27: 各工程の起動は工程別契約（Step 4 の契約表）に従うこと。inputs に指定された情報のみを渡し、output_contract に指定された結果のみを受領する


### PR DESCRIPTION
## 概要

OU-002 (Issue #1852) の配布 command handoff。REQ-006-083 で確定した orchestration pre-reader 契約を `src/opencode/commands/agentdev/case-auto.md` へ反映する。

REQ-006-083 の内容は Phase 1 (commit bd625c49) で REQ-006.md へ保存済み、artifact-contracts.md の req_draft consumer 4 集合も同 commit で確定済み。本 PR はそれらを受けて配布 command 定義を更新する。

## 変更内容

### `src/opencode/commands/agentdev/case-auto.md`

1. **G19 更新**: 従来の「req-save 段階（case-open 完了前）のみ draft を OU 情報の SSoT として扱う」表現を、REQ-006-083 の契約用語へ置換。
   - orchestration pre-reader として case-open 完了前のみ req_draft を読み込む
   - case-open 成功後は invalid post-case reader として req_draft を読まない
   - case-open 成功後の停止、再開、完了処理は Issue と Epic だけで成立させる

2. **case-open 完了後の分岐節へ req_draft reader lifecycle 追記**: case-open 境界での SSoT 遷移と、クリーンアップ検証ゲート（ドラフト削除検証）の由来を明示。

## 検証結果

### TS-002 (AG-003): orchestration pre-reader 明記

- REQ-006.md REQ-006-083 (L103): 「case-auto は case-open 前だけ req_draft を orchestration pre-reader として読み...」と明記
- artifact-contracts.md (L365): 「| orchestration pre-reader | `{case-auto}` | case-open 前だけ req_draft を読み...」と明記

### TS-004 (AG-005): Issue/Epic 単独成立

- REQ-006.md REQ-006-083 (L103): 「case-open 成功後の停止、再開、完了処理は Issue と Epic だけで成立させること」と明記
- REQ-008.md REQ-008-036 (L53): 「case-open 成功後は Issue と Epic を SSoT（唯一の情報源）とし... invalid post-case reader として req_draft を参照しないこと」と明記

### Indexes

`bun ./.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts` 実行 → no changes (already up-to-date)。コマンドファイル変更は index 対象外。

## 完了条件

- [x] REQ-006-083 が case-auto を orchestration pre-reader（case-open 前だけ req_draft 読取）として明記（Phase 1 commit bd625c49 で保存済み、本 PR で検証）
- [x] REQ-006-083 が case-open 成功後の invalid post-case reader としての req_draft 不読を明記（同上）
- [x] REQ-006-083 が case-open 成功後の停止、再開、完了処理を Issue と Epic だけで成立させることを明記（同上）
- [x] case-auto.md に orchestration pre-reader 契約（case-open 前だけ req_draft 読取）が反映されていること（本 PR で実装）

## Findings / Capture候補

なし。REQ-006-083 と artifact-contracts.md の双方で既に orchestration pre-reader 契約が確定しており、配布 command への反映のみで完結した。

## SPEC確定候補

なし。本変更は REQ-006-083 の配布物反映のみで、SPEC レベルの新規記述は発生しない。

Refs: #1852
