### PR TITLE
docs(agentdev-workflow-templates): test strategy 記述ガイドラインセクションを追加 (Refs: #1866)

### DIFF
--- a/docs/specs/skills/agentdev-workflow-templates.md
+++ b/docs/specs/skills/agentdev-workflow-templates.md
@@ -2,7 +2,7 @@
 title: `agentdev-workflow-templates` SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-07-24
+updated: 2026-07-27
 ---
 
 # `agentdev-workflow-templates` SPEC
@@ -92,6 +92,26 @@ child テンプレートの「レビュー判断」セクションは親 Epic Is
 ### 転記規則（AG-011）
 
 転記規則の詳細は [case-open.md](../commands/case-open.md)「review_dispositions の消費と証跡転記」節参照。単一 Standard Issue は全 disposition を当該 Issue へ、Epic flow は Epic Issue へ全 disposition を、複数 Standard Issue は各 Issue の OU 関連 disposition を当該 Issue へ、ドラフト全体の disposition をルート Issue へ転記する。
+
+## test strategy 記述ガイドライン（AG-006）
+
+issue_desc_*.md テンプレートの「テスト戦略」セクションに記述する pass_criteria は QG-4 評価で REQ content と照合される。記述品質のばらつきが QG-4 時に顕在化するため、以下を共通ガイドラインとして正規所有する。
+
+### 共通 pass_criteria のリスクと REQ 個別期待値推奨
+
+複数 REQ へまたがる共通の pass_criteria を起票する場合、各 REQ の pipeline stage（promote 系、review 系等）の違いを吸収せず、単一の文字列一致を要求すると QG-4 評価時に REQ content と pass_criteria 期待値が食い違う。Issue #1760 QG-4 で REQ-0129-012 を含む完了条件が REQ content と文字列一致せず、意味合致評価で処理された実績がある。共通化は避け、REQ 単位の個別期待値を pass_criteria へ記述することを推奨する。
+
+### 変更対象外 REQ 検証の正しい表現
+
+「変更対象外 REQ の変更がないこと」を検証する場合は「存在しないこと」と書かず「diff がないこと」として表現する。実在する REQ を「存在しないこと」と記述すると検証意図と検証方法がずれる。Issue #1760 TS-003 で「REQ-0147-010 が存在しないこと」と誤表現し、REQ-0147-010 は存在する（変更なし）ため正しい検証意図は「変更されていないこと」だった。
+
+### 存在確認の使用条件
+
+「存在しないこと」は新規作成禁止（例: 「REQ-0164 が存在しないこと」等の未作成確認）の場合のみ使用する。既存 REQ への変更有無の検証には使用しない。
+
+### テンプレートへのガイド反映
+
+feature、bug、child の各 issue_desc テンプレートは「テスト戦略」セクションへ本ガイドラインの要点を HTML コメントとして埋め込む。起票者が pass_criteria を記述する際に参照できるようにする。epic テンプレートは「テスト戦略」セクションを持たないため対象外とする。
 
 ## 対象外
 

--- a/src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_bug.md
+++ b/src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_bug.md
@@ -41,6 +41,11 @@ labels: bug
 <!-- 【必須】 -->
 
 <!-- テスト戦略: 各項目を verification（検証手順）/ pass_criteria（合格基準）/ on_failure（不合格時の処置）の3要素構造で記述 -->
+<!-- pass_criteria 記述ガイド（AG-006）:
+  - 共通 pass_criteria は複数 REQ の pipeline stage 違いで QG-4 食い違いを生むため、REQ 単位の個別期待値を推奨
+  - 「変更対象外 REQ の変更がないこと」は「diff がないこと」として表現し、「存在しないこと」とは書かない
+  - 「存在しないこと」は新規作成禁止（例: REQ-NNNN が存在しないこと）の場合のみ使用。既存 REQ の変更有無検証には使用しない
+  - 詳細は docs/specs/skills/agentdev-workflow-templates.md「test strategy 記述ガイドライン」参照 -->
 - id: TS-001
  target_item: [検証対象]
  verification: |

--- a/src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_child.md
+++ b/src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_child.md
@@ -39,6 +39,11 @@ REQ-{req_number}
 <!-- 【必須】 -->
 
 <!-- テスト戦略: case-open が draft-data の test_strategy を各項目の3要素構造（verification/pass_criteria/on_failure）で埋め込む -->
+<!-- pass_criteria 記述ガイド（AG-006）:
+  - 共通 pass_criteria は複数 REQ の pipeline stage 違いで QG-4 食い違いを生むため、REQ 単位の個別期待値を推奨
+  - 「変更対象外 REQ の変更がないこと」は「diff がないこと」として表現し、「存在しないこと」とは書かない
+  - 「存在しないこと」は新規作成禁止（例: REQ-NNNN が存在しないこと）の場合のみ使用。既存 REQ の変更有無検証には使用しない
+  - 詳細は docs/specs/skills/agentdev-workflow-templates.md「test strategy 記述ガイドライン」参照 -->
 - id: TS-001
  target_item: [検証対象]
  verification: |

--- a/src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_feature.md
+++ b/src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_feature.md
@@ -39,6 +39,11 @@ labels: enhancement
 <!-- 【必須】 -->
 
 <!-- テスト戦略: 各項目を verification（検証手順）/ pass_criteria（合格基準）/ on_failure（不合格時の処置）の3要素構造で記述 -->
+<!-- pass_criteria 記述ガイド（AG-006）:
+  - 共通 pass_criteria は複数 REQ の pipeline stage 違いで QG-4 食い違いを生むため、REQ 単位の個別期待値を推奨
+  - 「変更対象外 REQ の変更がないこと」は「diff がないこと」として表現し、「存在しないこと」とは書かない
+  - 「存在しないこと」は新規作成禁止（例: REQ-NNNN が存在しないこと）の場合のみ使用。既存 REQ の変更有無検証には使用しない
+  - 詳細は docs/specs/skills/agentdev-workflow-templates.md「test strategy 記述ガイドライン」参照 -->
 - id: TS-001
  target_item: [検証対象]
  verification: |


### PR DESCRIPTION
## 概要

Issue #1866: OU-002 - agentdev-workflow-templates へ test strategy 記述ガイドラインセクションを追加する。RU-0006 / AG-006 が指摘する pass_criteria 記述品質ガイド未整備を解消する。

## 変更内容

### docs/specs/skills/agentdev-workflow-templates.md

- frontmatter の updated を 2026-07-27 へ更新
- 「## test strategy 記述ガイドライン（AG-006）」セクションを新設
  - 共通 pass_criteria のリスクと REQ 個別期待値推奨
  - 変更対象外 REQ 検証の正しい表現（diff がないこと）
  - 存在確認の使用条件（新規作成禁止の場合のみ使用）
  - テンプレートへのガイド反映方針（feature/bug/child 対象、epic は対象外）

### src/opencode/skills/agentdev-workflow-templates/templates/

以下3テンプレートの「テスト戦略」セクション既存コメント直後へ、pass_criteria 記述ガイドコメント（AG-006）を追記:

- issue_desc_feature.md
- issue_desc_bug.md
- issue_desc_child.md

## 受け入れ基準（Issue #1866 完了条件）

- [x] docs/specs/skills/agentdev-workflow-templates.md に「## test strategy 記述ガイドライン」セクションが追加されていること
- [x] 共通 pass_criteria のリスクと REQ 個別期待値推奨が記載されていること
- [x] 変更対象外 REQ 検証の正しい表現（diff がないこと）が記載されていること
- [x] 存在確認の使用条件（新規作成禁止の場合のみ）が記載されていること
- [x] src/opencode/skills/agentdev-workflow-templates/ の issue_desc_*.md テンプレートに test strategy 記述ガイドが追記されていること

## テスト戦略検証（TS-006）

- verification: SPEC と issue_desc_*.md テンプレート両方へガイドラインが記載されていることを grep で確認
- pass_criteria: SPEC の「test strategy 記述ガイドライン」セクションに4ポイント全て記載、feature/bug/child 3テンプレートに要点コメント記載を確認
- 結果: 合格

## Findings / Capture候補

- epic テンプレート（issue_desc_epic.md）は「テスト戦略」セクションを持たないため、本ガイドラインの埋め込み対象外とした。Issue #1866 の完了条件「issue_desc_*.md テンプレートに追記」は、テスト戦略セクションを持つ feature/bug/child の3ファイルへ対応し、epic は構造上の対象外として処理した。SPEC 本文へ明記済み。
- issue_desc_backlog_child.md, issue_desc_backlog_epic.md は SPEC「参照する references」に列挙されているが、実ファイル存在を確認できない（別Issue候補）。

## SPEC確定候補

特になし。本 PR は SPEC 本文への追記が完結しており、新たな SPEC レベルの詳細は発見されなかった。

Refs: #1866
