### PR TITLE
feat(agentdev): case-open command 本体の deviation capture ガードレールを SPEC と整合

### DIFF
--- a/src/opencode/commands/agentdev/case-open.md
+++ b/src/opencode/commands/agentdev/case-open.md
@@ -243,6 +243,8 @@ push 失敗時は構造化エラーメッセージを表示して停止する
 - 単一REQ Epic → `templates/case-open/epic.md`
 - マルチREQ Epic → `templates/case-open/multi-req-epic.md`
 
+**Capture結果 小節（REQ-006-109）**: 完了報告テンプレートの `結果` 内に `Capture結果` 小節を含める。case-open 実行中に実観測した deviation を `agentdev-learning-capture` skill または `agentdev-intake-pipeline`（自動capture向け item 生成操作）へ委譲して保存した場合、保存した capture 成果物のパス・分類（intake/learning）・保存結果（成功/失敗、失敗時は理由）のみを含める。capture 本体は含めない。capture 成果物が無い場合は `Capture結果` 小節を省略する（共通意味契約は `artifact-contracts` SPEC「Capture結果 小節（共通意味契約）」節参照）
+
 ## ガードレール
 
 ### フェーズ制約
@@ -274,14 +276,14 @@ push 失敗時は構造化エラーメッセージを表示して停止する
 ### 出力制約
 - G17: 成果物本文（Issue本文、PR本文、commit message、保存対象ファイル本文、テンプレート成果物）はverbatimで返す。「verbatim」とはLF・空行・インデントを含む行構造をbyte単位で保持することを指し、文字列の正規化、改行圧縮、空白挿入・削除をすべて禁止する。委譲接続点（Step 2/6/8/9）と最終 gh CLI 渡し（Step 12/13）の双方に適用する。判定結果、調査過程、中間ログ、読解メモは要約、成果物パス、根拠、親判断事項、capture候補へ圧縮して返す
 
- ### Capture 非関与制約
-- G18: case-open は intake/ learning capture を行わない。capture 境界（capture-boundaries）の詳細は `agentdev-workflow-orchestration` を参照
+ ### deviation capture 制約
+- G18: case-open は自工程で実観測した deviation を `agentdev-learning-capture` skill または `agentdev-intake-pipeline`（自動capture向け item 生成操作）へ委譲して保存する。保存先は Split Rule（`agentdev-workflow-orchestration` 参照）に従う。`intake-capture` command 等、別 command を直接呼ばない（REQ-006-021、REQ-006-109）
 
 ### OU 処理制約
 - G19: case-open は自律的な要件分析に基づいて Epic Issue を作成すること。ただし機能要件、非機能要件、対象外、受け入れ条件を新規に作成しないこと
 - G20: case-open は複数 OU が存在する場合、要件分析に基づいて Epic Issue および子 Issue 構造を生成すること。単一 Issue で完結する場合は Epic を作成しないこと
 - G21: case-open の Issue 化単位は REQ doc 単位ではなく OU 単位とすること
-- G22: case-open の capture 責務は非関与。intake/ learning capture を行わない。境界の詳細は `agentdev-workflow-orchestration` 参照
+- G22: case-open の capture 責務は自工程 deviation capture のみ。`agentdev-learning-capture` skill または `agentdev-intake-pipeline`（自動capture向け item 生成操作）への委譲で保存し、capture 本文は完了報告に含めず保存した成果物のパス・分類・保存結果のみを `Capture結果` 小節へ含める（REQ-006-021、REQ-006-109）。境界の詳細は `agentdev-workflow-orchestration` 参照
 
 ### 並列実行安全 git 操作制約
 - G23: 共有作業ツリーでスイープ操作（`git add -A`/ `git add .`/ `git add --all`/ `git commit -a`/ `git checkout .`/ `git reset --hard`/ `git stash`/ 非所有パスへの `git checkout -- <path>`/ `git restore <path>`）を実行しないこと。`agentdev-git-worktree` の並列実行安全ステージングプロシージャに従うこと

--- a/src/opencode/commands/agentdev/templates/case-open/epic.md
+++ b/src/opencode/commands/agentdev/templates/case-open/epic.md
@@ -7,6 +7,10 @@
  - REQ-{NNNN} をEpic本文に反映
  - 子Issue: #{child1}, #{child2}, #{child3}（{count}件）
  - Wave構成: {wave_count} Wave（{wave_summary}）
