### PR TITLE
docs(specs): OU-006 agentdev-spec-file-manager へ APPEND 操作と search-target-area.ts 契約を追記

### DIFF
--- a/docs/specs/skills/agentdev-spec-file-manager.md
+++ b/docs/specs/skills/agentdev-spec-file-manager.md
@@ -2,7 +2,7 @@
 title: agentdev-spec-file-manager SPEC
 status: draft
 created: 2026-07-22
-updated: 2026-07-27
+updated: 2026-07-28
 ---
 
 # agentdev-spec-file-manager SPEC
@@ -47,6 +47,22 @@ SPEC operation の公式 enum は `create` / `update` であり、本 skill は�
 - SPEC 固有整合性確認（frontmatter 完全性、target_area マッチング規則、SPEC status ライフサイクル）
 - `search-target-area.ts`（SPEC 固有 script）の呼出契約。同 script は見出し行全体との完全一致のみを受け付け、前方一致、後方一致、部分一致を受け付けない（正規入力 `### IR-044` は見出し行 `### IR-044 - 題` とはマッチしない）。この契約は `target_area` マッチング規則と `spec-append` の anchor マッチング規則の双方に適用される
 - 共通検証（frontmatter 整合性、エントリ存在、変更範囲）は `agentdev-artifact-validation` の公開検証契約へ委譲
+
+### APPEND 操作（spec-append）
+
+`spec-append` は既存 SPEC ファイルへ新規セクションを追加する操作であり、公式 enum の `update` へ alias として映射される（REQ-008-058）。配置契約の実行詳細（`placement` 別挿入位置の算出、anchor マッチング規則）は `../commands/spec-save.md`「spec-append 操作時のセクション追加ロジック」が正規所有する。
+
+- `content` は新規見出し行から始まる
+- `placement`: `tail`（既定）/ `after_anchor` / `before_anchor` のいずれか
+- `anchor`: `placement` が `tail` 以外の場合は必須。見出し行全体で指定する
+- 同名見出し時: `target_area` と完全一致する見出しが既存 SPEC ファイルに存在する場合、追加をスキップし follow-up 報告を行う（重複追加防止、全体中止しない）
+- anchor 未検出時: `placement` が `tail` 以外で `anchor` 見出し行が存在しない場合、当該 action をスキップし follow-up 報告を行う（全体中止しない）
+- follow-up 報告は「operation を `spec-create` へ切り替えを推奨」を含む
+- 合格基準: 追加後の SPEC ファイルに `target_area` と完全一致する見出しが1つだけ存在すること
+
+### search-target-area.ts 契約
+
+`search-target-area.ts` は見出し行全体との完全一致のみを受け付ける。前方一致、後方一致、部分一致を受け付けない（前方一致廃止）。正規入力（例: `### IR-044`）で回帰テストを維持する。この契約は `target_area` マッチング規則と `spec-append` の anchor マッチング規則の双方に適用される。
 
 ## 参照する references
 


### PR DESCRIPTION
## 概要

