### PR TITLE
OU-001: agentdev-gh-cli Windows 環境固有手続き SPEC 参照追記と詳細手続き整備

### DIFF
--- a/docs/specs/skills/agentdev-gh-cli.md
+++ b/docs/specs/skills/agentdev-gh-cli.md
@@ -2,7 +2,7 @@
 title: `agentdev-gh-cli` SPEC
 status: accepted
 created: 2026-06-21
-updated: "2026-07-26"
+updated: "2026-07-27"
 ---
 
 # `agentdev-gh-cli` SPEC
@@ -104,6 +104,28 @@ gh WRITE 操作を行う全 command/ skill（case-open、case-run、case-close�
 ### ローカル版の扱い
 
 ローカル版は Case ファイル読み書きへ差し替えるため、本要件の対象外（gh CLI を使用しない）。ローカル版の具体的取扱いは v2:REQ-0150 参照。
+
+## Windows 環境固有手続き
+
+Windows 環境（Windows PowerShell 5.x / pwsh 7）での gh CLI 実行に特有の手続きを以下5項目として定義する（RU-0005）。
+本 SPEC は各手続きの存在と `references/standard-procedures.md` への参照関係のみを定め、詳細実装（gh CLI フラグ、PowerShell 式、ファイル配置、cleanup 手順）は同ファイルへ委譲する（REQ-011、ADR-004 decision #3）。
+ローカル版は Case ファイル読み書きへ差し替えるため本要件の対象外（gh CLI を使用しない）。
+
+### 対象手続き（5項目）
+
+| # | 項目 | 概要 | 詳細参照 |
+|---|------|------|---------|
+| 1 | cp932 化け対策 | Windows 環境での `--title` / inline `--input` 引数の使用禁止、`--body-file` / `gh api --input` 推奨。コンソールエンコーディング初期化（Section 2 Step 0）と `--title` 引数 decode を別問題として扱う | `references/standard-procedures.md`「共通制約」「Section 2 Step 0」。REQ-011-009 詳細は前節「WRITE 手続きの Windows encoding 初期化必須化」参照 |
+| 2 | title 修正 REST API PATCH 標準手続き | title 修正が必要な場合の `gh api -X PATCH /repos/{owner}/{repo}/issues/{N}` + UTF-8 JSON `--input` file 標準手続き | `references/standard-procedures.md`「title 修正 REST API PATCH 標準手続き」 |
+| 3 | 一時ファイル配置（`.agentdev/tmp/`）と cleanup 一体化 | 一時ファイル配置を `.agentdev/tmp/`（workspace-local）へ統一。create → gh 実行 → VERIFY → cleanup を1手順ユニットとし、cleanup を省略不可ステップ化 | `references/standard-procedures.md`「Section 2 標準手順」「Section 3 安全な読み取り手順」 |
+| 4 | PowerShell regex MatchEvaluator 内 -replace 注意と回避策 | PowerShell regex MatchEvaluator 内での `-replace` 演算子使用による意図しない置換破壊と回避策（Node.js `String.split/join` または PowerShell `[String]::Replace`） | `references/standard-procedures.md`「PowerShell regex MatchEvaluator 内 -replace 使用注意」 |
+| 5 | backreference `$N` 対策との区別 | 項目4とは別件。`-replace` 演算子右辺での regex backreference `$N` を PowerShell 変数補間から守るシングルクォート囲み規則 | `references/standard-procedures.md`「PowerShell 変数補間（regex backreference `$N`）」 |
+
+### cp932 化け対策と「WRITE 手続きの Windows encoding 初期化必須化」の関係
+
+前節「WRITE 手続きの Windows encoding 初期化必須化（REQ-011-009）」は項目1（cp932 化け対策）のうちコンソールエンコーディング初期化を REQ-011-009 として正規化した詳細要件である。
+本節は5項目カタログの文脈で cp932 化け対策の全体像（`--title` / inline `--input` 使用禁止、`--body-file` / `gh api --input` 推奨、コンソール初期化）を整理し、REQ-011-009 節と両立する。
+項目1が指す「コンソールエンコーディング初期化と `--title` 引数 decode の別問題性」とは、Section 2 Step 0（コンソールコードページ切替）が `--title` 引数の文字列出力経路とは独立していることを指す。Step 0 を実行しても `--title` の inline 渡しは cp932 経路のリスクを完全に除去しないため、`--title` / inline `--input` は原則使用禁止とし、title 修正は項目2の REST API PATCH 経由を標準とする。
 
 ## 薄いルーティング入口と references 分離
 

