### PR TITLE
feat(specs): OU-002 REQ-008 spec-append operation 第一級化のため REQ と SPEC 4件 を更新

### DIFF
--- a/docs/requirements/REQ-008.md
+++ b/docs/requirements/REQ-008.md
@@ -72,6 +72,7 @@ draft、RU、取り込み項目、学習エントリ、検出事項として com
 | REQ-008-055 | 永続ID は保存時に既存最大番号+1で割り当て、保存後の depends_on は RU-ID で記録すること |
 | REQ-008-056 | tentative_classification は既存7値のいずれかとし、欠落時は RU 生成を停止すること |
 | REQ-008-057 | 各RU本文は目的、対象、対象外、正規所有者とアンカー、依存関係、要件化の方向、決定的受け入れ条件、Source Summary の8セクションを必須とし、session 論理URI の解決なしに後工程が内容を判断できる自足性を保つこと |
+| REQ-008-058 | artifact_actions の operation 公式 enum は REQ/ADR {create, append, update}、SPEC {create, update} とし、各 SPEC は非正規 alias（spec-create, spec-update, spec-append 等）を受け付けること。alias から公式 enum への映射、alias 固有の契約（target_area 形式、placement、anchor、未検出時挙動等）は各 SPEC が定めること |
 
 ## 適用範囲
 

--- a/docs/specs/commands/req-define.md
+++ b/docs/specs/commands/req-define.md
@@ -2,7 +2,7 @@
 title: req-define SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-07-24
+updated: 2026-07-27
 ---
 
 # req-define SPEC
@@ -190,15 +190,18 @@ test_strategy:
 
 ## draft-data artifact_actions フィールド形式
 
-artifact_actions の各 entry が出力する `target_area` と `content` の扱いは operation 別に以下を規定する（REQ-004-078, REQ-004-079）。
+artifact_actions の各 entry が出力する `target_area` と `content` の扱いは operation 別に以下を規定する（REQ-004-078, REQ-004-079、REQ-008-058）。
+
+SPEC operation の公式 enum は `create` / `update` であり、req-define は非正規 alias（`spec-create`, `spec-update`, `spec-append`）も出力可能とする。alias から公式 enum への映射: `spec-create` → `create`、`spec-update` → `update`、`spec-append` → `update`（既存 SPEC ファイルへ新規セクションを追加する操作）。alias 固有の契約（placement, anchor 等）は後段の表および [spec-save.md](spec-save.md) に従う。
 
 | operation | target_area | content |
 |-----------|-------------|---------|
 | create / spec-create | 任意（省略時は spec-save が既存セクション構造から追加位置を判断） | 新規セクション本文 |
 | update / spec-update | 必須（対象セクション見出し、Markdown 見出し行形式。例: `### IR-044`） | 変更後セクション全文（対象セクションの見出し行から次の同レベル見出しの直前までの全内容） |
+| spec-append | 必須（anchor 見出し、Markdown 見出し行形式。例: `### IR-044`）。anchor 末尾への追加を示す `placement: tail`（既定）、anchor 直後を示す `placement: after_anchor`、anchor 直前を示す `placement: before_anchor` を action へ併せて出力できる（省略時は `tail`） | 追記する新規セクション本文（見出し行を含む） |
 
 req-define 側は出力形式のみを規定する。
-`target_area` の形式（Markdown 見出し行）、見出し階層の解釈規則、複数マッチ、未検出時の挙動は [spec-save.md](spec-save.md) 側に配置する。
+`target_area` の形式（Markdown 見出し行）、見出し階層の解釈規則、複数マッチ、未検出時の挙動、`spec-append` の placement 別挙動は [spec-save.md](spec-save.md) 側に配置する。
 
 ## review_dispositions の producer 契約
 

--- a/docs/specs/commands/spec-save.md
+++ b/docs/specs/commands/spec-save.md
@@ -36,13 +36,14 @@ req-save の次、case-open の前に実行する。
 ## 現在の動作
 
 - Step 1: 事前チェック（`draft-data` の `artifact_actions` から `artifact: spec` entry の有無を確認）。なければ no-op 完了。ドラフト不存在時はエラー中止
