### PR TITLE
docs(case-auto): REQ-006-110 の結果状態区別報告へ適合 (#1919)

### DIFF
--- a/docs/specs/commands/case-auto.md
+++ b/docs/specs/commands/case-auto.md
@@ -44,6 +44,7 @@ updated: 2026-07-23
 - Step 4: 各工程の実行
   - 委譲工程（req-save / spec-save / case-open / case-close）: 実行担当サブエージェントとして起動（v2:ADR-0127, REQ-006-006/084/085）。req-save / spec-save 統合委譲で順次実行、case-open / case-close は各コマンド委譲契約に従い起動。委譲起動不能時に delegation-unavailable 報告（REQ-002-003/004）
   - case-run（インライン実行）: case-auto が case-run.md を authoritative source として読み込み、準備/クリーンアップフェーズを自ら実行。実行担当サブエージェント委譲フェーズでは case-auto から直接実行担当サブエージェントへ委譲（委譲起点の折りたたみ/002）。adapter skill（agentdev-case-run-execution-adapter）を case-auto が読み込む
+  - 結果状態の4次元集約（REQ-006-110）: 各工程の output_contract から (1) 工程結果 pass/warn/fail、(2) artifact_action 適用結果 applied/skipped/failed/no-op、(3) 定義適用工程完了状態、(4) OU ライフサイクル完了状態を収集し混同なく保持する。集約規則の詳細は後述「結果状態の4次元集約（REQ-006-110）」セクション
 - Step 4-1: Wave 反復制御（Epic Issue 指定時）
   - case-auto が Epic Issue 番号を記録。Epic Issue 本文から Wave 構成、各子Issue ステータスを読み取る（読み取りのみ、Epic Issue 本文の書き込みは case-close の責務）
   - case-auto が現在 Wave の ready 子Issue を選択し、各子Issue ごとにインライン case-run を実行（最大5件並列、REQ-006-026 踏襲）。各子Issue の実行担当サブエージェントへ case-auto から直接委譲
@@ -53,7 +54,7 @@ updated: 2026-07-23
 - Step 5: 工程間の状態引き継ぎ（Issue番号、PR番号、RU ファイルパス、capture 対象情報を最終工程まで保持）
 - Step 6: 複数REQ対応（req-save 委譲の出力から複数 REQ doc または scale:large 検出時、case-open の Issue 構造ルールを使用）
 - Step 7: 停止条件の検出（停止時タイミング情報の追記。10項目の停止条件いずれかを検出時、実行停止）
-- Step 8: 完了報告（タイミング情報追記。インライン実行の適用を記録）
+- Step 8: 完了報告（タイミング情報追記。インライン実行の適用を記録。結果状態の4次元報告（REQ-006-110）を含める）
 
 ### 委譲起動不能時の扱い（REQ-002-003/004）
 
@@ -99,6 +100,27 @@ context 管理:
 - クリーンアップ検証ゲート（Standard / Epic Issue flow 双方）: ドラフトファイル、RU ファイルの残存がないこと
 - 出力制約: 成果物本文 verbatim、調査過程等は圧縮（G10）
 - タイミング情報: 開始時刻、終了時刻、所要時間を人間が読みやすい形式で報告（REQ-006-082/083）
+- 結果状態の4次元集約（REQ-006-110）: 後述「結果状態の4次元集約（REQ-006-110）」セクションの4状態次元と集約規則に従い、warn を pass へ変換しない
+
+## 結果状態の4次元集約（REQ-006-110）
+
+case-auto は各工程の結果を次の4状態次元で保持し、集約報告で次元を混同しない。各工程の output_contract（`src/opencode/commands/agentdev/case-auto.md` Step 4 工程別契約表）が情報源となる。
+
+| 次元 | 取得元 | 値 |
+|---|---|---|
+| (1) 工程結果 | 全工程（req-save+spec-save / case-open / case-run / case-close）の pass/warn/fail | pass / warn / fail |
+| (2) artifact_action 適用結果 | req-save+spec-save 統合委譲の action id ごとの適用結果 | applied / skipped / failed / no-op |
+| (3) 定義適用工程の完了状態 | (1)(2) の組み合わせから導出 | 定義適用完了 / 警告付き工程完了 / 定義適用未完了 |
+| (4) OU ライフサイクル完了状態 | case-open（Issue 作成）、case-run（PR 作成）、case-close（PR マージ、Issue クローズ）の各成否 | 各ライフサイクル事象ごとに 完了 / 未完了 |
+
+集約規則:
+
+- (3) の導出: 全必須 action が applied または正当な no-op で工程結果 (1) が pass → 定義適用完了。同条件で (1) が warn → 警告付き工程完了（warn を pass へ変換しない）。必須 action に skipped または failed が1件以上ある → 定義適用未完了（この場合は定義適用完了/警告付き工程完了と報告しない）。正当な no-op とは、対象外 artifact（例: spec-save における `artifact: spec` entry 不存在、後方互換の `artifact_actions` フィールド不存在）による action 不実施を指す。正当な理由なく必須 action を飛ばした場合は skipped として扱う
+- (4) の独立性: OU ライフサイクル完了状態は (3) と独立して扱う。(3) が定義適用完了/警告付き工程完了であっても case-open（Issue 作成）が未実行なら OU ライフサイクルは未完了と報告する
+- Phase 0 と OU 完了の分離: Phase 0 成功（(3) の定義適用完了/警告付き工程完了）と OU 完了（(4) の全ライフサイクル事象完了）を別々に報告する。一方を他方へすり替えて報告しない
+- warn 変換禁止: (1) が warn の工程を pass として集約しない。完了報告には warn を warn のまま残す
+
+完了報告（停止時フォーマットを含む）には上記4状態次元を工程別・action id 別・ライフサイクル事象別に列挙する。実行定義は `src/opencode/commands/agentdev/case-auto.md` Step 4「結果状態の4次元集約（REQ-006-110）」および Step 8「結果状態の4次元報告（REQ-006-110）」を正とする。
 
 ## 複数 execution_unit 並列 orchestration（REQ-006, v2:ADR-0129）
 

--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -69,16 +69,38 @@ case-auto は各工程を以下の契約で起動する:
 
 | 工程 | 起動方式 | inputs | output_contract |
 |---|---|---|---|
-| req-save + spec-save | 委譲（1 統合委譲、AG-005） | draft path, OU ID | 保存済みREQ/ADRリスト, 保存済みSPECリスト, draft status=saved, SPEC消費済みフラグ, pass/warn/fail |
-| case-open | 委譲 | draft path, OU ID | Issue番号(Epic含む), pass/warn/fail |
-| case-run | インライン実行（case-run.md を authoritative source として読み込み、case-auto が準備/クリーンアップフェーズを自ら実行、実行担当サブエージェントへ直接委譲、AG-001/002） | 単一 Issue番号 または Epic Issue番号（`#epic`、現在 Wave の子Issue を case-auto が並列委譲、最大5件） | completed-pr/blocked/failed/delegation-unavailable（Epic Wave 実行時は子Issue ごとの結果集合） |
-| case-close | 委譲 | 単一 Issue番号 または Epic Issue番号（`#epic`、現在 Wave の一括クローズ） | マージ結果, Capture保存結果, 削除済みブランチ, pass/warn/fail, Epic 最終 Wave 判定結果 |
+| req-save + spec-save | 委譲（1 統合委譲、AG-005） | draft path, OU ID | 保存済みREQ/ADRリスト, 保存済みSPECリスト, draft status=saved, SPEC消費済みフラグ, pass/warn/fail, **artifact_action 適用結果（action id ごとに applied/skipped/failed/no-op、REQ-006-110）** |
+| case-open | 委譲 | draft path, OU ID | Issue番号(Epic含む), pass/warn/fail, **OU lifecycle: Issue 作成 完了/未完了（REQ-006-110）** |
+| case-run | インライン実行（case-run.md を authoritative source として読み込み、case-auto が準備/クリーンアップフェーズを自ら実行、実行担当サブエージェントへ直接委譲、AG-001/002） | 単一 Issue番号 または Epic Issue番号（`#epic`、現在 Wave の子Issue を case-auto が並列委譲、最大5件） | completed-pr/blocked/failed/delegation-unavailable（Epic Wave 実行時は子Issue ごとの結果集合）, **OU lifecycle: PR 作成 完了/未完了（completed-pr のみ完了、REQ-006-110）** |
+| case-close | 委譲 | 単一 Issue番号 または Epic Issue番号（`#epic`、現在 Wave の一括クローズ） | マージ結果, Capture保存結果, 削除済みブランチ, pass/warn/fail, Epic 最終 Wave 判定結果, **OU lifecycle: PR マージ完了/未完了、Issue クローズ完了/未完了（REQ-006-110）** |
 
 各工程の side_effect_boundary は対応するコマンド定義のガードレールに従う。各工程の後段処理（case-open の RU 削除、case-close の learning/intake capture、.agentdev/ commit/push 等）は各コマンド定義に従う（case-run インライン実行時の worktree クリーンアップは case-auto が case-run.md に従って実行）。
 
 case-auto は req-save/case-open の委譲に draft path と OU ID のみを渡す（OU 本文の切り出しは行わない）。OU の統合・分割・REQ 操作分類・Issue 階層判定を再評価しない（各工程の判定結果に従う）。
 
 case-auto は各工程の結果に基づいて次工程へ進むか停止条件（Step 7）を判定する。
+
+#### 結果状態の4次元集約（REQ-006-110）
+
+case-auto は各工程の結果を以下の4状態次元で保持し、集約時に混同しない。各工程の `output_contract`（工程別契約表）がこれらの情報源となる。warn を pass へ変換する集約は禁止する。
+
+| 次元 | 取得元 | 値 |
+|---|---|---|
+| (1) 工程結果 | 全工程の `pass/warn/fail`（工程別契約表） | pass / warn / fail |
+| (2) artifact_action 適用結果 | req-save+spec-save 統合委譲の `artifact_action 適用結果`（action id ごと） | applied / skipped / failed / no-op |
+| (3) 定義適用工程の完了状態 | (1)(2) の組み合わせから導出 | 定義適用完了 / 警告付き工程完了 / 定義適用未完了 |
+| (4) OU ライフサイクル完了状態 | case-open（Issue 作成）、case-run（PR 作成）、case-close（PR マージ、Issue クローズ）の各成否 | 各ライフサイクル事象ごとに 完了 / 未完了 |
+
+集約規則:
+
+- **(3) 定義適用工程完了状態の導出**: 定義適用工程（req-save + spec-save）の完了状態は次で導出する:
+  - 全必須 action が `applied` または正当な `no-op` で、工程結果 (1) が `pass` → **定義適用完了**
+  - 全必須 action が `applied` または正当な `no-op` で、工程結果 (1) が `warn` → **警告付き工程完了**（warn を pass へ変換しない）
+  - 必須 action に `skipped` または `failed` が1件以上ある → **定義適用未完了**（この場合は「定義適用完了」または「警告付き工程完了」と報告しない）
+  - 「正当な no-op」とは、対象外 artifact（例: spec-save における `artifact: spec` entry 不存在、後方互換の `artifact_actions` フィールド不存在）による action 不実施を指す。正当な理由なく必須 action を飛ばした場合は `skipped` として扱う
+- **(4) OU ライフサイクル完了状態の独立性**: OU ライフサイクル完了状態は (3) の完了状態と独立して扱う。req-save/spec-save が成功（(3) が定義適用完了/警告付き工程完了）していても case-open（Issue 作成）が未実行なら OU ライフサイクルは未完了と報告する
+- **Phase 0 と OU 完了の分離**: Phase 0 成功（artifact_actions 適用完了 = (3) が定義適用完了/警告付き工程完了）と OU 完了（Issue/PR/Case 完了 = (4) の全ライフサイクル事象完了）を別々に報告する。一方を他方へすり替えて報告しない
+- **warn 変換禁止**: (1) が warn の工程を pass として集約しない。完了報告には warn を warn のまま残す
 
 #### case-open 完了後の分岐
 
@@ -281,6 +303,15 @@ execution_unit 分割可能性があるにもかかわらず case-open が停止
 **OU処理ループ**: Standard flow の case-close 完了後に未処理 OU が残存する場合は次 OU の処理を Step 2 から開始（OU処理順序は Step 4「OU処理順序」サブセクションに準拠）。全 OU の処理が完了した場合のみ全体完了報告を出力する。OU処理中に停止条件（Step 7）を検出した場合も完了済み OU・進行中 OU・未実行 OU・再開可能な次コマンドを報告する
 
 **orchestration stage 別結果・フォールバック理由・破棄回復記録**: 完了報告には orchestration stage 1（case-open 順次実行）、stage 2（case-run 並列実行）、stage 3（case-close 順次実行）の各 orchestration stage の実行結果を含める。orchestration stage 2 を順次フォールバックで実行した場合はその理由を記録する。orchestration stage 2 の bg task 破棄を検知して回復した場合は、検知した状態区分（commit 済みで PR 未作成、未コミット変更残存）と回復結果を記録する。
+
+**結果状態の4次元報告（REQ-006-110）**: 完了報告（停止時フォーマットを含む）には Step 4「結果状態の4次元集約」の4状態次元を次の形式で含めること。warn を pass へ変換して集約しないこと。
+
+- **(1) 工程結果**: 各工程（req-save+spec-save / case-open / case-run / case-close）の `pass/warn/fail` を工程別に列挙
+- **(2) artifact_action 適用結果**: 定義適用工程（req-save+spec-save）の action id ごとに `applied/skipped/failed/no-op` を列挙
+- **(3) 定義適用工程の完了状態**: `定義適用完了` / `警告付き工程完了` / `定義適用未完了` のいずれかとその根拠（warn の有無、必須 action の skipped/failed 有無）。必須 action に `skipped/failed` が1件以上ある場合は `定義適用未完了` と報告し、`定義適用完了`/`警告付き工程完了` と報告しない
+- **(4) OU ライフサイクル完了状態**: Issue 作成、PR 作成、PR マージ、Issue クローズの各事象ごとに `完了/未完了` を列挙。(3) が定義適用完了/警告付き工程完了であっても (4) のいずれかが未完了なら OU 完了とは報告しない
+
+Phase 0 成功（(3) の定義適用完了/警告付き工程完了）と OU 完了（(4) の全ライフサイクル事象完了）は別々に報告する。一方を他方へすり替えて報告しない。
 
 ## コンフリクト解消モデル（3レベルエスカレーション）
 


### PR DESCRIPTION
## 変更概要

case-auto command と SPEC を REQ-006-110（case-auto の結果状態区別報告）へ適合させる実装修飾。REQ-006-110 は commit c0130521 で `docs/requirements/REQ-006.md` へ APPEND 済み（前提）。本 PR は implementation レベルの適合修正と TS-002 検証を担う。

Issue #1919 (OU-002 / target_req: REQ-006 / source_ru: RU-0013) の完了条件を満たす。

## 変更内容

### src/opencode/commands/agentdev/case-auto.md

1. **Step 4 工程別契約 table**: 各工程行の `output_contract` へ REQ-006-110 の状態次元を明示
   - req-save+spec-save 行: artifact_action 適用結果（action id ごとに applied/skipped/failed/no-op）を追加
   - case-open 行: OU lifecycle Issue 作成 完了/未完了 を追加
   - case-run 行: OU lifecycle PR 作成 完了/未完了 を追加（completed-pr のみ完了）
   - case-close 行: OU lifecycle PR マージ完了/未完了、Issue クローズ完了/未完了 を追加

2. **Step 4 へ「結果状態の4次元集約（REQ-006-110）」サブセクション新設**: 4状態次元の定義表と集約規則を規定
   - (1) 工程結果 pass/warn/fail
   - (2) artifact_action 適用結果 applied/skipped/failed/no-op
   - (3) 定義適用工程完了状態: 定義適用完了 / 警告付き工程完了 / 定義適用未完了
   - (4) OU ライフサイクル完了状態: Issue 作成 / PR 作成 / PR マージ / Issue クローズ 各完了/未完了

3. **Step 8 完了報告へ「結果状態の4次元報告（REQ-006-110）」サブセクション追記**: 完了報告（停止時フォーマット含む）に4状態次元を列挙する形式を規定

### docs/specs/commands/case-auto.md

- 「現在の動作」Step 4 への4次元集約記載と、Step 8 の記載拡張
- 「検証観点」へ REQ-006-110 適合エントリを追加
- 「結果状態の4次元集約（REQ-006-110）」セクションを新設し、SPEC 記述として command と整合する4次元と集約規則を規定

## 集約規則（REQ-006-110 要求事項の実装）

- 全必須 action が applied または正当な no-op で工程結果 pass → **定義適用完了**
- 全必須 action が applied または正当な no-op で工程結果 warn → **警告付き工程完了**（warn を pass へ変換しない）
- 必須 action に skipped または failed が1件以上ある → **定義適用未完了**（「定義適用完了」/「警告付き工程完了」と報告しない）
- 正当な no-op: 対象外 artifact（例: spec-save における `artifact: spec` entry 不存在、後方互換の `artifact_actions` フィールド不存在）による action 不実施
- (4) OU ライフサイクル完了状態は (3) と独立。req-save/spec-save 成功でも case-open 未実行なら OU 未完了
- Phase 0 成功（(3) の定義適用完了/警告付き工程完了）と OU 完了（(4) の全事象完了）を別々に報告
- warn を pass へ変換する集約は禁止

## 検証結果

### TS-002 (REQ-006-110 verification)

6項目すべてパス。

| 項目 | 結果 | 証拠 |
|---|---|---|
| (1) pass/warn/fail と applied/skipped/failed/no-op を保持 | PASS | case-auto.md L72,89-90,309-310 / SPEC L47,111-112 |
| (2) warn + 全必須 action applied/no-op で警告付き工程完了 | PASS | case-auto.md L98 / SPEC L118 |
| (3) 必須 action skipped/failed 時に定義適用完了を報告しない | PASS | case-auto.md L99,311 / SPEC L118 |
| (4) warn → pass 変換集約なし | PASS | case-auto.md L85,103,307 / SPEC L103,121 |
| (5) req-save/spec-save 成功でも case-open 未実行時は OU 完了扱いしない | PASS | case-auto.md L101 / SPEC L119 |
| (6) Phase 0 成功と OU 完了が別々に報告 | PASS | case-auto.md L102,314 / SPEC L120 |

### 品質ゲート

- check_extensions.ts (IR-056): PASS (failures 0)
- check_changed_docs.ts (workflow=case-run, base-ref=origin/main): PASS (failures 0, warnings 0, files_checked=docs/specs/commands/case-auto.md)
- check_command_format.ts: PASS

## 完了条件 (#1919)

- [x] case-auto が4状態を区別して集約報告すること（Step 4「結果状態の4次元集約」）
- [x] warn かつ全必須 action applied/正当 no-op の場合「警告付き工程完了」と報告すること
- [x] 必須 action に skipped/failed が1件以上ある場合「定義適用完了」と報告しないこと
- [x] warn を pass へ変換して集約しないこと
- [x] Phase 0 成功と OU 完了を別々に報告すること
- [x] `src/opencode/commands/agentdev/case-auto.md` Step 4 output_contract と Step 7-1 停止理由分類への適合を確認（Step 4 output_contract 拡張完了。Step 7-1 は停止理由分類であり集約報告とは別軸のため追加変更不要）
- [x] REQ-006-085, REQ-006-086 への整合性を確認（Step 7-1 停止理由分類、Step 7 停止条件は REQ-006-110 と独立して既存実装のまま）
- [x] TS-002 がパスすること

## Findings / Capture候補

### intake

特になし。REQ-006-110 の要件は既に req-save (commit c0130521) で APPEND 済みであり、本 PR は implementation レベルの適合修正のみ。

### learning

特になし。Windows 環境固有の問題や再発防止知見は発生せず。

### docs-integrity

`check_changed_docs.ts --workflow case-run --base-ref origin/main --json` の結果:

```json
{
  "workflow": "case-run",
  "files_checked": ["docs/specs/commands/case-auto.md"],
  "coupled_files_checked": ["docs/DOC-MAP.md", "docs/README.md", "docs/specs/README.md"],
  "failures": [],
  "warnings": [],
  "doc_map_update_required": false,
  "spec_readme_update_required": false,
  "requirements_readme_update_required": false,
  "full_docs_check_recommended": false,
  "extensions_check_required": false,
  "docInputsCheckRequired": true
}
```

failures 0, warnings 0, README/DOC-MAP 更新不要。src/opencode/commands/agentdev/case-auto.md は case-run workflow profile の対象外（command 定義のため docs/ 配下ではない）。

### stale-reference

特になし。新規の REQ/ADR/SPEC ID を追加しておらず、既存 ID への参照のみ。

## SPEC確定候補

REQ-006-110 の4状態次元（(1) 工程結果、(2) artifact_action 適用結果、(3) 定義適用工程完了状態、(4) OU ライフサイクル完了状態）と3値の定義適用工程完了状態（定義適用完了 / 警告付き工程完了 / 定義適用未完了）は、将来的に SPEC `workflows/workflow-contracts.md` 等の result 4状態契約セクションへ一般化して配置する候補。現時点では case-auto command/SPEC に局所化し、横断 SPEC への一般化は別 Issue で扱う。

Refs: #1919
