### PR TITLE
fix(req-define): 未確定内容の auto_ready 抑止を Step 10-2a へ前置

### DIFF
--- a/docs/specs/commands/req-define.md
+++ b/docs/specs/commands/req-define.md
@@ -331,6 +331,66 @@ review_dispositions:
 
 `review_dispositions` は optional な soft-contract である。本フィールドを持たない旧ドラフトを req-save、case-open は入力として拒否しない（ADR-003 準拠）。
 
+## 未確定内容の auto_ready 抑止（REQ-008-059）
+
+req-define は、後続工程で決定する必要がある未確定事項、必須内容の欠落、暫定プレースホルダーが `agreed_items` または `artifact_actions` に残る場合、`auto_gate.auto_ready` を `true` にしないこと（REQ-008-059）。本抑止は REQ-008-030（`artifact_actions` の `content` 完全確定）の強制機構として働く。
+
+### 抑止条件
+
+Step 10-2（auto_gate完了ゲート）の判定前に、以下の2系統の検査を組み合わせて `auto_gate.auto_ready` を確定する。
+
+#### (A) 決定的マーカー検査
+
+`agreed_items` 各エントリの `content`、`artifact_actions` 各エントリの `content` について、以下の5種の代表マーカーのいずれかを部分文字列として含むか検査する。検査は意味解釈を伴わない文字列一致（大文字小文字区別なし）とし、QG-1 意味判定（後述 (B)）に先立って機械的に適用する。
+
+| # | マーカー | 意味 |
+|---|---|---|
+| 1 | `TBD` | 未決定事項の表明 |
+| 2 | `TODO` | 未実装・未確定事項の表明 |
+| 3 | `未定` | 日本語での未確定表明 |
+| 4 | `後続工程で確定` | 後工程への持ち越し表明 |
+| 5 | `case-run で確定` | case-run への持ち越し表明（前後の空白有無を許容） |
+
+いずれかのマーカーを検出した場合、`auto_gate.auto_ready: false` とし、検出元の AG-ID（`agreed_items` 由来）または ACT-ID（`artifact_actions` 由来）と検出マーカーを `auto_gate.stop_reasons` へ記録する。
+
+##### 引用・禁止事例の誤検知防止
+
+マーカー文字列が「禁止事項や過去事例の引用」として使われている文は抑止対象外とする。代表的な引用パターンを以下に示す。これらは意味判定ではなく、文脈パターンの文字列一致で除外する。
+
+| 引用パターン | 例 |
+|---|---|
+| 禁止を述べる文 | 「TBD を残さないこと」「TODO を含めないこと」「未定のまま保存しないこと」 |
+| 過去事例の引用 | 「前回の TBD 残存事例を参考に」 |
+| 検査項目としての言及 | 「TBD/ TODO/ 未定 を検出する」 |
+
+判定は文単位で行う。マーカーを含む文が上記いずれかの引用パターンに合致する場合、当該文のマーカーを検出扱いとしない。同一 AG-ID/ ACT-ID 内に引用以外の未確定を示すマーカー出現が残る場合は抑止を維持する。
+
+#### (B) QG-1 意味判定
+
+決定的マーカー検査 (A) に加え、QG-1（Definition Integrity Gate）の意味判定観点（必須フィールド欠落、曖昧要件、測定不能条件）を `agreed_items`/ `artifact_actions` の各エントリへ適用する。QG-1 が fail となるエントリがある場合、`auto_gate.auto_ready: false` とし、該当 AG-ID/ ACT-ID と QG-1 該当観点を `auto_gate.stop_reasons` へ記録する。
+
+### stop_reasons 記録形式
+
+抑止時に `auto_gate.stop_reasons` へ記録する各エントリは、対象 ID と理由を含む文字列とする。形式は soft-contract（ADR-003）とし厳格スキーマ検証を導入しないが、少なくとも以下の情報を含むこと。
+
+- 対象 ID（`AG-NNN` または `ACT-{ARTIFACT}-NNN`）
+- 抑止理由（検出マーカー、または QG-1 該当観点）
+- 該当箇所の要約（マーカー文字列、または欠落フィールド名）
+
+記述例:
+
+```yaml
+auto_gate:
+  auto_ready: false
+  stop_reasons:
+    - "ACT-REQ-003: 未確定マーカー 'TBD' が content に含まれる（対象: API仕様）"
+    - "AG-005: QG-1 必須フィールド欠落（target_area 未設定）"
+```
+
+### 後続ステップへの引き継ぎ
+
+抑止により `auto_ready: false` となった場合、Step 10-2（auto_gate完了ゲート）の既存手順に従い `stop_reasons` をユーザーへ提示し、壁打ち（Step 3）で解消方策を合意する。合意により未確定事項が解消され、(A)(B) いずれの検査も該当しなくなった場合に限り `auto_ready: true` へ更新する。ユーザーが「`auto_ready: false` のまま標準フローで手動実行する」と明示的に選択した場合は `conflict_resolutions` へ記録して継続する（REQ-004-048）。
+
 ## 参照する横断 SPEC
 
 - [workflows/workflow-contracts.md](../workflows/workflow-contracts.md)（フェーズ定義、SSoT 遷移）