-- Step 2: SPEC artifact_actions 読込（`artifact: spec` entry を読込）。`artifact_actions` フィールド不存在（旧形式 draft）の場合は SPEC 保存対象なしと判定し no-op 完了（後方互換）。各 action の `target`（file path または `new:{slug}`）、`operation`（create/update）、`content` を処理対象とする
+- Step 2: SPEC artifact_actions 読込（`artifact: spec` entry を読込）。`artifact_actions` フィールド不存在（旧形式 draft）の場合は SPEC 保存対象なしと判定し no-op 完了（後方互換）。各 action の `target`（file path または `new:{slug}`）、`operation`（公式 enum: create/update、非正規 alias: spec-create/spec-update/spec-append、REQ-008-058）、`content` を処理対象とする
 - Step 3: 配置先解決（既存 SPEC パス（例: `docs/specs/foundations/patterns.md`）→ update 操作）。`target_spec: {operation, domain, slug}` 構造化 → 新規 SPEC 作成（`docs/specs/{domain}/{topic-slug}.md`）。同一 `target` の action は1つの SPEC へ集約。配置先解決の決定的処理は `agentdev-req-file-manager/scripts/` の決定的スクリプトで実行（REQ-001-029、design-principles.md 第5節「決定的処理の Script 委譲原則」）
 - Step 4: SPEC 分離基準の最終確認（各 action が REQ-001-055（SPEC に置くべき内容の基準）に適合するか再確認）。安定契約例外（REQ-001-069）相当は除外し follow-up に明示
 - Step 5: SPEC ファイル操作。`target_area` 見出し検索は `agentdev-spec-file-manager/scripts/` の決定的スクリプトで実行
- - create: 新規 SPEC ファイルを frontmatter（`title`, `status: draft`, `created`, `updated`）付きで作成し、action の `content` をセクションとして記載
- - update: `target_area` 指定時は対象セクションを `content` で置換、未指定時は該当セクションへ `content` を追記。frontmatter `updated` を更新。`status` は変更しない。詳細は「target_area ベースのセクション置換ロジック」セクション参照
- - 各 action の `target_area`（指定時）に応じた適切なセクション見出しを用いる
+  - create / spec-create: 新規 SPEC ファイルを frontmatter（`title`, `status: draft`, `created`, `updated`）付きで作成し、action の `content` をセクションとして記載
+  - update / spec-update: `target_area` 指定時は対象セクションを `content` で置換、未指定時は該当セクションへ `content` を追記。frontmatter `updated` を更新。`status` は変更しない。詳細は「target_area ベースのセクション置換ロジック」セクション参照
+  - spec-append: 既存 SPEC ファイルへ `target_area`（anchor）と `placement` に基づき `content` を新規セクションとして追加。frontmatter `updated` を更新。`status` は変更しない。詳細は「spec-append 操作時のセクション追加ロジック」セクション参照
+  - 各 action の `target_area`（指定時）に応じた適切なセクション見出しを用いる
 - Step 6: インデックス整合（新規 SPEC 作成時は `docs/specs/README.md`（SPEC 一覧）に追加）。既存 SPEC 追記時は README 更新不要。エントリ存在確認は決定的スクリプトで実行
 - Step 7: DOC-MAP 影響確認（SPEC 操作が `docs/DOC-MAP.md` に影響するか確認し、影響がある場合は更新（`agentdev-doc-map`））
 - Step 8: ドラフト status 更新（`draft-data` に SPEC 消費済みフラグを付与）。commit/push より前に更新し commit 対象に含める
@@ -101,12 +102,15 @@ bootstrap 問題（宣言前に強制すると既存 SPEC 処理不能）を避�
 
 ## target_area ベースのセクション置換ロジック
 
-`operation: update` / `operation: spec-update` において action の `target_area` が指定された場合、spec-save は対象 SPEC ファイル内で `target_area` に一致する見出し行を検索し、セクション置換を行う（REQ-001-027）。
+`operation: update` / `operation: spec-update` において action の `target_area` が指定された場合、spec-save は対象 SPEC ファイル内で `target_area` に一致する見出し行を検索し、セクション置換を行う（REQ-001-027、REQ-008-058）。
+
+SPEC operation の公式 enum は `create` / `update` であり、`spec-append` は既存 SPEC ファイルへ新規セクションを追加する alias として `update` へ映射される（REQ-008-058）。`spec-append` の配置契約は後段「spec-append 操作時のセクション追加ロジック」に定める。
 
 ### マッチング規則
 
 - 対象 SPEC ファイル内の見出し行を走査し、`target_area` に一致する見出し行を検索する
 - **入力正規化**: `target_area` に Markdown 見出しプレフィックス（`##`、`###` 等）が含まれる場合、比較前にプレフィックスを除去して見出しテキスト部分へ正規化する。`## セクション名` と `セクション名` のいずれの形式でも同じ結果となる
