### PR TITLE
OU-009: agentdev-intake-pipeline.md へ操作一覧セクション追加 (RU-0009)

### DIFF
--- a/docs/specs/skills/agentdev-intake-pipeline.md
+++ b/docs/specs/skills/agentdev-intake-pipeline.md
@@ -2,7 +2,7 @@
 title: `agentdev-intake-pipeline` SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-07-18
+updated: 2026-07-28
 ---
 
 # `agentdev-intake-pipeline` SPEC
@@ -26,6 +26,52 @@ intake-from-github（GitHub 残課題抽出）と intake-promote（review、分�
 - Review 観点、採用/保留/却下判定
 - Split Rule（intake / learning 分離）
 - Git 永続化手順
+
+## 操作一覧
+
+本スキルが提供する操作を体系化する。intake 系 command が呼び出す操作と、主ワークフロー各工程 command からの自動 deviation capture 要求を受ける操作の2系統を持つ。
+
+### intake 系 command 向け操作
+
+- **抽出操作**: クローズ済み Issue/PR からの本筋外課題抽出（`intake-from-github` が呼出元）。期間解釈、gh CLI によるデータ取得、構造的検出、LLM 全文解析を経て item を生成する
+- **promote 操作**: `inbox/` item の review、分類（採用/保留/却下）、整形保存（`intake-promote` が呼出元）
+
+### 自動 capture 向け item 生成操作
+
+各工程 command（`req-save` / `spec-save` / `case-open` / `case-close`）からの自動 deviation capture 要求を受ける item 生成操作。Command→Skill 依存方向（[artifact-contracts.md](../responsibilities/artifact-contracts.md)「依存方向」、[capture-boundaries.md](../workflows/capture-boundaries.md)「委譲契約（Command→Skill 依存方向）」参照）に従い、command は `intake-capture` 等の他 command を直接呼び出さず本スキルへ一方向に委譲する。
+
+#### 呼出元 command と委譲契約の根拠
+
+| 呼出元 command | REQ 根拠 | 委譲対象 |
+|---|---|---|
+| `req-save` | REQ-006-106 | `req-save` 実行中に実観測した deviation のうち intake 該当分（REQ 再構成 intake を含む） |
+| `spec-save` | REQ-006-107 | `spec-save` 実行中に実観測した deviation のうち intake 該当分 |
+| `case-open` | REQ-006-021 | `case-open` 実行中に実観測した deviation のうち intake 該当分 |
+| `case-close` | REQ-006-105 | `case-close` 実行中に実観測した deviation のうち intake 該当分（PR 本文から回収した intake 候補を含む） |
+
+`case-run` は `.agentdev/` 直接変更を禁止し PR 本文記録のみを行うため、本操作の呼出元とならない（[capture-boundaries.md](../workflows/capture-boundaries.md)「各コマンドの capture 責務」参照）。
+
+#### 本操作の責務（呼出元に対する提供）
+
+- 実観測ベースで intake 該当分を判定する（[capture-boundaries.md](../workflows/capture-boundaries.md) Split Rule 準拠）
+- `.agentdev/intake/inbox/*.md` へ item を生成、保存する。REQ 再構成 intake は `.agentdev/intake/inbox/req-restructure/` 配下へ配置する（REQ-010）
+- Split Rule に基づき learning 該当分を `agentdev-learning-capture` skill へ分割指示する（混在させない）
+
+#### 呼出元 command の責務（本操作が委譲しないもの）
+
+- git 永続化（commit、push）は呼出元 command が担う。本操作は item 生成と file 書き込みまでを担い、commit 実行を委譲しない
+- 完了報告の `Capture結果` 小節に保存先パス、分類（intake）、保存結果（成功/失敗、件数、コミットハッシュ等）を含める
+
+#### `intake-capture` command との区別
+
+本操作と `intake-capture` command は別操作である。
+
+| 区分 | 入力形式 | 呼出元 | 役割 |
+|---|---|---|---|
+| 自動 capture 向け item 生成操作（本操作） | 各工程 command が実観測した deviation（構造化済み） | `req-save` / `spec-save` / `case-open` / `case-close`（プログラム的委譲） | 自動 deviation capture |
+| `intake-capture` command | ユーザー手動入力 | ユーザー（対話的） | ユーザー主導の作業候補収集 |
+
+`intake-capture` command はユーザー手動入力を想定し、入力形式も異なる。本操作は command から委譲される構造化入力のみを扱い、`intake-capture` command の入力形式は継承しない。
 
 ## 参照する references
 