--- a/src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md
+++ b/src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md
@@ -11,6 +11,11 @@
 - 書き込み後の VERIFY 操作（[verify.md](verify.md)）を全環境で実行する
 - 保存形式は **UTF-8 (BOMなし)**、改行コード **LF** とする
 - **Windows 環境での WRITE 手続きはコンソールエンコーディング初期化（Section 2 Step 0）を必須前置する（REQ）**: 全 WRITE 手続き（Issue 作成、Issue 本文更新、Issue コメント追加、PR 作成、PR merge、Issue close 等）は Section 2 の標準手順に従い、Step 0 を経由してコンソールエンコーディング初期化の恩恵を受ける。Linux/ macOS/ WSL 等の Windows 以外の環境では既定で UTF-8 コンソールのため実行不要
+- **Windows 環境での引数渡し制約（cp932 化け対策、RU-0005 AG-001）**: Windows 環境では gh CLI への引数渡し経路が cp932 化けを生むため、以下を遵守する
+ - **`--title "..."` の inline 使用禁止**: `gh issue create --title "日本語"`、`gh pr create --title "日本語"` 等、日本語を含む `--title` 引数の inline 渡しを禁止する。Section 2 Step 0 のコンソールエンコーディング初期化を実行しても `--title` 引数の decode 経路が独立して cp932 影響を受けるため、Step 0 は `--title` 化けの完全な対策にならない
+ - **inline `--input` 使用禁止**: `gh api --input -`（stdin 経由）等の inline 入力を禁止する
+ - **推奨**: 本文は `--body-file`/ `-F`、API 操作は `gh api --input @file.json`（UTF-8 JSON ファイル）を使用する
+ - **title 修正**: 日本語 title を設定または修正する場合は `gh api -X PATCH` 経由（後述「title 修正 REST API PATCH 標準手続き」）を標準とする。ASCII 限定 title のみ inline `--title` を許容する
 
 ## Windows 固有の制約
 
@@ -36,6 +41,31 @@
 - **例（NG）**: `"pattern" -replace "(foo)", "$1-bar"`（`$1` が PowerShell 変数として展開され、空文字列になる）
 - **例（OK）**: `"pattern" -replace "(foo)", '$1-bar'`（シングルクォートで backreference を保持）
 
+### PowerShell regex MatchEvaluator 内 -replace 使用注意（RU-0005 AG-004）
+
+`[regex]::Replace()` の MatchEvaluator（スクリプトブロック）内で `-replace` 演算子を使用すると、MatchEvaluator が返す文字列そのものが再度 `-replace` の対象となり、意図しない置換破壊を生じる。前節「PowerShell 変数補間（regex backreference `$N`）」とは発生原理が異なり、対策も異なるため両者を区別して扱う。
+
+#### 発生原理
+
+`[regex]::Replace(input, pattern, MatchEvaluator)` の MatchEvaluator は一致箇所ごとに呼ばれ、戻り値が置換結果となる。MatchEvaluator 内で `-replace` を使用すると、MatchEvaluator の戻り値（置換後文字列）がそのまま最終置換結果として採用されるはずが、`-replace` が MatchEvaluator の戻り値に対して再度パターンマッチを行い、予期せぬ二次置換を発生させる。
+
+- **適用場面**: Issue/ PR 本文の行単位 regex 置換、Epic ステータステーブルの行編集、`-replace` を MatchEvaluator 内で組み合わせる処理等
+- **例（NG）**: `[regex]::Replace($text, $pattern, { param($m) $m.Value -replace 'foo', 'bar' })`（MatchEvaluator 戻り値の `-replace` が二次置換を生じる）
+- **例（NG）**: `'foo' -replace '(\w+)', { param($m) $m.Groups[1].Value -replace 'o', 'O' }`（`-replace` 右辺のスクリプトブロック内 `-replace` が意図しない置換破壊を生じる）
+
+#### 回避策（前節 backreference `$N` 対策との区別）
+
+backreference `$N` 対策は「`-replace` 演算子右辺の `$N` を PowerShell 変数補間から守る」ことが目的で、シングルクォート囲みで対応する。一方、MatchEvaluator 内 `-replace` 問題は「MatchEvaluator 内で `-replace` を使わない」ことが目的で、別の回避策をとる。
+
+- **回避策1（Node.js `String.split`/ `join`）**: PowerShell ではなく Node.js 側で文字列置換を実行する。`String.split(pattern).join(replacement)` を使用し、regex 依存を避ける。READ 手続き（Section 3）の Node.js `execSync` 経由と親和性が高い
+- **回避策2（PowerShell `[String]::Replace`）**: PowerShell 側で処理する場合は `[String]::Replace(oldValue, newValue)` を使用する。`[String]::Replace` は regex を解釈しないため、MatchEvaluator 内の二次置換問題が発生しない
+- **例（OK、Node.js）**: `node -e "const s=require('fs').readFileSync('.agentdev/tmp/source.md','utf-8');require('fs').writeFileSync('.agentdev/tmp/out.md', s.split('foo').join('bar'))"`
+- **例（OK、PowerShell）**: `[regex]::Replace($text, $pattern, { param($m) $m.Groups[1].Value.Replace('foo', 'bar') })`（MatchEvaluator 内で `[String]::Replace` を使用）
+
+#### backreference `$N` との併発ケース
+
+両者が同時に発生する場合は、MatchEvaluator 内での `-replace` 使用を避けた上で、`[String]::Replace` 内の置換文字列に `$N` が含まれないかを確認する。`[String]::Replace` は regex 解釈しないため `$N` もリテラル扱いとなり、backreference の問題は生じない。
+
 ## WRITE 手続き（書き込み安全性）
 
 ### 1. 禁止事項