+- **見出し行全体完全一致**: 正規化後の見出しテキストが見出し行全体と完全一致する場合のみマッチとする。前方一致、後方一致、部分一致は受け付けない（例: 正規入力 `### IR-044` は見出し行 `### IR-044 - 題` とはマッチしない）。この規則は `search-target-area.ts` が正規契約に従うことを要求する
 - 当該見出し行から次の同レベル（または上位レベル）見出し行の直前までを「セクション」として特定する
   - 例: `### X` で検索した場合、次の `###` または `##` または `#` 見出しの直前までを範囲とする
 - 特定したセクションを action の `content` で置換する
@@ -123,6 +127,52 @@ bootstrap 問題（宣言前に強制すると既存 SPEC 処理不能）を避�
 
 `target_area` が未指定の draft（旧形式）、または `operation` が create/spec-create の場合は従来の「追記」動作を維持する（REQ-001-028）。
 `target_area` が指定された場合のみ「置換」動作を適用し、既存 draft の破壊を防ぐ。
+
+## spec-append 操作時のセクション追加ロジック
+
+`operation: spec-append` は既存 SPEC ファイルへ新規セクションを追加する操作であり、公式 enum の `update` へ alias として映射される（REQ-008-058）。`target_area`（anchor）と `placement` を用いて追加位置を明示する。
+
+### 入力契約
+
+| field | 必須性 | 形式 |
+|---|---|---|
+| `target_area` | 必須 | anchor 見出し行（Markdown 見出し行形式。例: `### IR-044`） |
+| `placement` | 任意（省略時 `tail`） | `tail` / `after_anchor` / `before_anchor` のいずれか |
+| `content` | 必須 | 追加する新規セクション本文（見出し行を含む） |
+
+### placement 別挙動
+
+| placement | 追加位置 |
+|---|---|
+| `tail`（既定） | anchor セクションの末尾（次の同レベルまたは上位レベル見出し行の直前） |
+| `after_anchor` | anchor 見出し行の直後（anchor セクション本文の先頭） |
+| `before_anchor` | anchor 見出し行の直前 |
+
+`tail` は anchor セクション全体の末尾へ新規セクションを追加する。`after_anchor` は anchor セクション本文の先頭へ挿入する。`before_anchor` は anchor セクションの前に新規セクションを挿入する。
+
+### anchor マッチング規則
+
+- 「target_area ベースのセクション置換ロジック」の「マッチング規則」と同一の規則を適用する（入力正規化、見出し行全体完全一致）
+- anchor 見出し行が複数存在する場合、最初のマッチを採用し warn を出力する
+
+### anchor 未検出時の挙動
+
+anchor 見出し行が存在しない場合、当該 action をスキップし、follow-up として「anchor 未検出、operation を spec-create へ切り替えを推奨」を報告する（全体中止しない）。
+
+### 同名見出し時の挙動
+
+`content` の見出し行と同名の見出しが既存 SPEC ファイルに存在する場合、spec-save は warn を出力し、追加処理は継続する（重複防止のための事前拒否は行わない）。重複見出しの整理は別工程（inspect-docs 等）で扱う。
+
+### 合格基準
+
+- anchor が特定でき、`placement` に従った位置へ `content` が挿入されていること
+- 挿入結果の SPEC ファイルが Markdown 構造として破損しないこと（見出し階層の不整合がないこと）
+- frontmatter `updated` が更新されていること
+- `status` は変更しないこと（G06）
+
+### 後方互換（create / spec-create / update / spec-update）
+
+`spec-append` は新規 alias であり、既存の `create` / `spec-create` / `update` / `spec-update` 動作は従来通り維持する。`spec-append` が指定された場合のみ本節のロジックを適用する。
 
 ## 参照する横断 SPEC
 

--- a/docs/specs/responsibilities/artifact-contracts.md
+++ b/docs/specs/responsibilities/artifact-contracts.md
@@ -404,7 +404,7 @@ draft type registry の allowed consumers 列、REQ-008、REQ-006-083、document
 |---|---|
 | `id` | `ACT-REQ-NNN` / `ACT-ADR-NNN` / `ACT-SPEC-NNN` |
 | `artifact` | `req` / `adr` / `spec` |