OU-006 (RU-0011, Epic #1881)。`docs/specs/skills/agentdev-spec-file-manager.md` の「## 提供する判断・操作」セクションへ `### APPEND 操作（spec-append）` と `### search-target-area.ts 契約` の H3 セクションを追記し、契約を明確化する。

## 実装内容

`docs/specs/skills/agentdev-spec-file-manager.md` の「## 提供する判断・操作」セクション末尾（既存 bullet 群の後、`## 参照する references` の前）へ以下の H3 セクションを追記:

- `### APPEND 操作（spec-append）`: spec-append が `update` への alias である旨、配置契約詳細の正規所有参照、続く bullet 群で `content` 先頭見出し行、`placement`（tail/after_anchor/before_anchor）、`anchor` 必須性、同名見出し時スキップ + follow-up、anchor 未検出時スキップ + follow-up、合格基準（target_area と完全一致する見出しが1つだけ存在）を記載
- `### search-target-area.ts 契約`: 見出し行全体との完全一致のみ受け付け、前方一致廃止、正規入力（例: `### IR-044`）で回帰テスト維持、target_area マッチングと spec-append anchor マッチングの双方へ適用、を記載

frontmatter `updated` を `2026-07-27` → `2026-07-28` へ更新。

差分: 1 file changed, 17 insertions(+), 1 deletion(-)。

## 完了条件

- [x] `docs/specs/skills/agentdev-spec-file-manager.md` の「## 提供操作」セクションに APPEND 操作（spec-append）の契約が明確化されていること
- [x] content が新規見出し行から始まることが記載されていること
- [x] 同名見出し時のスキップ + follow-up 報告、anchor 未検出時のスキップ + follow-up 報告が記載されていること
- [x] placement/anchor の契約が記載されていること
- [x] 合格基準（target_area と完全一致する見出しが1つだけ存在すること）が記載されていること
- [x] search-target-area.ts が見出し行全体との完全一致のみを受け付ける（前方一致廃止）ことが記載されていること

## テスト結果

### TS-005 (spec-append 契約)

検証: 追記した契約（placement/anchor/同名見出し/anchor 未検出時/合格基準）を `artifact-contracts.md`（OU-003 完了済み、lines 474-512）と照合。

結果: Issue 本文の内容と `artifact-contracts.md` の契約に完全一致。REQ-008-058 alias 契約、`placement` 列挙、`anchor` 必須性、同名見出し時スキップ + follow-up、合格基準「target_area と完全一致する見出しが1つだけ存在すること」の全項目で整合。

`spec-save.md`（lines 162-171）との間に「同名見出し時の挙動」で既知の相違あり（spec-save.md は warn + 継続、artifact-contracts.md は skip + follow-up）。本 Issue の対象範囲外（agentdev-spec-file-manager.md のみ）のため Findings へ記録。Issue 本文は artifact-contracts.md 側に沿って記載。

### TS-006 (search-target-area.ts 正規契約)

検証: 追記した H3 セクションに「前方一致廃止」「正規入力（例: `### IR-044`）で回帰テストを維持」が記載されていることを確認。

結果: pass_criteria（前方一致廃止、正規入力での回帰テスト維持の記載）を充足。`spec-save.md`（line 113）のマッチング規則記述と整合。

### targeted docs guard (Step 5-4)

`bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --files docs/specs/skills/agentdev-spec-file-manager.md --json`

結果: `failures: []`、`warnings: []`。`spec_readme_update_required: false`（既存 SPEC 行のため README 更新不要）。

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 変更ファイル数 | 1 | agentdev-spec-file-manager.md のみ | ✅ |
| 挿入行数 | 17 | 最小 diff | ✅ |
| docs-check failures | 0 | 0 件 | ✅ |
| LSP diagnostics | 該当なし（Markdown） | - | ✅ |

## Findings/ Capture候補

### intake

`docs/specs/commands/spec-save.md`（lines 162-171）の「同名見出し時の挙動」と「合格基準」が `docs/specs/responsibilities/artifact-contracts.md`（OU-003 で更新、lines 500-510）と不整合。

- spec-save.md line 164: 「`content` の見出し行と同名の見出しが既存 SPEC ファイルに存在する場合、spec-save は warn を出力し、追加処理は継続する」
- artifact-contracts.md line 502: 「`target_area` と完全一致する見出しが既存 SPEC ファイルに存在する場合、追加をスキップし follow-up 報告を行う」
- 合格基準も artifact-contracts.md は「target_area と完全一致する見出しが1つだけ存在すること」、spec-save.md は「anchor 特定 + Markdown 構造保持 + frontmatter updated + status 変更しない」と表現が異なる。

artifact-contracts.md（OU-003 最新）を正とする場合、spec-save.md の「spec-append 操作時のセクション追加ロジック」節の更新が別途必要。本 Issue（OU-006）のスコープ外。

### learning

該当なし

## 関連Issue

Closes #1887

Parent Epic: #1881