@@ -58,11 +88,13 @@
  - **理由**: 既定の Shift-JIS コンソール（`chcp 932`）では、gh CLI が `--title` の日本語引数やメタデータを Shift-JIS として扱い文字化けが発生する。`[Console]::OutputEncoding` は gh CLI の標準出力、標準エラーの読み取りエンコーディング、`$OutputEncoding` は PowerShell からネイティブコマンドへパイプで渡す際のエンコーディング、`chcp 65001` はコンソールのコードページそのものを UTF-8 に設定する。3 行すべてが独立した役割を持つため省略不可。
  - **Windows 以外の環境（Linux/ macOS/ WSL 等）では不要**: 既定で UTF-8 コンソールのため実行不要。実行してもエラーになるため実行しないこと。
  - **既存の `[System.IO.File]::WriteAllText`（UTF-8 BOM なし）規定との両立関係**: Step 0 はコンソールエンコーディング初期化（新規ステップ）、Step 1 はファイル書き出し（既存規定）。両者は独立しており、Step 0 を実行しても Step 1 の `[System.IO.File]::WriteAllText` による UTF-8 BOM なし書き出し規定は変更されない。ファイル書き出しは引き続き `[System.IO.File]::WriteAllText` を使用し、`Out-File`/ `Set-Content`/ `>` 等の禁止コマンドは Step 0 の有無にかかわらず引き続き禁止（Section 1 参照）。
+ - **Step 0 と `--title` 引数 decode の別問題性（RU-0005 AG-001）**: Step 0 はコンソールコードページを UTF-8 へ切替える処理であり、`--title` 引数の inline 文字列が gh CLI 内部で decode される経路とは独立している。Step 0 を実行しても `--title` の inline 渡しが cp932 経路の影響を完全に回避できないため、日本語 `--title` の inline 使用は禁止し（共通制約参照）、title 修正は後述「title 修正 REST API PATCH 標準手続き」経由を標準とする。Step 0 と `--title` 禁止は補完関係にあり、Step 0 が `--title` 禁止を撤回するものではない。
 
-1. テキスト（Issue本文、PR説明など）を一時ファイル `$env:TEMP/agentdev/gh-temp-{timestamp}.md` に書き出す。**PowerShell で `[System.IO.File]::WriteAllText` を使用すること**:
+1. テキスト（Issue本文、PR説明など）を一時ファイル `.agentdev/tmp/gh-temp-{timestamp}.md`（workspace-local）に書き出す（RU-0005 AG-003）。**PowerShell で `[System.IO.File]::WriteAllText` を使用すること**:
  ```
- [System.IO.File]::WriteAllText("$env:TEMP/agentdev/gh-temp-{timestamp}.md", $content, (New-Object System.Text.UTF8Encoding($false)))
+ [System.IO.File]::WriteAllText(".agentdev/tmp/gh-temp-{timestamp}.md", $content, (New-Object System.Text.UTF8Encoding($false)))
  ```
