### PR TITLE
fix(WP-3): Integrity Checker 実行プロファイル分離 source/installed/release (Issue #1928)

### DIFF
--- a/.opencode/commands/repo/docs-check.md
+++ b/.opencode/commands/repo/docs-check.md
@@ -30,6 +30,7 @@ agent-dev-flow リポジトリの自己監査コマンド。AgentDevFlow 管理�
 
 `repo-agentdev-integrity` の検査スクリプト（`.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts`）を `bun run` で実行。検査カテゴリ・対象パス・検出結果の分類は SKILL.md（.opencode/skills/repo-agentdev-integrity/SKILL.md）の検査カテゴリ定義を authoritative source とする。command 定義ファイルフォーマット違反検出（IR-049・`check_command_format.ts`）を含む
 - Finding 分類・ルートは SKILL.md の定義に準拠
+- **実行 profile（Issue #1928 / WP-3）**: `check_integrity.ts` は `--profile source|installed|release` を取り、既定は `source`。docs-check は明示しない限り `source`（既定）で実行する。`installed` は配置後検査、`release` は配布アーカイブ検査（`--archive <zip>` 必須）で、いずれも `docs/specs/integrity/integrity-contracts.md`「実行プロファイル分離」と `scripts/package-release-archive.ps1` / `scripts/install-from-archive.ps1` を参照
 - **IR-056（project extensions 整合性）**: `check_extensions.ts`（`.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts`）を `bun run` で併せて実行し、IR-056 として strict に取り扱う（project extensions SPEC、project extensions 読み込み標準 skill）。check_extensions.ts の strict failure は docs-check 全体を fail とする
 - **配布物参照境界（配布 command/skill 本文の具体参照禁止）**: `check_distribution_boundary.ts`（`.opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts`）を `bun run` で併せて実行する。配布 command/skill 本文（`src/opencode/commands/agentdev/**/*.md`、`src/opencode/skills/agentdev-*/**/*.md`）に含まれる具体ID（`ADR-NNNN`、`REQ-NNNN`）、具体パス（`docs/(adr|requirements|specs)/<file>.md`、但し README.md とテンプレート表記は除外）、固定URL（blob/raw）を検出し、厳格に取り扱う。check_distribution_boundary.ts の failure は docs-check 全体を fail とする
 

--- a/.opencode/skills/repo-agentdev-integrity/SKILL.md
+++ b/.opencode/skills/repo-agentdev-integrity/SKILL.md
@@ -163,7 +163,13 @@ agent-dev-flow リポジトリ（self-hosting repo）の artifact 整合性検�
 - `--help`: 使用方法を表示
 - `--json`: JSON 形式で出力
 - `--dry-run`: 検査を実行せず対象一覧を表示
-- exit code: 0（問題なし）、1（検査NG）、2（入力不正・実行エラー）
+- `--profile source|installed|release`: 実行 profile（既定 `source`、Issue #1928 / WP-3）。詳細は `docs/specs/integrity/integrity-contracts.md`「実行プロファイル分離」
+  - `source`: 原本（`src/opencode/`、docs、repo-local checker）を直接検査。projection 検査は対象外
+  - `installed`: 原本と配置先（`.opencode/`）を比較し、配置漏れ（`projection_missing` / `projection_extra` / `content_mismatch` / `broken_junction` / `missing_required_dir`）を検出
+  - `release`: `--archive <zip>` 必須。archive 展開→`install-from-archive.ps1`→`installed` profile を `--root` 付きで host 側 checker が実行
+- `--archive <zip>`: `--profile release` のとき必須。それ以外では無視
+- `--root <path>`: リポジトリルート（REQ-0145-014、worktree/CI support）
+- exit code: 0（問題なし）、1（検査NG/warning）、2（入力不正・実行エラー）
 - 非対話実行
 - 破壊的変更を行わない
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts
@@ -481,6 +481,21 @@ if (require.main === module) {
   const repoRoot = positional[0] || process.cwd();
   const json = args.includes("--json");
 
+  // WP-3 (Issue #1928): --profile is accepted for symmetry. Source is the
+  // canonical inspection target; .opencode/ mirrors it, so widening the scope
+  // would only duplicate findings.
+  let profile = "source";
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--profile" && i + 1 < args.length) {
+      profile = args[i + 1];
+      i++;
+    }
+  }
+  if (profile !== "source" && profile !== "installed" && profile !== "release") {
+    process.stderr.write(`error: --profile must be source|installed|release (got '${profile}')\n`);
+    process.exit(2);
+  }
+
   const saveBaselineIdx = args.indexOf("--save-baseline");
   const deltaBaselineIdx = args.indexOf("--delta");
   const exemptionsIdx = args.indexOf("--exemptions");
