### PR TITLE
docs(specs): req-define.md へ artifact_actions 生成セクションを追加 (OU-004)

### DIFF
--- a/docs/specs/commands/req-define.md
+++ b/docs/specs/commands/req-define.md
@@ -2,7 +2,7 @@
 title: req-define SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-07-27
+updated: 2026-07-28
 ---
 
 # req-define SPEC
@@ -187,6 +187,49 @@ test_strategy:
 |------|------|---------|
 | fix-and-reverify | 実装を修正して再検証する | 修正可能な実装不良の場合 |
 | record-in-findings | Findings に out-of-scope として記録する | スコープ外または修正困難な事象の場合 |
+
+## artifact_actions 生成
+
+req-define は `artifact_actions` の producer である。Step 7-3 で要件展開の結果を `draft-data` の `artifact_actions` へ出力する。本節は req-define 側の生成契約（operation の選択基準、`spec-append` の生成、誤記との機械的区別、後方互換）を規定する。各 operation の `target_area` と `content` の出力形式は後段「[draft-data artifact_actions フィールド形式](#draft-data-artifact_actions-フィールド形式)」を参照。
+
+### operation の選択基準
+
+req-define は変更の性質に応じて SPEC operation を選択する。SPEC operation の公式 enum、非正規 alias、alias から公式 enum への映射、consumer 側の後方互換は [artifact-contracts.md](../responsibilities/artifact-contracts.md)「artifact_actions operation」が正規所有する。
+
+| 変更の性質 | operation | 意図 |
+|---|---|---|
+| 新規 SPEC ファイル作成 | `create` / `spec-create` | SPEC ファイルを新規作成する |
+| 既存 SPEC ファイルの既存セクション置換 | `update` / `spec-update` | 既存セクション全体を新しい内容で置換する |
+| 既存 SPEC ファイルへの新規セクション追加 | `spec-append` | 既存 SPEC ファイルへ新規セクションを追加する |
+
+`create` / `update` は公式 enum であり、`spec-create` / `spec-update` / `spec-append` は非正規 alias である。
+
+### spec-append の生成契約
+
+req-define は既存 SPEC ファイルへ新規セクションを追加する場合、`operation: spec-append` として action を出力する。入力フィールドは以下の通り。
+
+| field | 必須性 | 形式 |
+|---|---|---|
+| `target` | 必須 | 既存 SPEC ファイルパス |
+| `target_area` | 必須 | 追加する新規セクションの見出し（Markdown 見出し行形式。例: `### IR-044`） |
+| `content` | 必須 | 追加する新規セクション全文（見出し行から始まる） |
+| `placement` | 任意（省略時 `tail`） | `tail` / `after_anchor` / `before_anchor` のいずれか |
+| `anchor` | `placement` が `tail` 以外は必須 | 挿入位置の基準となる見出し行（`target_area` と同一形式） |
+
+`placement` 別の追加位置、`anchor` マッチング規則、anchor 未検出時の挙動、同名見出し時の挙動、合格基準は [artifact-contracts.md](../responsibilities/artifact-contracts.md)「spec-append operation」および [spec-save.md](spec-save.md)「spec-append 操作時のセクション追加ロジック」が正規所有する。req-define 側は入力フィールドの選択と値の生成のみを規定し、配置実行の詳細は規定しない。
+
+### 新規セクション追加と target_area 誤記の機械的区別
+
+`spec-append` を用いることで、意図的な新規セクション追加と `target_area` の誤字・古い見出し名・参照先間違いを機械的に区別できる。
+
+- `update` / `spec-update`: 既存セクションを置換する意図。`target_area` に一致する見出しが存在しない場合、consumer（spec-save）は未検出として follow-up 報告を行う。`target_area` の誤字、古い見出し名、参照先間違いはこの経路で検出される
+- `spec-append`: 新規セクションを追加する意図。`target_area` は追加する新規セクションの見出しを示し、既存見出しとの一致を前提としない。配置位置は `placement` と `anchor` で指示する
+
+両者を operation で明示することで、consumer 側は `target_area` が既存見出しと一致しない事象を「置換対象の誤記」と「新規セクション追加の意図」で区別して処理できる。
+
+### 後方互換
+
+既存の `create` / `update` および alias `spec-create` / `spec-update` は従来通り出力可能であり、consumer（spec-save）は `create` / `update` / `spec-create` / `spec-update` / `spec-append` の全てを受理する（後方互換）。`target_area`、`placement`、`anchor` 等のフィールドを持たない旧形式 draft も consumer は入力として拒否しない。後方互換の正規定義は [artifact-contracts.md](../responsibilities/artifact-contracts.md)「SPEC operation enum と非正規 alias」を参照。
 
 ## draft-data artifact_actions フィールド形式
 


### PR DESCRIPTION
## 概要

OU-004 (Epic #1881): `docs/specs/commands/req-define.md` へ `## artifact_actions 生成` セクションを新設し、spec-append operation の producer 側生成契約を規定する。

req-define.md には Step 7-3「artifact_actions 生成」の参照があったが、対応する SPEC セクションが存在しなかった。本 PR で producer 契約節を新設し、operation 選択基準、spec-append の入力フィールド、target_area 誤記との機械的区別、consumer 後方互換を記載する。配置実行詳細（placement 別挙動、anchor マッチング規則）は SSoT である artifact-contracts.md および spec-save.md へ参照で委譲する。

## 変更内容

- `docs/specs/commands/req-define.md`: `## artifact_actions 生成` セクションを新設（+44 行）
  - `### operation の選択基準`: 変更の性質と operation の対応表
  - `### spec-append の生成契約`: 入力フィールド（target/target_area/content/placement/anchor）
  - `### 新規セクション追加と target_area 誤記の機械的区別`: update と spec-append の意図の違い
  - `### 後方互換`: create/update/spec-create/spec-update/spec-append の consumer 受理
  - frontmatter `updated`: 2026-07-27 → 2026-07-28

## 完了条件

- [x] `docs/specs/commands/req-define.md` の「## artifact_actions 生成」セクションに spec-append 生成契約が追記されていること
- [x] 入力フィールド（target/target_area/content/placement/anchor）が記載されていること
- [x] 意図的な新規セクション追加と target_area 誤字等の区別が機械的にできる旨が記載されていること

## テスト戦略 (TS-004)

- id: TS-004 / target_item: AG-004 (SPEC operation enum 拡張)
- verification: req-define.md で spec-append が処理対象として記載されていることを確認。既存 create/update が consumer で後方互換として受理されることが記載されていることを確認
- 結果: 合格
  - spec-append は「operation の選択基準」テーブルおよび「spec-append の生成契約」節で処理対象として記載
  - create/update の consumer 後方互換は「後方互換」節で明記（artifact-contracts.md SSoT 参照）

## 検証

- targeted docs guard (case-run): `check_changed_docs.ts --workflow case-run --files docs/specs/commands/req-define.md` → failures 0件、warnings 0件
- coupled files (DOC-MAP.md / README.md / specs/README.md): 更新不要（既存 SPEC へのセクション追加のため index 登録不要）

## Findings / Capture候補

特になし。artifact-contracts.md（OU-003, PR #1907）と spec-save.md で既に定義されている spec-append 契約を req-define producer 側へ整理して参照する構成であり、新規の契約矛盾や差分は検出されなかった。

## SPEC確定候補

特になし。

Refs: #1885
