### PR TITLE
OU-003: artifact-contracts.md へ spec-append operation 契約を追記

### DIFF
--- a/docs/specs/responsibilities/artifact-contracts.md
+++ b/docs/specs/responsibilities/artifact-contracts.md
@@ -460,6 +460,57 @@ req_draft の frontmatter は最小限のメタデータのみとする。
 - 最小 frontmatter fields: `draft_type`, `topic_slug`, `status`, `created_at`、optional で `source_rus`
 - frontmatter は lightweight metadata のみ。後続工程の主入力は `# draft-data` fenced YAML であり、frontmatter ではない
 
+## artifact_actions operation
+
+`artifact_actions` の `operation` フィールドは REQ/ADR 操作と SPEC 操作で扱う値が異なる。REQ/ADR 操作（`create` / `append` / `update`）は従来通り維持する。本節は SPEC 操作の公式 enum、非正規 alias、consumer 側の後方互換、および `spec-append` operation の契約を正規所有する。各 action の field 構成は「req_draft 出力構造」節の「artifact_actions 詳細構造」を参照。
+
+### SPEC operation enum と非正規 alias
+
+- SPEC operation の公式 enum は `create` / `update` の2値とする（REQ-008-058）
+- 各 SPEC（req-define / spec-save）は非正規 alias として `spec-create` / `spec-update` / `spec-append` を受け付ける
+- alias から公式 enum への映射: `spec-create` → `create`、`spec-update` → `update`、`spec-append` → `update`（既存 SPEC ファイルへ新規セクションを追加する操作）
+- consumer（spec-save）は `create` / `update` / `spec-create` / `spec-update` / `spec-append` の全てを受理する（後方互換）
+
+### spec-append operation
+
+`spec-append` は既存 SPEC ファイルへ新規セクションを追加する操作であり、公式 enum の `update` へ alias として映射される（REQ-008-058）。
+
+#### 意味
+
+既存 SPEC ファイルへ `target_area` と `placement` で指示した位置へ新規セクションを追加する。
+
+#### 入力フィールド
+
+| field | 必須性 | 形式 |
+|---|---|---|
+| `target` | 必須 | 既存 SPEC ファイルパス |
+| `target_area` | 必須 | 追加対象の見出し行全体（Markdown 見出し行形式。例: `### IR-044`）。見出しプレフィックス（`##`、`###` 等）の有無は正規化により吸収する |
+| `content` | 必須 | 追加する新規セクション本文（見出し行から始まる） |
+| `placement` | 任意（省略時 `tail`） | `tail` / `after_anchor` / `before_anchor` のいずれか |
+| `anchor` | `placement` が `tail` 以外は必須 | 挿入位置の基準となる見出し行（`target_area` と同一形式） |
+
+`placement` 別の追加位置は次の通り。
+
+| placement | 追加位置 |
+|---|---|
+| `tail`（既定） | `target_area` セクションの末尾（次の同レベルまたは上位レベル見出し行の直前） |
+| `after_anchor` | `anchor` 見出し行の直後 |
+| `before_anchor` | `anchor` 見出し行の直前 |
+
+#### 挙動
+
+- **同名見出し時**: `target_area` と完全一致する見出しが既存 SPEC ファイルに存在する場合、追加をスキップし follow-up 報告を行う（重複追加防止、全体中止しない）
+- **anchor 未検出時**: `placement` が `tail` 以外で `anchor` 見出し行が存在しない場合、当該 action をスキップし follow-up 報告を行う（全体中止しない）
+- follow-up 報告は「operation を `spec-create` へ切り替えを推奨」を含む
+
+#### 合格基準
+
+- 追加後の SPEC ファイルに `target_area` と完全一致する見出しが1つだけ存在すること
+- frontmatter `updated` を更新していること
+- `status` は変更しないこと（G06）
+
+配置契約の実行詳細（`placement` 別挿入位置の算出、anchor マッチング規則）は `specs/commands/spec-save.md`「spec-append 操作時のセクション追加ロジック」が正規所有する。
+
 ## RU アーティファクト契約（session由来RU）
 
 session由来RU（`source_type: chat`、`generated_by: session`）の生成、承認、保存、永続化の追跡可能な二段階手続きを定義する。本節は REQ-008 に基づき session 経路に不足する契約を追加し、既存の `source_type: chat` と7値の `tentative_classification` を維持する。