+ **`.agentdev/tmp/` 配置の理由（RU-0005 AG-003）**: `$env:TEMP/agentdev/`（システム一時ディレクトリ）から `.agentdev/tmp/`（workspace-local）へ変更する。workspace 配下へ配置することで worktree 削除時に一時ファイルが確実に破棄され、かつ VERIFY や事後調査が同一 workspace 内で完結する。
  **OpenCode の Write tool は新規ファイル作成時に限定して使用可能**（BOMなしUTF-8で書き出す）。
 既存 UTF-8（BOM なし）ファイル編集時は edit ツール（per-line string replace）を優先すること。
 Windows 環境で Write tool が既存 UTF-8 ファイルを cp932 で書き出す事象が実証されているため、Write tool の全面上書きは新規作成時のみ許可する。
@@ -80,7 +112,9 @@ PowerShell の `Out-File`, `Set-Content`, `>` 等は使用禁止（Section 1 参
  | `gh issue comment` | `--body` | `--body-file` | `-F` |
  | `gh pr create` | `--body` | `--body-file` | `-F` |
 
-4. 実行完了後、一時ファイルを削除する。
+4. **WRITE ユニットの完了と cleanup（RU-0005 AG-003、省略不可）**: WRITE 手続きは create（Step 1） → gh 実行（Step 3） → VERIFY（[verify.md](verify.md)） → cleanup を1ユニットとし、cleanup を省略不可ステップとする。VERIFY が PASS した後にのみ cleanup を実行する。VERIFY が FAIL の場合は cleanup を実行せず、一時ファイルを残して [retry.md](retry.md) のリトライロジックへ移行する（一時ファイルはリトライ時の比較、原因調査の情報源となる）。これにより「VERIFY を忘れて cleanup し、問題を事後検出できなくなる」事態を構造的に防止する。
+ - **cleanup 対象**: `.agentdev/tmp/` 配下の当該 WRITE ユニットで生成した一時ファイル
+ - **VERIFY FAIL 時の一時ファイル保管期間**: リトライまたは停止手続きの完了後、[retry.md](retry.md) に従い cleanup する
 
 ## READ 手続き（読み取り安全性）
 
@@ -88,7 +122,7 @@ PowerShell の `Out-File`, `Set-Content`, `>` 等は使用禁止（Section 1 参
 
 1. `gh` コマンドの出力を **Node.js `child_process.execSync`** で取得し、一時ファイルに書き出す:
  ```
- node -e "const{execSync}=require('child_process');const{writeFileSync}=require('fs');const r=execSync('gh issue view {N} --json body -q .body',{encoding:'utf-8'});writeFileSync('$env:TEMP/agentdev/gh-read-{timestamp}.md',r)"
+ node -e "const{execSync}=require('child_process');const{writeFileSync}=require('fs');const r=execSync('gh issue view {N} --json body -q .body',{encoding:'utf-8'});writeFileSync('.agentdev/tmp/gh-read-{timestamp}.md',r)"
  ```
  **PowerShell の `>` リダイレクトは使用禁止**（pwsh 7 も含む。ネイティブコマンドのstdout出力がパイプライン経由でエンコーディング変換され、日本語が文字化けするため）。
 **理由**: Node.js の `execSync` は pwsh パイプラインをバイパスして gh CLI の生の UTF-8 出力を直接取得するため、エンコーディング変換による文字化けが発生しない。
