### PR TITLE
OU-001: REQ-008 UPDATE 内容検証 + 配布 command handoff（case-run.md req_draft 参照除去）

### DIFF
--- a/src/opencode/commands/agentdev/case-run.md
+++ b/src/opencode/commands/agentdev/case-run.md
@@ -167,7 +167,7 @@ Issue 本文に req-define 壁打ち合意の実行計画方向性（参考情�
 - 外部実行ハーネスの plan artifact 等の中間成果物の内部構造に依存した処理、検証を行わない。最終結果は PR URL で受領する
 - 実行担当サブエージェントが Issue 完了条件チェックボックスを更新しない（case-close QG-4 の責務）
 - Findings/ Capture 候補は実行担当サブエージェントが PR 本文の `## Findings / Capture候補` に記録する
-- **外部実行手段の中間成果物**: 外部実行手段の plan artifact 等の中間成果物を AgentDevFlow の永続成果物（draft/Issue/PR/REQ/ADR/SPEC）として扱わない
+- **外部実行手段の中間成果物**: 外部実行手段の plan artifact 等の中間成果物を AgentDevFlow の永続成果物（Issue/PR/REQ/ADR/SPEC）として扱わない。draft は一時成果物であり（REQ-008-001）、case-open 成功後は invalid post-case reader として参照しない（REQ-008-036）
 - **SPEC確定候補**: 実装時に発見された SPEC レベルの詳細（SPEC に記載すべき schema、enum、判定表、内部アルゴリズム等、実装で判明した仕様詳細）は、実行担当サブエージェントが PR 本文の `## SPEC確定候補` セクションに記録する。`## Findings / Capture候補`（本筋外発見、intake/learning 候補）とは別セクションとし、混在させない。SPEC確定候補は case-close Step 3 で SPEC 確定チェックの入力となり、draft → accepted 昇格または spec-save 再起動の判断材料となる
 
 ### Step 7: 実行担当サブエージェント result 処理


### PR DESCRIPTION
## 概要

Issue #1851 (OU-001, Wave 1) の handoff 実装。REQ-008-008/036 の内容検証と配布 command の req_draft 参照除去。

## 変更内容

- `src/opencode/commands/agentdev/case-run.md` Step 6「外部実行手段の中間成果物」行の分類誤りを是正:
  - 修正前: 「AgentDevFlow の永続成果物（**draft/**Issue/PR/REQ/ADR/SPEC）として扱わない」
  - 修正後: 「AgentDevFlow の永続成果物（Issue/PR/REQ/ADR/SPEC）として扱わない。draft は一時成果物であり（REQ-008-001）、case-open 成功後は invalid post-case reader として参照しない（REQ-008-036）」
- `src/opencode/commands/agentdev/case-close.md` は修正不要（req_draft 参照なし、`draft → accepted` は SPEC status のみ）

## REQ-008 内容検証（Phase 1 commit bd625c49 で保存済み）

- REQ-008-008: direct consumer 集合 `{req-save, spec-save, case-open}` ✓
- REQ-008-036: invalid post-case reader 集合 `{case-auto, case-run, case-close}` と req_draft 参照禁止を明記 ✓
- REQ-008-036: case-open 成功後は Issue と Epic を SSoT とし req_draft は削除可能 ✓

## Test Strategy 検証結果

- **TS-001 (AG-002)**: 合格。REQ-008-008 と `artifact-contracts.md` line 318 (draft type registry), line 364 (direct consumer) で direct consumer 集合 `{req-save, spec-save, case-open}` が一致
- **TS-003 (AG-004)**: 合格。`artifact-contracts.md` line 356-372「req_draft consumer 4 集合」セクションに invalid post-case reader `{case-auto, case-run, case-close}` 記載、REQ-008-036 が参照禁止を明記
- **TS-004 (AG-005)**: 合格。REQ-006-083 が「case-open 成功後の停止、再開、完了処理は Issue と Epic だけで成立させること」を直接明記、REQ-008-036 が SSoT 遷移を明記

## 完了条件対応

- [x] REQ-008-008 が direct consumer 集合 {req-save, spec-save, case-open} へ更新（Phase 1 で保存済み、本 PR で検証）
- [x] REQ-008-036 が invalid post-case reader 集合 {case-auto, case-run, case-close} と req_draft 参照禁止を明記（Phase 1 で保存済み、本 PR で検証）
- [x] REQ-008-036 が case-open 成功後の停止/再開/完了処理を Issue と Epic だけで成立させることを明記（Phase 1 で保存済み、REQ-006-083 と整合）
- [x] case-run.md から case-open 成功後の req_draft 参照を除去（draft を永続成果物リストから除去）
- [x] case-close.md から case-open 成功後の req_draft 参照を除去（元より参照なし、SPEC status draft→accepted のみ）

## Findings / Capture候補

特になし。

## SPEC確定候補

特になし。

Refs: #1851
