### PR TITLE
docs(specs/local): runtime-package-boundary の inspect-extensions 削除・3 command 縮約

### DIFF
--- a/docs/specs/local/runtime-package-boundary.md
+++ b/docs/specs/local/runtime-package-boundary.md
@@ -1,6 +1,8 @@
 ---
 status: accepted
-updated: 2026-07-26
+updated: 2026-07-27
+spec_logical_division: catalog
+canonical_owner: runtime-package-boundary
 ---
 
 # 実行時パッケージ境界
@@ -303,7 +305,7 @@ wrong target 検出、再作成ロジックは LocalMode と通常版 install �
 |--------|------|------|
 | `agentdev-*` 全 27 件 | 配布物依存 | `src/opencode/skills/` 配下、`agentdev-*` グロブで自動 junction |
 | `japanese-tech-writing` | 配布物依存 | `agentdev-doc-writing` が執筆規範 SSoT として参照（PR #1385 で昇格）。`agentdev-*` 非準拠のため install script で個別 junction 対象 |
-| `repo-agentdev-integrity` | repo-local 専用 | `/repo/docs-check` 実行スキル。REQ-001 の `repo-*` 卡out 対象。配布物（`agentdev-*` 以外）が実行時参照する一部コマンド（`req-save`, `spec-save`, `case-close`, `inspect-extensions`）が `repo-agentdev-integrity/scripts/*.ts` を呼び出すが、当該参照は consumer 環境で実行時欠落する別課題（本 SPEC の対象外） |
+| `repo-agentdev-integrity` | repo-local 専用 | `/repo/docs-check` 実行スキル。REQ-001 の `repo-*` 卡out 対象。検証スクリプトを呼び出す command は ADR-006 により3 command（`docs-check`, `inspect-skills`, `inspect-promote`）へ正規化済み。これらが `repo-agentdev-integrity/scripts/*.ts` を呼び出すが、当該参照は consumer 環境で実行時欠落する別課題（本 SPEC の対象外） |
 
 ## 関連項目（See Also）
 


### PR DESCRIPTION
## 概要

OU-005 (Epic #1888): `docs/specs/local/runtime-package-boundary.md` L306 周辺の列挙から `inspect-extensions` を削除し、後継3 command（`docs-check`, `inspect-skills`, `inspect-promote`）へ縮約する。ADR-006 により inspect-extensions は独立公開 command として廃止され、後継 command へ移管済みだが、local SPEC には stale reference が残存していたため ADR-006 準拠へ更新する。

## 変更内容

- **frontmatter**: `spec_logical_division: catalog`, `canonical_owner: runtime-package-boundary` を追加、`updated` を 2026-07-27 へ更新
- **L306 (repo-agentdev-integrity 行の備考)**: 4 command（`req-save`, `spec-save`, `case-close`, `inspect-extensions`）の列挙を ADR-006 準拠の3 command（`docs-check`, `inspect-skills`, `inspect-promote`）へ縮約
- 隣接する実行時欠落記述（consumer 環境で実行時欠落する別課題）は ADR-006 の3層責務分離へ正規化済みという文脈へ整理

## 完了条件

- [x] L306 周辺に inspect-extensions が存在しないこと
- [x] 3 command（docs-check, inspect-skills, inspect-promote）が列挙されていること
- [x] 隣接する実行時欠落記述が ADR-006 準拠へ更新されていること
- [x] docs-check で ADR-006 との整合性が確認されること

## 検証結果

### TS-009 (AG-009: inspect-extensions 削除・3 command 縮約)

- `docs/specs/local/runtime-package-boundary.md` に対する `inspect-extensions` grep 結果: 0 件（削除確認完了）
- 3 command 列挙確認: L308 に `docs-check`, `inspect-skills`, `inspect-promote` が列挙されていることを確認
- pass_criteria 満たす

### TS-010 (AG-010: 隣接記述 ADR-006 準拠)

- targeted docs guard (`check_changed_docs.ts --workflow case-run --files docs/specs/local/runtime-package-boundary.md`): failures 0 件、warnings 0 件
- full docs-check (`check_integrity.ts`): runtime-package-boundary.md に対する NG finding 0 件を確認（他ファイルの pre-existing NG は本 PR の対象外）
- ADR-006 への整合性確認完了

## Findings / Capture候補

本 Issue スコープ外の発見事項なし。

## SPEC確定候補

本 Issue 実装中に発見された SPEC レベルの詳細なし。

Refs: #1892
