### PR TITLE
feat(agentdev-req-file-manager): REQ-ID 形式契約の一律性を SPEC へ明記し extractAllCompositeIds を 3桁/4桁両対応へ修正 (#1882)

### DIFF
--- a/docs/specs/skills/agentdev-req-file-manager.md
+++ b/docs/specs/skills/agentdev-req-file-manager.md
@@ -2,7 +2,7 @@
 title: `agentdev-req-file-manager` SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-07-26
+updated: 2026-07-27
 ---
 
 # `agentdev-req-file-manager` SPEC
@@ -55,6 +55,18 @@ REQ ファイルの作成、追記、更新を管理する知識ベースとし�
 - 日付フォーマットの正当性
 - 反映作業のみの要件行が混入していないか
 - REQ 番号の連番、一意性（空き番号再利用禁止）
+
+## 実装詳細
+
+### REQ-ID 形式契約の一律性
+
+`alloc-composite-id.ts` が提供する複合ID（要件行ID）の抽出・認識関数は、REQ 番号の桁数として3桁（`REQ-001-NNN`）と4桁（`REQ-0011-NNN`）の両方を一貫して認識する。現行 REQ 群が3桁（REQ-001〜REQ-011）、旧 REQ 群（v2:REQ-0001〜0050）が4桁であった歴史的経緯に由来する。
+
+関数間で正規表現の桁数契約を不一致させてはならない。`extractAllCompositeIds`、`extractCompositeIdNumbers`、`extractReqNumber`、`reqNumberFromFilename` は全て `(\d{3,4})` を用い、3桁と4桁を同一に扱う。一部の関数だけ `(\d{4})` に固定する変更を加えてはならない。
+
+採番結果（`formatCompositeId`）の正規化出力は4桁ゼロ埋めとする。入力認識は3桁と4桁を許容するが、新規採番結果は4桁へ正規化する。
+
+採番検証テスト（`scripts/tests/alloc-composite-id.test.ts`）は、3桁 REQ 群（REQ-001, REQ-003, REQ-006, REQ-008, REQ-010）と4桁 REQ 群（REQ-0011）が混在する入力で `extractAllCompositeIds` と `extractCompositeIdNumbers` が正しく max を返すことを検証する。桁数混在による max 計算の歪みを検出するため、混在入力を必須とする。
 
 ## See Also
 

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/src/alloc-composite-id.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/src/alloc-composite-id.ts
@@ -1,8 +1,11 @@
 /**
  * 複合ID（要件行ID）採番スクリプト（AG-002、AG-006、REQ-0103-159/160）。
  *
- * 指定 REQ ファイル本文から既存の `REQ-NNNN-MMM` 形式の要件行IDを抽出し、
+ * 指定 REQ ファイル本文から既存の要件行IDを抽出し、
  * その最大行番号 + 1 を採番する。欠番埋め禁止。
+ *
+ * 入力は REQ 番号3桁（REQ-001-NNN）と4桁（REQ-0011-NNN）の両形式を一貫して認識する
+ * （REQ-ID 形式契約の一律性、他関数と同一）。採番結果の正規化出力は4桁ゼロ埋めとする。
  *
  * I/O:
  *   入力: argv[2] = 対象 REQ ファイルパス、argv[3] = 親 REQ 番号（例: 0103、オプション・ファイル名から推定）
@@ -27,11 +30,13 @@ export function formatCompositeId(req: number, row: number): string {
 }
 
 /**
- * 本文から `REQ-NNNN-MMM` 形式のIDを全て抽出する（純粋関数）。
+ * 本文から `REQ-NNN-MMM` / `REQ-NNNN-MMM` 形式のIDを全て抽出する（純粋関数）。
+ * REQ 番号は3桁（REQ-001-NNN）と4桁（REQ-0011-NNN）の両方を許容する
+ * （`extractCompositeIdNumbers` 等の REQ-ID 形式契約と同一）。
  * 重複除去は行わない（重複は整合性チェックの対象）。
  */
 export function extractAllCompositeIds(content: string): string[] {
-  const re = /REQ-(\d{4})-(\d{3})/g;
+  const re = /REQ-(\d{3,4})-(\d{3})/g;
   const ids: string[] = [];
   let m: RegExpExecArray | null;
   while ((m = re.exec(content)) !== null) {

--- a/src/opencode/skills/agentdev-req-file-manager/scripts/tests/alloc-composite-id.test.ts
+++ b/src/opencode/skills/agentdev-req-file-manager/scripts/tests/alloc-composite-id.test.ts
@@ -4,6 +4,7 @@ import {
   formatCompositeId,
   extractAllCompositeIds,
 } from "../src/alloc-composite-id.ts";
+import { extractCompositeIdNumbers } from "../lib/frontmatter.ts";
 
 describe("nextRowNumber", () => {
   test("returns 1 for empty list", () => {
@@ -40,5 +41,44 @@ Not REQ-0103 or REQ-NNNN-MMM pattern.
   test("returns empty array when no IDs match", () => {
     const content = "No IDs here";
     expect(extractAllCompositeIds(content)).toEqual([]);
+  });
+
+  test("extracts 3-digit REQ IDs (REQ-NNN-MMM) consistently with 4-digit", () => {
+    const content = `
+3-digit: REQ-001-001, REQ-008-003, REQ-010-002
+4-digit: REQ-0011-005
+Neither: REQ-12-001 (too short), REQ-12345-001 (too long)
+`;
+    const ids = extractAllCompositeIds(content);
+    expect(ids).toEqual([
+      "REQ-001-001",
+      "REQ-008-003",
+      "REQ-010-002",
+      "REQ-0011-005",
+    ]);
+  });
+
+  test("mixed 3-digit and 4-digit REQ IDs return correct max via extractCompositeIdNumbers (REQ-ID 形式契約の一律性)", () => {
+    const content = `
+REQ-001-001
+REQ-003-002
+REQ-006-004
+REQ-008-007
+REQ-010-003
+REQ-0011-009
+`;
+    const ids = extractAllCompositeIds(content);
+
+    const parsed = ids
+      .map((id) => extractCompositeIdNumbers(id))
+      .filter((p): p is { req: number; row: number } => p !== null);
+
+    const maxRow = parsed.reduce((acc, p) => (p.row > acc ? p.row : acc), 0);
+    expect(maxRow).toBe(9);
+
+    const req8Rows = parsed
+      .filter((p) => p.req === 8)
+      .map((p) => p.row);
+    expect(req8Rows).toEqual([7]);
   });
 });


### PR DESCRIPTION
## 概要

Issue #1882 (OU-001, Epic #1881) の実装。`docs/specs/skills/agentdev-req-file-manager.md` の実装詳細セクションへ「REQ-ID 形式契約の一律性（3桁/4桁両形式を一貫して認識すること）」を明記し、関数間で正規表現形式契約が不一致しないことを SPEC 上の制約として文書化する。

RU-0008 (AG-001, AG-002, AG-003) をソースとする。

## 変更内容

### AG-003: SPEC への契約明記 (TS-003)

`docs/specs/skills/agentdev-req-file-manager.md` に `## 実装詳細` セクションを新設し、`### REQ-ID 形式契約の一律性` を記載した。以下を SPEC 上の制約として文書化:

- `extractAllCompositeIds`、`extractCompositeIdNumbers`、`extractReqNumber`、`reqNumberFromFilename` は全て `(\d{3,4})` を用い、3桁（`REQ-001-NNN`）と4桁（`REQ-0011-NNN`）を同一に扱う
- 関数間で正規表現の桁数契約を不一致させてはならない
- 採番結果の正規化出力は4桁ゼロ埋めとする
- 採番検証テストは3桁 REQ 群と4桁 REQ 群の混在入力で max を検証すること

### AG-001: extractAllCompositeIds の正規表現修正 (TS-001)

`src/opencode/skills/agentdev-req-file-manager/scripts/src/alloc-composite-id.ts` の `extractAllCompositeIds` が使用する正規表現を `/REQ-(\d{4})-(\d{3})/g` から `/REQ-(\d{3,4})-(\d{3})/g` へ修正した。

他の5関数（`extractCompositeIdNumbers`、`extractReqNumber`、`extractAdrNumber`、`reqNumberFromFilename`、`adrNumberFromFilename`）は既に `(\d{3,4})` で一貫していたが、`extractAllCompositeIds` のみ4桁固定だった不具合を解消した。

### AG-002: 採番検証テストの追加 (TS-002)

`src/opencode/skills/agentdev-req-file-manager/scripts/tests/alloc-composite-id.test.ts` に2テストを追加:

- 3桁 REQ ID の抽出が4桁と一貫することを検証
- 3桁 REQ 群（REQ-001, REQ-003, REQ-006, REQ-008, REQ-010）と4桁 REQ 群（REQ-0011）が混在する入力で `extractAllCompositeIds` と `extractCompositeIdNumbers` が正しく max（行番号 009）を返すことを検証

## 検証結果

### テスト戦略 (TS)

| TS | 対象 | 検証結果 |
|---|---|---|
| TS-001 | AG-001 正規表現修正 | PASS: regex が `/REQ-(\d{3,4})-(\d{3})/g` に変更済み、3桁 REQ を正しく認識 |
| TS-002 | AG-002 採番検証テスト | PASS: `bun test` 22 pass / 0 fail。3桁/4桁混在で正しい max を返す |
| TS-003 | AG-003 SPEC 明記 | PASS: 実装詳細セクションに「REQ-ID 形式契約の一律性」が明記済み |

### docs integrity guard (case-run Step 5-4)

```
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
  --workflow case-run --files docs/specs/skills/agentdev-req-file-manager.md --json
```

結果: `failures: []`, `warnings: []`, coupled file updates 不要 (`spec_readme_update_required: false`)。

### 型チェック

`bun run tsc --noEmit` は環境起因の事前エラー（`@types/node`・bun types 未設定）のみ。本変更に起因する型エラーはなし。`bun test` が成功しているため実行時問題なし。

## 補足

- Phase 0 コミット (614f2b32) で spec-save の ACT-SPEC-004 が spec-update 契約不適合（content がセクション全文置換でなく追記のみ）でスキップされたため、本 PR で直接 SPEC へ追記した
- worktree クリーン。Issue 完了条件チェックボックスは case-close QG-4 の責務のため本 PR では更新しない

Refs: #1882