@@ -101,14 +135,14 @@ PowerShell の `Out-File`, `Set-Content`, `>` 等は使用禁止（Section 1 参
 
 6. **軽量回避策（第1段階）**: `--json` で JSON 全体を取得し、JS 内で `JSON.parse()` 後にフィルタする:
  ```
- node -e "const{execSync}=require('child_process');const{writeFileSync}=require('fs');const r=JSON.parse(execSync('gh issue view {N} --comments --json comments',{encoding:'utf-8'}));writeFileSync('$env:TEMP/agentdev/gh-read-{timestamp}.md',r.comments[r.comments.length-1].body)"
+ node -e "const{execSync}=require('child_process');const{writeFileSync}=require('fs');const r=JSON.parse(execSync('gh issue view {N} --comments --json comments',{encoding:'utf-8'}));writeFileSync('.agentdev/tmp/gh-read-{timestamp}.md',r.comments[r.comments.length-1].body)"
  ```
  この方法はインラインで解決可能なクォート競合向け。
  `-q` を使わず JSON 全体を取得することでクォート階層の競合を回避する。
 
 7. **退避策（第2段階）**: パイプ `|`、変数、複数段階の条件式を含む場合は `.js` スクリプトファイル（Write tool で作成）への退避を推奨する。
 `.js` ファイル内であればクォートやシェル解釈の制約を受けない。
-一時スクリプトは `$env:TEMP/agentdev/` に配置し、使用後に削除する。
+一時スクリプトは `.agentdev/tmp/`（workspace-local、RU-0005 AG-003）に配置し、使用後に削除する。
 
 8. **禁止事項**: シングルクォート、パイプを含む式での `node -e` 使用を禁止する。
 ただし `-q .body` 等の単純なドットアクセス式は禁止しない。
@@ -121,12 +155,12 @@ PowerShellがバッククォートをコマンド置換として解釈するた�
 
  ❌ 禁止される例（テンプレートリテラル使用）:
  ```
- node -e "const{execSync}=require('child_process');const{writeFileSync}=require('fs');const r=execSync('gh issue view {N} --json body -q .body',{encoding:'utf-8'});writeFileSync('$env:TEMP/agentdev/gh-read-{timestamp}.md', \`Body: ${r}\`)"
+ node -e "const{execSync}=require('child_process');const{writeFileSync}=require('fs');const r=execSync('gh issue view {N} --json body -q .body',{encoding:'utf-8'});writeFileSync('.agentdev/tmp/gh-read-{timestamp}.md', \`Body: ${r}\`)"
  ```
 
  ✅ 推奨される例（`.join()` 使用）:
  ```
- node -e "const{execSync}=require('child_process');const{writeFileSync}=require('fs');const r=execSync('gh issue view {N} --json body -q .body',{encoding:'utf-8'});writeFileSync('$env:TEMP/agentdev/gh-read-{timestamp}.md',['Body: ',r].join(''))"
+ node -e "const{execSync}=require('child_process');const{writeFileSync}=require('fs');const r=execSync('gh issue view {N} --json body -q .body',{encoding:'utf-8'});writeFileSync('.agentdev/tmp/gh-read-{timestamp}.md',['Body: ',r].join(''))"
  ```
 
  **注**: 退避策（Section 3 項目7）による `.js` スクリプトファイル内では、テンプレートリテラルの使用は許可される。
@@ -290,6 +324,52 @@ intake-from-github 等の検索系操作で使用する。
 
 - Issue 一覧: `gh issue list --state {state} --search "{query}" --limit {N} --json {fields}`
 - PR 一覧: `gh pr list --state {state} --search "{query}" --limit {N} --json {fields}`