### PR DESCRIPTION
## 概要

OU-003 (RU-0011, Epic #1881): `docs/specs/responsibilities/artifact-contracts.md` へ `## artifact_actions operation` セクションを新設し、SPEC operation enum、非正規 alias、consumer 後方互換、`spec-append` operation の契約を正規所有する。

Issue #1884 の完了条件6項を満たす。

## 変更内容

`docs/specs/responsibilities/artifact-contracts.md` (+51 行、新規セクション追加):

- `## artifact_actions operation`（トップレベルセクション、`## req_draft 出力構造` と `## RU アーティファクト契約` の間）
  - `### SPEC operation enum と非正規 alias`: 公式 enum `create`/`update`、非正規 alias `spec-create`/`spec-update`/`spec-append`、alias → 公式 enum 映射、consumer (spec-save) が全てを受理する（後方互換）
  - `### spec-append operation`: 意味、入力フィールド（`target`/`target_area`/`content`/`placement`/`anchor`）、placement 別追加位置表、挙動（同名見出し時スキップ+follow-up、anchor 未検出時スキップ+follow-up）、合格基準（`target_area` と完全一致する見出しが1つだけ存在）

既存 line 407 の operation field 記述（OU-002 で追加済み）は field schema 专域として維持、新セクションは operation level の契約を正規所有する。

## 検証結果

### TS-004 (AG-004: SPEC operation enum 拡張): PASS

- 公式 enum `create`/`update` 明記 (line 469)
- 非正規 alias `spec-create`/`spec-update`/`spec-append` 受け付け明記 (line 470)
- consumer (spec-save) 後方互換明記 (line 472)

### TS-005 (AG-005: spec-append 契約 3 SPEC 一貫性): 部分一致（OU-005/#1886 未完了に伴う）

artifact-contracts.md と spec-save.md で `placement`/`anchor`/`anchor 未検出時`/`合格基準` は一致するが、**同名見出し時挙動**が不一致:

- artifact-contracts.md (本 PR): 「追加をスキップし follow-up 報告を行う（重複追加防止）」
- spec-save.md (現行): 「warn を出力し、追加処理は継続する（重複防止のための事前拒否は行わない）」

spec-save.md の更新は OU-005 (#1886, Wave 3) で実施される計画。Epic #1881 の Wave 構成において、OU-003 (本 Issue, Wave 2) と OU-005 (#1886, Wave 3) は別 Issue で分割実行される。本 PR は OU-003 のスコープ（artifact-contracts.md のみ）に専念し、spec-save.md の更新は OU-005 へ委譲する。

### targeted docs guard (case-run profile): PASS

```
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
  --workflow case-run --files docs/specs/responsibilities/artifact-contracts.md --json
```

結果: `failures: []`, `warnings: []`, `doc_map_update_required: false`, `spec_readme_update_required: false`

## Findings / Capture候補

### docs-integrity

targeted docs guard で failures/warnings 0件。DOC-MAP、SPEC README の更新不要（既存 SPEC へのセクション追記のため新規エントリ不要）。

### stale-reference

該当なし。Issue 本文の参照パスに stale なし。

### test-strategy cross-OU dependency

TS-005 の 3 SPEC 一貫性は、spec-save.md の更新を担当する OU-005 (#1886) の完了によって回復する。本 PR の時点では一時的な部分不一致が存在するが、これは Epic #1881 の Wave 分割計画（OU-003 = Wave 2, OU-005 = Wave 3）に基づく既知の状態である。case-close QG-4 にて最終的な 3 SPEC 一貫性を再評価することを推奨。

## SPEC確定候補

該当なし。本 PR は既存 SPEC (artifact-contracts.md) の契約追記であり、新たな schema、enum、判定表、内部アルゴリズムを発見していない。

## 関連

- Parent Epic: #1881
- Issue: #1884
- 依存元 (完了): #1883 (OU-002)
- 後続 (Wave 3): #1885 (OU-004), #1886 (OU-005), #1887 (OU-006)