### PR TITLE
feat(scripts): 導入スクリプト install/check/sync-self の使いやすさ改善 (#1922)

### DIFF
--- a/scripts/check-consumer-opencode.ps1
+++ b/scripts/check-consumer-opencode.ps1
@@ -4,6 +4,22 @@
     Check consumer repository AgentDevFlow installation status.
 
 .DESCRIPTION
+    導入先リポジトリの AgentDevFlow インストール状態を確認する。clone しない軽量確認
+    （検証のみ、ファイル変更なし）。既存の .agentdev-plugin/ と junction を検証し、
+    乖離を報告する。
+
+    関連3モードの技術的差（参考）:
+    - check（当スクリプト / install -Mode check）: clone せず既存状態を検証
+    - install -Mode check                      : clone して検証（ファイル変更なし）
+    - install -Mode dry-run                    : clone して予測（ファイル変更なし）
+    - install -Mode apply                      : clone して実行（ファイル変更あり）
+
+    当スクリプトと install -Mode check の使い分け:
+    - 当スクリプト（check-consumer-opencode.ps1）: clone しない軽量確認。.agentdev-plugin/
+      が未インストールや破損時でも速く確認できる。orphan 検出を含む。
+    - install -Mode check: clone（または更新）した上で検証する。初回導入時や、原本側の最新を
+      取り込んでから検証したい場合に使う。
+
     Verifies that the consumer repository's AgentDevFlow installation is healthy:
     - .agentdev-plugin/ exists and is a git repository
     - All expected junctions exist and point to correct targets
@@ -17,6 +33,7 @@
 
 .PARAMETER PluginDir
     Directory name for the agent-dev-flow checkout (default: .agentdev-plugin).
+    上級者向け: clone 先ディレクトリ名を変更した環境でのみ指定。通常は既定値を使用する。
 
 .EXAMPLE
     ./scripts/check-consumer-opencode.ps1
@@ -28,6 +45,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
 $RepoRoot = $PWD.Path
 $PluginPath = Join-Path $RepoRoot $PluginDir
 $SourceDir = Join-Path $PluginPath 'src\opencode'
@@ -40,6 +58,39 @@ $SkillsDir = Join-Path $ProjectionDir 'skills'
 $LocalModeRedirectSkill = 'agentdev-gh-cli'
 
 # --- Helper Functions ---
+
+function Assert-ValidConsumerCwd {
+    <#
+    .SYNOPSIS
+        実行ディレクトリが AgentDevFlow 導入先として適切か検査する。
+        想定外ディレクトリの場合、即座に停止する（REQ-009-041）。
+    #>
+    $cwd = $PWD.Path
+
+    # 1. .agentdev-plugin/ 配下（clone 先）
+    if ($cwd -match '[\\/]\.agentdev-plugin([\\/]|$)') {
+        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow の clone 先です。1つ上のフォルダへ移動してください。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        exit 1
+    }
+
+    # 2. src/opencode/ 配下（原本領域）
+    if ($cwd -match '[\\/]src[\\/]opencode([\\/]|$)') {
+        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow の原本領域です。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        exit 1
+    }
+
+    # 3. .opencode/ 配下（実行時領域）
+    if ($cwd -match '[\\/]\.opencode([\\/]|$)') {
+        Write-Host "現在のフォルダ: $cwd。このフォルダは OpenCode の実行時領域です。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        exit 1
+    }
+
+    # 4. .git 無し（Git リポジトリでない）
+    if (-not (Test-Path -LiteralPath (Join-Path $cwd '.git'))) {
+        Write-Host "現在のフォルダ: $cwd。このフォルダは Git リポジトリではありません。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        exit 1
+    }
+}
 
 function Test-Junction {
     param([string]$Path)
@@ -71,6 +122,9 @@ function Get-TargetSourcePath {
 }
 
 # --- Main ---
+
+# cwd 安全化（REQ-009-041）
+Assert-ValidConsumerCwd
 
 Write-Host '=== Consumer Install Status Check ==='
 $divergences = 0

--- a/scripts/install-consumer-opencode.ps1
+++ b/scripts/install-consumer-opencode.ps1
@@ -4,10 +4,10 @@
     Install AgentDevFlow runtime artifacts into a consumer repository.
 
 .DESCRIPTION
-    Three modes:
-    - dry-run : Show what would change without making changes
-    - check   : Report divergence between expected and actual state
-    - apply   : Clone/update agent-dev-flow and create selective junctions
+    導入系スクリプト。3つのモードの技術的差は以下の通り:
+    - check   : clone しない軽量確認（検証のみ、ファイル変更なし）
+    - dry-run : clone して予測（ファイル変更なし）
+    - apply   : clone して実行（ファイル変更あり）
 
     Creates junctions for public runtime artifacts ONLY:
     - .opencode/commands/agentdev/  = junction -> .agentdev-plugin/src/opencode/commands/agentdev/
@@ -25,23 +25,33 @@
 
 .PARAMETER Mode
     One of: dry-run, check, apply
+    省略可能。引数なし起動時（-Mode 未指定）は対話ウィザードが起動し、Mode と環境を問う（REQ-009-040）。
 
 .PARAMETER LocalMode
     Switch. When set, agentdev-gh-cli is junctioned to src/opencode-local/agentdev-gh-cli/
     instead of src/opencode/skills/agentdev-gh-cli/. All other agentdev-* command/skill
     junctions target src/opencode/ as normal (REQ-0103-158, ADR-0131 decision #3).
 
+    判断基準: GitHub Issue/PR を使わずローカルファイル（.agentdev/cases/）で運用する環境
+    （ローカル版 OpenCode）では -LocalMode を指定する。
+
 .PARAMETER PluginDir
     Directory name for the agent-dev-flow checkout (default: .agentdev-plugin).
     This directory is created relative to the consumer repo root.
+    上級者向け: clone 先ディレクトリ名を変更する場合のみ指定。通常は既定値を使用する。
 
 .PARAMETER RepoUrl
     Git remote URL for agent-dev-flow (default: https://github.com/yogata/agent-dev-flow.git)
+    上級者向け: clone 元リポジトリ URL を変更する場合（フォーク等）のみ指定。通常は既定値を使用する。
 
 .PARAMETER Branch
     Branch to checkout from agent-dev-flow (default: main)
+    上級者向け: clone 元ブランチを変更する場合のみ指定。通常は既定値を使用する。
 
 .EXAMPLE
+    ./scripts/install-consumer-opencode.ps1
+    引数なし起動時は対話ウィザードが Mode と環境を問う（REQ-009-040）。
+
     ./scripts/install-consumer-opencode.ps1 -Mode dry-run
     ./scripts/install-consumer-opencode.ps1 -Mode check
     ./scripts/install-consumer-opencode.ps1 -Mode apply
@@ -50,7 +60,7 @@
 #>
 
 param(
-    [Parameter(Mandatory)]
+    [Parameter()]
     [ValidateSet('dry-run', 'check', 'apply')]
     [string]$Mode,
 
@@ -64,6 +74,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
 $RepoRoot = $PWD.Path
 $PluginPath = Join-Path $RepoRoot $PluginDir
 $SourceDir = Join-Path $PluginPath 'src\opencode'
@@ -80,6 +91,79 @@ $RepoLocalSkillPrefix = 'repo-'
 $LocalModeRedirectSkill = 'agentdev-gh-cli'
 
 # --- Helper Functions ---
+
+function Assert-ValidConsumerCwd {
+    <#
+    .SYNOPSIS
+        実行ディレクトリが AgentDevFlow 導入先として適切か検査する。
+        想定外ディレクトリの場合、即座に停止する（REQ-009-041）。
+    #>
+    $cwd = $PWD.Path
+
+    # 1. .agentdev-plugin/ 配下（clone 先）
+    if ($cwd -match '[\\/]\.agentdev-plugin([\\/]|$)') {
+        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow の clone 先です。1つ上のフォルダへ移動してください。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        exit 1
+    }
+
+    # 2. src/opencode/ 配下（原本領域）
+    if ($cwd -match '[\\/]src[\\/]opencode([\\/]|$)') {
+        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow の原本領域です。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        exit 1
+    }
+
+    # 3. .opencode/ 配下（実行時領域）
+    if ($cwd -match '[\\/]\.opencode([\\/]|$)') {
+        Write-Host "現在のフォルダ: $cwd。このフォルダは OpenCode の実行時領域です。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        exit 1
+    }
+
+    # 4. .git 無し（Git リポジトリでない）
+    if (-not (Test-Path -LiteralPath (Join-Path $cwd '.git'))) {
+        Write-Host "現在のフォルダ: $cwd。このフォルダは Git リポジトリではありません。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        exit 1
+    }
+}
+
+function Invoke-InstallWizard {
+    <#
+    .SYNOPSIS
+        引数なし起動時（-Mode 未指定）の対話ウィザード。Mode と環境を問う（REQ-009-040）。
+    #>
+    Write-Host '=== AgentDevFlow 導入ウィザード ==='
+    Write-Host ''
+    Write-Host 'Q1. 目的を選んでください（番号を入力）:'
+    Write-Host '  1) 新規インストール（apply: clone して実行）'
+    Write-Host '  2) 更新・再同期（apply: clone して実行）'
+    Write-Host '  3) 状態確認（check: clone しない軽量確認、ファイル変更なし）'
+    Write-Host '  4) 変更予測（dry-run: clone するがファイル変更なし）'
+    $modeChoice = Read-Host '番号'
+    switch ($modeChoice) {
+        '1' { $script:Mode = 'apply' }
+        '2' { $script:Mode = 'apply' }
+        '3' { $script:Mode = 'check' }
+        '4' { $script:Mode = 'dry-run' }
+        default {
+            Write-Host "無効な選択です: $modeChoice"
+            exit 1
+        }
+    }
+
+    Write-Host ''
+    Write-Host 'Q2. 環境を選んでください（番号を入力）:'
+    Write-Host '  1) GitHub 版（通常）'
+    Write-Host '  2) ローカル版（GitHub Issue/PR を使わずローカルファイルで運用）'
+    $envChoice = Read-Host '番号'
+    switch ($envChoice) {
+        '1' { }
+        '2' { $script:LocalMode = $true }
+        default {
+            Write-Host "無効な選択です: $envChoice"
+            exit 1
+        }
+    }
+    Write-Host ''
+}
 
 function Test-Junction {
     param([string]$Path)
@@ -173,6 +257,14 @@ function Initialize-PluginCheckout {
 }
 
 # --- Main ---
+
+# cwd 安全化（REQ-009-041）。ウィザードの前に通過すること。
+Assert-ValidConsumerCwd
+
+# 引数なし起動時（-Mode 未指定）の対話ウィザード（REQ-009-040）
+if (-not $Mode) {
+    Invoke-InstallWizard
+}
 
 # Clone/update first for all modes (need source to enumerate targets)
 if ($Mode -ne 'check') {

--- a/scripts/sync-self-opencode.ps1
+++ b/scripts/sync-self-opencode.ps1
@@ -4,10 +4,16 @@
     Sync .opencode/ projection with selective junctions from src/opencode/ (self-hosting repo).
 
 .DESCRIPTION
-    Three modes:
-    - dry-run : Show what would change without making changes
-    - check   : Report divergence between source and projection
-    - apply   : Sync projection to match source
+    本体（agent-dev-flow 自己ホスト）リポジトリ専用の同期スクリプト。導入先リポジトリでは
+    install-consumer-opencode.ps1 を使うこと。
+
+    関連3モードの技術的差は以下の通り:
+    - check   : clone しない軽量確認（検証のみ、ファイル変更なし）。当スクリプトは clone せず、
+                src/opencode/ と .opencode/ の乖離を報告する。
+    - dry-run : clone して予測（ファイル変更なし）。当スクリプトは原本ディレクトリを直接参照する
+                ため clone 相当の取得は不要、変更内容の予測のみを行う。
+    - apply   : clone して実行（ファイル変更あり）。当スクリプトは原本ディレクトリから junction
+                を再作成し、.opencode/ を同期する。
 
     Uses selective junctions instead of whole-directory junction:
     - .opencode/             = real directory (not a junction)
@@ -23,15 +29,19 @@
 
 .PARAMETER Mode
     One of: dry-run, check, apply
+    省略可能。引数なし起動時（-Mode 未指定）は対話ウィザードが起動し、Mode を問う（REQ-009-040）。
 
 .EXAMPLE
+    ./scripts/sync-self-opencode.ps1
+    引数なし起動時は対話ウィザードが Mode を問う（REQ-009-040）。
+
     ./scripts/sync-self-opencode.ps1 -Mode dry-run
     ./scripts/sync-self-opencode.ps1 -Mode check
     ./scripts/sync-self-opencode.ps1 -Mode apply
 #>
 
 param(
-    [Parameter(Mandatory)]
+    [Parameter()]
     [ValidateSet('dry-run', 'check', 'apply')]
     [string]$Mode
 )
@@ -48,6 +58,42 @@ $RepoLocalCommandNames = @('repo')
 $RepoLocalSkillPrefix = 'repo-'
 
 # --- Helper Functions ---
+
+function Assert-SelfHostRepo {
+    <#
+    .SYNOPSIS
+        本スクリプトが agent-dev-flow 本体リポジトリ配下で実行されているか検査する。
+        本体以外（導入先リポジトリ等）へコピーして実行された場合、停止する（REQ-009-041）。
+    #>
+    if (-not (Test-Path -LiteralPath $SourceDir)) {
+        Write-Host "このスクリプトは AgentDevFlow 本体リポジトリ専用です。$RepoRoot には src\opencode がありません。導入先リポジトリでは install-consumer-opencode.ps1 を使ってください。"
+        exit 1
+    }
+}
+
+function Invoke-SyncSelfWizard {
+    <#
+    .SYNOPSIS
+        引数なし起動時（-Mode 未指定）の対話ウィザード。Mode を問う（REQ-009-040）。
+    #>
+    Write-Host '=== AgentDevFlow 本体同期ウィザード ==='
+    Write-Host ''
+    Write-Host 'Q1. 目的を選んでください（番号を入力）:'
+    Write-Host '  1) 同期実行（apply: ファイル変更あり）'
+    Write-Host '  2) 乖離確認（check: ファイル変更なし）'
+    Write-Host '  3) 変更予測（dry-run: ファイル変更なし）'
+    $modeChoice = Read-Host '番号'
+    switch ($modeChoice) {
+        '1' { $script:Mode = 'apply' }
+        '2' { $script:Mode = 'check' }
+        '3' { $script:Mode = 'dry-run' }
+        default {
+            Write-Host "無効な選択です: $modeChoice"
+            exit 1
+        }
+    }
+    Write-Host ''
+}
 
 function Test-Junction {
     param([string]$Path)
@@ -95,9 +141,12 @@ function Get-SelectiveJunctionTargets {
 
 # --- Main ---
 
-if (-not (Test-Path -LiteralPath $SourceDir)) {
-    Write-Error "[ERROR] Source directory not found: $SourceDir"
-    exit 1
+# 本体リポジトリ外（src/opencode が存在しない）での実行を検出して停止（REQ-009-041）
+Assert-SelfHostRepo
+
+# 引数なし起動時（-Mode 未指定）の対話ウィザード（REQ-009-040）
+if (-not $Mode) {
+    Invoke-SyncSelfWizard
 }
 
 $targets = Get-SelectiveJunctionTargets


### PR DESCRIPTION
## 概要

<!-- 【必須】 -->

Issue #1922。導入系スクリプト3本（install/check/sync-self）の使いやすさ改善。REQ-009-040〜043 を実装し、対話ウィザード、cwd 安全化、ヘルプ明示、上級者向けオプション注記の4点を追加した。詳細仕様は `docs/specs/local/install-script-usability.md` に従い、核心ロジック（junction/clone/orphan/VERIFY）は維持した。

## 実装内容

<!-- 【必須】 -->

`scripts/install-consumer-opencode.ps1`、`scripts/check-consumer-opencode.ps1`、`scripts/sync-self-opencode.ps1` の3ファイルへ以下を実装した。

- **REQ-009-040 対話ウィザード**:
  - install: `-Mode` を Optional 化。引数なし起動時に `Invoke-InstallWizard` が Mode（4択）と環境（2択）を問う。Q1 選択肢に dry-run/check/apply の技術的差を併記。
  - sync-self: `-Mode` を Optional 化。引数なし起動時に `Invoke-SyncSelfWizard` が Mode（3択）を問う。
  - check: Mode を持たないため対象外。
  - いずれも引数あり（`-Mode` 明示）の場合はウィザードを起動しない。
- **REQ-009-041 cwd 安全化**:
  - install/check: `Assert-ValidConsumerCwd` を追加（install/check で重複定義、RD-004 方針）。`.agentdev-plugin/` 内、`src/opencode/` 内、`.opencode/` 内、`.git` 無しのいずれかで停止し、現在のパスと移動先を案内。停止メッセージは SPEC 形式に忠実（「導入先ルート」「ルート」の用語不使用）。
  - sync-self: `Assert-SelfHostRepo` を追加。`$PSScriptRoot` の親に `src/opencode` が無い場合、本体リポジトリ外として停止。
- **REQ-009-042 ヘルプ明示**:
  - 3スクリプトの `.DESCRIPTION` に dry-run/check/apply の3モードの技術的差（check=clone しない軽量確認、dry-run=clone して予測、apply=clone して実行）を明示。
  - install の `.PARAMETER LocalMode` に判断基準（GitHub Issue/PR を使わずローカルファイル運用）を明示。
  - check の `.DESCRIPTION` に install -Mode check との使い分け（clone するか否か）を明示。
- **REQ-009-043 上級者向けオプション注記**:
  - install の `-PluginDir`、`-RepoUrl`、`-Branch` に上級者向け注記を追加。
  - check の `-PluginDir` に上級者向け注記を追加。
  - sync-self は上級者向けオプションなし（本体専用のため）。

## 完了条件

<!-- 【必須】 -->

- [x] `scripts/install-consumer-opencode.ps1` が引数なし起動時（-Mode 未指定）に対話ウィザードを起動すること（REQ-009-040）
- [x] `scripts/sync-self-opencode.ps1` が引数なし起動時に対話ウィザードを起動すること（REQ-009-040）
- [x] `scripts/check-consumer-opencode.ps1` は Mode を持たないため対話ウィザード対象外であること（REQ-009-040）
- [x] 引数あり（-Mode 明示）で起動した場合、ウィザードが起動しないこと（REQ-009-040）
- [x] `scripts/install-consumer-opencode.ps1` と `scripts/check-consumer-opencode.ps1` が想定外ディレクトリ（`.git` 無し、`.agentdev-plugin/` 内、`src/opencode/` 内、`.opencode/` 内）で停止し、現在のパスと移動先を表示すること（REQ-009-041）
- [x] `scripts/install-consumer-opencode.ps1` と `scripts/check-consumer-opencode.ps1` が正常系（Git リポジトリのルート）で通過すること（REQ-009-041）
- [x] `scripts/sync-self-opencode.ps1` が本体リポジトリ外（`src/opencode` が存在しない）での実行を検出して停止すること（REQ-009-041）
- [x] `scripts/install-consumer-opencode.ps1`、`scripts/check-consumer-opencode.ps1`、`scripts/sync-self-opencode.ps1` の .DESCRIPTION に dry-run/check/apply の3モードの違いが表示されること（REQ-009-042）
- [x] `scripts/install-consumer-opencode.ps1` のヘルプに -LocalMode の判断基準が表示されること（REQ-009-042）
- [x] `scripts/check-consumer-opencode.ps1` のヘルプに install -Mode check との使い分けが表示されること（REQ-009-042）
- [x] `scripts/install-consumer-opencode.ps1` の -PluginDir, -RepoUrl, -Branch に上級者向けである旨の注記が表示されること（REQ-009-043）
- [x] `scripts/check-consumer-opencode.ps1` の -PluginDir に上級者向けである旨の注記が表示されること（REQ-009-043）

## テスト結果

<!-- 【必須】 -->

TS-001〜004 の test-fix ループを全て実施。SPEC「適用範囲」に従いダミー導入先リポジトリ（`.git` あり）を作成して検証した。

- **TS-001（対話ウィザード）**: install 引数なし → ウィザード起動、Q1「3」Q2「1」選択で check モードへ遷移。sync-self 引数なし → ウィザード起動、Q1「2」選択で check モード完走。install/sync-self とも `-Mode check` 明示でウィザード非起動を確認。
- **TS-002（cwd 安全化）**: install/check を `.agentdev-plugin/` 内、`src/opencode/` 内、`.opencode/` 内、`.git` 無しディレクトリで起動し、それぞれ SPEC 通りの理由文で停止することを確認。正常系（`.git` ありルート）は通過。sync-self をダミー導入先へコピーして実行し、「本体リポジトリ専用です」メッセージで停止することを確認。本体（worktree）では通過。
- **TS-003（ヘルプ明示）**: `Get-Help -Detailed` で3スクリプトの `.DESCRIPTION` を確認。dry-run/check/apply の3モードの違い、install の -LocalMode 判断基準、check の install -Mode check との使い分け、sync-self の本体専用である旨、全て表示を確認。
- **TS-004（上級者向けオプション注記）**: `Get-Help -Detailed` で install の -PluginDir/-RepoUrl/-Branch、check の -PluginDir の上級者向け注記を確認。sync-self は上級者向けオプションなしを確認。

## 品質メトリクス

<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 完了条件（Issue #1922） | 12/12 項目 | 12/12 | ✅ |
| TS-001 対話ウィザード | 4ケース合格 / 4ケース | 全合格 | ✅ |
| TS-002 cwd 安全化 | 12ケース合格 / 12ケース | 全合格 | ✅ |
| TS-003 ヘルプ明示 | 3スクリプト合格 / 3スクリプト | 全合格 | ✅ |
| TS-004 上級者向け注記 | install 3オプション + check 1オプション合格 | 全合格 | ✅ |
| PowerShell 構文エラー | 3ファイル 0件 | 0件 | ✅ |
| worktree 隔離 | worktree root 配下のみ編集 | worktree root 配下のみ | ✅ |
| スコープ外変更 | docs/、REQ/ADR/SPEC、.agentdev/ は非変更 | 非変更 | ✅ |

## Findings/ Capture候補

<!-- 【必須】 -->

### intake

- **原本の `#Requires -Version 7.0` が comment-based help の `Get-Help` 認識を阻害する**
  - 発見元: TS-003/TS-004 検証時
  - 内容: 3スクリプトの先頭にある `#Requires -Version 7.0` が PowerShell の comment-based help 認識を妨げ、`Get-Help <script>.ps1 -Detailed` で `.DESCRIPTION` や `.PARAMETER` が表示されない（Synopsis と Syntax のみ表示）。`#Requires` 行を削除したテンポラリコピーでは正常に表示されることを確認済み。PowerShell の仕様で、comment-based help はスクリプト本文の最初のコメントブロックとして認識される必要があり、`#Requires`（RequiresStatement）がその判定を妨げていると推定。
  - 分類: intake（原本改善候補）。REQ-009-042「ヘルプ明示」の使いやすさを原本構造が制約している。改善候補: `#Requires` を comment-based help の後に配置、または `.externalhelp` XML ベースヘルプへ移行。
  - 影響範囲: 今回の変更では原本の `#Requires` を維持（原本仕様の尊重、スコープ外）。TS-003/TS-004 は `#Requires` を外したテンポラリコピーで検証し、comment-based help の内容が正しいことを確認。実運用では `Get-Help` で表示されない制約が残る。

### learning

該当なし

## SPEC確定候補

- **`Assert-ValidConsumerCwd` の判定順**: SPEC「cwd 安全化 停止条件」のリスト順（1. .agentdev-plugin/ 配下、2. src/opencode/ 配下、3. .opencode/ 配下、4. .git 無し）を優先順位として実装。`.agentdev-plugin/` 内は `.git` を持つ場合がある（clone 先）ため、`.git` 無し判定の前に具体的なサブディレクトリ判定を配置。
- **`Assert-ValidConsumerCwd` の重複定義**: install と check で同名関数を重複定義（RD-004 方針）。モジュール化せず1ファイル完結を維持。導入先リポジトリへのコピー運用で自己完結させるため。
- **ウィザードの無効入力処理**: `Invoke-InstallWizard` / `Invoke-SyncSelfWizard` は無効な選択番号を受け取った場合、日本語の「無効な選択です: <入力値>」メッセージを表示し `exit 1` で停止。SPEC には規定なし、実装上の判断。
- **`Invoke-InstallWizard` の Mode 1/2 同義**: Q1 の「1) 新規インストール」と「2) 更新・再同期」は共に apply に対応（SPEC「対話ウィザード install-consumer-opencode.ps1」通り）。ユーザーの意図に合わせた選択肢を提示しつつ、内部的には同じ Mode に集約。

## 決定事項

- `Assert-ValidConsumerCwd` を Main ブロック冒頭ではなく Helper Functions セクション定義後の Main 実処理として配置。PowerShell の関数定義は実行時評価のため、呼び出し位置より前で定義ステートメントを実行する必要がある。`sync-self` は元々 Main が Helper Functions の後にあり、今回の変更でも同構造を維持。

## 関連Issue

<!-- 【必須】 -->

Closes #1922