+
+## title 修正 REST API PATCH 標準手続き（RU-0005 AG-002）
+
+日本語 title を設定、修正する場合の標準手続き。Windows 環境での `--title` inline 使用禁止（共通制約参照）に伴い、`gh issue create --title "..."`、`gh pr create --title "..."` で日本語 title を渡せないため、REST API PATCH 経由で title を設定する。
+
+### 適用条件
+
+- 日本語を含む title を設定または修正する場合（Windows 環境）
+- 既存 Issue/ PR の title 修正が必要な場合（全環境）
+- ASCII 限定 title の初回作成は `--title` inline 使用を許容する（共通制約参照）
+
+### 標準手順
+
+1. **JSON ファイル作成**: title を含む JSON を `.agentdev/tmp/title-patch-{N}-{timestamp}.json` へ書き出す（Section 2 Step 1 と同一規定、`[System.IO.File]::WriteAllText` + `UTF8Encoding($false)`）:
+
+ ```
+ {"title": "日本語タイトル文字列"}
+ ```
+
+ ファイル配置は `.agentdev/tmp/`（workspace-local）へ統一（RU-0005 AG-003）。
+
+2. **コンソールエンコーディング初期化（Windows 環境のみ）**: Section 2 Step 0 の3行を実行する。`gh api --input` 経由であっても Windows 環境では必須（gh CLI がコンソールコードページを参照するため）。
+
+3. **REST API PATCH 実行**:
+
+ ```
+ gh api -X PATCH /repos/{owner}/{repo}/issues/{N} --input .agentdev/tmp/title-patch-{N}-{timestamp}.json
+ ```
+
+ Issue の場合は `/repos/{owner}/{repo}/issues/{N}`、PR の場合は `/repos/{owner}/{repo}/pulls/{N}` を使用する。
+
+ - `--input` はファイルパスを指定し、inline `--input -`（stdin 経由）は使用禁止（共通制約参照）
+ - `{owner}/{repo}` は `gh repo view --json owner,name` 等で取得するか、`--hostname` と組み合わせて既定値を使用する
+
+4. **VERIFY**: title 更新後、`gh issue view {N} --json title -q .title` または `gh pr view {N} --json title -q .title` で読み戻し、JSON ファイルの title と一致することを確認する（READ 手続き Section 3 に従い Node.js `execSync` で取得）。
+
+5. **cleanup**: VERIFY が PASS した後に `.agentdev/tmp/title-patch-{N}-{timestamp}.json` を削除する（WRITE ユニット cleanup 規定、RU-0005 AG-003）。VERIFY が FAIL の場合は [retry.md](retry.md) リトライロジックへ移行し、cleanup を実行しない。
+
+### title 設定を伴う新規 Issue / PR 作成時のシーケンス
+
+新規作成時に日本語 title を設定する場合、以下の2段階シーケンスを標準とする:
+
+1. **仮 title で作成**: ASCII 文字列（例: `placeholder`）を `--title` で指定して `gh issue create` / `gh pr create` を実行し、Issue/ PR 番号を取得する
+2. **REST API PATCH で正式 title を設定**: 取得した Issue/ PR 番号に対し、本手続きの標準手順で日本語 title を PATCH する
+
+新規作成と PATCH を分離することで、Windows 環境の `--title` cp932 化けを構造的に回避する。
 
 ## Merge Conflict 対応パターン
 


### PR DESCRIPTION
## 概要

Issue #1865 (OU-001: agentdev-gh-cli Windows 環境固有手続き, RU-0005) の実装。
`docs/specs/skills/agentdev-gh-cli.md` へ「## Windows 環境固有手続き」セクションを新設し、RU-0005 AG-001〜AG-005 の5項目カタログと `standard-procedures.md` への参照関係を明示する。
詳細実装（gh CLI フラグ、PowerShell 式、ファイル配置、cleanup 手順）は `src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md` へ整備した。

## 実装サマリー

### 変更ファイル

| ファイル | 変更種別 | 概要 |
|---|---|---|
| `docs/specs/skills/agentdev-gh-cli.md` | UPDATE | 「## Windows 環境固有手続き」セクション新設（5項目カタログ）、frontmatter `updated` を `2026-07-27` へ更新 |
| `src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md` | UPDATE | AG-001〜AG-004 の詳細実装を整備 |

### 実装内容

**SPEC 側（agentdev-gh-cli.md）**

- 「## Windows 環境固有手続き」セクションを新設
- 5項目カタログテーブル（cp932 化け対策、title 修正 REST API PATCH、.agentdev/tmp/ 配置・cleanup 一体化、MatchEvaluator 内 -replace 注意、backreference $N 対策との区別）
- 各項目から `references/standard-procedures.md` 該当セクションへの参照関係を明示
- 既存「WRITE 手続きの Windows encoding 初期化必須化（REQ-011-009）」節との関係節を設け、cp932 化け対策の全体像と REQ-011-009 の詳細要件を両立

**references 側（standard-procedures.md）**