--- a/src/opencode/commands/agentdev/req-define.md
+++ b/src/opencode/commands/agentdev/req-define.md
@@ -163,7 +163,13 @@ Step 7 の構造化 `draft-data` 形式（`# draft-data` fenced YAML block）で
 
  - **10-1. 実装詳細の分離**: ドラフトに実装詳細（個別ファイルの編集指示、修正候補リスト、検出事項カタログ等）が含まれる場合、当該内容を `artifact_actions` の `content` とは分離されたセクションに配置し、合意内容の判読性を確保すること。実装詳細がドラフト全体の過半を占める場合は、完了条件チェックボックスへの要約をユーザーに提案すること
 
- - **10-2. auto_gate完了ゲート**: ドラフト保存後、`auto_gate.auto_ready` を確認する。`auto_ready:true` の場合は Step 11 へ進む。`auto_ready:false` または未解決 item（`unresolved_questions`/`unresolved_conflicts`/`out_of_repo_operations`/`stop_reasons`）が残る場合、`stop_reasons` をユーザーに提示し、解消方策（作業分散、対象絞り込み、スコープ削除等）を壁打ち（Step 3）で合意する。合意により解消された場合は `auto_ready:true` に更新して Step 11 へ進む。ユーザーが「`auto_ready:false` のまま標準フローで手動実行する」と明示的に選択した場合、当該選択を `conflict_resolutions` に記録して Step 11 へ進む（REQ）。上記いずれにも該当しない（未解決のまま）場合は Step 3（壁打ち）へ差し戻す（REQ）
+ - **10-2. auto_gate完了ゲート**: ドラフト保存後、`auto_gate.auto_ready` を確認する。`auto_ready:true` の場合は Step 11 へ進む。`auto_ready:false` または未解決 item（`unresolved_questions`/`unresolved_conflicts`/`out_of_repo_operations`/`stop_reasons`）が残る場合、`stop_reasons` をユーザーに提示し、解消方策（作業分散、対象絞り込み、スコープ削除等）を壁打ち（Step 3）で合意する。合意により解消された場合は `auto_ready:true` に更新して Step 11 へ進む。ユーザーが「`auto_ready:false` のまま標準フローで手動実行する」と明示的に選択した場合、当該選択を `conflict_resolutions` に記録して Step 11 へ進む（REQ）。上記いずれにも該当しない（未解決のまま）場合は Step 3（壁打ち）へ差し戻し（REQ）
+
+ - **10-2a. 未確定内容の auto_ready 抑止**: Step 10-2 の判定前に、`agreed_items` 各エントリの `content`、`artifact_actions` 各エントリの `content` について未確定内容の有無を検査し、`auto_gate.auto_ready` と `auto_gate.stop_reasons` を確定すること（REQ）。検査は req-define command SPEC（extension 経由）「未確定内容の auto_ready 抑止」節に従う。以下の手順を機械的に実行する:
+  - **(A) 決定的マーカー検査**: `agreed_items`/`artifact_actions` の各 `content` 文字列に対し、`TBD`/`TODO`/`未定`/`後続工程で確定`/`case-run で確定` の5マーカーを大文字小文字区別なしで部分文字列検索する。いずれかを検出した場合、当該 AG-ID または ACT-ID と検出マーカーを `auto_gate.stop_reasons` へ追加し、`auto_gate.auto_ready: false` とする
+  - **(A') 引用・禁止事例の誤検知除外**: マーカーを含む文が「禁止事項や過去事例の引用」（例: 「TBD を残さないこと」「TODO を含めないこと」「未定のまま保存しないこと」「TBD/ TODO/ 未定 を検出する」等）である場合、当該文のマーカーは検出扱いとしない。同一 ID 内に引用以外の未確定マーカーが残る場合は抑止を維持する
+  - **(B) QG-1 意味判定の併用**: (A) の結果に加え、QG-1（Definition Integrity Gate）の意味判定観点（必須フィールド欠落、曖昧要件、測定不能条件）を `agreed_items`/`artifact_actions` 各エントリへ適用する。QG-1 が fail となるエントリがある場合、該当 AG-ID/ ACT-ID と QG-1 該当観点を `auto_gate.stop_reasons` へ追加し、`auto_gate.auto_ready: false` とする
+  - **stop_reasons 記録**: 抑止時の `stop_reasons` 各エントリは、対象 ID（`AG-NNN` または `ACT-{ARTIFACT}-NNN`）、抑止理由（検出マーカーまたは QG-1 該当観点）、該当箇所の要約を含むこと。詳細な記録形式、代表 fixture、引用誤検知除外パターンは req-define command SPEC（extension 経由）「未確定内容の auto_ready 抑止」節を参照
 
 ### Step 11: 要件doc確認
 

--- a/src/opencode/commands/agentdev/templates/req-define/req-draft.md
+++ b/src/opencode/commands/agentdev/templates/req-define/req-draft.md
@@ -29,11 +29,14 @@ summary: {合意内容の1段落要約}
 # auto_gate: case-auto 自走可否の判定材料
 auto_gate:
   # auto_ready が false の場合、または未解決 item が残る場合、後続コマンドは停止する
+  # 未確定内容抑止: agreed_items/artifact_actions の content に TBD/TODO/未定/後続工程で確定/case-run で確定
+  #   のいずれかを含む場合、auto_ready: false とし該当 AG-ID/ACT-ID と理由を stop_reasons へ記録する
+  #   （引用・禁止事例の言及は誤検知対象外）。QG-1 意味判定（必須フィールド欠落等）も併用する
   auto_ready: true
   unresolved_questions: []      # 未解決質問が残る場合は停止理由として列挙
   unresolved_conflicts: []      # 未解決衝突が残る場合は停止理由として列挙
   out_of_repo_operations: []    # repo 外操作が必要な場合は停止理由として列挙
-  stop_reasons: []              # その他の停止理由
+  stop_reasons: []              # その他の停止理由（未確定内容抑止時の AG-ID/ACT-ID と理由を含む）
 
 # agreed_items: 合意された個別項目。artifact_actions.source_items から ID 参照される
 # 必要十分な長文として保持し、項目数を増やして短い値を多数並べない

--- a/src/opencode/skills/agentdev-quality-gates/references/qg-1-definition-integrity.md
+++ b/src/opencode/skills/agentdev-quality-gates/references/qg-1-definition-integrity.md
@@ -83,10 +83,16 @@ SPEC 等に配置すべきと判定された要件行候補が、ドラフトの
 
 要件doc draft の `auto_gate` フィールドが、req-define の完了条件として妥当に設定されているか（REQ, REQ）。
 `auto_ready:false` の場合は `stop_reasons` が記録され、かつユーザー承認（合意による解消、または明示的な false 選択）が得られているか。
+未確定内容抑止（決定的マーカー検査 + 意味判定の組み合わせ）が `agreed_items`/ `artifact_actions` へ適用済みか（REQ）。
 
-- **fail**: `auto_gate` フィールドが不在、または `auto_ready:false` で `stop_reasons` が空。
+未確定内容抑止適用時の検査内容:
+- **決定的マーカー検査**: `agreed_items`/ `artifact_actions` 各 `content` に `TBD`/`TODO`/`未定`/`後続工程で確定`/`case-run で確定` の5マーカーが含まれないか。引用・禁止事例（例: 「TBD を残さないこと」）としての言及は検出対象外とする
+- **意味判定の併用**: 必須フィールド欠落、曖昧要件、測定不能条件に該当するエントリがないか
+- **stop_reasons 記録**: 抑止時に該当 AG-ID または ACT-ID と理由が `auto_gate.stop_reasons` へ記録されているか
+
+- **fail**: `auto_gate` フィールドが不在、または `auto_ready:false` で `stop_reasons` が空。未確定内容抑止対象（未確定マーカー、必須フィールド欠落等）が `agreed_items`/ `artifact_actions` に残るのに `auto_ready: true` となっている。
 - **warn**: `auto_ready:false` で `stop_reasons` が記載されているが、ユーザー承認（合意による解消、または明示的 false 選択の `conflict_resolutions` 記録）が未確認。
-- **pass**: `auto_ready:true`、または `auto_ready:false` で `stop_reasons` がユーザー承認済み（`conflict_resolutions` 記録済み）。
+- **pass**: `auto_ready:true`（未確定内容抑止の決定的マーカー検査と意味判定をいずれも通過）、または `auto_ready:false` で `stop_reasons` がユーザー承認済み（`conflict_resolutions` 記録済み）。
 
 ### 10. test_strategy 3要素完全性（REQ）
 


### PR DESCRIPTION
# 未確定 draft の auto_ready 抑止 (REQ-008-059)

Refs: #1918

## 概要

REQ-008-059（commit c0130521 で REQ-008.md へ APPEND 済み）の implementation レベル適合と TS-001 検証を行う。

`agreed_items` または `artifact_actions` の `content` に未確定事項を示す決定的マーカー（`TBD`/`TODO`/`未定`/`後続工程で確定`/`case-run で確定`）が含まれる場合、`auto_gate.auto_ready` を `false` とし、該当 AG-ID または ACT-ID と理由を `auto_gate.stop_reasons` へ記録する。引用・禁止事例としての言及は誤検知対象外とし、QG-1 の意味判定（必須フィールド欠落、曖昧要件、測定不能条件）を併用する。

## 変更内容

### docs/specs/commands/req-define.md
- 「未確定内容の auto_ready 抑止（REQ-008-059）」節を新設。抑止条件、決定的マーカー検査 (A)、引用・禁止事例の誤検知防止 (A')、QG-1 意味判定 (B)、stop_reasons 記録形式、後続ステップへの引き継ぎを規定

### src/opencode/commands/agentdev/req-define.md
- Step 10-2a「未確定内容の auto_ready 抑止」を追加。Step 10-2（auto_gate完了ゲート）の判定前に前置し、(A) 決定的マーカー検査、(A') 引用誤検知除外、(B) QG-1 意味判定の併用、stop_reasons 記録を LLM が機械的に実行する手順を明記

### src/opencode/skills/agentdev-quality-gates/references/qg-1-definition-integrity.md
- 観点9（auto_gate完全性）へ未確定内容抑止の検査内容（決定的マーカー検査、意味判定の併用、stop_reasons 記録）を追記。fail/warn/pass 基準を拡張

### src/opencode/commands/agentdev/templates/req-define/req-draft.md
- `auto_gate` セクションのコメントへ未確定内容抑止規則（5マーカー、AG-ID/ACT-ID 記録、引用誤検知除外、QG-1 意味判定併用）を注記

## 設計判断

- **soft-contract（ADR-003）準拠**: 本リポジトリは QG-1 を LLM 判断型として運用し、決定的スクリプトを導入しない。「決定的マーカー検査」は LLM が従う決定的手順（文字列一致）として command/SPEC へ明文化し、QG-1 意味判定と組み合わせる構成とした
- **配布物境界原則の遵守**: 配布ファイル（`src/opencode/`）から `REQ-NNNN` 参照を除外し、IR-055 delta を増加させないよう調整した。REQ ID 参照は `docs/` SPEC 側に限定している
- **REQ-008-030 との整合**: 本抑止は REQ-008-030（`artifact_actions` の `content` 完全確定）の強制機構として働く。未確定マーカー残存 = content 未確定 = 030 違反、を 059 が検出する

## TS-001 検証結果

本リポジトリは soft-contract で QG-1 が LLM 判断型のため、TS-001 は代表 fixture を更新後の SPEC/command 記載ロジックへなぞらえ、期待する `auto_ready` 値と `stop_reasons` が導かれることを trace で検証する。

### 参照ロジック（更新後）
- Step 10-2a (A): `agreed_items`/`artifact_actions` 各 `content` から5マーカーを部分文字列検索（大文字小文字区別なし）。検出時 `auto_ready=false`、AG-ID/ACT-ID とマーカーを `stop_reasons` へ記録
- Step 10-2a (A'): 引用・禁止事例パターンに合致する文は検出対象外
- Step 10-2a (B): QG-1 意味判定（必須フィールド欠落、曖昧要件、測定不能条件）で fail のエントリは `auto_ready=false`、AG-ID/ACT-ID と該当観点を `stop_reasons` へ記録

### (1) 代表 fixture 5種 → 全て auto_ready=false

| Fixture | content 抜粋 | trace 結果 |
|---|---|---|
| TBD | `ACT-REQ-001.content: "新規APIの仕様はTBD"` | (A) "TBD" 検出 → auto_ready=false ✓ |
| TODO | `ACT-REQ-001.content: "エラーハンドリングはTODO"` | (A) "TODO" 検出 → auto_ready=false ✓ |
| 未定 | `AG-003.content: "対象バージョンは未定"` | (A) "未定" 検出 → auto_ready=false ✓ |
| 後続工程で確定 | `ACT-SPEC-001.content: "詳細スキーマは後続工程で確定"` | (A) 検出 → auto_ready=false ✓ |
| case-run で確定 | `ACT-REQ-002.content: "... case-run で確定"` | (A) 検出（空白許容）→ auto_ready=false ✓ |

### (2) 引用 fixture → 誤検知なし（auto_ready=true 維持）

| Fixture | content 抜粋 | trace 結果 |
|---|---|---|
| 禁止事例引用 | `AG-001.content: "content に TBD を残さないこと"` | (A) "TBD" マッチ → (A') 「TBD を残さないこと」は禁止事例引用パターンへ合致 → 除外。他マーカーなし → auto_ready=true ✓ |

### (3) stop_reasons へ AG-ID/ACT-ID と理由が記録される

SPEC「stop_reasons 記録形式」が対象 ID（AG-NNN または ACT-{ARTIFACT}-NNN）、抑止理由（検出マーカーまたは QG-1 該当観点）、該当箇所の要約を必須情報として規定。記述例（YAML）を SPEC へ掲載済み ✓

### (4) QG-1 意味判定で必須フィールド欠落 → auto_ready=false

| Fixture | 状態 | trace 結果 |
|---|---|---|
| target_area 欠落 | `ACT-SPEC-001` が `operation: update` で `target_area` 未設定（REQ-008-032 違反） | (A) マーカーなし → (B) QG-1 必須フィールド欠落で fail → auto_ready=false、stop_reasons += "ACT-SPEC-001: QG-1 必須フィールド欠落（target_area 未設定）" ✓ |

### pass_criteria 確認

- (1) 代表 fixture 5種で全て auto_ready=false ✓
- (2) 引用 fixture で誤検知なし ✓
- (3) stop_reasons に ID と理由が記録される ✓
- (4) QG-1 意味判定で必須フィールド欠落 fixture が auto_ready=false ✓

**TS-001 PASS**

## 品質ゲート結果

- `check_extensions.ts` (IR-056): ok=true, failures=0
- `check_changed_docs.ts --workflow case-run --base-ref origin/main`: files_checked=[docs/specs/commands/req-define.md], failures=[], warnings=[]
- `check_integrity.ts`: IR-055 delta = 0（本 PR による新規違反なし。before/after ともに 109 unmanaged NG で横ばい。既存の事前違反は本 PR 起因ではない）
- `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/`: 402 pass / 67 fail（67 件は agentdev-workflow-templates 参照欠落関連の事前失敗。本 PR 前後で同一）

## Findings / Capture候補

### intake
（特記事項なし）

### learning
- Windows 環境で git commit メッセージに日本語を含める場合、`Out-File -Encoding utf8` は BOM 付きとなり化け発生。`node -e` + `fs.writeFileSync(..., 'utf-8')` でファイル書き出し後 `git commit -F` する手法が安定した（agentdev-gh-cli WRITE 標準手順の `[System.IO.File]::WriteAllText` と等価）。git commit メッセージ作成時のencoding手順も standard-procedures.md へ明文化すると再発防止になる候補

### docs-integrity
- `check_changed_docs.ts --workflow case-run --base-ref origin/main`:
  - `files_checked`: `docs/specs/commands/req-define.md`
  - `failures`: []（0件）
  - `warnings`: []（0件）
  - `doc_map_update_required`: false
  - `spec_readme_update_required`: false

### stale-reference
（特記事項なし）

## SPEC確定候補

- 「決定的マーカー検査」のマーカー一覧（5種）と「引用・禁止事例の誤検知除外パターン」は req-define command SPEC へ規定した。将来マーカー追加・引用パターン拡張が必要になった場合、本 SPEC 節が拡張対象となる。現時点では SPEC レベルの詳細（schema/enum/判定表）は本節で十分網羅しており、独立 SPEC への切り出しは不要と判断した
