### PR TITLE
docs(specs): req-save deviation capture 整合 (tracking, OU-003)

### DIFF
--- a/docs/specs/commands/req-save.md
+++ b/docs/specs/commands/req-save.md
@@ -2,7 +2,7 @@
 title: req-save SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-07-27
+updated: 2026-07-28
 ---
 
 # req-save SPEC
@@ -96,7 +96,7 @@ req-save は check_integrity.ts（全体監査）を使用しない（保存工�
 - push 後の status 更新（G07、commit 対象に status 変更を含めること）
 - Step 9-1 の hash 一致検証省略（G08）
 - Issue 作成（G11、case-open 責務）
-- intake / learning capture の実施（G12、例外: REQ 再構成 intake のみ）
+- intake / learning capture の直接実施（G12）。deviation capture は Skill 委譲で実施（「副作用」セクション参照）
 - SPEC artifact_actions の処理（spec-save 責務）
 - `work_type` 固定分岐による工程判定（G09、`artifact_actions` 有無で判定）
 


### PR DESCRIPTION
## 概要

OU-003 (Issue #1874): `docs/specs/commands/req-save.md` の「## 副作用」セクションに deviation capture 責務を追記する Issue。

Phase 0 (commit `736bc3af`) が req-save + spec-save 統合実行で既に副作用セクションの3行置換を適用済み。本 PR は tracking PR として、既存実装の整合性確認と、Phase 0 が更新しなかった対象外セクションの G12 参照行を副作用セクションと整合させる。

## 変更内容

### 副作用セクション（Phase 0 適用済み、確認のみ）

commit `736bc3af` により以下の3行が「## 副作用」セクションへ適用済み:

- deviation capture: req-save 実行中に実観測した deviation を `agentdev-learning-capture` skill または `agentdev-intake-pipeline`（自動capture向け item 生成操作）へ委譲して保存。保存先は capture-boundaries.md の Split Rule に従う。REQ 再構成 intake のみ（現行維持）も本責務に含む。
- git 永続化: capture 成果物を req-save 自身の既存 commit/push 処理内で永続化。
- 完了報告: 保存した capture 成果物のパス・分類・保存結果を `Capture結果` 小節（`結果` 内）に含める。

### 対象外セクション（本 PR による整合修正）

Phase 0 が対象外セクションを更新しなかったため、G12 参照行が旧記述のまま残存し、副作用セクションの deviation capture Skill 委譲と矛盾していた。以下の整合修正を適用:

- 旧: `intake / learning capture の実施（G12、例外: REQ 再構成 intake のみ）`
- 新: `intake / learning capture の直接実施（G12）。deviation capture は Skill 委譲で実施（「副作用」セクション参照）`

direct 実施は対象外（G12）、Skill 委譲は実施（副作用セクション参照）と明確化。

## 完了条件の検証

| 完了条件 | 結果 | 根拠 |
|---|---|---|
| 副作用セクションに deviation capture 責務が追記されていること | PASS | Phase 0 適用済み（行35-40） |
| intake-capture command への呼出しがなく、Skill 委譲のみが記載されていること | PASS | `agentdev-learning-capture` skill / `agentdev-intake-pipeline` のみ記載、`intake-capture` command 呼出しなし |
| 完了報告に `Capture結果` 小節が含まれること | PASS | 行40 で `Capture結果` 小節（`結果` 内）を宣言 |

## テスト戦略の検証

- **TS-002** (AG-002 Command→Skill 依存方向): PASS
  - req-save.md 本文に `intake-capture` command 呼出しなし
  - `agentdev-learning-capture` skill または `agentdev-intake-pipeline` への委譲が記載されている
- **TS-003** (AG-003 完了報告): PASS
  - 副作用セクション行40 で `Capture結果` 小節（`結果` 内）を宣言
  - capture 本文を含まず、パス・分類・保存結果のみを含む構造

## 検証ツール結果

- `check_changed_docs.ts --workflow case-run --files docs/specs/commands/req-save.md`: failures=0, warnings=0

## Findings / Capture候補

### command-file-g12-inconsistency

`src/opencode/commands/agentdev/req-save.md` 行314 の G12 制約定義が旧記述のまま残存:

> G12: req-save の capture 責務は原則非関与。intake/ learning capture を行わない。例外: REQ 再構成 intake（`.agentdev/intake/inbox/req-restructure/**`）のみ生成可能。

本 Issue の対象範囲は `docs/specs/commands/req-save.md`（SPEC）のみであり、command file の G12 定義は対象外。別途 case-update または follow-up Issue で整合させる必要がある。

## SPEC確定候補

なし。本変更は既存 SPEC の一貫性修正であり、新規の schema/enum/判定表を追加しない。

## refs

- Issue #1874 (OU-003)
- Epic #1871
- Phase 0 commit: `736bc3af`
- RU-0009 (AG-001, AG-002, AG-003)