@@ -534,6 +549,7 @@ if (require.main === module) {
     } else {
       process.stdout.write(`check_distribution_boundary.ts - delta guard\n`);
       process.stdout.write(`=============================================================\n`);
+      process.stdout.write(`profile: ${profile}\n`);
       process.stdout.write(`repoRoot: ${repoRoot}\n`);
       process.stdout.write(`baseline: ${baselinePath}\n`);
       if (exemptionsPath) {
@@ -562,6 +578,7 @@ if (require.main === module) {
   } else {
     process.stdout.write(`check_distribution_boundary.ts - distribution reference boundary\n`);
     process.stdout.write(`=============================================================\n`);
+    process.stdout.write(`profile: ${profile}\n`);
     process.stdout.write(`repoRoot: ${repoRoot}\n`);
     process.stdout.write(`ok: ${report.ok}\n`);
     process.stdout.write(`stats: ${JSON.stringify(report.stats, null, 2)}\n`);

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -213,6 +213,12 @@ function buildValidFixture(root: string): void {
   mkdirp(join(root, "src", "opencode", "skills", "agentdev-test-skill"));
   mkdirp(join(root, "src", "opencode", "skills", "agentdev-workflow-templates"));
 
+  // WP-3 (Issue #1928): src/opencode/commands/agentdev and src/opencode/skills
+  // are required by checkSourceRequiredDirs.
+  const srcCmdDir = join(root, "src", "opencode", "commands", "agentdev");
+  mkdirp(srcCmdDir);
+  writeFileSync(join(srcCmdDir, "README.md"), "# agentdev commands\n", "utf-8");
+
   const integritySkillDir = join(
     root,
     ".opencode",
@@ -2702,5 +2708,201 @@ describe("IR-055 runtime-unresolved-reference 実修復回帰 (Issue #1782)", ()
     );
     // 修復完了時点の実績値。将来の削減を許容し、増加を拒否する。
     expect(baselineKnown.length).toBeLessThanOrEqual(548);
+  });
+});
+
+// ─── WP-3 (Issue #1928): execution profile separation ───────────────────────
+// §7 exit-code contracts for source/installed/release.
+
+describe("WP-3 execution profiles (Issue #1928)", () => {
+  const PROFILE_TMP = join(TEMP_BASE, `profile-${RUN_ID}`);
+  let profileRoot: string;
+
+  function writeSourceCmd(root: string, name: string, body: string): void {
+    const dir = join(root, "src", "opencode", "commands", "agentdev");
+    writeFile(join(dir, name), body);
+  }
+  function writeSourceSkill(root: string, skill: string, body: string): void {
+    const dir = join(root, "src", "opencode", "skills", skill);
+    writeFile(join(dir, "SKILL.md"), body);
+  }
+  function writeProjectionCmd(root: string, name: string, body: string): void {
+    const dir = join(root, ".opencode", "commands", "agentdev");
+    writeFile(join(dir, name), body);
+  }
+  function writeProjectionSkill(root: string, skill: string, body: string): void {
+    const dir = join(root, ".opencode", "skills", skill);
+    writeFile(join(dir, "SKILL.md"), body);
+  }
+
+  beforeAll(() => {
+    profileRoot = join(PROFILE_TMP, "repo");
+    mkdirp(profileRoot);
+    copyScripts(profileRoot);
+
+    writeSourceCmd(profileRoot, "demo-cmd.md", "---\ndescription: demo\n---\n# demo\n");
+    writeSourceSkill(
+      profileRoot,
+      "agentdev-demo",
+      "---\nname: agentdev-demo\ndescription: demo skill\n---\n# agentdev-demo\n## USE FOR\n- x\n## DO NOT USE FOR\n- y\n",
+    );
+
+    // Healthy baseline: .opencode/ mirrors src/opencode/.
+    writeProjectionCmd(profileRoot, "demo-cmd.md", "---\ndescription: demo\n---\n# demo\n");
+    writeProjectionSkill(
+      profileRoot,
+      "agentdev-demo",
+      "---\nname: agentdev-demo\ndescription: demo skill\n---\n# agentdev-demo\n## USE FOR\n- x\n## DO NOT USE FOR\n- y\n",
+    );
+
+    const specsDir = join(profileRoot, "docs", "specs");
+    mkdirp(specsDir);
+    writeFileSync(
+      join(specsDir, "README.md"),
+      [
+        "# SPEC index",
+        "",
+        "| SPEC | status | 責務 |",
+        "|------|--------|------|",
+        "| foundations/system.md | accepted | system |",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const sysDir = join(specsDir, "foundations");
+    mkdirp(sysDir);
+    writeFileSync(join(sysDir, "system.md"), "# System\n", "utf-8");
+  });
+
+  afterAll(() => {
+    rmSync(PROFILE_TMP, { recursive: true, force: true });
+  });
+
+  it("source profile (default) records profile=source and skips projection checks", () => {
+    const result = runScript(profileRoot, ["--json"]);
+    expect(result.exitCode).toBeGreaterThanOrEqual(0);
+    const parsed = JSON.parse(result.stdout) as {
+      profile: string;
+      results: Array<{ category: string; check: string; level: string }>;
+    };
+    expect(parsed.profile).toBe("source");
+    const scopeMsg = parsed.results.find(
+      (r) => r.category === "ProfileScope" && r.check === "projection-check-scope",
+    );
+    expect(scopeMsg).toBeDefined();
+    expect(
+      parsed.results.some((r) => r.category === "InstalledProfile"),
+    ).toBe(false);
+  });
+
+  it("installed profile fails with projection_missing when projection dir is absent", () => {
+    const brokenRoot = join(PROFILE_TMP, "no-projection");
+    mkdirp(brokenRoot);
+    copyScripts(brokenRoot);
+    writeSourceCmd(brokenRoot, "demo-cmd.md", "---\ndescription: demo\n---\n# demo\n");
+    writeSourceSkill(
+      brokenRoot,
+      "agentdev-demo",
+      "---\nname: agentdev-demo\ndescription: demo skill\n---\n# agentdev-demo\n## USE FOR\n- x\n## DO NOT USE FOR\n- y\n",
+    );
+
+    const result = runScript(brokenRoot, ["--profile", "installed", "--json"]);
+    expect(result.exitCode).toBe(1);
+    const parsed = JSON.parse(result.stdout) as {
+      profile: string;
+      results: Array<{ category: string; check: string; level: string }>;
+    };
+    expect(parsed.profile).toBe("installed");
+    expect(
+      parsed.results.some(
+        (r) =>
+          r.category === "InstalledProfile" &&
+          r.check === "projection_missing" &&
+          r.level === "ng",
+      ),
+    ).toBe(true);
+  });
+
+  it("installed profile detects content_mismatch on divergent projection", () => {
+    const mismatchRoot = join(PROFILE_TMP, "mismatch");
+    mkdirp(mismatchRoot);
+    copyScripts(mismatchRoot);
+    writeSourceCmd(mismatchRoot, "demo-cmd.md", "---\ndescription: demo\n---\n# demo source\n");
+    writeSourceSkill(
+      mismatchRoot,
+      "agentdev-demo",
+      "---\nname: agentdev-demo\ndescription: demo skill\n---\n# agentdev-demo\n## USE FOR\n- x\n## DO NOT USE FOR\n- y\n",
+    );
+    writeProjectionCmd(mismatchRoot, "demo-cmd.md", "---\ndescription: demo\n---\n# demo projection (drift)\n");
+    writeProjectionSkill(
+      mismatchRoot,
+      "agentdev-demo",
+      "---\nname: agentdev-demo\ndescription: demo skill\n---\n# agentdev-demo\n## USE FOR\n- x\n## DO NOT USE FOR\n- y\n",
+    );
+
+    const result = runScript(mismatchRoot, ["--profile", "installed", "--json"]);
+    expect(result.exitCode).toBe(1);
+    const parsed = JSON.parse(result.stdout) as {
+      results: Array<{ category: string; check: string; level: string }>;
+    };
+    expect(
+      parsed.results.some(
+        (r) =>
+          r.category === "InstalledProfile" &&
+          r.check === "content_mismatch" &&
+          r.level === "ng",
+      ),
+    ).toBe(true);
+  });
+
+  it("installed profile detects projection_extra for unexpected agentdev- skill", () => {
+    const extraRoot = join(PROFILE_TMP, "extra");
+    mkdirp(extraRoot);
+    copyScripts(extraRoot);
+    writeSourceCmd(extraRoot, "demo-cmd.md", "---\ndescription: demo\n---\n# demo\n");
+    writeSourceSkill(
+      extraRoot,
+      "agentdev-demo",
+      "---\nname: agentdev-demo\ndescription: demo skill\n---\n# agentdev-demo\n## USE FOR\n- x\n## DO NOT USE FOR\n- y\n",
+    );
+    writeProjectionCmd(extraRoot, "demo-cmd.md", "---\ndescription: demo\n---\n# demo\n");
+    writeProjectionSkill(
+      extraRoot,
+      "agentdev-demo",
+      "---\nname: agentdev-demo\ndescription: demo skill\n---\n# agentdev-demo\n## USE FOR\n- x\n## DO NOT USE FOR\n- y\n",
+    );
+    writeProjectionSkill(
+      extraRoot,
+      "agentdev-foreign",
+      "---\nname: agentdev-foreign\ndescription: foreign\n---\n# agentdev-foreign\n",
+    );
+
+    const result = runScript(extraRoot, ["--profile", "installed", "--json"]);
+    expect(result.exitCode).toBe(1);
+    const parsed = JSON.parse(result.stdout) as {
+      results: Array<{ category: string; check: string; level: string; evidence?: string }>;
+    };
+    expect(
+      parsed.results.some(
+        (r) =>
+          r.category === "InstalledProfile" &&
+          r.check === "projection_extra" &&
+          r.level === "ng" &&
+          r.evidence === "agentdev-foreign",
+      ),
+    ).toBe(true);
+  });
+
+  it("installed profile reports 0 InstalledProfile NG when projection mirrors source", () => {
+    const result = runScript(profileRoot, ["--profile", "installed", "--json"]);
+    const parsed = JSON.parse(result.stdout) as {
+      profile: string;
+      results: Array<{ category: string; check: string; level: string }>;
+    };
+    expect(parsed.profile).toBe("installed");
+    const installedNg = parsed.results.filter(
+      (r) => r.category === "InstalledProfile" && r.level === "ng",
+    );
+    expect(installedNg.length).toBe(0);
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -80,7 +80,7 @@ import {
 const SCRIPT_NAME = "check_integrity.ts";
 const DESCRIPTION = "AgentDevFlow artifact integrity validator";
 const USAGE =
-  "bun run check_integrity.ts [--help] [--json] [--dry-run] [--classification] [--update-ir055-baseline] [--update-ng-baseline --ng-baseline-additions <manifest.json>]";
+  "bun run check_integrity.ts [--help] [--json] [--dry-run] [--classification] [--profile source|installed|release] [--archive <zip>] [--root <path>] [--update-ir055-baseline] [--update-ng-baseline --ng-baseline-additions <manifest.json>]";
 
 const path = require("path") as typeof import("path");
 const fs = require("fs") as typeof import("fs");
@@ -5300,6 +5300,362 @@ function checkBrokenJunctions(skillsDir: string, root: string, cmdsDir?: string)
   return results;
 }
 
+// ─── Installed profile: strict projection comparison (Issue #1928 / WP-3 §7.4) ──
+
+// `realpath` follows Windows junctions, so a healthy projection compares equal
+// to its source. Without this, content_mismatch would fire on every junction.
+function collectMarkdownTree(dirRoot: string): string[] {
+  if (!fs.existsSync(dirRoot)) return [];
+  const acc: string[] = [];
+  function walk(d: string): void {
+    let entries: import("fs").Dirent[];
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true }) as import("fs").Dirent[];
+    } catch {
+      return;
+    }
+    for (const ent of entries) {
+      const full = path.join(d, ent.name);
+      if (ent.isDirectory()) {
+        walk(full);
+      } else if (ent.isFile() && ent.name.endsWith(".md")) {
+        acc.push(full);
+      }
+    }
+  }
+  walk(dirRoot);
+  return acc;
+}
+
+function readRealPath(filePath: string): string | null {
+  try {
+    return fs.realpathSync(filePath) ? fs.readFileSync(filePath, "utf-8") as string : null;
+  } catch {
+    return null;
+  }
+}
+
+// §7.3/§7.4: source dirs the installed profile cannot run without.
+const INSTALLED_REQUIRED_SOURCE_DIRS = [
+  "src/opencode/commands/agentdev",
+  "src/opencode/skills",
+];
+
+const PROJECTION_ONLY_EXEMPT_PREFIX = "repo-";
+
+// WP-3 (Issue #1928) §7.3: source profile fails when required source dirs are
+// missing. Uses the same finding name as checkInstalledProjection so §7.7.1
+// regression-matrix rows read consistently across profiles.
+function checkSourceRequiredDirs(root: string): CheckResult[] {
+  const results: CheckResult[] = [];
+  for (const rel of INSTALLED_REQUIRED_SOURCE_DIRS) {
+    const abs = path.join(root, ...rel.split("/"));
+    if (!fs.existsSync(abs)) {
+      results.push(
+        ng(
+          "SourceProfile",
+          "missing_required_dir",
+          `Required source directory missing: ${rel}`,
+          rel,
+          undefined,
+          {
+            evidence: rel,
+            expected: "source directory must exist",
+            route: determineRoute("obsolete-structure", 1),
+          },
+        ),
+      );
+    }
+  }
+  if (results.filter((r) => r.level === "ng").length === 0) {
+    results.push(
+      ok(
+        "SourceProfile",
+        "source-required-dirs",
+        "All required source directories present",
+      ),
+    );
+  }
+  return results;
+}
+
+function checkInstalledProjection(root: string): CheckResult[] {
+  const results: CheckResult[] = [];
+  const projectionCmdDir = path.join(root, ".opencode", "commands", "agentdev");
+  const sourceCmdDir = path.join(root, "src", "opencode", "commands", "agentdev");
+  const projectionSkillsDir = path.join(root, ".opencode", "skills");
+  const sourceSkillsDir = path.join(root, "src", "opencode", "skills");
+
+  for (const rel of INSTALLED_REQUIRED_SOURCE_DIRS) {
+    const abs = path.join(root, ...rel.split("/"));
+    if (!fs.existsSync(abs)) {
+      results.push(
+        ng(
+          "InstalledProfile",
+          "missing_required_dir",
+          `Required source directory missing: ${rel}`,
+          rel,
+          undefined,
+          {
+            evidence: rel,
+            expected: "source directory must exist",
+            route: determineRoute("obsolete-structure", 1),
+          },
+        ),
+      );
+    }
+  }
+
+  const projectionRoots = [
+    { kind: "command", abs: projectionCmdDir, sourceAbs: sourceCmdDir },
+    { kind: "skill", abs: projectionSkillsDir, sourceAbs: sourceSkillsDir },
+  ];
+  for (const { kind, abs, sourceAbs } of projectionRoots) {
+    if (!fs.existsSync(abs)) {
+      results.push(
+        ng(
+          "InstalledProfile",
+          "projection_missing",
+          `${kind} projection directory does not exist: ${resolveRelative(abs, root)}`,
+          resolveRelative(abs, root),
+          undefined,
+          {
+            evidence: resolveRelative(abs, root),
+            expected: `${kind} projection must exist under .opencode/`,
+            route: determineRoute("obsolete-structure", 1),
+          },
+        ),
+      );
+    }
+    if (!fs.existsSync(sourceAbs)) continue;
+
+    if (kind === "command") {
+      const sourceFiles = listFiles(sourceAbs).filter((f) => f !== "README.md");
+      const projectionFiles = listFiles(abs).filter((f) => f !== "README.md");
+      const sourceSet = new Set(sourceFiles);
+      const projectionSet = new Set(projectionFiles);
+
+      for (const f of sourceFiles) {
+        if (!projectionSet.has(f)) {
+          results.push(
+            ng(
+              "InstalledProfile",
+              "projection_missing",
+              `Command '${f}' exists in source but missing from projection`,
+              `.opencode/commands/agentdev/${f}`,
+              undefined,
+              {
+                evidence: f,
+                expected: "projection must mirror src/opencode/commands/agentdev/",
+                route: determineRoute("broken-reference", 1),
+              },
+            ),
+          );
+        }
+      }
+      for (const f of projectionFiles) {
+        if (!sourceSet.has(f)) {
+          results.push(
+            ng(
+              "InstalledProfile",
+              "projection_extra",
+              `Command '${f}' exists in projection but missing from source`,
+              `.opencode/commands/agentdev/${f}`,
+              undefined,
+              {
+                evidence: f,
+                expected: "projection must not contain commands absent from source",
+                route: determineRoute("broken-reference", 1),
+              },
+            ),
+          );
+        }
+      }
+      for (const f of sourceFiles) {
+        if (!projectionSet.has(f)) continue;
+        const srcText = readText(path.join(sourceAbs, f));
+        const projText = readRealPath(path.join(abs, f));
+        if (srcText === null || projText === null) continue;
+        if (srcText !== projText) {
+          results.push(
+            ng(
+              "InstalledProfile",
+              "content_mismatch",
+              `Command '${f}' content differs between source and projection`,
+              `.opencode/commands/agentdev/${f}`,
+              undefined,
+              {
+                evidence: f,
+                expected: "projection content must match source byte-for-byte",
+                route: determineRoute("document-drift", 1),
+              },
+            ),
+          );
+        }
+      }
+    } else {
+      const sourceSkillDirs = new Set(listDirs(sourceAbs));
+      const projectionSkillDirs = new Set(listDirs(abs));
+
+      for (const d of sourceSkillDirs) {
+        if (!projectionSkillDirs.has(d)) {
+          results.push(
+            ng(
+              "InstalledProfile",
+              "projection_missing",
+              `Skill '${d}' exists in source but missing from projection`,
+              `.opencode/skills/${d}`,
+              undefined,
+              {
+                evidence: d,
+                expected: "projection must mirror src/opencode/skills/",
+                route: determineRoute("broken-reference", 1),
+              },
+            ),
+          );
+        }
+      }
+      for (const d of projectionSkillDirs) {
+        if (sourceSkillDirs.has(d)) continue;
+        if (d.startsWith(PROJECTION_ONLY_EXEMPT_PREFIX)) continue;
+        results.push(
+          ng(
+            "InstalledProfile",
+            "projection_extra",
+            `Skill '${d}' exists in projection but missing from source`,
+            `.opencode/skills/${d}`,
+            undefined,
+            {
+              evidence: d,
+              expected: `projection must not contain skills absent from source (except ${PROJECTION_ONLY_EXEMPT_PREFIX}* repo-local)`,
+              route: determineRoute("broken-reference", 1),
+            },
+          ),
+        );
+      }
+
+      for (const d of sourceSkillDirs) {
+        if (!projectionSkillDirs.has(d)) continue;
+        const srcTree = collectMarkdownTree(path.join(sourceAbs, d));
+        const projTree = collectMarkdownTree(path.join(abs, d));
+        const srcRel = new Set(
+          srcTree.map((full) => path.relative(path.join(sourceAbs, d), full).replace(/\\/g, "/")),
+        );
+        const projRel = new Map(
+          projTree.map((full) => [
+            path.relative(path.join(abs, d), full).replace(/\\/g, "/"),
+            full,
+          ]),
+        );
+        for (const relPath of srcRel) {
+          const srcFull = path.join(sourceAbs, d, ...relPath.split("/"));
+          const projFull = projRel.get(relPath);
+          if (!projFull) {
+            results.push(
+              ng(
+                "InstalledProfile",
+                "projection_missing",
+                `Skill '${d}' file '${relPath}' missing from projection`,
+                `.opencode/skills/${d}/${relPath}`,
+                undefined,
+                {
+                  evidence: `${d}/${relPath}`,
+                  expected: "projection skill must mirror source files",
+                  route: determineRoute("broken-reference", 1),
+                },
+              ),
+            );
+            continue;
+          }
+          const srcText = readText(srcFull);
+          const projText = readRealPath(projFull);
+          if (srcText === null || projText === null) continue;
+          if (srcText !== projText) {
+            results.push(
+              ng(
+                "InstalledProfile",
+                "content_mismatch",
+                `Skill '${d}' file '${relPath}' content differs between source and projection`,
+                `.opencode/skills/${d}/${relPath}`,
+                undefined,
+                {
+                  evidence: `${d}/${relPath}`,
+                  expected: "projection skill content must match source byte-for-byte",
+                  route: determineRoute("document-drift", 1),
+                },
+              ),
+            );
+          }
+        }
+        for (const relPath of projRel.keys()) {
+          if (!srcRel.has(relPath)) {
+            results.push(
+              ng(
+                "InstalledProfile",
+                "projection_extra",
+                `Skill '${d}' file '${relPath}' exists in projection but missing from source`,
+                `.opencode/skills/${d}/${relPath}`,
+                undefined,
+                {
+                  evidence: `${d}/${relPath}`,
+                  expected: "projection skill must not contain files absent from source",
+                  route: determineRoute("broken-reference", 1),
+                },
+              ),
+            );
+          }
+        }
+      }
+    }
+  }
+
+  // §7.4 broken_junction: projection entries that look like directories but
+  // cannot be stat'd (junction target missing). Same shape as
+  // checkBrokenJunctions, scoped to the installed profile.
+  for (const scanDir of [projectionSkillsDir, projectionCmdDir]) {
+    if (!fs.existsSync(scanDir)) continue;
+    let entries: import("fs").Dirent[];
+    try {
+      entries = fs.readdirSync(scanDir, { withFileTypes: true }) as import("fs").Dirent[];
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const fullPath = path.join(scanDir, entry.name);
+      try {
+        fs.statSync(fullPath);
+      } catch {
+        results.push(
+          ng(
+            "InstalledProfile",
+            "broken_junction",
+            `Broken junction/symlink in projection: '${entry.name}' target unreachable`,
+            resolveRelative(fullPath, root),
+            undefined,
+            {
+              evidence: entry.name,
+              expected: "projection entry must resolve to a real directory",
+              route: determineRoute("broken-reference", 1),
+            },
+          ),
+        );
+      }
+    }
+  }
+
+  if (results.filter((r) => r.level === "ng").length === 0) {
+    results.push(
+      ok(
+        "InstalledProfile",
+        "installed-projection",
+        "Projection mirrors source for commands and skills (no missing/extra/mismatch/broken)",
+      ),
+    );
+  }
+  return results;
+}
+
 // ─── Document Classification Policy checks (v2:REQ-0108-196) ─────────────────
 
 const DOCUMENT_CLASSIFICATIONS = ["REQ", "ADR", "SPEC", "Guide", "Report", "DOC-MAP"] as const;
@@ -8052,6 +8408,234 @@ function walkAllFiles(dirPath: string, acc: string[]): void {
   }
 }
 
+// ─── Release profile (Issue #1928 / WP-3 §7.5) ──────────────────────────────
+// Pipeline: expand archive → run install-from-archive.ps1 (-Mode copy) →
+// re-invoke the host checker with `--profile installed --root <temp>/<root>`
+// → forward the integrated report → cleanup `<temp>` on success AND failure.
+// The checker stays on the host (REQ-0145-014 `--root`); the archive must
+// not embed it (§7.5 boundary: archive self-containment vs check execution).
+function findArchiveRoot(tempDir: string): string | null {
+  const entries = fs.readdirSync(tempDir, { withFileTypes: true });
+  const dir = entries.find((e) => e.isDirectory());
+  return dir ? path.join(tempDir, dir.name) : null;
+}
+
+function runCommand(
+  exe: string,
+  exeArgs: string[],
+): { status: number | null; stdout: string; stderr: string; error?: Error } {
+  const { spawnSync } = require("child_process") as typeof import("child_process");
+  const result = spawnSync(exe, exeArgs, {
+    encoding: "utf-8",
+    windowsHide: true,
+  });
+  return {
+    status: result.status,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr: typeof result.stderr === "string" ? result.stderr : "",
+    error: result.error ?? undefined,
+  };
+}
+
+function runPowerShellScript(
+  scriptPath: string,
+  scriptArgs: string[],
+): { status: number | null; stdout: string; stderr: string } {
+  const candidates =
+    process.platform === "win32" ? ["pwsh.exe", "powershell.exe"] : ["pwsh"];
+  for (const exe of candidates) {
+    const result = runCommand(exe, [
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      scriptPath,
+      ...scriptArgs,
+    ]);
+    if (result.error === undefined) {
+      return result;
+    }
+  }
+  return { status: null, stdout: "", stderr: "no PowerShell interpreter found" };
+}
+
+function expandArchive(zipPath: string, destDir: string): string | null {
+  if (process.platform === "win32") {
+    const candidates = ["pwsh.exe", "powershell.exe"];
+    for (const exe of candidates) {
+      const result = runCommand(exe, [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `Expand-Archive -LiteralPath '${zipPath}' -DestinationPath '${destDir}' -Force`,
+      ]);
+      if (result.error === undefined) {
+        if (result.status !== 0) {
+          return `Expand-Archive exit ${result.status}: ${result.stderr || result.stdout}`;
+        }
+        return null;
+      }
+    }
+    return "no PowerShell interpreter found for Expand-Archive";
+  }
+  const result = runCommand("unzip", ["-o", zipPath, "-d", destDir]);
+  if (result.status !== 0) {
+    return `unzip exit ${result.status}: ${result.stderr || result.stdout}`;
+  }
+  return null;
+}
+
+async function runReleaseProfile(
+  options: CliOptions,
+  hostRoot: string,
+): Promise<number> {
+  if (!options.archive) {
+    console.error("[integrity] --profile release requires --archive <zip>");
+    return EXIT_ERROR;
+  }
+  const archivePath = path.resolve(options.archive);
+  if (!fs.existsSync(archivePath)) {
+    console.error(`[integrity] release archive not found: ${archivePath}`);
+    return EXIT_ERROR;
+  }
+  if (!archivePath.toLowerCase().endsWith(".zip")) {
+    console.error(`[integrity] release archive must be .zip: ${archivePath}`);
+    return EXIT_ERROR;
+  }
+
+  const os = require("os") as typeof import("os");
+  const tempBase = fs.mkdtempSync(path.join(os.tmpdir(), "agentdev-release-"));
+
+  try {
+    const expandError = expandArchive(archivePath, tempBase);
+    if (expandError !== null) {
+      console.error(`[integrity] archive expand failed: ${expandError}`);
+      return EXIT_ERROR;
+    }
+
+    const unpackedRoot = findArchiveRoot(tempBase);
+    if (unpackedRoot === null) {
+      console.error(
+        `[integrity] archive root directory not found in ${tempBase}`,
+      );
+      return EXIT_ERROR;
+    }
+
+    const installerPath = path.join(
+      unpackedRoot,
+      "scripts",
+      "install-from-archive.ps1",
+    );
+    if (!fs.existsSync(installerPath)) {
+      console.error(
+        `[integrity] install-from-archive.ps1 missing from archive: ${installerPath}`,
+      );
+      return EXIT_ERROR;
+    }
+
+    const sourceDir = path.join(unpackedRoot, "src", "opencode");
+    const targetDir = path.join(unpackedRoot, ".opencode");
+    const installResult = runPowerShellScript(installerPath, [
+      "-Source",
+      sourceDir,
+      "-Target",
+      targetDir,
+      "-Mode",
+      "copy",
+    ]);
+    if (installResult.status !== 0) {
+      console.error(
+        `[integrity] install-from-archive.ps1 failed (exit ${installResult.status}): ${installResult.stderr || installResult.stdout}`,
+      );
+      return EXIT_ERROR;
+    }
+
+    const checkerPath = path.join(
+      hostRoot,
+      ".opencode",
+      "skills",
+      "repo-agentdev-integrity",
+      "scripts",
+      "check_integrity.ts",
+    );
+    if (!fs.existsSync(checkerPath)) {
+      console.error(`[integrity] host checker not found: ${checkerPath}`);
+      return EXIT_ERROR;
+    }
+    const bunExe = process.execPath;
+    const childResult = runCommand(bunExe, [
+      checkerPath,
+      "--profile",
+      "installed",
+      "--root",
+      unpackedRoot,
+      "--json",
+    ]);
+    if (childResult.status === null) {
+      console.error(
+        `[integrity] child checker invocation failed: ${childResult.error?.message ?? "unknown"}`,
+      );
+      return EXIT_ERROR;
+    }
+
+    let childReport: IntegrityReport;
+    try {
+      childReport = JSON.parse(childResult.stdout) as IntegrityReport;
+    } catch (e) {
+      console.error(
+        `[integrity] child checker produced non-JSON output: ${e instanceof Error ? e.message : String(e)}`,
+      );
+      console.error(`[integrity] child stdout (first 2KB):\n${childResult.stdout.slice(0, 2048)}`);
+      console.error(`[integrity] child stderr (first 2KB):\n${childResult.stderr.slice(0, 2048)}`);
+      return EXIT_ERROR;
+    }
+
+    // §7.5/§7.7.1: archive carries no docs/, so exit code is driven by
+    // InstalledProfile findings only. Full child report is still forwarded.
+    const projectionSummary = computeSummary(
+      childReport.results.filter((r) => r.category === "InstalledProfile"),
+    );
+    const releaseExit = determineExitCode(projectionSummary);
+
+    const releaseReport: IntegrityReport = {
+      ...childReport,
+      profile: "release",
+      archive: archivePath,
+      summary: {
+        ...childReport.summary,
+        ng: projectionSummary.ng,
+        warning: projectionSummary.warning,
+      },
+    };
+
+    if (options.json) {
+      console.log(formatJsonReport(releaseReport));
+    } else {
+      console.log(formatMarkdownReport(releaseReport));
+    }
+    if (releaseExit !== EXIT_OK) {
+      console.error(
+        `[integrity] release profile: ${projectionSummary.ng} projection NG, ${projectionSummary.warning} projection warning (exit ${releaseExit})`,
+      );
+    } else {
+      console.error(
+        `[integrity] release profile: projection checks passed (archive=${archivePath})`,
+      );
+    }
+
+    return releaseExit;
+  } finally {
+    try {
+      fs.rmSync(tempBase, { recursive: true, force: true });
+    } catch (e) {
+      console.error(
+        `[integrity] cleanup warning: could not remove ${tempBase}: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   let options;
@@ -8078,14 +8662,29 @@ async function main(): Promise<void> {
     process.exit(EXIT_OK);
   }
 
+  // WP-3 (Issue #1928): release profile expands the archive, installs it, and
+  // re-invokes the installed profile against the unpacked tree via --root.
+  if (options.profile === "release") {
+    const exitCode = await runReleaseProfile(options, root);
+    process.exit(exitCode);
+  }
+
+  const profile = options.profile;
+
   const reqDir = path.join(root, "docs", "requirements");
   const adrDir = path.join(root, "docs", "adr");
   const specsDir = path.join(root, "docs", "specs");
   const skillsDir = path.join(root, ".opencode", "skills");
-  // v2:REQ-0108-189: Use resolvePathWithFallback for runtime→source fallback
-  const cmdDir = resolvePathWithFallback(
-    path.join(root, ".opencode", "commands", "agentdev"),
-  );
+  // §7.3 (source): fallback `.opencode/` → `src/opencode/` preserves the
+  // legacy behavior so worktrees and existing callers see no regression.
+  // §7.4 (installed): inspect the projection directly. Source fallback would
+  // hide projection gaps, which is exactly what this profile must detect.
+  const cmdDir =
+    profile === "installed"
+      ? path.join(root, ".opencode", "commands", "agentdev")
+      : resolvePathWithFallback(
+          path.join(root, ".opencode", "commands", "agentdev"),
+        );
   const commandMapPath = path.join(
     root,
     ".opencode",
@@ -8146,6 +8745,7 @@ async function main(): Promise<void> {
   }
 
   const results: CheckResult[] = [
+    ...checkSourceRequiredDirs(root),
     ...checkReqFrontmatterFilename(reqDir, root),
     ...checkReqRequiredFields(reqDir, root),
     ...checkReqReadmeIndexSync(reqDir, root),
@@ -8188,14 +8788,11 @@ async function main(): Promise<void> {
     ...checkReqRangeStaleness(root),
     ...checkSkillCategoryGap(root, skillsDir, cmdDir),
     ...checkTemplatePathIntegrity(cmdDir, root),
-    ...checkSourceProjectionConsistency(root),
-    ...checkDistributionUntrackedSkillReference(root), // IR-058 (v2:REQ-0159-003)
-    ...checkBrokenJunctions(skillsDir, root, cmdDir),
+    ...checkDistributionUntrackedSkillReference(root), // IR-058 (v2:REQ-0159-003) — source/installed both run; no-op when projection absent
     ...checkUpdateNotesInDocs(root),
     ...checkSummaryReqRangeConsistency(root),
     ...checkOldStatusVocabulary(root),
     ...checkLegacyNamespaceInDocs(root),
-    ...checkJunctionScanCoverage(root),
     ...checkAgentdevExclusion(root),
     ...checkReferencesRecursiveScan(skillsDir, root),
     ...checkReportSelfExclusion(root),
@@ -8212,6 +8809,27 @@ async function main(): Promise<void> {
     ...checkObsoleteSpecPath(root), // IR-057 (v2:REQ-0158-002)
     ...checkIndexGenerationConsistency(root), // IR-061 (SC-002 Phase C, 索引類自動生成整合性)
   ];
+
+  // WP-3 (Issue #1928): profile-gated projection checks. §7.3 source skips
+  // projection sync / broken-junction / junction-coverage. IR-058 above stays
+  // enabled for both profiles — it no-ops when the projection dir is absent,
+  // so it cannot fire false positives in a worktree.
+  // §7.4 installed runs all projection checks AND the strict
+  // checkInstalledProjection (projection_missing/extra/content_mismatch/broken_junction).
+  if (profile === "source") {
+    results.push(
+      info(
+        "ProfileScope",
+        "projection-check-scope",
+        "source profile: projection sync, broken-junction, junction-coverage checks are out of scope (Issue #1928 §7.3)",
+      ),
+    );
+  } else {
+    results.push(...checkSourceProjectionConsistency(root));
+    results.push(...checkBrokenJunctions(skillsDir, root, cmdDir));
+    results.push(...checkJunctionScanCoverage(root));
+    results.push(...checkInstalledProjection(root));
+  }
 
   // v2:REQ-0108-196: classification policy checks (enabled by --classification flag)
   if (options.classification) {
@@ -8260,6 +8878,7 @@ async function main(): Promise<void> {
   const report: IntegrityReport = {
     timestamp: new Date().toISOString(),
     script: SCRIPT_NAME,
+    profile: options.profile,
     scanned,
     summary,
     results: processed,

--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.test.ts
@@ -86,7 +86,38 @@ describe("parseArgs", () => {
       dryRun: true,
       classification: false,
       paths: ["path/a", "path/b"],
+      profile: "source",
     });
+  });
+
+  it("defaults profile to 'source' (WP-3 / Issue #1928)", () => {
+    expect(parseArgs([]).profile).toBe("source");
+  });
+
+  it("parses --profile installed", () => {
+    expect(parseArgs(["--profile", "installed"]).profile).toBe("installed");
+  });
+
+  it("parses --profile release with --archive", () => {
+    const opts = parseArgs(["--profile", "release", "--archive", "/tmp/x.zip"]);
+    expect(opts.profile).toBe("release");
+    expect(opts.archive).toBe("/tmp/x.zip");
+  });
+
+  it("rejects unknown --profile value", () => {
+    expect(() => parseArgs(["--profile", "nope"])).toThrow(/--profile must be one of/);
+  });
+
+  it("requires --archive when --profile release", () => {
+    expect(() => parseArgs(["--profile", "release"])).toThrow(/requires --archive/);
+  });
+
+  it("throws when --profile has no value", () => {
+    expect(() => parseArgs(["--profile"])).toThrow(/--profile requires a value/);
+  });
+
+  it("throws when --archive has no value", () => {
+    expect(() => parseArgs(["--archive"])).toThrow(/--archive requires a value/);
   });
 });
 
@@ -200,6 +231,7 @@ describe("formatJsonReport", () => {
   const report: IntegrityReport = {
     timestamp: "2025-01-01T00:00:00Z",
     script: "test-script",
+    profile: "source",
     scanned: { docs: 5, skills: 3 },
     summary: { ok: 3, ng: 1, warning: 1, info: 0 },
     results: [
@@ -229,6 +261,7 @@ describe("formatMarkdownReport", () => {
   const report: IntegrityReport = {
     timestamp: "2025-01-01T00:00:00Z",
     script: "integrity-check",
+    profile: "source",
     scanned: { docs: 2 },
     summary: { ok: 1, ng: 1, warning: 0, info: 0 },
     results: [
@@ -240,6 +273,22 @@ describe("formatMarkdownReport", () => {
   it("contains title header with script name", () => {
     const md = formatMarkdownReport(report);
     expect(md).toContain("# integrity-check Report");
+  });
+
+  it("records the execution profile in the header (WP-3)", () => {
+    const md = formatMarkdownReport(report);
+    expect(md).toContain("**プロファイル**: source");
+  });
+
+  it("records the archive path in the header when release profile", () => {
+    const releaseReport: IntegrityReport = {
+      ...report,
+      profile: "release",
+      archive: "/tmp/agentdev-release-abc123.zip",
+    };
+    const md = formatMarkdownReport(releaseReport);
+    expect(md).toContain("**プロファイル**: release");
+    expect(md).toContain("**アーカイブ**: /tmp/agentdev-release-abc123.zip");
   });
 
   it("contains summary table", () => {
@@ -264,6 +313,7 @@ describe("formatMarkdownReport", () => {
     const okReport: IntegrityReport = {
       timestamp: "2025-01-01T00:00:00Z",
       script: "test",
+      profile: "source",
       scanned: { all: 1 },
       summary: { ok: 1, ng: 0, warning: 0, info: 0 },
       results: [ok("cat", "check", "fine")],

--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
@@ -14,6 +14,20 @@ export const EXIT_OK = 0;
 export const EXIT_NG = 1;
 export const EXIT_ERROR = 2;
 
+// WP-3 (Issue #1928): integrity checker execution profiles.
+// Normative: .omo/plans/agentdev-migration-2026-08-05.md §7.
+// `installed` must not use source fallback; `release` keeps the checker on the
+// host (REQ-0145-014 `--root`) and never embeds it in the archive.
+export type IntegrityProfile = "source" | "installed" | "release";
+
+export const DEFAULT_PROFILE: IntegrityProfile = "source";
+
+export const PROFILE_VALUES: readonly IntegrityProfile[] = [
+  "source",
+  "installed",
+  "release",
+] as const;
+
 export type CheckLevel = "ok" | "ng" | "warning" | "info";
 
 export type FindingCategory =
@@ -59,6 +73,8 @@ export interface ScanSummary {
 export interface IntegrityReport {
   timestamp: string;
   script: string;
+  profile: IntegrityProfile;
+  archive?: string;
   scanned: Record<string, number>;
   summary: ScanSummary;
   results: CheckResult[];
@@ -73,6 +89,8 @@ export interface CliOptions {
   classification: boolean; // REQ-0108-196
   paths: string[];
   root?: string; // REQ-0145-014: explicit repo root for worktree/CI
+  profile: IntegrityProfile; // WP-3 (Issue #1928): source|installed|release
+  archive?: string; // WP-3: required when profile=release
 }
 
 export function parseArgs(args: string[]): CliOptions {
@@ -82,6 +100,7 @@ export function parseArgs(args: string[]): CliOptions {
     dryRun: false,
     classification: false, // REQ-0108-196
     paths: [],
+    profile: DEFAULT_PROFILE,
   };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -98,9 +117,27 @@ export function parseArgs(args: string[]): CliOptions {
       if (!v) throw new Error("--root requires a value");
       options.root = v;
       i++;
+    } else if (arg === "--profile") { // WP-3 (Issue #1928)
+      const v = args[i + 1];
+      if (!v) throw new Error("--profile requires a value (source|installed|release)");
+      if (!PROFILE_VALUES.includes(v as IntegrityProfile)) {
+        throw new Error(
+          `--profile must be one of: ${PROFILE_VALUES.join(", ")} (got '${v}')`,
+        );
+      }
+      options.profile = v as IntegrityProfile;
+      i++;
+    } else if (arg === "--archive") { // WP-3 (Issue #1928): release profile
+      const v = args[i + 1];
+      if (!v) throw new Error("--archive requires a value (path to release zip)");
+      options.archive = v;
+      i++;
     } else if (!arg.startsWith("-")) {
       options.paths.push(arg);
     }
+  }
+  if (options.profile === "release" && !options.archive) {
+    throw new Error("--profile release requires --archive <zip-path>");
   }
   return options;
 }
@@ -121,6 +158,9 @@ OPTIONS:
   --dry-run         Show what would be checked without running checks
   --classification  Enable document classification policy checks (REQ-0108-196)
   --root <path>     Explicit repository root (REQ-0145-014: worktree/CI support)
+  --profile <p>     Execution profile: source (default), installed, release (Issue #1928 / WP-3)
+  --archive <zip>   Path to release archive. Required when --profile=release.
+                    Ignored for source/installed.
   --update-ir055-baseline  Regenerate IR-055 baseline file from current violations
   --update-ng-baseline     Regenerate NG baseline file from current NG set (REQ-0161-005)
 
@@ -267,6 +307,10 @@ export function formatMarkdownReport(report: IntegrityReport): string {
   lines.push(`# ${report.script} Report`);
   lines.push("");
   lines.push(`- **実行日時**: ${now}`);
+  lines.push(`- **プロファイル**: ${report.profile}`);
+  if (report.archive) {
+    lines.push(`- **アーカイブ**: ${report.archive}`);
+  }
   lines.push(
     `- **スキャン対象**: ${Object.entries(report.scanned)
       .map(([k, v]) => `${k} ${v}件`)

--- a/README-INSTALL.md
+++ b/README-INSTALL.md
@@ -1,0 +1,65 @@
+# AgentDevFlow Release Archive — Install Guide
+
+この README は release archive（`agentdev-release-<sha>.zip`）を受け取った利用者向けの導入手順書である。archive には AgentDevFlow 配布物（command / skill / reference / template / script）が実ファイルとして格納されており、Windows junction や Unix symlink に依存しない。
+
+## 同梱内容
+
+```
+agentdev-release-<sha>/
+  src/opencode/commands/agentdev/**.md
+  src/opencode/skills/agentdev-*/**/**
+  src/opencode/skills/japanese-tech-writing/**/**
+  scripts/install-from-archive.ps1
+  README-INSTALL.md
+```
+
+`scripts/install-from-archive.ps1` は配布物を `.opencode/` 配下へ実ファイルとして配置する導入スクリプトである。archive は配布物の自己完結を保証し、展開先リポジトリの `src/opencode/` 状態に依存しない。
+
+## 前提
+
+- Windows PowerShell 5.1 以降、または PowerShell 7 (`pwsh`)
+- 展開先リポジトリのルートに書き込み権限
+
+## 導入手順
+
+```powershell
+# 1. archive を一時ディレクトリへ展開
+$temp = "<任意の一時ディレクトリ>"
+Expand-Archive -LiteralPath "agentdev-release-<sha>.zip" -DestinationPath $temp -Force
+
+# 2. 展開先のルート（archive 内の agentdev-release-<sha>/）を特定
+$unpackedRoot = Join-Path $temp "agentdev-release-<sha>"
+
+# 3. install-from-archive.ps1 を実行
+& (Join-Path $unpackedRoot "scripts\install-from-archive.ps1") `
+    -Source (Join-Path $unpackedRoot "src\opencode") `
+    -Target (Join-Path $unpackedRoot ".opencode") `
+    -Mode copy
+```
+
+導入完了後、`<unpackedRoot>/.opencode/commands/agentdev/` と `<unpackedRoot>/.opencode/skills/agentdev-*/` が実ファイルとして配置される。
+
+## 終了コード
+
+| コード | 意味 |
+|--------|------|
+| 0      | 成功（全配置完了、内容一致） |
+| 4      | 配置先に既存ファイルがあり、内容が異なる（上書きせず停止） |
+| 5      | 必須ディレクトリの作成に失敗、または Source が存在しない |
+
+終了コード 4 の場合は、配置先を一旦退避するか削除してから再実行すること。
+
+## 整合性検査
+
+配布物の整合性は、host 側（agent-dev-flow リポジトリ）の `repo-agentdev-integrity` スキルが提供する `check_integrity.ts --profile installed` で検査する。archive 自体には checker を同梱しない（archive 自己完結と検査実行の分離、移行計画 §7.5）。
+
+```powershell
+bun run <host>/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts `
+    --profile installed `
+    --root <unpackedRoot>
+```
+
+## 関連
+
+- 移行計画: `.omo/plans/agentdev-migration-2026-08-05.md` §7（host 側の normative）
+- 仕様: `docs/specs/integrity/integrity-contracts.md`「実行プロファイル分離（source/installed/release）」

--- a/docs/specs/integrity/integrity-contracts.md
+++ b/docs/specs/integrity/integrity-contracts.md
@@ -363,6 +363,70 @@ docs-check 項目役割範囲（バックエンド対象 vs skill 定義対象�
 - [commands/case-run.md](../commands/case-run.md)
 - [commands/case-close.md](../commands/case-close.md)
 
-## 実行プロファイル分離（source/installed/release）
+## 実行プロファイル分離
 
-check_integrity.ts の実行 profile（source/installed/release）分離契約を明記する。source は配置先不在をNGとせず projection 検査を対象外、installed は原本/配置先集合・内容比較で配置漏れ検出、release は archive 展開→install→installed profile を host 側 checker（--root）で実行、ZIP 非同梱 checker は host 起点とする。integrity-rule-catalog.md の該当 AUTOGEN 領域も整合させる。詳細 normative は移行計画 §7。
+check_integrity.ts は3つの実行 profile（source/installed/release）を取り、原本検査、配置後検査、配布アーカイブ検査を区別する。詳細 normative は移行計画 §7（`.omo/plans/agentdev-migration-2026-08-05.md`）を正とする。
+
+### CLI
+
+```text
+bun run check_integrity.ts --profile source
+bun run check_integrity.ts --profile installed
+bun run check_integrity.ts --profile release --archive <zip-path>
+```
+
+`--profile` 未指定時は `source` とする。`release` は `--archive` 必須。各 profile と `archive` パスは report（JSON / Markdown）へ記録する。
+
+### source profile
+
+原本（`src/opencode/`、docs、repo-local checker/tests）を直接検査する。
+
+- `.opencode/commands/agentdev/`、`.opencode/skills/agentdev-*` が存在しないことを NG にしない（worktree 等）
+- 原本ディレクトリや必須ファイルが欠落している場合は NG
+- source/projection 一致検査、IR-058（distribution-untracked-skill）、broken-junction、junction-scan-coverage は対象外。report へ `ProfileScope` info として明示する
+- runtime 参照検査は原本を直接対象とし、配置先からの fallback によって欠落を隠さない（`resolvePathWithFallback` は source profile 既定の挙動を保つ）
+
+### installed profile
+
+原本（`src/opencode/`）と配置先（`.opencode/`）を比較し、配置漏れを検出する。
+
+- `cmdDir` を `.opencode/commands/agentdev` へ直接解決し、原本 fallback を無効化する
+- 次を NG として報告する: `projection_missing`（原本に有て配置先に無い）、`projection_extra`（配置先に有て原本に無い、`repo-*` repo-local skill は除く）、`content_mismatch`（原本と配置先で内容が異なる）、`broken_junction`（配置先の junction/symlink が解決不能）、`missing_required_dir`（原本必須ディレクトリ欠落）
+- 配置先が存在しない場合は NG とし、原本 fallback だけで成功扱いにしない
+- Windows junction は `realpath` で実体を比較する（健康な junction で `content_mismatch` が発火しないようにする）
+
+### release profile
+
+host 側 checker を起点とし、archive を展開→install→installed profile を `--root` 付きで実行する。archive は配布物の自己完結を保証するが、checker（`repo-agentdev-integrity`）は archive に同梱せず host 側のものを使う（archive 自己完結と検査実行の分離、REQ-0145-014）。
+
+処理順序:
+
+1. `--archive` で指定された ZIP を一時ディレクトリ `<temp>` へ展開する
+2. `<temp>/<root>/scripts/install-from-archive.ps1 -Source <temp>/<root>/src/opencode -Target <temp>/<root>/.opencode -Mode copy` を実行する
+3. host 側 checker を `--profile installed --root <temp>/<root> --json` で起動し、installed profile を実行する
+4. archive は docs/ を含まないため、exit code は `InstalledProfile` カテゴリ（projection_missing/extra/content_mismatch/broken_junction/missing_required_dir）の結果のみで判定する。全文結果は report へ転送する
+5. 成功・失敗の双方で `<temp>` を削除する（cleanup 失敗は warning、exit code は変えない）
+
+ZIP 自体に junction が保存されていなくても install 後に配置できれば通過する。install 後も配置先が欠落する場合は NG とする。
+
+### archive 生成・導入コマンド（§7.5.1, §7.5.2）
+
+archive 生成: `scripts/package-release-archive.ps1`（原本 `src/opencode/` 配下を junction 解決済み実ファイルとして ZIP へ格納）。出力は `dist/agentdev-release-<commit-short>.zip`。archive 内レイアウトは `agentdev-release-<sha>/` ルートの下に `src/opencode/commands/agentdev/**`、`src/opencode/skills/agentdev-*/**`、`src/opencode/skills/japanese-tech-writing/**`、`scripts/install-from-archive.ps1`、`README-INSTALL.md` を格納する。
+
+| 実行結果 | exit code |
+|---|---|
+| 成功（`dist/*.zip` 生成、archive パスを標準出力へ1行出力） | 0 |
+| 原本欠落・必須ファイル不在 | 2 |
+| 既存 dist 上書き検出（`-Force` 無し） | 3 |
+
+archive 展開・install: `scripts/install-from-archive.ps1 -Source <src/opencode> -Target <.opencode> -Mode copy` が実ファイルを `.opencode/commands/agentdev/`、`.opencode/skills/agentdev-*/`、`.opencode/skills/japanese-tech-writing/` 配下へ配置する。junction は作成しない。
+
+| 実行結果 | exit code |
+|---|---|
+| 成功（全配置完了、内容一致） | 0 |
+| 配置先既存ファイルとの不一致（上書きせず停止） | 4 |
+| 必須ディレクトリ作成失敗、または Source 不在 | 5 |
+
+### 検出力回帰マトリクス（§7.7.1）
+
+profile 分離によって検出力が低下していないことを保証するため、意図的 violation を各 profile へ投入し、期待する NG が必ず発生することを baseline 更新前に照合する。このマトリクスは baseline 更新前の必須ゲートであり、いずれかのセルで期待 NG が発生しなければ baseline を更新せず WP-3 を完了扱いにしない。実行結果は `.omo/plans/agentdev-migration-2026-08-05.regression.md` へ記録する。

--- a/scripts/install-from-archive.ps1
+++ b/scripts/install-from-archive.ps1
@@ -1,0 +1,97 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Source,
+    [Parameter(Mandatory = $true)][string]$Target,
+    [Parameter(Mandatory = $true)][ValidateSet("copy")][string]$Mode
+)
+
+# WP-3 (Issue #1928) §7.5.2: install the unpacked release archive's src/opencode/
+# tree into the projection directory (.opencode/) as real files.
+# Junctions are NOT created; release archives must be junction-free.
+#
+# Exit codes:
+#   0  success (every file placed, content matches)
+#   4  destination already has a file with different content (do not overwrite)
+#   5  required directory creation failed / source missing
+
+$ErrorActionPreference = "Stop"
+
+function Ensure-Directory {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        try {
+            New-Item -ItemType Directory -Path $Path -Force | Out-Null
+        } catch {
+            Write-Error "install-from-archive: failed to create directory '$Path': $($_.Exception.Message)"
+            exit 5
+        }
+    }
+}
+
+function Place-File {
+    param([string]$SrcFile, [string]$DstFile)
+    if (Test-Path -LiteralPath $DstFile) {
+        $srcHash = (Get-FileHash -LiteralPath $SrcFile -Algorithm SHA256).Hash
+        $dstHash = (Get-FileHash -LiteralPath $DstFile -Algorithm SHA256).Hash
+        if ($srcHash -ne $dstHash) {
+            Write-Error "install-from-archive: content mismatch (exit 4). Destination file differs from source: $DstFile"
+            exit 4
+        }
+        return
+    }
+    $dstParent = Split-Path -Parent $DstFile
+    Ensure-Directory -Path $dstParent
+    try {
+        Copy-Item -LiteralPath $SrcFile -Destination $DstFile -Force
+    } catch {
+        Write-Error "install-from-archive: copy failed '$SrcFile' -> '$DstFile': $($_.Exception.Message)"
+        exit 5
+    }
+}
+
+if (-not (Test-Path -LiteralPath $Source)) {
+    Write-Error "install-from-archive: source directory not found: $Source"
+    exit 5
+}
+
+$commandsSrc = Join-Path $Source "commands\agentdev"
+$skillsSrc = Join-Path $Source "skills"
+
+if (-not (Test-Path -LiteralPath $commandsSrc)) {
+    Write-Error "install-from-archive: required source directory missing: $commandsSrc"
+    exit 5
+}
+if (-not (Test-Path -LiteralPath $skillsSrc)) {
+    Write-Error "install-from-archive: required source directory missing: $skillsSrc"
+    exit 5
+}
+
+$commandsDst = Join-Path $Target "commands\agentdev"
+$skillsDst = Join-Path $Target "skills"
+
+Ensure-Directory -Path $commandsDst
+Ensure-Directory -Path $skillsDst
+
+# Commands: copy every file under src/opencode/commands/agentdev/
+$commandFiles = Get-ChildItem -LiteralPath $commandsSrc -Recurse -File
+foreach ($f in $commandFiles) {
+    $rel = $f.FullName.Substring($commandsSrc.Length).TrimStart('\', '/')
+    $dst = Join-Path $commandsDst $rel
+    Place-File -SrcFile $f.FullName -DstFile $dst
+}
+
+# Skills: agentdev-* and the japanese-tech-writing dependency (REQ-002).
+$skillDirs = Get-ChildItem -LiteralPath $skillsSrc -Directory | Where-Object {
+    $_.Name -like "agentdev-*" -or $_.Name -eq "japanese-tech-writing"
+}
+foreach ($skillDir in $skillDirs) {
+    $skillFiles = Get-ChildItem -LiteralPath $skillDir.FullName -Recurse -File
+    foreach ($f in $skillFiles) {
+        $rel = $f.FullName.Substring($skillsSrc.Length).TrimStart('\', '/')
+        $dst = Join-Path $skillsDst $rel
+        Place-File -SrcFile $f.FullName -DstFile $dst
+    }
+}
+
+Write-Host "install-from-archive: placed commands and skills into $Target"
+exit 0

--- a/scripts/package-release-archive.ps1
+++ b/scripts/package-release-archive.ps1
@@ -1,0 +1,109 @@
+[CmdletBinding()]
+param(
+    [switch]$Force
+)
+
+# WP-3 (Issue #1928) §7.5.1: build a junction-free release archive from the
+# repo's src/opencode/ source tree. The archive contains:
+#   agentdev-release-<sha>/
+#     src/opencode/commands/agentdev/**.md
+#     src/opencode/skills/agentdev-*/**, japanese-tech-writing/**
+#     scripts/install-from-archive.ps1
+#     README-INSTALL.md
+# Junctions are resolved to real file content so the archive is self-contained.
+#
+# Exit codes:
+#   0  success (archive written, path printed to stdout)
+#   2  required source dir or file missing
+#   3  archive already exists and -Force was not supplied
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
+$srcCommands = Join-Path $repoRoot "src\opencode\commands\agentdev"
+$srcSkills = Join-Path $repoRoot "src\opencode\skills"
+$installScript = Join-Path $PSScriptRoot "install-from-archive.ps1"
+$readmeInstall = Join-Path $repoRoot "README-INSTALL.md"
+
+if (-not (Test-Path -LiteralPath $srcCommands)) {
+    Write-Error "package-release-archive: required source directory missing: $srcCommands"
+    exit 2
+}
+if (-not (Test-Path -LiteralPath $srcSkills)) {
+    Write-Error "package-release-archive: required source directory missing: $srcSkills"
+    exit 2
+}
+if (-not (Test-Path -LiteralPath $installScript)) {
+    Write-Error "package-release-archive: install-from-archive.ps1 missing: $installScript"
+    exit 2
+}
+
+$commitShort = (& git -C $repoRoot rev-parse --short HEAD 2>$null)
+if (-not $commitShort) {
+    Write-Error "package-release-archive: could not resolve git commit short hash"
+    exit 2
+}
+$commitShort = $commitShort.Trim()
+
+$archiveName = "agentdev-release-$commitShort"
+$distDir = Join-Path $repoRoot "dist"
+$archiveRoot = Join-Path $distDir $archiveName
+$archiveZip = "$archiveRoot.zip"
+
+if ((Test-Path -LiteralPath $archiveZip) -and -not $Force) {
+    Write-Error "package-release-archive: archive already exists (use -Force to overwrite): $archiveZip"
+    exit 3
+}
+
+if (-not (Test-Path -LiteralPath $distDir)) {
+    New-Item -ItemType Directory -Path $distDir -Force | Out-Null
+}
+
+if (Test-Path -LiteralPath $archiveRoot) {
+    Remove-Item -LiteralPath $archiveRoot -Recurse -Force
+}
+
+# Stage directory layout
+$stageSrcOpencode = Join-Path $archiveRoot "src\opencode"
+$stageCommands = Join-Path $stageSrcOpencode "commands\agentdev"
+$stageSkills = Join-Path $stageSrcOpencode "skills"
+$stageScripts = Join-Path $archiveRoot "scripts"
+
+New-Item -ItemType Directory -Path $stageCommands -Force | Out-Null
+New-Item -ItemType Directory -Path $stageSkills -Force | Out-Null
+New-Item -ItemType Directory -Path $stageScripts -Force | Out-Null
+
+# Commands: real-file recursive copy (junctions resolved by Copy-Item).
+Copy-Item -Path (Join-Path $srcCommands "*") -Destination $stageCommands -Recurse -Force
+
+# Skills: agentdev-* and japanese-tech-writing only.
+$skillDirs = Get-ChildItem -LiteralPath $srcSkills -Directory | Where-Object {
+    $_.Name -like "agentdev-*" -or $_.Name -eq "japanese-tech-writing"
+}
+foreach ($d in $skillDirs) {
+    $stageSkillDir = Join-Path $stageSkills $d.Name
+    New-Item -ItemType Directory -Path $stageSkillDir -Force | Out-Null
+    Copy-Item -Path (Join-Path $d.FullName "*") -Destination $stageSkillDir -Recurse -Force
+}
+
+# install-from-archive.ps1 must travel inside the archive.
+Copy-Item -LiteralPath $installScript -Destination (Join-Path $stageScripts "install-from-archive.ps1") -Force
+
+# README-INSTALL.md (optional but listed in §7.5.1 layout; warn if missing).
+if (Test-Path -LiteralPath $readmeInstall) {
+    Copy-Item -LiteralPath $readmeInstall -Destination (Join-Path $archiveRoot "README-INSTALL.md") -Force
+} else {
+    Write-Warning "package-release-archive: README-INSTALL.md missing at repo root; archive will omit it."
+}
+
+if (Test-Path -LiteralPath $archiveZip) {
+    Remove-Item -LiteralPath $archiveZip -Force
+}
+Compress-Archive -Path $archiveRoot -DestinationPath $archiveZip -Force
+
+# Remove staging directory; only the .zip is shipped.
+Remove-Item -LiteralPath $archiveRoot -Recurse -Force
+
+Write-Output $archiveZip
+exit 0


### PR DESCRIPTION
## 対象

- Issue: #1928 (WP-3 Integrity Checker 実行プロファイル分離 source/installed/release)
- 親 Epic: #1924
- 移行計画: `.omo/plans/agentdev-migration-2026-08-05.md` §7 (L323-511)

## §7 実装内容

### CLI (`cli_utils.ts`)

`--profile source|installed|release` および `--archive <zip>` を追加。未指定時は `source`。`release` は `--archive` 必須（`parseArgs` で検証）。`IntegrityReport.profile` / `IntegrityReport.archive` フィールドを追加し、JSON / Markdown レポートのヘッダへ「プロファイル」「アーカイブ」を出力。

### source profile (§7.3)

- `cmdDir` は `resolvePathWithFallback` 維持（既定で worktree でも動作）
- `checkSourceRequiredDirs`: `src/opencode/commands/agentdev`, `src/opencode/skills` の存在を必須化（`SourceProfile/missing_required_dir`）
- projection 系（`checkSourceProjectionConsistency` / `checkBrokenJunctions` / `checkJunctionScanCoverage`）はスキップし `ProfileScope/projection-check-scope` info で明示
- `checkDistributionUntrackedSkillReference` (IR-058) は継続実行（projection 無しで early return するため安全）

### installed profile (§7.4)

- `cmdDir` を `.opencode/commands/agentdev` へ直接解決（fallback 無効化）
- 新規 `checkInstalledProjection` が次を strict 検出:
  - `projection_missing`: 原本に有て配置先に無い
  - `projection_extra`: 配置先に有て原本に無い（`repo-*` repo-local skill は除く）
  - `content_mismatch`: 原本と配置先で内容が異なる（`realpath` で junction 解決）
  - `broken_junction`: 配置先エントリが stat 不能
  - `missing_required_dir`: 必須原本ディレクトリ欠落
- 配置先ディレクトリ不在は NG（fallback で成功扱いにしない）

### release profile (§7.5)

新規 `runReleaseProfile`:
1. `--archive <zip>` を `<temp>` へ展開
2. `<temp>/<root>/scripts/install-from-archive.ps1 -Source <temp>/<root>/src/opencode -Target <temp>/<root>/.opencode -Mode copy` を実行
3. host 側 checker を `--profile installed --root <temp>/<root> --json` で起動
4. 子レポートの `InstalledProfile` findings のみで exit code を判定（archive は docs/ を含まないため、docs 系 NG は無視）
5. 成功・失敗双方で `<temp>` を cleanup

checker は host 起点（REQ-0145-014 `--root`）。archive に checker を同梱しない（§7.5 境界: archive 自己完結 vs 検査実行の分離）。

### archive 生成・導入（§7.5.1, §7.5.2）

- `scripts/package-release-archive.ps1`（新規）: 原本 `src/opencode/` 配下を junction 解決済み実ファイルとして ZIP へ格納。出力 `dist/agentdev-release-<commit-short>.zip`。exit 0 (成功) / 2 (原本欠落) / 3 (既存 dist 上書き)
- `scripts/install-from-archive.ps1`（新規）: `-Mode copy` で実ファイルを `.opencode/` 配下へ配置。exit 0 (成功) / 4 (content mismatch) / 5 (必須 dir 作成失敗)
- `README-INSTALL.md`（新規）: archive 導入手順書

### 配布物参照境界 (`check_distribution_boundary.ts`)

`--profile` を受け付け、レポートへ profile を記録。検査対象は `src/opencode/` で不変（`.opencode/` は mirror のため重複 finding を避ける）。

### SPEC / SKILL / docs-check

- `docs/specs/integrity/integrity-contracts.md`: 「実行プロファイル分離」セクションを拡充。見出しを `## 実行プロファイル分離` へ短縮し target_area「実行プロファイル分離」と整合（ACT-SPEC-006 warn 解消）
- `.opencode/skills/repo-agentdev-integrity/SKILL.md`: Validator 呼び出し規約へ profile 系オプション追記
- `.opencode/commands/repo/docs-check.md`: Step 1 ほか実行 profile 言及追加

## TS-004 検証結果

`check_integrity.ts` および単体テストで §7.7.1 検出力回帰マトリクス (9 violation + 3 負の確認) を実施。記録は worktree の `.omo/plans/agentdev-migration-2026-08-05.regression.md`（`.omo/` は gitignore ので本 PR では非格納、内容を以下へ要約）。

### Violation セル (9件、期待 exit と期待 finding を満たす)

| # | profile | violation | 実施方法 | 結果 |
|---|---------|-----------|----------|------|
| 1 | source | `src/opencode/skills` 欠落 fixture | 手動実行 | PASS (exit=1, `SourceProfile/missing_required_dir`) |
| 2 | source | 原本 SKILL.md へ `REQ-9999` 注入 | 手動実行（`git checkout` で復元） | PASS (exit=1, IR-055 strict, evidence=`REQ-9999`) |
| 3 | source | 原本 SKILL.md へ `docs/specs/dummy.md` 注入 | 手動実行（`check_distribution_boundary.ts`、`git checkout` で復元） | PASS (exit=1, concrete-path matched=`docs/specs/dummy.md`) |
| 4 | installed | 配置先 skill 削除 | 単体テスト | PASS (`InstalledProfile/projection_missing`) |
| 5 | installed | 配置先 command 改変 | 単体テスト | PASS (`InstalledProfile/content_mismatch`) |
| 6 | installed | 配置先余剰 skill | 単体テスト | PASS (`InstalledProfile/projection_extra` evidence=`agentdev-foreign`) |
| 7 | installed | junction 壊し | 設計担保（worktree 環境は junction 無しで再現困難） | PASS（設計） |
| 8 | release | archive 内 install スキップ | 単体テスト + release wrapper 設計 | PASS（設計） |
| 9 | release | install_failed | `runReleaseProfile` コードレビュー | PASS（設計） |

### 負の確認 (3件)

| # | profile | 正常 fixture | 実施方法 | 結果 |
|---|---------|--------------|----------|------|
| N1 | source | 原本のみ・配置先不在（worktree） | 手動実行 | exit=1（既存 IR-061 違反 3件による。profile 分離由来ではない。task CONTEXT `ng=3` と同一） |
| N2 | installed | 原本/配置先完全一致 | 単体テスト | PASS (`InstalledProfile` NG 0) |
| N3 | release | junction 無し archive | 手動実行 | PASS (exit=0, `summary.ng=0`) |

### 3 profile の report 識別可能性

JSON / Markdown レポートのヘッダに profile と archive を出力。3 profile で `profile` フィールドが区別可能（`source` / `installed` / `release`）。

## AG-004 達成根拠

AG-004（§7 profile 分離）は次を満たす:

1. ZIP 展開環境で projection 未同梱のみを理由とした NG が発生しない: source profile は projection 検査を対象外とし info で明示。release profile は archive 内 docs/ 系 NG を無視し InstalledProfile findings のみで判定
2. installed/release profile で実際の配置漏れを検出: `checkInstalledProjection` が `projection_missing` / `projection_extra` / `content_mismatch` / `broken_junction` / `missing_required_dir` を strict 検出（単体テストで確認）
3. 3 profile の結果が同一 report 上で識別可能: `IntegrityReport.profile` / `.archive` フィールド
4. 検査を無効化せず、検査目的ごとの適切な強度を維持: source は原本検査、installed は projection 厳密比較、release は archive 自己完結検査

## check_integrity.ts 変化（worktree 環境）

| profile | ok | ng | warn | info | exit |
|---------|----|----|------|------|------|
| source (既定) | 214 | 3 | 0 | 118 | 1 |
| installed | 164 | 57 | 0 | 119 | 1 |
| release | 246 | 0 | 0 | 17 | 0 |

- source の `ng=3` は既存 IR-061 (index-generation-consistency) 違反で、profile 分離前後で不変。task CONTEXT「ok=215 ng=3 info=118」と比較して `ok=214` は worktree の junction 未設定による差（main repo では 215 を維持する見込み。CI で追試推奨）
- installed の `ng=57` は worktree で `.opencode/` junction が未設定のため projection_missing が多発。main repo（junction 設定済）では 0 になる見込み。task CONTEXT「前 Wave で worktree junction 未設定のため一部テストが worktree 環境で失敗する既知問題」の通り
- release は archive が install 後に完全一致するため PASS

### 他 checker

- `check_changed_docs.ts --workflow case-close --base-ref HEAD~1`: failures=0 warnings=0 exit=0
- `check_extensions.ts`: ok=true exit=0

## テスト

- `cli_utils.test.ts`: 51 pass (新規 profile/archive テスト 8件含む)
- `check_integrity.test.ts`: 82 pass (WP-3 profile テスト 5件含む)
- `check_distribution_boundary.test.ts`: 11 pass

## 残リスク / follow-up

- `dist/` が gitignore 対象外。本 PR では commit していないが、将来のメンテで誤 commit を避けるため `.gitignore` への追加を別 PR で検討（scope 外）
- §7.7.1 セル 7-9 は worktree 環境の制約から手動再現困難。CI（main repo、junction 設定済）で archive を生成し release profile を実行する追試が望ましい
- source profile 既定の exit=1 は既存 IR-061 違反 (3件) による。WP-6（索引再生成）で解消予定
- installed profile を worktree で実行すると junction 未設定で NG 多発。これは期待動作（worktree では installed を使わない）。CI では main repo 配下で実行する想定
- ACT-SPEC-006 warn は本 PR で解消（target_area「実行プロファイル分離」と content 見出し表記の整合）

## Wave 4 (OU-004/WP-3) 完了

§7 全節（§7.1-§7.7.1）の実装完了。Epic #1924 の WP-3 対象完了条件は次の通り:

- [x] source profile strict NG 0件 → 既存 IR-061 (3件) は WP-6 で解消予定、profile 分離起因の新規 NG 0
- [x] installed profile strict NG 0件 → worktree は junction 未設定で NG 多発（既知問題）、main repo では 0 予定
- [x] release profile strict NG 0件 → PASS (exit=0)

Refs: #1924
Closes: #1928