### PR TITLE
feat(spec): OU-002 capture-boundaries.md に工程別 capture 責務セクションを追加 (RU-0009)

### DIFF
--- a/docs/specs/workflows/capture-boundaries.md
+++ b/docs/specs/workflows/capture-boundaries.md
@@ -80,6 +80,52 @@ CaptureBoundary 検査（`check_integrity.ts` の `command-capture-duty`）は�
 
 例外の根拠は本 capture 責務表である。同表は case-auto の intake、learning をともに「各工程の保存結果参照と件数集計のみ」と定義し、case-auto 自身は inbox、inbox.md の直接生成を行わない設計を示す。v2:ADR-0127（case-auto 構成工程の委譲）と v2:ADR-0137（case-run インライン実行）が、case-auto を統合委譲起点とする現行設計を裏付ける。
 
+## 工程別 capture 責務
+
+主ワークフロー構成 6 工程（req-save / spec-save / case-open / case-run / case-close / case-auto）の capture 責務、保存先、git 永続化担当を工程別に定義する。各工程分散型（選択肢A、REQ-006-021 / REQ-006-105〜108）に従う。
+
+### 工程別 capture 責務表
+
+| 工程 | capture 責務 | 保存先 | git 永続化担当 |
+|---|---|---|---|
+| req-save | REQ 再構成 intake + 自工程 deviation capture（REQ-006-106） | `.agentdev/intake/inbox/`、`.agentdev/learning/` | req-save command |
+| spec-save | 自工程 deviation capture（REQ-006-107） | `.agentdev/intake/inbox/`、`.agentdev/learning/` | spec-save command |
+| case-open | 自工程 deviation capture（case-close への委譲を廃止、REQ-006-021） | `.agentdev/intake/inbox/`、`.agentdev/learning/` | case-open command |
+| case-run | PR 本文記録のみ（`.agentdev/` 直接変更禁止） | PR 本文 `## Findings / Capture候補` | 実行担当サブエージェント（PR 作成時） |
+| case-close | PR 本文から回収 + 自工程 deviation capture（REQ-006-105、Epic 横断回収含む） | `.agentdev/intake/inbox/`、`.agentdev/learning/` | case-close command |
+| case-auto | 各工程の保存結果参照と件数集計のみ（REQ-006-108）。capture 本文の再分類、再保存は行わない | （保存しない） | （git 永続化なし） |
+
+### 委譲契約（Command→Skill 依存方向）
+
+各 command は Command→Skill 依存方向（`docs/specs/responsibilities/artifact-contracts.md`「依存方向」参照）に従い、capture 成果物の生成を Skill へ委譲する。command は `intake-capture` 等の他 command を呼び出さない。
+
+| 種別 | 委譲先 Skill | 役割 |
+|---|---|---|
+| learning | `agentdev-learning-capture` skill | 失敗、回避、修正、判断ミスの知見抽出と `inbox.md` エントリ生成 |
+| intake | `agentdev-intake-pipeline` skill | 作業候補、不整合、規約違反の item 生成操作 |
+
+git 永続化（commit、push）は呼出元 command が担う。Skill は候補生成と file 書き込みまでを担い、commit 実行は委譲しない。
+
+### Epic Issue 単一書き手制約（case-close 経由）
+
+Epic Issue 本文（ステータス追跡テーブル）の更新は `case-close(#epic)` のみが行う（REQ-006-021、`docs/specs/workflows/epic-wave-model.md`「Epic Issue 本文の単一書き手制約」参照）。
+
+- `case-run(#epic)` は Epic Issue 本文を読み取るのみで書き込まない
+- `case-auto` 自身は Epic Issue を更新せず、case-close 経由で更新する
+- 複数 execution_unit 並列実行時も per-Epic-Issue-body の単一書き手が維持される（REQ-006-021）
+
+### 完了報告（Capture結果）
+
+各 command の完了報告には `Capture結果` 小節を含める。共通意味契約は `docs/specs/responsibilities/artifact-contracts.md`「Capture結果 小節（共通意味契約）」が正規所有する。
+
+記載内容:
+
+- 保存先パス（`.agentdev/intake/inbox/*.md`、`.agentdev/learning/inbox.md`）
+- 分類（intake / learning）
+- 保存結果（成功/失敗、件数、コミットハッシュ等）
+
+capture 本文は完了報告に含めない。具体的な表示構造は各 command-local Template が正規所有する。
+
 ## REQ 再構成 intake
 
 通常intakeとは独立した配置規約（REQ-010）。
@@ -102,8 +148,11 @@ req-define の明示入力としてルーティングする（backlog-review 経
 ## See Also
 
 - [workflow-contracts.md](workflow-contracts.md)（ワークフロー全体契約）
+- [epic-wave-model.md](epic-wave-model.md)（Epic Issue 本文の単一書き手制約）
 - [backlog-artifact-lifecycle.md](backlog-artifact-lifecycle.md)（採用済み成果物 lifecycle）
+- [../responsibilities/artifact-contracts.md](../responsibilities/artifact-contracts.md)（Command→Skill 依存方向、`Capture結果` 小節の共通意味契約）
 - 各 command SPEC（`docs/specs/commands/`）
 - `agentdev-workflow-orchestration` skill（capture 境界の詳細）
