### PR TITLE
docs(specs): quality-specs.md へ必須シナリオ10シナリオ一覧セクションを追加 (Issue #1869)

### DIFF
--- a/docs/specs/quality/quality-specs.md
+++ b/docs/specs/quality/quality-specs.md
@@ -27,3 +27,29 @@ AgentDevFlow の品質基準、検証ルールを定義する。
 - Command 行数上限: 100行目標、150行上限、200行以内（200行超は分割対象）
 - Skill 行数上限: 200行超で分割候補報告
 - 執筆完了基準（Authoring DoD）: 行数、Steps、共通化、正規パス（`canonical path`）
+
+## 必須シナリオ（10シナリオ）
+
+ADR-001 決定6（リリース条件）の条件4「SPECが定義する10件の必須シナリオをすべて通過する」（ADR-001 L114）が参照する10シナリオの正規一覧を定義する（REQ-001、REQ-010）。
+シナリオの定義は本 SPEC が正規所有し、実行結果（通過/未通過の証跡）は Release Report が所有する（規範情報と非規範情報の分離、RU-0026 準拠）。
+
+### シナリオ一覧
+
+| ID | シナリオ名 | 合格基準 | 関連 REQ |
+|----|-----------|---------|---------|
+| S-001 | 単一REQ保存 | req-save がREQファイルへ要件行を保存し check-frontmatter-consistency.ts が ok を返す | REQ-008 |
+| S-002 | SPECセクション保存 | spec-save が target_area ベースでSPECへセクション追記・置換を行い search-target-area.ts が正しくマッチする | REQ-008 |
+| S-003 | Issue作成 | case-open が draft-data から Issue 本文を生成し QG-2 が通る | REQ-006 |
+| S-004 | 標準実行 | case-run が単一 Issue を実行し PR を作成する | REQ-006 |
+| S-005 | 標準クローズ | case-close が PR を merge し Issue を close し capture を実施する | REQ-006 |
+| S-006 | Epic Wave実行 | case-open が Epic Issue を作成し case-run が Wave 内子 Issue を並列実行し Epic が close される | REQ-006 |
+| S-007 | 全自動実行 | case-auto が draft から merge まで自走し main へ反映される | REQ-006 |
+| S-008 | GitHub課題取り込み | intake-from-github が課題を抽出し intake-promote が採用/却下を判定する | REQ-007 |
+| S-009 | 学びの捕捉と昇格 | case-close が learning を capture し learning-promote が評価・採用する | REQ-007 |
+| S-010 | 文書整合性検証 | docs-check / inspect-docs が REQ/ADR/SPEC の整合性を検証し全て ok を返す | REQ-010 |
+
+### ADR-001 との参照関係
+
+- 本セクションは ADR-001 決定6 条件4（L114）が参照する10シナリオの正規一覧を所有する
+- ADR-001 はシナリオ定義を本 SPEC へ委譲し、シナリオの列挙や合格基準を ADR 本文へ重複して記述しない
+- シナリオの実行結果は Release Report が証跡として記録し、本 SPEC へ実行結果を規範内容として持ち込まない（RU-0026）


### PR DESCRIPTION
## 関連 Issue

Refs: #1869 (Parent: #1868)

## 概要

`docs/specs/quality/quality-specs.md` へ「## 必須シナリオ（10シナリオ）」セクションを新設し、ADR-001 決定6 条件4（L114）「SPECが定義する10件の必須シナリオをすべて通過する」が参照する10シナリオ（S-001〜S-010）の正規一覧を定義する。

## 変更内容

- `docs/specs/quality/quality-specs.md` へ「## 必須シナリオ（10シナリオ）」セクションを追記
- シナリオ一覧テーブル（S-001〜S-010）を追加。各シナリオに ID、シナリオ名、合格基準、関連 REQ を定義
- ADR-001 L114 との参照関係を明記し、シナリオ定義の正規所有者が本 SPEC であることを宣言
- 実行結果は Release Report が所有する（RU-0026 準拠）旨を記載

## 完了条件

- [x] `docs/specs/quality/quality-specs.md` に「## 必須シナリオ（10シナリオ）」セクションが存在すること
- [x] 10シナリオの一覧テーブル（S-001〜S-010）が存在すること
- [x] 各シナリオに ID、シナリオ名、合格基準、関連 REQ が定義されていること
- [x] ADR-001 L114 との参照関係が記載されていること

## テスト戦略検証

### TS-003

- **verification**: `docs/specs/quality/quality-specs.md` に「## 必須シナリオ（10シナリオ）」セクションが存在すること、10シナリオの枠組み（S-001〜S-010）が定義されていること、各シナリオに名称・合格基準・関連 REQ が定義されていることを確認
- **検証結果**: pass
  - セクション存在: 1 件（L31）
  - テーブルヘッダ: 1 件（L38 `| ID | シナリオ名 | 合格基準 | 関連 REQ |`）
  - S-001〜S-010 行: 10 件（L40〜L49）
  - ADR-001 L114 参照: 1 件（L33）
  - ADR-001 との参照関係セクション: 1 件（L51）

## 品質ゲート

- **QG-3 (Implementation Deviation Gate)**: no-deviation。Issue 本文の提案内容（10シナリオ一覧テーブル、合格基準、関連 REQ）通りに実装。スコープ外ファイルへの変更なし。
- **encoding**: UTF-8 (BOM なし)。`file` コマンドで `Unicode text, UTF-8 text` を確認。
- **check-frontmatter-consistency.ts**: `{"ok": true, "errors": [], "warnings": []}` を確認。
- **artifact-validation test suite**: 22 pass / 0 fail。

## スコープ外（OU-002 へ委譲）

- ADR-001 本文（L114）から本 SPEC への参照リンク追加は OU-002（ADR-001 直接編集）が担当。本 PR は quality-specs.md のみ。

## Findings / Capture候補

特になし。Issue 本文の提案内容（10シナリオ一覧）をそのまま正規一覧として採用した。