+ Capture結果: {該当なし省略可 / 以下capture 成果物がある場合のみ}
+  - パス: {.agentdev/intake/inbox/*.md または .agentdev/learning/inbox.md への相対パス}
+  - 分類: {intake/learning}
+  - 保存結果: {成功/失敗（理由）}
 検証結果: ✅ OK
 git 永続化: {該当なし/ ✅ OK（commit {hash}, push 済み, HEAD = origin/main 同期確認OK）}
 次のコマンド:/agentdev/case-run {epic_N}

--- a/src/opencode/commands/agentdev/templates/case-open/multi-req-epic.md
+++ b/src/opencode/commands/agentdev/templates/case-open/multi-req-epic.md
@@ -7,6 +7,10 @@
  - 対象REQ: {REQ番号リスト}（{req_count}件）
  - 子Issue: #{child1}, #{child2}, #{child3}（{count}件）
  - Wave構成: {wave_count} Wave（{wave_summary}）
+ Capture結果: {該当なし省略可 / 以下capture 成果物がある場合のみ}
+  - パス: {.agentdev/intake/inbox/*.md または .agentdev/learning/inbox.md への相対パス}
+  - 分類: {intake/learning}
+  - 保存結果: {成功/失敗（理由）}
 検証結果: ✅ OK
 git 永続化: {該当なし/ ✅ OK（commit {hash}, push 済み, HEAD = origin/main 同期確認OK）}
 次のコマンド:/agentdev/case-run {epic_N}

--- a/src/opencode/commands/agentdev/templates/case-open/standard.md
+++ b/src/opencode/commands/agentdev/templates/case-open/standard.md
@@ -5,6 +5,10 @@
 結果:
  - Issue #{N} を作成
  - {機能追加の場合: REQ-{NNNN} をIssue本文に反映}
+ Capture結果: {該当なし省略可 / 以下capture 成果物がある場合のみ}
+  - パス: {.agentdev/intake/inbox/*.md または .agentdev/learning/inbox.md への相対パス}
+  - 分類: {intake/learning}
+  - 保存結果: {成功/失敗（理由）}
 検証結果: ✅ OK
 git 永続化: {該当なし/ ✅ OK（commit {hash}, push 済み, HEAD = origin/main 同期確認OK）}
 次のコマンド:/agentdev/case-run {N}


### PR DESCRIPTION
## 概要

Issue #1876 (OU-005, RU-0009): `docs/specs/commands/case-open.md` の「## 副作用」セクション更新に伴う command 本体側のガードレール整合。

## 対象範囲

- `src/opencode/commands/agentdev/case-open.md` の G18, G22, Step 15 完了報告
- `src/opencode/commands/agentdev/templates/case-open/{standard,epic,multi-req-epic}.md` の `Capture結果` 小節追記

## 背景

Phase 0 (PR #1906/#1907) で以下は適用済み:
- `docs/specs/commands/case-open.md` の「## 副作用」セクション（deviation capture 3行へ置換）
- `docs/specs/responsibilities/artifact-contracts.md` の「Capture結果 小節（共通意味契約）」節
- `docs/specs/workflows/capture-boundaries.md` の「工程別 capture 責務」セクション

Issue 補足情報※ で「case-open.md command 本体（`src/opencode/commands/agentdev/case-open.md`）のガードレール G18/G22『capture 非関与』も本変更に整合して更新が必要（case-run 工程で実施）」と明示されていた後追い作業を本 PR で実施。

## 変更内容

### `src/opencode/commands/agentdev/case-open.md`

- G18: 「capture 非関与」→ 自工程 deviation capture を `agentdev-learning-capture` skill または `agentdev-intake-pipeline`（自動capture向け item 生成操作）へ委譲保存。`intake-capture` command 等の別 command を直接呼ばない（REQ-006-021, REQ-006-109）
- G22: 同様に自工程 deviation capture のみへ変更。capture 本文は完了報告に含めず、保存した成果物のパス・分類・保存結果のみを `Capture結果` 小節へ含める
- Step 15: 完了報告テンプレートの `結果` 内に `Capture結果` 小節を含める旨を追記。共通意味契約は `artifact-contracts` SPEC 参照

### `src/opencode/commands/agentdev/templates/case-open/*.md`

3テンプレート（standard, epic, multi-req-epic）の `結果` セクション内に `Capture結果` 小節を追記:
- パス（`intake/inbox/*.md` または `learning/inbox.md` への相対パス）
- 分類（intake/learning）
- 保存結果（成功/失敗、失敗時は理由）

capture 本文は含めず、capture 成果物が無い場合は省略可。

## 完了条件

- [x] `docs/specs/commands/case-open.md` の「## 副作用」セクションに deviation capture 責務が追記されていること（Phase 0 で適用済み）
- [x] case-close への capture 委譲が廃止されていること（SPEC, command 共に記述なし）
- [x] intake-capture command への呼出しがなく、Skill 委譲のみが記載されていること（TS-002 PASS）
- [x] 完了報告に `Capture結果` 小節（パス・分類・保存結果）が含まれること（TS-003 PASS）

## テスト戦略検証

### TS-002 (AG-002: Command→Skill 依存方向)

- verification: case-open.md の本文に intake-capture command への呼出しがなく、agentdev-learning-capture skill または agentdev-intake-pipeline への委譲が記載されていること
- 結果: **PASS**
  - command 本体: `intake-capture` は G18 で否定的文脈（「別 command を直接呼ばない」）でのみ登場、呼出し（起動）なし
  - `agentdev-learning-capture` / `agentdev-intake-pipeline` 委譲は Step 15, G18, G22 の3箇所
  - SPEC: `intake-capture` 言及 0件、Skill 委譲のみ

### TS-003 (AG-003: 完了報告)

- verification: case-open の完了報告に capture 本文が含まれず、保存した capture 成果物のパス・分類・保存結果のみが含まれること
- 結果: **PASS**
  - 3テンプレートとも `Capture結果` 小節は「パス・分類・保存結果」の3項目のみ
  - capture 本文は含まない

## 検証

- `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts`:
  - 本 PR に起因する新しい strict NG なし
  - 本 PR に起因する新しい heuristic WARNING なし（docs/specs/ 直接パス参照は SPEC 名称へ抽象化済み）
  - 残りは全て baseline-known（既存）

## Findings / Capture候補

なし。本 Issue スコープ内で完結。

## SPEC確定候補

なし。SPEC 側は Phase 0 で確定済み。

Refs: #1876
