### PR TITLE
OU-008: agentdev-learning-capture.md に呼出元 command 契約セクションを追加 (RU-0009)

### DIFF
--- a/docs/specs/skills/agentdev-learning-capture.md
+++ b/docs/specs/skills/agentdev-learning-capture.md
@@ -2,7 +2,7 @@
 title: `agentdev-learning-capture` SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-07-18
+updated: 2026-07-27
 ---
 
 # `agentdev-learning-capture` SPEC
@@ -31,8 +31,36 @@ updated: 2026-07-18
 ## 現在の動作
 
 - ユーザー承認なしで `inbox.md` に追記
-- git 永続化は呼出元コマンド（case-close 等）の責務
+- git 永続化は呼出元 command（req-save / spec-save / case-open / case-close）の責務（後述「呼出元 command 契約」参照）
 - 実観測ベース（実際に検知、回避、修正した問題のみ）
+
+## 呼出元 command 契約
+
+本スキルは、主ワークフロー構成工程 command（req-save / spec-save / case-open / case-close）から委譲を受ける。
+各 command は自工程で実観測した deviation のうち learning 該当分を本スキルへ委譲する。
+command は他 command を直接呼び出さず、Skill へ一方向に委譲する（Command→Skill 依存方向、[artifact-contracts.md](../responsibilities/artifact-contracts.md)「依存方向」、[capture-boundaries.md](../workflows/capture-boundaries.md)「委譲契約（Command→Skill 依存方向）」参照）。
+
+### 呼出元 command と委譲契約の根拠
+
+| 呼出元 command | REQ 根拠 | 委譲対象 |
+|---|---|---|
+| req-save | REQ-006-106 | req-save 実行中に実観測した deviation のうち learning 該当分 |
+| spec-save | REQ-006-107 | spec-save 実行中に実観測した deviation のうち learning 該当分 |
+| case-open | REQ-006-021 | case-open 実行中に実観測した deviation のうち learning 該当分 |
+| case-close | REQ-006-105 | case-close 実行中に実観測した deviation のうち learning 該当分（PR 本文から回収した learning 候補を含む） |
+
+`case-run` は `.agentdev/` 直接変更を禁止し PR 本文記録のみを行うため、本スキルへの委譲を行わない（[capture-boundaries.md](../workflows/capture-boundaries.md)「各コマンドの capture 責務」参照）。
+
+### 本スキルの責務（呼出元に対する提供）
+
+- 実観測ベースで learning 該当分を判定する（[capture-boundaries.md](../workflows/capture-boundaries.md) Split Rule 準拠）
+- 13フィールド形式で `inbox.md` エントリを生成、追記する
+- extraction（知見の分類、抽出）を担う
+
+### 呼出元 command の責務（本スキルが委譲しないもの）
+
+- git 永続化（commit、push）は呼出元 command が担う。本スキルは候補生成と file 書き込みまでを担い、commit 実行を委譲しない
+- 完了報告の `Capture結果` 小節に保存先パス、分類（learning）、保存結果（成功/失敗、件数、コミットハッシュ等）を含める
 
 ## 対象外
 


### PR DESCRIPTION
## 概要

Issue #1879 (OU-008: agentdev-learning-capture.md 呼出元 command 契約更新) の case-run 実装。

`docs/specs/skills/agentdev-learning-capture.md` に新規セクション `## 呼出元 command 契約` を追加し、主ワークフロー構成 4 工程 command（req-save / spec-save / case-open / case-close）からの自工程 deviation capture 委譲契約、本スキル責務、呼出元 command 責務（git 永続化、Capture結果 報告）を明文化する。Command→Skill 一方向依存を遵守する。

PR #1906 (OU-002 capture-boundaries.md 工程別 capture 責務) で確定した委譲契約を受ける側の SPEC として、learning-capture skill の呼出元契約を正規所有する。

## 変更内容

- `docs/specs/skills/agentdev-learning-capture.md`
  - frontmatter `updated` を 2026-07-27 へ更新
  - `## 現在の動作` の git 永続化行を整正（`case-close 等` から 4 command 明示 + 新セクション参照へ）
  - 新規セクション `## 呼出元 command 契約` を追加（`## 現在の動作` と `## 対象外` の間）
    - `### 呼出元 command と委譲契約の根拠`（4 command × REQ 根拠 × 委譲対象、REQ-006-106/107/021/105、case-run は対象外の明記）
    - `### 本スキルの責務（呼出元に対する提供）`（learning 該当分判定、13フィールド形式エントリ生成・追記、extraction）
    - `### 呼出元 command の責務（本スキルが委譲しないもの）`（git 永続化、完了報告 Capture結果 小節）
  - Command→Skill 一方向依存を冒頭で明記（`docs/specs/responsibilities/artifact-contracts.md`「依存方向」、`docs/specs/workflows/capture-boundaries.md`「委譲契約（Command→Skill 依存方向）」参照）

## 完了条件の検証

- [x] `docs/specs/skills/agentdev-learning-capture.md` に自動 capture 向け呼出契約が追記されていること
  - 新規 `## 呼出元 command 契約` セクションを追加、各 command の自工程 deviation capture 委譲を記載
- [x] 4 command（req-save/spec-save/case-open/case-close）からの委譲が記載されていること
  - 委譲契約表に 4 command を列挙、各 REQ 根拠（REQ-006-106/107/021/105）を付記
  - case-run は `.agentdev/` 直接変更禁止のため対象外であることを明記
- [x] git 永続化は呼出元 command 担当であることが明記されていること
  - 「呼出元 command の責務」節で「git 永続化（commit、push）は呼出元 command が担う。本スキルは候補生成と file 書き込みまでを担い、commit 実行を委譲しない」を明記
  - 完了報告 `Capture結果` 小節への記載責務も明記

## テスト戦略の検証

- **TS-002 (Command→Skill 依存方向)**: PASS
  - 新規セクション「呼出元 command 契約」において冒頭で「command は他 command を直接呼び出さず、Skill へ一方向に委譲する（Command→Skill 依存方向）」を明記
  - `docs/specs/responsibilities/artifact-contracts.md`「依存方向」、`docs/specs/workflows/capture-boundaries.md`「委譲契約（Command→Skill 依存方向）」を二重に参照
  - 委譲元を 4 command に限定し、他 command 呼出し契約は存在しない

## Step 5-4: targeted docs guard

```
$ bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts `
    --workflow case-run --files docs/specs/skills/agentdev-learning-capture.md --json
{
  "workflow": "case-run",
  "files_checked": ["docs/specs/skills/agentdev-learning-capture.md"],
  "coupled_files_checked": ["docs/DOC-MAP.md", "docs/README.md", "docs/specs/README.md"],
  "failures": [],
  "warnings": [],
  "doc_map_update_required": false,
  "spec_readme_update_required": false,
  "requirements_readme_update_required": false,
  "full_docs_check_recommended": false,
  "extensions_check_required": false,
  ...
}
```

DOC-MAP / SPEC README / Requirements README のいずれも更新不要（既存 SPEC へのセクション追加のため）。

## Findings / Capture候補

（なし）

## SPEC確定候補

（なし）

## 関連

- Parent Epic: #1871
- 前提 PR: #1906 (OU-002 capture-boundaries.md 工程別 capture 責務、委譲契約の包括定義)
- 前提 PR: #1898 (OU-001 REQ-006 各工程分散型 capture 責務)

Refs: #1879