-| `operation` | REQ/ADR: `create` / `append` / `update`、SPEC: `create` / `update` |
+| `operation` | REQ/ADR: `create` / `append` / `update`、SPEC: `create` / `update`（公式 enum）。各 SPEC は非正規 alias（`spec-create`, `spec-update`, `spec-append`）を受け付ける（REQ-008-058）。alias から公式 enum への映射、alias 固有の契約（target_area 形式、placement、anchor、未検出時挙動等）は各 SPEC が定める |
 | `target` | file path または `new:{slug}` |
 | `target_area` | optional: section / area 指定 |
 | `source_items` | 対応する agreed_item ID の list |

--- a/docs/specs/skills/agentdev-spec-file-manager.md
+++ b/docs/specs/skills/agentdev-spec-file-manager.md
@@ -2,7 +2,7 @@
 title: agentdev-spec-file-manager SPEC
 status: draft
 created: 2026-07-22
-updated: 2026-07-24
+updated: 2026-07-27
 ---
 
 # agentdev-spec-file-manager SPEC
@@ -37,12 +37,15 @@ SPEC ファイルの作成、更新、配置先判断、target_area 処理、SPE
 
 ## 提供する判断・操作
 
-- SPEC 作成、追記、target_area 置換の配置先解決
-- 新規 SPEC 作成時の frontmatter（`title`、`status: draft`、`created`、`updated`）付与
-- 既存 SPEC 追記時の `status` 維持（変更しない）
-- target_area が指定された update/spec-update 操作におけるセクション置換ロジック（REQ-001-027/028）
+SPEC operation の公式 enum は `create` / `update` であり、本 skill は非正規 alias（`spec-create`, `spec-update`, `spec-append`）を受け付ける（REQ-008-058）。alias から公式 enum への映射: `spec-create` → `create`、`spec-update` → `update`、`spec-append` → `update`（既存 SPEC ファイルへ新規セクションを追加する操作）。create/update は後方互換のため維持し、alias も同等に受け付ける。
+
+- SPEC 作成、追記、target_area 置換、spec-append 追加の配置先解決
+- 新規 SPEC 作成時（`create` / `spec-create`）の frontmatter（`title`、`status: draft`、`created`、`updated`）付与
+- 既存 SPEC 変更時（`update` / `spec-update` / `spec-append`）の `status` 維持（変更しない）
+- target_area が指定された `update` / `spec-update` 操作におけるセクション置換ロジック（REQ-001-027/028）
+- `spec-append` 操作における新規セクション追加ロジック（anchor と placement に基づく追加、REQ-008-058）。詳細な契約（placement 別挙動、anchor マッチング規則、anchor 未検出時挙動、同名見出し時挙動、合格基準）は `../commands/spec-save.md`「spec-append 操作時のセクション追加ロジック」が正規所有する
 - SPEC 固有整合性確認（frontmatter 完全性、target_area マッチング規則、SPEC status ライフサイクル）
-- `search-target-area.ts`（SPEC 固有 script）の呼出契約
+- `search-target-area.ts`（SPEC 固有 script）の呼出契約。同 script は見出し行全体との完全一致のみを受け付け、前方一致、後方一致、部分一致を受け付けない（正規入力 `### IR-044` は見出し行 `### IR-044 - 題` とはマッチしない）。この契約は `target_area` マッチング規則と `spec-append` の anchor マッチング規則の双方に適用される
 - 共通検証（frontmatter 整合性、エントリ存在、変更範囲）は `agentdev-artifact-validation` の公開検証契約へ委譲
 
 ## 参照する references
@@ -54,9 +57,10 @@ SPEC ファイルの作成、更新、配置先判断、target_area 処理、SPE
 ## 現在の動作
 
 - `spec-save` は `target_area` 指定時、当該 skill の配置先解決、target_area マッチング規則を適用してセクション置換を行う
+- `spec-save` は `operation: spec-append` 指定時、当該 skill の配置先解決、anchor と placement に基づく新規セクション追加を行う（REQ-008-058）
 - 新規 SPEC 作成時は frontmatter `status: draft` を必ず付与する（G05）
