### PR TITLE
feat(spec): OU-001 REQ-006 capture 責務境界の各工程分散型変更 (capture-boundaries.md 追随)

### DIFF
--- a/docs/specs/workflows/capture-boundaries.md
+++ b/docs/specs/workflows/capture-boundaries.md
@@ -2,7 +2,7 @@
 title: キャプチャ境界
 status: accepted
 created: 2026-06-21
-updated: 2026-07-24
+updated: 2026-07-27
 ---
 
 # キャプチャ境界（Capture Boundaries）
@@ -55,12 +55,12 @@ PR 本文の capture 関連セクションは以下を分離する:
 | コマンド | intake | learning | 備考 |
 |---|---|---|---|
 | req-define | 非関与 | 非関与 | - |
-| req-save | REQ再構成 intake（`.agentdev/intake/inbox/req-restructure/`）のみ生成可能 | 非関与 | 例外のみ許可 |
-| spec-save | 非関与 | 非関与 | - |
-| case-open | 非関与 | 非関与 | - |
+| req-save | REQ 再構成 intake に加え自工程 deviation capture | 自工程 deviation capture | Split Rule で分類、Skill 委譲で保存（REQ-006-106） |
+| spec-save | 自工程 deviation capture | 自工程 deviation capture | 従来非関与から変更（REQ-006-107） |
+| case-open | 自工程 deviation capture | 自工程 deviation capture | case-close への委譲を廃止（REQ-006-021） |
 | case-run | PR 本文記録のみ（直接 inbox 変更禁止） | PR 本文記録のみ（直接 inbox.md 変更禁止） | 実行担当サブエージェント経由 |
-| case-close | PR 本文から回収し inbox へ保存 | PR 本文から回収し inbox.md へ保存 | Epic 横断回収含む |
-| case-auto | 各工程の責務を継承 | 各工程の責務を継承 | - |
+| case-close | PR 本文から回収 + 自工程 deviation capture | PR 本文から回収 + 自工程 deviation capture | Epic 横断回収含む（REQ-006-105） |
+| case-auto | 各工程の保存結果参照と件数集計のみ | 各工程の保存結果参照と件数集計のみ | capture 本文の再分類・再保存は行わない（REQ-006-108） |
 | case-update | 非関与 | 非関与 | REQ 更新、レビュー NG コメント、Issue 本文更新のみ |
 | intake-* | 各コマンド責務（各 command SPEC 参照） | - | - |
 | learning-promote | - | 各コマンド責務（command SPEC 参照） | - |
@@ -75,10 +75,10 @@ CaptureBoundary 検査（`check_integrity.ts` の `command-capture-duty`）は�
 
 判定規則は次のとおり。
 
-- capture 責務表の intake または learning 列が「各工程の責務を継承」または「非関与」と定義する command は、`capture-boundaries` 参照を個別に持たなくても CaptureBoundary 検査の検出対象としない。
-- capture 責務表の intake または learning 列が具体的な責務記述（PR 本文記録、回収、REQ再構成 intake 生成等）である command は、`capture-boundaries` 参照を個別に持ち、対応する capture 導線を実装する。
+- capture 責務表の intake または learning 列が「各工程の保存結果参照と件数集計のみ」または「非関与」と定義する command は、`capture-boundaries` 参照を個別に持たなくても CaptureBoundary 検査の検出対象としない。
+- capture 責務表の intake または learning 列が具体的な責務記述（PR 本文記録、回収、自工程 deviation capture、REQ 再構成 intake 生成等）である command は、`capture-boundaries` 参照を個別に持ち、対応する capture 導線を実装する。
 
-例外の根拠は本 capture 責務表である。同表は case-auto の intake、learning をともに「各工程の責務を継承」と定義し、case-auto 自身は inbox、inbox.md の直接生成を行わない設計を示す。v2:ADR-0127（case-auto 構成工程の委譲）と v2:ADR-0137（case-run インライン実行）が、case-auto を統合委譲起点とする現行設計を裏付ける。
+例外の根拠は本 capture 責務表である。同表は case-auto の intake、learning をともに「各工程の保存結果参照と件数集計のみ」と定義し、case-auto 自身は inbox、inbox.md の直接生成を行わない設計を示す。v2:ADR-0127（case-auto 構成工程の委譲）と v2:ADR-0137（case-run インライン実行）が、case-auto を統合委譲起点とする現行設計を裏付ける。
 
 ## REQ 再構成 intake
 


