### PR TITLE
feat(commands): session由来RU 契約参照を backlog-review と req-define へ追加

### DIFF
--- a/src/opencode/commands/agentdev/backlog-review.md
+++ b/src/opencode/commands/agentdev/backlog-review.md
@@ -65,6 +65,20 @@ status: draft
 {req-define に渡す要件化の方向性}
 ```
 
+## session由来RU 生成形式（参照）
+
+`source_type: chat` かつ `generated_by: session` のRU（session由来RU）の生成形式は、REQ-008-051..057 および `docs/specs/responsibilities/artifact-contracts.md`「RU アーティファクト契約（session由来RU）」セクションを正規原本とする。本コマンドは同契約を再定義せず、以下を参照ポイントとして扱う。
+
+- frontmatter 必須フィールド: 通常のRU フィールドに加え `generation_actor`、`agreement_confirmed_at`、`generation_stage`、`logical_key` を必須とする（REQ-008-051、SPEC「frontmatter 必須フィールド」表）
+- 二段階承認: 第1承認はRU案内容のみを対象とし、第2承認のみが採番、保存、commit、push を許可する（REQ-008-052、SPEC「二段階承認」）
+- `agreement_confirmed_at` と `generated_at`: ISO 8601 形式で `generated_at >= agreement_confirmed_at` を満たし、保存完了前に req-define を開始しない（REQ-008-053）
+- session 論理URI: `sources[].type: chat` の場合のみ `sources[].path` へ `session:...` を解決しない論理URIとして許可する（REQ-008-054、SPEC「session 論理URI」）
+- RU 本文必須8セクション: 目的、対象、対象外、正規所有者とアンカー、依存関係、要件化の方向、決定的受け入れ条件、Source Summary（REQ-008-057、SPEC「RU 本文必須8セクション」）
+- 永続ID 採番: 保存時に既存最大番号+1で割り当て、保存後の `depends_on` は RU-ID で記録する（REQ-008-055、SPEC「保存先と永続ID」）
+- `tentative_classification`: 既存7値のいずれか。欠落時はRU 生成を停止する（REQ-008-056）
+
+各項目の判定基準、検証観点は正規原本（REQ-008 + artifact-contracts SPEC）へ委譲する。
+
 ## 手順
 
 ### Step 1: 実行前同期
@@ -114,6 +128,8 @@ status: draft
 ### Step 6: RU 生成
 
 RU 生成ルール、frontmatter スキーマ、depends_on 検証は `agentdev-backlog-integration` を参照
+
+**session由来RU の場合（REQ-008）**: `source_type: chat`、`generated_by: session` のRU は「session由来RU 生成形式（参照）」セクションに従う。二段階承認、frontmatter 必須フィールド、session 論理URI、RU 本文必須8セクション、採番、保存手続きは正規原本（REQ-008-051..057、artifact-contracts SPEC「RU アーティファクト契約（session由来RU）」）へ委譲する
 
 ### Step 7: 成功成果物の削除
 

--- a/src/opencode/commands/agentdev/req-define.md
+++ b/src/opencode/commands/agentdev/req-define.md
@@ -30,6 +30,17 @@ description: 要件を整理、定義する（機能追加、バグ修正共通�
 - extension が破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する
 - 詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
+## session由来RU 消費契約（参照）
+
+`source_type: chat` かつ `generated_by: session` のRU（session由来RU）を受領した場合、REQ-008-051..057 および `docs/specs/responsibilities/artifact-contracts.md`「RU アーティファクト契約（session由来RU）」セクションを正規原本として以下を扱う。本コマンドは同契約を再定義しない。
+
+- `logical_key` によるRU案特定: 第1承認済みのRU案を読み込む。第1承認は内容のみを対象とし、第2承認が採番、保存、commit、push を許可する（REQ-008-052、SPEC「二段階承認」）
+- `session:...` 論理URI の非解決: `sources[].type: chat` で `sources[].path` が `session:...` の場合、ファイル取得、URL取得、外部セッション取得の解決処理へ渡さない（REQ-008-054、SPEC「session 論理URI」）
+- 必須8セクション読み取り契約: RU 本文8セクション（目的、対象、対象外、正規所有者とアンカー、依存関係、要件化の方向、決定的受け入れ条件、Source Summary）は session 論理URI の解決なしに後工程が判断可能な自足性を前提とする（REQ-008-057、SPEC「RU 本文必須8セクション」）
+- `tentative_classification` → 最終分類: 暫定値を入力とし、Step 5-2 で document-model SPEC（extension 経由）の文書7分類モデルへ照らして最終分類を確定し、暫定分類を上書きする（REQ-008-056、SPEC「req-define による最終分類の扱い」）。`tentative_classification` は既存7値のいずれかであり、欠落時は受領しない
+
+各項目の判定基準、検証観点は正規原本（REQ-008 + artifact-contracts SPEC）へ委譲する。
+
 ## 手順
 
 ### Step 1: セッションコンテキスト検知（引数なし単体実行時のみ）
@@ -51,6 +62,8 @@ Read tool で読み込み、壁打ちの初期コンテキストとして扱う�
 0件なら Step 3 へ。
 2件以上なら候補一覧を表示し自動選択しない。
 セッション履歴、現在コンテキストおよび RU のいずれからも有効な入力を構成できない場合、壁打ち対話を開始する
+
+ **2-1. session由来RU 受領時（REQ-008）**: 読み込んだRU が `source_type: chat`、`generated_by: session` の場合、「session由来RU 消費契約（参照）」セクションに従う。`session:...` 論理URI の解決、必須8セクション読み取り契約、`tentative_classification` → 最終分類の扱いは正規原本（REQ-008-051..057、artifact-contracts SPEC）へ委譲する
 
 ### Step 3: 壁打ち対話
 


### PR DESCRIPTION
## 概要

Issue #1860 の handoff 作業。REQ-008-051..057 および artifact-contracts SPEC「RU アーティファクト契約（session由来RU）」セクションを正規原本とする参照アンカーを配布 command 2ファイルへ追加する。

## 変更内容

- `src/opencode/commands/agentdev/backlog-review.md`
  - 「session由来RU 生成形式（参照）」セクション追加（RU フォーマットと手順の間）
  - Step 6（RU 生成）へ session由来RU 参照ノート追加
- `src/opencode/commands/agentdev/req-define.md`
  - 「session由来RU 消費契約（参照）」セクション追加（project extensions と手順の間）
  - Step 2-1 へ session由来RU 受領時参照ノート追加

両ファイルとも契約の再定義を行わず、REQ-008 + artifact-contracts SPEC へ委譲する形で参照ポイントを記載する。

## 検証

- TS-007: git diff で両ファイルへ参照追加を確認、重複定義なし、UTF-8 no-BOM を確認済み
- generate_indexes.ts: no changes（command ファイル変更は索引に影響しない）

Refs: #1860
Parent: #1857

## Findings / Capture候補

特になし。handoff 作業は原本参照の追加のみで完結し、新たな契約上の発見事項なし。