-- 既存 SPEC へ追記時は当該 SPEC の `status` を変更しない（G06、v2:ADR-0123 Decision #1）
-- SPEC 固有 script は `search-target-area.ts`（target_area 見出し検索）を正規所有対象とする
+- 既存 SPEC 変更時（`update` / `spec-update` / `spec-append`）は当該 SPEC の `status` を変更しない（G06、v2:ADR-0123 Decision #1）
+- SPEC 固有 script は `search-target-area.ts`（target_area 見出し検索、見出し行全体完全一致）を正規所有対象とする。`spec-update` の target_area マッチングと `spec-append` の anchor マッチングの双方で使用する
 - 共通検証 script（`check-frontmatter-consistency.ts`、`check-entry-existence.ts`、`check-change-impact.ts`）は `agentdev-artifact-validation` が所有し、本 skill は公開検証契約経由で委譲する
 
 ## 境界
@@ -78,16 +82,18 @@ SPEC ファイルの作成、更新、配置先判断、target_area 処理、SPE
 ## 検証観点
 
 - 新規 SPEC 作成時の frontmatter 完全性（`title`、`status: draft`、`created`、`updated`）
-- 既存 SPEC 追記時の `status` 変更がないこと（G06）
+- 既存 SPEC 変更時（`update` / `spec-update` / `spec-append`）の `status` 変更がないこと（G06）
 - target_area マッチング規則の適用結果（単一マッチ、複数マッチ時の warn、未検出時のスキップ + follow-up）
+- `spec-append` 操作時の anchor マッチング、placement 別挙動の適用結果、挿入後の Markdown 構造破損がないこと
 - 共通検証委譲の結果（`agentdev-artifact-validation` 公開検証契約経由）
 - `docs/specs/README.md` の新規 SPEC エントリ登録（REQ-001-004）
 
 ## See Also
 
+- [spec-save.md](../commands/spec-save.md)（SPEC 操作 command。`spec-append` 操作時のセクション追加ロジック詳細を正規所有）
 - [agentdev-req-file-manager.md](agentdev-req-file-manager.md)（REQ 操作 skill）
 - [agentdev-adr-file-manager.md](agentdev-adr-file-manager.md)（ADR 操作 skill）
 - [agentdev-artifact-validation.md](agentdev-artifact-validation.md)（共通検証 skill）
 - [agentdev-doc-diagnostics.md](agentdev-doc-diagnostics.md)（docs 横断診断 skill）
 - v2:ADR-0123（SPEC lifecycle と spec-save の導入）
-- REQ-001（REQ/SPEC 責務分離）、REQ-002-159（script 所有権）
+- REQ-001（REQ/SPEC 責務分離）、REQ-002-159（script 所有権）、REQ-008-058（SPEC operation enum 公式契約と alias 受け付け）


### PR DESCRIPTION
## 概要

