### PR TITLE
docs(specs): document-model.md の6処置相互参照を追記 (L163/L612)

### DIFF
--- a/docs/specs/foundations/document-model.md
+++ b/docs/specs/foundations/document-model.md
@@ -177,6 +177,8 @@ INFERENCE は「明文化を残す KEEP」とも「別成果物に残す MOVE」
 
 処置の判定根拠は非排他的な情報として記録する。観測事実、適用した既存規則、意味判断、ユーザー合意、機械検出結果等が併存し得る。判定根拠の伝播は REQ-001-033 が定義する分類根拠フィールドへ統合し、INFERENCE/MANUAL/RULE のような排他的 enum は導入しない。
 
+本節の6処置は昇格前の適格性判定に適用する。「6 処置モデル」節（「恒久基準と非規範情報の整理」配下）も同名の KEEP/MERGE/REFERENCE/MOVE/RETIRE/INFERENCE を定義するが、cleanup 実行モデルの処置であり、適用フェーズと参照する正規所有契約が異なる。両者は独立した正規所有契約であり、統合しない。
+
 #### intake・learning 昇格分類との違い
 
 intake・learning パイプラインの対応要否分類（action-required / covered / duplicate / verification-only / deferred / rejected）と対応形態分類（local-fix / example-or-test / knowledge-only / permanent-contract-candidate）は、本節の6処置とは別の分類である。昇格分類は採用済み成果物をどう処理するかの前段階判定であり、既存成果物を実際に変更する段階で必要に応じて6処置を適用する。
@@ -624,6 +626,8 @@ req-health-metrics.md と対となる SPEC 健全性の定量メトリクスを�
 
 - MOVE または REFERENCE には解決可能な移動先または参照先が存在すること
 - RETIRE または INFERENCE には理由と履歴保持先が記録されること
+
+本節の6処置は cleanup 実行モデルに適用する。「既存成果物の6処置」節（「恒久契約適格性と既存成果物処置分類」配下）も同名の KEEP/MERGE/REFERENCE/MOVE/RETIRE/INFERENCE を定義するが、昇格前の適格性判定に適用する。両者は独立した正規所有契約であり、統合しない。
 
 ### 処置後の記録と再検証
 


### PR DESCRIPTION
## 概要

Issue 1893 (OU-004) の実装。docs/specs/foundations/document-model.md の「既存成果物の6処置」節（昇格前適格性判定）と「6 処置モデル」節（cleanup 実行モデル）に相互参照を追記し、両者が独立した正規所有契約であること、統合しないことを明示する。

## 変更内容

docs/specs/foundations/document-model.md のみ変更（1 file changed, 4 insertions）。

- 「既存成果物の6処置」節（L163 周辺、昇格前適格性判定）の末尾に「6 処置モデル」節への相互参照を追記
- 「6 処置モデル」節（L612 周辺、cleanup 実行モデル）の末尾に「既存成果物の6処置」節への相互参照を追記
- セクション名参照（行番号非依存）で参照の安定性を確保

両節とも KEEP/MERGE/REFERENCE/MOVE/RETIRE/INFERENCE の同名6処置を定義するが、適用フェーズと参照する正規所有契約が異なる。統合は行わず、相互参照のみ追加する（Issue 提案内容通り）。

## 関連 Issue

- Refs: 1893
- Parent: 1888
- 前提: 1891 (PR 1899 で merge 済、L27/L139 dangling 修正)

## Test Strategy 検証

- TS-007 (AG-007, L163 相互参照): PASS
  - 「既存成果物の6処置」節末尾から「6 処置モデル」節（「恒久基準と非規範情報の整理」配下）への相互参照が存在
  - 両者が独立した正規所有契約であること、統合しないことを明示
- TS-008 (AG-008, L612 相互参照): PASS
  - 「6 処置モデル」節末尾から「既存成果物の6処置」節（「恒久契約適格性と既存成果物処置分類」配下）への相互参照が存在
  - 統合は行われず、相互参照のみであることを明示

## Findings / Capture候補

なし。

## SPEC確定候補

なし。