### PR DESCRIPTION
## 概要

Issue #1872 (OU-001: REQ-006 capture 責務境界の各工程分散型変更) の case-run 実装。

REQ-006-021 UPDATE および REQ-006-105〜109 NEW は Phase 0 コミット `736bc3af` で main 適用済みのため、本 PR は Issue のテスト戦略 TS-001 の on_failure (fix-and-reverify) に基づき、`docs/specs/workflows/capture-boundaries.md` の「各コマンドの capture 責務」表を REQ-006 の各工程分散型へ整合させる SPEC 追随修正を実施する。

## 変更内容

- `docs/specs/workflows/capture-boundaries.md`
  - frontmatter `updated`: 2026-07-24 → 2026-07-27
  - 「各コマンドの capture 責務」表の req-save / spec-save / case-open / case-close / case-auto 行を REQ-006-021/105/106/107/108 へ整合
  - CaptureBoundary 検査例外規則の case-auto 表現を「各工程の責務を継承」から「各工程の保存結果参照と件数集計のみ」へ更新

## 完了条件の検証

- [x] REQ-006 にて case-open が自工程 capture を担当し case-close への委譲を廃止、req-save/spec-save/case-close が自工程 capture を担当する旨が記載されていること
  - REQ-006-021 (case-open 自工程 capture、case-close 委譲廃止)
  - REQ-006-105 (case-close 自工程 deviation capture)
  - REQ-006-106 (req-save 自工程 deviation capture)
  - REQ-006-107 (spec-save 自工程 deviation capture)
- [x] case-auto の責務記述に capture 本文の再分類・再保存が含まれず、各工程の保存結果参照と件数集計のみであること
  - REQ-006-108
- [x] case-auto 自身は Epic Issue を更新せず、case-close 経由であること
  - REQ-006-095、epic-wave-model.md「Epic Issue 本文の単一書き手制約」

## テスト戦略の検証

- **TS-001 (各工程分散型)**: PASS
  - REQ-006-021/105/106/107/108 全て存在
  - capture-boundaries.md 表が各工程分散型（選択肢A）の6項目（req-save/spec-save/case-open/case-run/case-close/case-auto）と一致
- **TS-005 (case-auto 集計のみ)**: PASS
  - REQ-006-108、capture-boundaries.md case-auto 行
- **TS-006 (Epic 単一書き手)**: PASS
  - REQ-006-095、epic-wave-model.md per-Epic 単一書き手

## Findings / Capture候補

### intake

- 本 PR の capture-boundaries.md 表行更新は OU-002 (Issue #1873) のスコープと重複する。OU-001 (本 Issue) のテスト戦略 TS-001 の on_failure (fix-and-reverify) に基づく修正。#1873 case-run 時は本 PR の変更を前提とする（新規セクション「## 工程別 capture 責務」の追加や委譲契約/Epic 単一書き手/完了報告の詳細化が #1873 の残作業候補）
- Phase 0 コミット `736bc3af` で AUTOGEN block（`docs/specs/quality/req-health-metrics.md` の REQ-006 要件数: 104→109）の再生成が未実施（事前存在、本 Issue スコープ外、`check_integrity.ts` の IndexGenerationConsistency で検出済み）

### learning

- Phase 0 戦略は「target_area 未検出 SPEC は follow-up Issue へ分割」とするが、子 Issue のテスト戦略が親 Epic 由来の検証要件を含む場合、SPEC 整合性の修正スコープが子 Issue にまたがる。テスト戦略 on_failure へ「要件定義か SPEC の記載を修正して再検証」が明示されている場合は子 Issue での修正を許容する運用が有効

## SPEC確定候補

（なし）

## 関連

- Parent Epic: #1871
- 重複スコープ: #1873 (OU-002 capture-boundaries.md)
- Phase 0 コミット: `736bc3af` (REQ-006-021 UPDATE + 105-109 NEW + 5 command/SPEC)

Refs: #1872