OU-002 (Issue #1883, Epic #1881): REQ-008 へ spec-append operation 追加要否判定と要件行更新を実施する。REQ-008 の構造化ハンドオフ要件（artifact_actions 構造）へ spec-append operation を追加するかどうかを判定し、要件レベルで APPEND と UPDATE の区別を外部契約として保証するため REQ-008-058 を新設、加えて SPEC 4 件を spec-append 第一級化へ向けて整合更新した。

## 判定結果

REQ-008 へ spec-append operation を追加する要否判定結果: **追加する（新規要件行で公式 enum と alias ポリシーを正規化）**

判定根拠:
- REQ-008 は artifact_actions 構造の正規所有者（REQ-008-027、Epic #1881「REQ 正規所有関係」）であり、operation enum の公式契約を REQ レベルで保持する必要がある
- 従来 REQ-008 は operation の取り得る値を明示しておらず、SPEC レベル（artifact-contracts.md）でのみ `{create, update}` が記載されていた
- Epic #1881 の設計判断（公式 enum: create/update、各 SPEC は非正規 alias 受け付け）は、alias ポリシーを含む構造的契約であり、REQ-008 が正規所有すべき性質である
- REQ-008-032（SPEC update 時の対象見出し必須出力）は公式 enum「update」で包摂されるため改修不要。alias 運用は REQ-008-058 の「alias 固有の契約は各 SPEC が定める」で委譲する

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `docs/requirements/REQ-008.md` | REQ-008-058 を新設。artifact_actions operation 公式 enum（REQ/ADR {create, append, update}、SPEC {create, update}）と非正規 alias 受け付けポリシー、alias 固有契約の委譲先を明文化 |
| `docs/specs/responsibilities/artifact-contracts.md` | artifact_actions operation 行へ alias 受け付けポリシー（spec-create/spec-update/spec-append、REQ-008-058 参照）を追記 |
| `docs/specs/commands/req-define.md` | draft-data artifact_actions フィールド形式へ alias 映射（spec-create→create, spec-update→update, spec-append→update）と spec-append 操作行（target_area=anchor, placement=tail/after_anchor/before_anchor, content=新規セクション本文）を追記 |
| `docs/specs/commands/spec-save.md` | Step 2/5 へ alias 受け付けと spec-append 処理を明記。target_area マッチング規則へ「見出し行全体完全一致」を強化。新規セクション「spec-append 操作時のセクション追加ロジック」（入力契約、placement 別挙動、anchor マッチング、anchor 未検出時、同名見出し時、合格基準、後方互換）を追加 |
| `docs/specs/skills/agentdev-spec-file-manager.md` | 提供する判断・操作、現在の動作、検証観点、See Also へ spec-create/spec-update/spec-append の取扱いと見出し行全体完全一致契約を反映 |

## test strategy 検証結果 (TS-007)

- id: TS-007
- target_item: AG-007 (REQ 正規所有関係)
- verification: REQ-008/REQ-004 の要件行が正しく更新されているか（または更新不要と判定されたか）を確認。req-save 実行時に要件行追加要否が判定され、結果が記録されていることを確認する。
- pass_criteria: REQ-008/REQ-004 の更新要否判定が記録され、必要な場合は要件行が追加されていること。不要の場合は SPEC のみ更新されていること。
- 実行結果: **PASS**
  - REQ-008 へ REQ-008-058 を追加し、要件行追加要否判定結果（追加する）を本 PR「判定結果」セクションへ記録した
  - REQ-004 は実行プロセス所有者であり、本 Issue の operation enum 正規化対象外。REQ-004 の要件行追加は不要と判定した（構造化ハンドオフ要件は REQ-008、実行プロセスは REQ-004、operation enum 詳細は SPEC、の責務分界に従う）
  - SPEC 4 件（artifact-contracts.md、req-define.md、spec-save.md、agentdev-spec-file-manager.md）を整合更新した

## 検証

- targeted docs guard: `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --files <changed-paths> --json` を実行。`failures: []`、`warnings: []`、`doc_map_update_required: false`、`spec_readme_update_required: false`、`requirements_readme_update_required: false`、`extensions_check_required: false` で合格
- git diff: 変更範囲は Issue スコープ内の 5 ファイル（REQ-008.md + SPEC 4 件）。`docs/specs/**` と `docs/requirements/**` のみで、`src/opencode/**`、`.opencode/**`、`.agentdev/**` は未変更
- lsp_diagnostics: Markdown LSP サーバ未設定のためスキップ（当リポジトリの標準挙動）

## Findings / Capture候補

特になし。本 PR は Issue #1883 のスコープ（REQ-008 判定と SPEC 整合更新）に専念し、スコープ外事項は後続 OU（#1884〜#1887 相当）または別工程へ委譲する。

### docs-integrity

targeted docs guard (case-run profile) の検出結果: strict severity の failure 0 件、warning 0 件。

## SPEC確定候補

特になし。本 PR で確定した spec-append 契約（placement=tail/after_anchor/before_anchor、anchor 見出し行全体完全一致、anchor 未検出時スキップ+follow-up、同名見出し時 warn）は既に spec-save.md 本文へ直接記載しており、SPEC確定候補セクションで別途保持すべき未確定事項はない。

## 後続作業（参考）

本 PR は Epic #1881 OU-002 (#1883) のスコープで完結する。以下は後続 OU の対象:

- OU-001 (#1882): `src/opencode/skills/agentdev-req-file-manager/scripts/src/alloc-composite-id.ts` の正規表現修正、agentdev-req-file-manager.md 実装詳細更新
- search-target-area.ts 実装修正（見出し行全体完全一致への移行）: Epic 完了条件にあるが、本 Issue では SPEC 契約のみ文書化し、実装修正は後続 Issue で実施する。本 PR の SPEC 変更と実装修正は独立して進行可能

Refs: #1883