- **AG-001 (cp932 化け対策)**: 共通制約へ Windows 環境での `--title` / inline `--input` 使用禁止、`--body-file` / `gh api --input` 推奨を明記。Section 2 Step 0 へ「Step 0 と `--title` 引数 decode の別問題性」を追記
- **AG-002 (REST API PATCH)**: 「title 修正 REST API PATCH 標準手続き」セクションを新設。JSON ファイル作成 → コンソールエンコーディング初期化 → `gh api -X PATCH` 実行 → VERIFY → cleanup の標準手順と、新規作成時の2段階シーケンス（仮 title 作成 → REST API PATCH）を規定
- **AG-003 (.agentdev/tmp/ 配置・cleanup 一体化)**: 一時ファイル配置を `$env:TEMP/agentdev/` から `.agentdev/tmp/`（workspace-local）へ変更。Section 2 Step 4 を「WRITE ユニットの完了と cleanup（省略不可）」へ拡充し、create → gh 実行 → VERIFY → cleanup の1ユニット化と VERIFY FAIL 時の一時ファイル保管を規定
- **AG-004 (MatchEvaluator 内 -replace 注意)**: 「PowerShell regex MatchEvaluator 内 -replace 使用注意」セクションを新設。発生原理、回避策（Node.js `String.split/join` / PowerShell `[String]::Replace`）、前節 backreference `$N` 対策との区別、併発ケースを明示

## 完了条件の検証

| 完了条件 | 結果 | 証拠 |
|---|---|---|
| `docs/specs/skills/agentdev-gh-cli.md` に「## Windows 環境固有手続き」セクションが存在すること | PASS | L108 に `## Windows 環境固有手続き` ヘッダー存在 |
| standard-procedures.md への参照関係が明示されていること | PASS | L111、対象手続きテーブル「詳細参照」列の各セルで明示 |
| 対象手続き5項目がすべて列挙されていること | PASS | L116-122 の5行テーブル（cp932 化け対策、title 修正 REST API PATCH、.agentdev/tmp/ 配置・cleanup 一体化、MatchEvaluator 内 -replace 注意と回避策、backreference $N 対策との区別） |
| cp932 化け対策、title 修正 REST API PATCH 手続き、.agentdev/tmp/ 配置・cleanup 一体化、MatchEvaluator 内 -replace 注意と回避策、backreference $N 対策との区別が含まれていること | PASS | 上記5項目すべてテーブルおよび references 詳細実装に含まれる |

## テスト戦略の検証

| ID | target_item | 結果 | 証拠 |
|---|---|---|---|
| TS-001 | AG-001 (cp932 化け対策) | PASS | standard-procedures.md L14-18 に Windows 環境 `--title` / inline `--input` 使用禁止、`--body-file` / `gh api --input` 推奨を明記。L91 に「Step 0 と `--title` 引数 decode の別問題性」を追記 |
| TS-002 | AG-002 (REST API PATCH 標準手続き) | PASS | standard-procedures.md に「## title 修正 REST API PATCH 標準手続き（RU-0005 AG-002）」セクションを新設。`gh api -X PATCH /repos/{owner}/{repo}/issues/{N}` + UTF-8 JSON `--input` file の標準手順を実行可能な形式で記載 |
| TS-003 | AG-003 (.agentdev/tmp/ 配置・cleanup 一体化) | PASS | standard-procedures.md Section 2 Step 1 の一時ファイルパスを `.agentdev/tmp/gh-temp-{timestamp}.md` へ変更、配置理由を明記。Step 4 を「WRITE ユニットの完了と cleanup（省略不可）」へ拡充し、create → gh 実行 → VERIFY → cleanup の1ユニット化を規定 |
| TS-004 | AG-004 (MatchEvaluator 内 -replace 注意と回避策) | PASS | standard-procedures.md に「### PowerShell regex MatchEvaluator 内 -replace 使用注意（RU-0005 AG-004）」セクションを新設。回避策（Node.js `String.split/join`、PowerShell `[String]::Replace`）を明示、前節 backreference `$N` 対策（L36-42）と区別して記載 |
| TS-005 | AG-005 (SPEC への参照追記) | PASS | agentdev-gh-cli.md L108-128 に「## Windows 環境固有手続き」セクションが存在し、L111 で `references/standard-procedures.md` への参照を明示 |

## 品質ゲート

- `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --files docs/specs/skills/agentdev-gh-cli.md src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md --fail-level warning` を実行し、failures: 0、warnings: 0 を確認済み

## Findings / Capture候補

特になし。RU-0005 AG-001〜AG-005 の要求事項はすべて本 PR で実装完了しており、仕様上の制約やスコープ外事項は発生しなかった。

## SPEC確定候補

特になし。本 Issue は SPEC の参照追記と references の詳細実装整備が完了しており、SPEC レベルの未確定事項（schema、enum、判定表、内部アルゴリズム等）は新たに発生していない。

Refs: #1865