### PR DESCRIPTION
## 概要

Issue #1880 (OU-009): `docs/specs/skills/agentdev-intake-pipeline.md` へ「## 操作一覧」新規セクションを追加し、自動 capture 向け item 生成操作を記載する。

Epic #1871 の最終 Issue。Phase 0 で未対応だった SPEC アクションの回収。

## 変更内容

`docs/specs/skills/agentdev-intake-pipeline.md` へ以下を追加:

- 「## 操作一覧」新規セクション（既存「## 提供する判断、操作」の直後）
  - 「### intake 系 command 向け操作」: 抽出操作、promote 操作（既存機能の体系化）
  - 「### 自動 capture 向け item 生成操作」: 新規操作
    - 呼出元 command と委譲契約の根拠（req-save / spec-save / case-open / case-close の4 command、REQ-006-106/107/021/105）
    - 本操作の責務（intake 該当分判定、`.agentdev/intake/inbox/*.md` item 生成、Split Rule による learning 分割）
    - 呼出元 command の責務（git 永続化、完了報告の `Capture結果` 小節）
    - `intake-capture` command との区別（入力形式、呼出元、役割の比較表）
- frontmatter `updated: 2026-07-28`

学習捕捉 SPEC（`agentdev-learning-capture.md`）の「呼出元 command 契約」セクションと対称的パターン。[capture-boundaries.md](../workflows/capture-boundaries.md)「委譲契約（Command→Skill 依存方向）」に準拠。

## 完了条件

- [x] `docs/specs/skills/agentdev-intake-pipeline.md` の「## 操作一覧」セクションに自動 capture 向け item 生成操作が追記されていること
- [x] 4 command からの受信が記載されていること
- [x] intake/inbox/*.md への item 保存を担うことが記載されていること
- [x] git 永続化は呼出元 command 担当であることが明記されていること
- [x] intake-capture command とは別操作であることが明記されていること

## test strategy 検証結果

### TS-002 (AG-002: Command→Skill 依存方向)

- **verification**: agentdev-intake-pipeline.md に自動 capture 向け item 生成操作が記載されていること。intake-capture command とは別操作であることが明記されていること。
- **pass_criteria**: agentdev-intake-pipeline.md に自動 capture 向け item 生成操作が記載され、intake-capture command と区別されていること。
- **結果**: **PASS**
  - 「### 自動 capture 向け item 生成操作」セクションに操作を記載
  - 「#### `intake-capture` command との区別」セクションに比較表で明示的に区別

## 検証結果

### targeted docs guard (case-run profile)

```
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
  --workflow case-run --files docs/specs/skills/agentdev-intake-pipeline.md --json
```

- files_checked: `docs/specs/skills/agentdev-intake-pipeline.md`
- coupled_files_checked: `docs/DOC-MAP.md`, `docs/README.md`, `docs/specs/README.md`
- failures: 0、warnings: 0
- `doc_map_update_required`: false（既存 SPEC への UPDATE、新規 SPEC 追加ではない）
- `spec_readme_update_required`: false（既存 SPEC 行のままで status 列も accepted のまま更新不要）

## Findings / Capture候補

（該当なし）

### docs-integrity

targeted docs guard 実施。failures 0、warnings 0。

### stale-reference

（該当なし。Step 5-3 staleness check で差異検出なし）

## SPEC確定候補

（該当なし）

## 関連 Issue

Refs: #1880
Epic: #1871