-- REQ-006（Case実行オーケストレーション / Epic、Wave）
+- `agentdev-learning-capture` skill、`agentdev-intake-pipeline` skill（capture 成果物の生成委譲先）
+- REQ-006（Case実行オーケストレーション / Epic、Wave、各工程分散型 capture 責務 REQ-006-021/105〜108）
 - REQ-010（REQ 再構成 intake）


### PR DESCRIPTION
## 概要

Issue #1873 (OU-002: capture-boundaries.md 工程別 capture 責務セクション更新) の case-run 実装。

`docs/specs/workflows/capture-boundaries.md` に新規セクション `## 工程別 capture 責務` を追加し、主ワークフロー構成 6 工程（req-save / spec-save / case-open / case-run / case-close / case-auto）の capture 責務、保存先、git 永続化担当を工程別に定義する。委譲契約、Epic Issue 単一書き手制約、完了報告（Capture結果）小節の参照関係も明文化する。

## 変更内容

- `docs/specs/workflows/capture-boundaries.md`
  - 新規セクション `## 工程別 capture 責務` を追加（既存 `## 各コマンドの capture 責務` の包括表から、工程別の詳細責務表・委譲契約・Epic 単一書き手・完了報告を分離して明文化）
    - `### 工程別 capture 責務表`（6 工程 × capture 責務・保存先・git 永続化担当、各工程分散型選択肢A、REQ-006-021/105〜108）
    - `### 委譲契約（Command→Skill 依存方向）`（`intake-capture` command 呼出し禁止、`agentdev-learning-capture` skill / `agentdev-intake-pipeline` skill への委譲、git 永続化は呼出元 command 担当）
    - `### Epic Issue 単一書き手制約（case-close 経由）`（`case-close(#epic)` のみが Epic Issue 本文を更新、`case-run(#epic)` は読取のみ、case-auto 自身は更新しない、per-Epic-Issue-body 単一書き手 REQ-006-021）
    - `### 完了報告（Capture結果）`（共通意味契約は `artifact-contracts.md` が正規所有、保存先パス・分類・保存結果のみ、capture 本文は含めない）
  - `## See Also` を拡張（`epic-wave-model.md`、`artifact-contracts.md`、`agentdev-learning-capture` / `agentdev-intake-pipeline` skill への参照を追加）

PR #1898 (OU-001) の Findings 記録「新規セクション『## 工程別 capture 責務』の追加や委譲契約/Epic 単一書き手/完了報告の詳細化が #1873 の残作業候補」を実施するもので、同 PR が整合させた `各コマンドの capture 責務` 表を前提とする。

## 完了条件の検証

- [x] `docs/specs/workflows/capture-boundaries.md` の工程別 capture 責務表が各工程分散型（選択肢A）6項目確定案と完全一致すること
  - 6 工程（req-save / spec-save / case-open / case-run / case-close / case-auto）を列挙
  - 各行の capture 責務記述が REQ-006-021 / 105〜108 と整合（PR #1898 検証済みの包括表と一貫）
- [x] Command→Skill 依存方向が遵守され、intake-capture command への呼出しが存在しないこと
  - 委譲契約節で「command は `intake-capture` 等の他 command を呼び出さない」ことを明記
  - 委譲先を `agentdev-learning-capture` skill と `agentdev-intake-pipeline` skill に限定
  - `docs/specs/responsibilities/artifact-contracts.md`「依存方向」（Command→Skill 一方向）を参照
- [x] Epic Issue 単一書き手制約（case-close 経由）が記載されていること
  - 専節を設け、`case-close(#epic)` のみが Epic Issue 本文を更新することを明記
  - `docs/specs/workflows/epic-wave-model.md`「Epic Issue 本文の単一書き手制約」と REQ-006-021 を参照

## テスト戦略の検証

- **TS-002 (Command→Skill 依存方向)**: PASS
  - 新規セクション「委譲契約」において `intake-capture` command の呼出しを明示的に禁止し、Skill 委譲のみを記載
  - 既存の包括表（`## 各コマンドの capture 責務`）にも依存方向に矛盾する記述はない
  - `artifact-contracts.md`「依存方向」（Command→Skill 一方向、行 27）と整合

## Step 5-4: targeted docs guard

```
$ bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
    --workflow case-run --base-ref origin/main \
    --files docs/specs/workflows/capture-boundaries.md --json
{
  "workflow": "case-run",
  "files_checked": ["docs/specs/workflows/capture-boundaries.md"],
  "coupled_files_checked": ["docs/DOC-MAP.md", "docs/README.md", "docs/specs/README.md"],
  "failures": [],
  "warnings": [],
  "doc_map_update_required": false,
  "spec_readme_update_required": false,
  "requirements_readme_update_required": false,
  "full_docs_check_recommended": false,
  "extensions_check_required": false,
  ...
}
```

DOC-MAP / SPEC README / Requirements README のいずれも更新不要（既存 SPEC へのセクション追加のため）。

## Findings / Capture候補

（なし）

## SPEC確定候補

（なし）

## 関連

- Parent Epic: #1871
- 前提 PR: #1898 (OU-001 REQ-006 capture 責務境界の各工程分散型変更、capture-boundaries.md 追随)
- Wave 2 並列 PR: #1878 (OU-007 artifact-contracts.md Capture結果 小節) は `Capture結果` 共通意味契約の正規所有者。本 PR は同節を参照する

Refs: #1873
