### PR TITLE
refactor(WP-4): agentdev command 薄型化（主要7 + 二次3 計10ファイル）

### DIFF
--- a/src/opencode/commands/agentdev/backlog-review.md
+++ b/src/opencode/commands/agentdev/backlog-review.md
@@ -33,51 +33,11 @@ description: 採用済み成果物を分析、統合し、ユーザー承認後�
 
 ## RU フォーマット
 
-RU-*.md は以下の構造に従う:
-
-```markdown
----
-source_type: {intake | learning | inspect | mixed | chat}
-generated_by: backlog-review
-generated_at: {ISO 8601 timestamp}
-status: draft
-  depends_on: [RU-{NNNN}] (optional)
-  tentative_classification: {REQ | 挙動SPEC | カタログSPEC | guide | learning維持 | 作業記録 | 対象外} (REQ)
-  sources:
-  - path: {.agentdev/intake/promoted/xxx.md | .agentdev/learning/promoted/xxx.md | .agentdev/inspect/promoted/xxx.md}
-    type: {intake | learning | inspect}
----
-
-## Sources
-
-{各 source artifact の要点抽出。パススルー禁止}
-
-## Source Summary
-
-{全 source の共通テーマ・論点の統合サマリ}
-
-## 統合理由
-
-{N:1 統合または 1:N 分割の理由}
-
-## 要件化の方向
-
-{req-define に渡す要件化の方向性}
-```
+RU-*.md の構造（frontmatter: `source_type`, `generated_by`, `generated_at`, `status`, `depends_on`, `tentative_classification`, `sources` / 本文: Sources, Source Summary, 統合理由, 要件化の方向）は `agentdev-backlog-integration` を正とする。`tentative_classification` は document-model SPEC（extension 経由）の文書7分類モデル（REQ、挙動SPEC、カタログSPEC、guide、learning維持、作業記録、対象外）のいずれかを記録する（REQ）。
 
 ## session由来RU 生成形式（参照）
 
-`source_type: chat` かつ `generated_by: session` のRU（session由来RU）の生成形式は、一時成果物ライフサイクル要件と artifact-contracts SPEC「RU アーティファクト契約（session由来RU）」セクションを正規原本とする。本コマンドは同契約を再定義せず、以下を参照ポイントとして扱う。
-
-- frontmatter 必須フィールド: 通常のRU フィールドに加え `generation_actor`、`agreement_confirmed_at`、`generation_stage`、`logical_key` を必須とする（SPEC「frontmatter 必須フィールド」表）
-- 二段階承認: 第1承認はRU案内容のみを対象とし、第2承認のみが採番、保存、commit、push を許可する（SPEC「二段階承認」）
-- `agreement_confirmed_at` と `generated_at`: ISO 8601 形式で `generated_at >= agreement_confirmed_at` を満たし、保存完了前に req-define を開始しない
-- session 論理URI: `sources[].type: chat` の場合のみ `sources[].path` へ `session:...` を解決しない論理URIとして許可する（SPEC「session 論理URI」）
-- RU 本文必須8セクション: 目的、対象、対象外、正規所有者とアンカー、依存関係、要件化の方向、決定的受け入れ条件、Source Summary（SPEC「RU 本文必須8セクション」）
-- 永続ID 採番: 保存時に既存最大番号+1で割り当て、保存後の `depends_on` は RU-ID で記録する（SPEC「保存先と永続ID」）
-- `tentative_classification`: 既存7値のいずれか。欠落時はRU 生成を停止する
-
-各項目の判定基準、検証観点は正規原本（一時成果物ライフサイクル要件 + artifact-contracts SPEC）へ委譲する。
+`source_type: chat` かつ `generated_by: session` のRU（session由来RU）の生成形式は、一時成果物ライフサイクル要件と artifact-contracts SPEC「RU アーティファクト契約（session由来RU）」セクションを正規原本とする。本コマンドは frontmatter 必須フィールド、二段階承認、`agreement_confirmed_at`、session 論理URI、RU 本文必須8セクション、永続ID 採番、`tentative_classification` の各要件を同 SPEC へ委譲し、再定義しない
 
 ## 手順
 

--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -8,12 +8,7 @@ description: req-save→spec-save→case-open→case-run→case-closeを順次�
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-auto.yaml`）を読み込む。
-
-- extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
-- extension が存在しない場合は標準動作で続行する
-- extension が破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する
-- 詳細な読み込み契約は `agentdev-project-extensions` skill 参照
+本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-auto.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
 ## 入力
 
@@ -46,196 +41,14 @@ description: req-save→spec-save→case-open→case-run→case-closeを順次�
 ### Step 3: 工程分岐（`work_type` 固定分岐ではなく `artifact_actions` 存在による動的判定）
 
 - **Issue番号/URL入力**: case-run → case-close（req-save、spec-save、case-open、work_type読取をスキップ）。Step 1 で解決した Issue番号/URL を case-run にそのまま渡す。draft-data の読取は行わない
-- **artifact_actions ベース分岐**:
-  - `artifact: req` または `artifact: adr` entry → req-save を実行
-  - `artifact: spec` entry → spec-save を実行（req-save の後）。entry が空ならスキップ。`artifact_actions` フィールド不存在（旧形式 draft）は後方互換で spec-save スキップ
-  - 常に → case-open → case-run → case-close
+- **artifact_actions ベース分岐**: `artifact: req` または `artifact: adr` entry → req-save を実行。`artifact: spec` entry → spec-save を実行（req-save の後、entry が空ならスキップ、`artifact_actions` フィールド不存在は後方互換で spec-save スキップ）。常に → case-open → case-run → case-close
 - **auto_gate preflight**: `draft-data` の `auto_gate.auto_ready` が false または未解決 item（unresolved_questions/ unresolved_conflicts/ out_of_repo_operations/ stop_reasons）が残る場合は停止
+
 ### Step 4: 各工程の実行
 
-#### 実行モデル原則
+実行モデル原則、工程別契約（req-save+spec-save 統合委譲 AG-005、case-open、case-run インライン実行 AG-001/002、case-close）、QG-1〜QG-4 の継承、タイムスタンプ計測（L1）、インライン実行時のコンテキスト管理、結果状態の4次元集約（工程結果 / artifact_action 適用結果 / 定義適用工程の完了状態 / OU ライフサイクル完了状態、warn 変換禁止）、case-open 完了後の分岐（Standard flow / Epic Issue flow、クリーンアップ検証ゲート）、Wave 反復制御（case-auto 直接制御 AG-003、Epic Issue 本文読み取りのみ、子Issue インライン case-run 並列実行 最大5件、委譲→case-close(#epic)、次 Wave 判定、blocked/failed の扱い）、OU 処理順序（必須依存で結合した execution_unit 群は順次、必須依存のない execution_unit 群は並列、3つの「5件」文脈の区別）、クリーンアップ検証ゲート（ドラフト/RU 削除検証）、委譲起動判定（AG-004、delegation-unavailable 停止条件）、Subagent 委譲プロトコル（category 選定ガイドライン、MUST NOT DO 必須化）、orchestration stage モデル（stage 1 case-open / stage 2 case-run bg task 最大5件 / stage 3 case-close）、子 task bg task 破棄検知時の回復（AG-001〜AG-004、3状態分類、ライフサイクル分離）の各詳細は `agentdev-workflow-orchestration`、`agentdev-case-run-execution-adapter`、`agentdev-git-worktree`、各対応 skill を参照。case-run インライン実行時も case-run.md を authoritative source として読み込む
 
-- **委譲工程**（req-save / spec-save / case-open / case-close）: 各コマンドの委譲契約に従い起動。**インライン実行は原則禁止**（コンテキスト枯渇防止）。委譲起動不能時は後述「委譲起動判定」に従い `delegation-unavailable` として報告（AG-004）
-- **case-run**: **インライン実行**（標準動作、AG-001）。case-run.md を authoritative source として読み込み、準備フェーズ（worktree 作成、委譲 prompt 構築等）とクリーンアップフェーズ（worktree 削除、result 処理等）を case-auto が自ら実行。実行担当サブエージェント委譲フェーズでは case-auto から直接委譲し、委譲チェーンを case-auto → 実行担当サブエージェントの1段階に圧縮（委譲起点の折りたたみ、AG-002）。adapter skill（`agentdev-case-run-execution-adapter`）を case-auto が読み込む
-- **case-auto 自らは実装を行わない**: case-run インライン実行といえども、case-auto は実装実行・PR作成を自ら行わない。実装は実行担当サブエージェントへ委譲。インライン実行は case-run の準備/クリーンアップフェーズのオーケストレーションを case-auto が自ら実行することを指す
-- **req-save + spec-save 統合委譲（AG-005）**: req-save と spec-save を1つの統合委譲で順次実行。委譲内では両コマンドの定義（req-save.md, spec-save.md）を順次読み込み、draft を1回読み込み、req-save の手順を実行した後に引き続き spec-save の手順を実行。commit/push は1回に統合（REQ と SPEC の変更を1コミットにまとめる）。統合委譲に両コマンドのガードレールを適用（req-save G02: `docs/requirements/**`, `docs/adr/**`, `docs/README.md`, `.agentdev/drafts/**`、spec-save G02: `docs/specs/**`, `.agentdev/drafts/**`）。req-save/spec-save のコマンド定義・責務・ガードレール自体は変更しない（CR-002）
-- **QG-1〜QG-4 の継承**: case-auto は QG を独自実装しない。構成コマンド（req-save: QG-1, case-open: QG-2, case-run: QG-3, case-close: QG-4）がそれぞれ `agentdev-quality-gates` スキルを参照して Gate を適用。case-run インライン実行時、QG-3 前置 staleness check、targeted docs guard は case-auto が case-run.md に従って実行（G07, G09）
-- **タイムスタンプ計測（L1）**: 各工程（req-save+spec-save 統合委譲 / case-open / case-run / case-close）の起動直前・直後に壁時計タイムスタンプ（JST）を記録。Step 8 完了報告・Step 7 停止報告の工程別内訳として使用。全体開始・終了時刻記録を廃止せず工程別内訳を併記。ハーネス内部メトリクス（L3）は対象外。case-run 内の L2 計測は case-run result に含まれ、case-auto は case-run インライン実行の壁時計時間（L1）として扱う
-- **インライン実行時のコンテキスト管理**: harness の機能（compress 等）で対応し、AGENTS.md / references/<harness>.md に配置。親コンテキスト非累積は case-run インライン実行時の例外として取り扱う。インライン実行の適用を完了報告（Step 8）に記録
-
-#### 工程別契約
-
-case-auto は各工程を以下の契約で起動する:
-
-| 工程 | 起動方式 | inputs | output_contract |
-|---|---|---|---|
-| req-save + spec-save | 委譲（1 統合委譲、AG-005） | draft path, OU ID | 保存済みREQ/ADRリスト, 保存済みSPECリスト, draft status=saved, SPEC消費済みフラグ, pass/warn/fail, **artifact_action 適用結果（action id ごとに applied/skipped/failed/no-op）** |
-| case-open | 委譲 | draft path, OU ID | Issue番号(Epic含む), pass/warn/fail, **OU lifecycle: Issue 作成 完了/未完了** |
-| case-run | インライン実行（case-run.md を authoritative source として読み込み、case-auto が準備/クリーンアップフェーズを自ら実行、実行担当サブエージェントへ直接委譲、AG-001/002） | 単一 Issue番号 または Epic Issue番号（`#epic`、現在 Wave の子Issue を case-auto が並列委譲、最大5件） | completed-pr/blocked/failed/delegation-unavailable（Epic Wave 実行時は子Issue ごとの結果集合）, **OU lifecycle: PR 作成 完了/未完了（completed-pr のみ完了）** |
-| case-close | 委譲 | 単一 Issue番号 または Epic Issue番号（`#epic`、現在 Wave の一括クローズ） | マージ結果, Capture保存結果, 削除済みブランチ, pass/warn/fail, Epic 最終 Wave 判定結果, **OU lifecycle: PR マージ完了/未完了、Issue クローズ完了/未完了** |
-
-各工程の side_effect_boundary は対応するコマンド定義のガードレールに従う。各工程の後段処理（case-open の RU 削除、case-close の learning/intake capture、.agentdev/ commit/push 等）は各コマンド定義に従う（case-run インライン実行時の worktree クリーンアップは case-auto が case-run.md に従って実行）。
-
-case-auto は req-save/case-open の委譲に draft path と OU ID のみを渡す（OU 本文の切り出しは行わない）。OU の統合・分割・REQ 操作分類・Issue 階層判定を再評価しない（各工程の判定結果に従う）。
-
-case-auto は各工程の結果に基づいて次工程へ進むか停止条件（Step 7）を判定する。
-
-#### 結果状態の4次元集約
-
-case-auto は各工程の結果を以下の4状態次元で保持し、集約時に混同しない。各工程の `output_contract`（工程別契約表）がこれらの情報源となる。warn を pass へ変換する集約は禁止する。
-
-| 次元 | 取得元 | 値 |
-|---|---|---|
-| (1) 工程結果 | 全工程の `pass/warn/fail`（工程別契約表） | pass / warn / fail |
-| (2) artifact_action 適用結果 | req-save+spec-save 統合委譲の `artifact_action 適用結果`（action id ごと） | applied / skipped / failed / no-op |
-| (3) 定義適用工程の完了状態 | (1)(2) の組み合わせから導出 | 定義適用完了 / 警告付き工程完了 / 定義適用未完了 |
-| (4) OU ライフサイクル完了状態 | case-open（Issue 作成）、case-run（PR 作成）、case-close（PR マージ、Issue クローズ）の各成否 | 各ライフサイクル事象ごとに 完了 / 未完了 |
-
-集約規則:
-
-- **(3) 定義適用工程完了状態の導出**: 定義適用工程（req-save + spec-save）の完了状態は次で導出する:
-  - 全必須 action が `applied` または正当な `no-op` で、工程結果 (1) が `pass` → **定義適用完了**
-  - 全必須 action が `applied` または正当な `no-op` で、工程結果 (1) が `warn` → **警告付き工程完了**（warn を pass へ変換しない）
-  - 必須 action に `skipped` または `failed` が1件以上ある → **定義適用未完了**（この場合は「定義適用完了」または「警告付き工程完了」と報告しない）
-  - 「正当な no-op」とは、対象外 artifact（例: spec-save における `artifact: spec` entry 不存在、後方互換の `artifact_actions` フィールド不存在）による action 不実施を指す。正当な理由なく必須 action を飛ばした場合は `skipped` として扱う
-- **(4) OU ライフサイクル完了状態の独立性**: OU ライフサイクル完了状態は (3) の完了状態と独立して扱う。req-save/spec-save が成功（(3) が定義適用完了/警告付き工程完了）していても case-open（Issue 作成）が未実行なら OU ライフサイクルは未完了と報告する
-- **Phase 0 と OU 完了の分離**: Phase 0 成功（artifact_actions 適用完了 = (3) が定義適用完了/警告付き工程完了）と OU 完了（Issue/PR/Case 完了 = (4) の全ライフサイクル事象完了）を別々に報告する。一方を他方へすり替えて報告しない
-- **warn 変換禁止**: (1) が warn の工程を pass として集約しない。完了報告には warn を warn のまま残す
-
-#### case-open 完了後の分岐
-
-case-open 委譲の完了後、出力を確認して以下のいずれかに分岐:
-
-- **Standard flow（単一 Issue）**: case-open 委譲が共通終了処理（コメント追加、ドラフト削除、RU削除、完了報告）を完了していることを確認 → クリーンアップ検証ゲート（後述）→ 既存の直列フロー（case-run → case-close）
-- **Epic Issue flow（マルチREQ または 単一REQ Epic flow）**: 同上の確認 → クリーンアップ検証ゲート → Wave 反復制御（後述）
-
-**req_draft reader lifecycle**: case-auto は orchestration pre-reader として case-open 完了前のみ req_draft を読み込む。case-open 成功後は invalid post-case reader として req_draft を読まず、停止、再開、完了処理は Issue と Epic だけで成立させる（G19）。クリーンアップ検証ゲートでドラフト削除を検証するのもこの lifecycle に由来する。
-
-#### Wave 反復制御（case-auto 直接制御、AG-003）
-
-Epic Issue 番号を記録。Epic Issue 本文（SSoT）から Wave 構成・各子Issue ステータスを読み取る（**読み取りのみ、Epic Issue 本文の書き込みは case-close の単一書き手責務**、G16）。case-run(#epic) への委譲は行わない。各子Issue ごとにインライン case-run を実行。以下の反復ループを実行:
-
-1. **現在 Wave の ready 子Issue 選択**: Epic Issue 本文（ステータス追跡テーブル）から現在 ready な Wave の子Issue を特定。`ready` がない場合、依存が満たされた `pending` Issue を `ready` に遷移させて選択。前提Issue が blocked/failed の場合は `pending` のまま選択対象外。各子Issue の worktree 作成前に `git fetch origin` を実行し、origin/main の鮮度を確認（`agentdev-git-worktree` 参照）
-
-2. **各子Issue のインライン case-run 並列実行**（最大5件）: 各 ready 子Issue を adapter skill（`agentdev-case-run-execution-adapter`）を読み込んだ実行担当サブエージェントへ case-auto から直接並列委譲。各子Issue ごとに case-run.md に従い準備フェーズ（worktree 作成、委譲 prompt 構築、QG-3 前置 staleness check、targeted docs guard）を case-auto が実行し、実行担当サブエージェントへ委譲、result 処理、クリーンアップフェーズを実行。委譲の起動手段・実行制御パラメータは AGENTS.md / references/<harness>.md 参照。1 Wave の実行（PR作成まで）で次工程へ進む
-
-3. **委譲→case-close(#epic)**: インライン case-run の結果（子Issue ごとの completed-pr/blocked/failed/delegation-unavailable）を確認。completed-pr の子Issue がある場合、Epic Issue 番号を case-close 委譲に渡す。case-close は現在 Wave の PR作成済み子Issue を一括マージ・クローズし、Epic status table を更新（単一書き手）、最終 Wave 判定を行う
-
-4. **次 Wave 判定**: case-close 委譲の結果から Epic 全 Wave 完了可否を判定:
-   - **全 Wave 完了（Epic クローズ済み）**: Epic 完了報告（Step 8）へ進む
-   - **残 Wave あり**: 手順 1（現在 Wave の ready 子Issue 選択）に戻り次 Wave を実行（べき等、Epic Issue 本文から進行状況判定）
-
-5. **blocked/failed の扱い**: インライン case-run が blocked/failed を返した子Issue は case-close 対象外。一部 completed-pr がある場合は case-close(#epic) で completed-pr のみ処理し、その後停止条件（Step 7）の判定へ。全子Issue が blocked/failed の場合は Wave 反復を停止し部分完了報告（Step 8）へ。停止時は完了済み OU・進行中 OU・未実行 OU・再開可能な次コマンドを報告
-
-#### OU 処理順序
-
-- 必須依存（`depends_on`）で結合した execution_unit 群は順次処理
-- 必須依存のない execution_unit 群は並列実行。本並列は3つの「5件」文脈のうち **execution_unit 全体並列（上限なし）** に該当し、**case-run Wave 内子 Issue 並列上限（最大5件）** および **orchestration stage 2 同時起動数（最大5件）** とは別文脈である。3つの「5件」は混同しない（文脈別の区別は epic-wave-model SPEC「並列上限と停止条件の整理」セクション参照）。ファイル衝突等の技術的依存（L0-L3）は並列判定軸から外し直列化要因としない
-- `recommended_order` は処理順序のヒントであり直列化ゲートではない
-- Standard flow でも Epic flow でも適用。Standard flow で case-close完了後に未処理 OU が残れば、当該 OU の `artifact_actions` に応じた工程分岐で Step 2 に戻り次 OU の処理を開始。全 OU 処理完了でのみ全体完了報告。次 OU の draft ファイル不在時は停止し報告
-- 複数の必須依存のない execution_unit を case-open 委譲が自動的に Epic Issue 化し Wave 1 に全 OU を配置（G21）。並列実行完了後、残りに必須依存のある execution_unit があれば順次処理
-- 採番・index 更新・draft 更新・commit・push・Epic 本文更新は各工程が対応するコマンド定義に従い、並列実行の完了を待ってから実行（直列集約）
-
-#### クリーンアップ検証ゲート
-
-Standard flow の case-run 移行前、Epic Issue flow の Wave 反復制御開始前の双方で以下を検証:
-
-- ドラフトファイル（`.agentdev/drafts/req-draft-*.md`）が削除されていること。残存時は停止し手動削除を依頼
-- 当該ケースで消費した RU ファイル（`.agentdev/backlog/req-units/RU-*.md`）が削除されていること。残存時は停止し手動削除を依頼
-- 検証結果（成功、残存ファイル一覧）を case-auto 完了報告（Step 8）に含める
-
-#### 委譲起動判定（AG-004）
-
-委譲工程（req-save / spec-save / case-open / case-close）の委譲起動後または起動失敗時に委譲起動可否を判定。本判定は委譲工程のみに適用し、case-run インライン実行時の実行担当サブエージェントへの委譲失敗には適用しない（後述）。
-
-**委譲起動不能トリガー**:
-1. 委譲起動失敗（ツール不在、ハードリジェクト、agent type 拒否）
-2. 委譲結果が blocked/failed で、理由が委譲 chain 破綾（起動失敗、ネスト委譲制限等）
-
-genuine blocker（実装上の問題、スコープ外操作、コンフリクト解消不能等）は `delegation-unavailable` 対象外。Step 7 停止条件として扱う。
-
-**判定材料**: 委譲工程 result 本文、Issue コメント（SSoT）、エラーメッセージのパターンマッチ（"Invalid agent type", "Only explore, librarian are allowed", "delegation not available" 等）。パターンに合致しない blocked/failed は genuine blocker として扱い、`delegation-unavailable` とはしない（安全側に倒す）。
-
-**委譲起動不能時の扱い**:
-- 当該工程を `delegation-unavailable` として報告。委譲工程のインライン実行への切替えは行わない
-- context 管理（compress 等）は harness の責務として AGENTS.md / references/<harness>.md に配置
-- 親コンテキスト非累積は委譲起動不能時の例外として取り扱う
-- `delegation-unavailable` 発生を完了報告（Step 8）に記録
-
-**case-run インライン実行時の実行担当サブエージェント委譲失敗の扱い（AG-004）**: 本節の `delegation-unavailable` 停止条件には該当しない。case-run result 契約（completed-pr / blocked / failed / delegation-unavailable）に従い処理。`delegation-unavailable` を返した場合は当該子Issue を `pending` に戻す。詳細な事後処理（worktree の `git status` 確認、残留箇所の grep、手動修正または PR 化）は `agentdev-case-run-execution-adapter` スキル参照
-
-#### Subagent 委譲プロトコル（category 選定、MUST NOT DO 必須）
-
-case-auto が各工程を subagent へ委譲する際、委譲 prompt の category と MUST NOT DO セクションは以下の要件を満たす（Issue #1538 由来）。本要件は case-auto 委譲時に限定せず、subagent 委譲する全場面（case-auto/ case-open/ case-run/ case-update/ case-close）に共通適用する。case-run インライン実行時の実行担当サブエージェント委譲も本要件に従う。
-
-**category 選定ガイドライン**:
-
-- 委譲先 command の責務（事務的手続き、実装作業、執筆作業等）と category 名の意味的距離を評価し、subagent の振る舞いを誤誘導しない category を選定する
-- command 名と category 名の意味的距離が大きい場合、subagent が関連スキルを発火させ本来責務から逸脱するリスクがある。Issue #1538 では case-open を `category=writing` で委譲した際、`japanese-tech-writing` 等の発火スキルと相互作用して subagent が文書監査ファイル生成や draft 作成へ逸脱した
-- category 別の推奨用途:
-  - **`unspecified-high`**: 事務的手続き（Issue 作成、VERIFY、ラベル設定、状態遷移、コメント追加、ファイル移動等）の委譲。既定の category であり特定の発火スキルと結合しないため事務的手続きに適する
-  - **`writing`**: 執筆作業（docs 記述、article 作成、REQ/ ADR/ SPEC 本文執筆等）の委譲のみに限定する。事務的手続き委譲に `writing` を使用してはならない
-
-**MUST NOT DO セクション必須化**:
-
-- 全ての委譲 prompt に MUST NOT DO セクションを必須とする。スコープ外作業を明示的に列挙し、subagent がスコープ境界を推定せずに従えるようにする
-- MUST NOT DO に列挙すべき代表的項目:
-  - 当該 command 責務外のファイル作成（例: case-open 委譲での文書監査ファイル、draft、replacement-dictionary 等の生成）
-  - REQ/ SPEC/ src の直接修正（当該 command に許可されていない場合）
-  - 文書監査の実施（`japanese-audit` 等の監査ファイル生成、`japanese-tech-writing` 等の発火スキルによる監査的振る舞い）
-  - スコープ外調査、スコープ外実装、capture 境界を超える `.agentdev/` 直接変更
-- MUST NOT DO の記載は特定 command に限定せず、subagent 委譲する全場面で共通適用可能な形とする
-
-**subagent 委譲プロンプトテンプレート要件**:
-
-- 委譲 prompt の標準テンプレートは category 選定基準と MUST NOT DO 記載要件を統合した形式をとる
-- case-auto、case-open、case-run、case-update、case-close の全委譲場面で共通適用可能な形とし、特定 command 名と category 名の意味的距離が大きい場合の注意事項を含む
-- case-auto は各工程の委譲 prompt 構築時に本要件を適用する（case-run インライン実行時の実行担当サブエージェント委譲も含む）。委譲プロトコルと category 設計の関係整理は `agentdev-case-run-execution-adapter` スキル参照
-
-#### orchestration stage モデル
-
-case-auto が複数対象を処理する場合、orchestration stage モデルを採用する。orchestration stage は case-auto が管理する command 間進行であり、case-run internal lifecycle（単一 Issue または Wave 内の準備、実行、提出）とは別の概念である（responsibility-boundary-purification SPEC「case 実行責務の 4 用語と所有者」参照）。
-
-- **orchestration stage 1**: 全対象の case-open を順次実行する
-- **orchestration stage 2**: case-run を bg task として最大5件ずつ並列実行し、結果と破棄を収集する
-- **orchestration stage 3**: case-close を順次実行する
-
-各 orchestration stage は前 stage の対象処理の完了後に開始する。orchestration stage 1 と 3 を main push と capture の直列集約ポイントとし、commit も並列実行区間の外で処理する。
-
-並列実行はデフォルト挙動とし、bg task を利用できない場合のみ順次フォールバックへ切り替え、フォールバック理由を完了報告（Step 8）に含める。実行担当サブエージェント内部の制御と bg task API の具体は harness 側に維持し、case-auto は起動 API と引数仕様を規定しない（`references/<harness>.md` 参照）。
-
-#### 子 task bg task 破棄検知時の回復（AG-001〜AG-004）
-
-orchestration stage 2 で起動した子 task の bg task がシステムにより破棄されたことを検知した場合、case-auto 親ループが当該子 task の状態を回復する。回復契約の詳細は SPEC `case-auto SPEC`「子 task 中断回復パス」セクションを正とし、本節はその実行指示を記載する。
-
-**中断検知と3状態分類（AG-001）**: 子 task の bg task 破棄を検知した場合、当該子 task の worktree で `git status` を実行し、以下の3状態のいずれかに分類する。
-
-| 状態 | 判定条件 |
-|---|---|
-| (a) commit 済み、PR 未作成 | commit 履歴があるが PR が未作成 |
-| (b) 未コミット変更あり | worktree に未コミット変更が残留 |
-| (c) クリーン | commit 履歴も未コミット変更もない |
-
-状態 (c) クリーンの場合は回復対象がないため回復処理をスキップし、当該子 task を pending へ戻す。状態 (a) (b) はそれぞれ後述の手順へ進む。
-
-**状態 (a) の回復（commit 済み、PR 未作成、AG-002）**: case-auto 親ループが当該 worktree で回復処理を代行する。
-
-1. `git rebase origin/main` で最新の main へ追従する（必要時）。rebase で解消できないコンフリクトは「コンフリクト解消モデル（3レベルエスカレーション）」の Level 2/3 へ委譲する
-2. `git push` でリモートへ反映する
-3. PR 作成を代行する。PR の base branch、タイトル、本文は子 task の Issue 紐づく情報（Issue 番号、Issue タイトル、受け入れ条件、work_type）から生成する
-4. 作成した PR 番号を子 task の result に `completed-pr` として記録する
-5. 通常の case-close フローへ合流させる
-
-回復時の PR 作成代行は case-auto 親ループの責務であり、子 task 側で再び委譲を起こさない。
-
-**状態 (b) の回復（未コミット変更あり、AG-003）**: 未コミット変更の帰属は安全上の懸念となるため、作業意図整合確認ステップを必須とする。安全のため未確認の変更を強制 commit しない。強制 commit は帰属不明の変更を本流へ持ち込む原因となる。
-
-1. worktree の変更内容（`git diff`、`git status`）を確認する
-2. 変更内容が子 task の case-run 作業意図（Issue の受け入れ条件、実装計画）と整合するかを確認する
-3. 整合確認ができた場合のみ commit、push、PR 作成を代行する（PR 生成情報の Issue 紐づけは状態 (a) と同じ）
-4. 整合確認できない場合（別 Issue 由来の変更混入、意図不明の変更等）は当該子 task を `blocked` とし、停止理由を「未コミット変更の帰属不明」（Step 7 停止条件 (10)）として報告する
-
-**子 task ライフサイクルと成果物ライフサイクルの分離（AG-004）**: 子 task の bg task 破棄は子 task のライフサイクル事象であり、当該子 task が作成中の成果物（commit、PR）のライフサイクルとは独立に扱う。回復処理はこの分離を維持し、子 task の状態（pending 戻し、blocked 報告等）と成果物の状態（PR 作成済み、未作成等）を別々に管理する。bg task 破棄が子 task の成果物へ意図せぬ影響を与えることをこの分離によって防ぐ。
+case-auto は各工程の結果に基づいて次工程へ進むか停止条件（Step 7）を判定する。req-save/case-open の委譲に draft path と OU ID のみを渡す（OU 本文の切り出しは行わない）。OU の統合・分割・REQ 操作分類・Issue 階層判定を再評価しない（各工程の判定結果に従う）
 
 ### Step 5: 工程間の状態引き継ぎ
 
@@ -247,103 +60,23 @@ req-save 委譲の出力から複数 REQ doc または scale:large を検出し�
 
 ### Step 7: 停止条件の検出
 
-以下のいずれかを検出した場合、実行を停止し停止理由・現在地点・再開可能な次コマンドを報告する（11項目）:
+以下のいずれかを検出した場合、実行を停止し停止理由・現在地点・再開可能な次コマンドを報告する（11項目）: (1) req-define合意要件からの逸脱、(2) 要件未合意のscope拡大、(3) repo外実体変更の必要性、(4) DB migration実行の必要性、(5) deploy/applyの必要性、(6) 認証・秘密・権限変更の必要性、(7) CI/test/lint失敗がself-healing不能、(8) コンフリクト解消モデル Level 1〜3 全てを試行しても解消不能なコンフリクト（Level 2 インライン case-run 再実行を上限回数 2回試行しても解消しない場合、機械的競合 Level 1 で自動解決可能は停止条件外、remote hash 不一致は停止条件）、(9) 作成元不明branch/user-owned branch/他作業branchの削除検出、(10) 未コミット変更の帰属不明、(11) command 契約・実装不整合（execution_unit へ分割可能にも関わらず case-open が単一 Epic 子 Issue 上限により停止した場合を含む）
 
-- (1) req-define合意要件からの逸脱（合意済み要件、対象外、受け入れ条件の変更、合意されていない機能要件または制約の追加、合意済み OU の欠落・統合・分割による要件の意味変更のみに限定）
-- (2) 要件未合意のscope拡大
-- (3) repo外実体変更の必要性
-- (4) DB migration実行の必要性
-- (5) deploy/applyの必要性
-- (6) 認証、秘密、権限変更の必要性
-- (7) CI/test/lint失敗がself-healing不能
-- (8) コンフリクト解消モデル（後述）の Level 1〜3 すべてを試行しても解消不能なコンフリクト。操作的定義: Level 2 のインライン case-run 再実行を上限回数（2回、元の並列実行を含む計3回の case-run 実行）試行してもコンフリクトが解消しない場合。機械的競合（Level 1 rebase で自動解決可能）は停止条件に含めない。remote hash 不一致は従来通り停止条件
-- (9) 作成元不明branch / user-owned branch / 他作業branchの削除検出
-- (10) 未コミット変更の帰属不明
-- (11) command 契約・実装不整合（case-open または後続工程の契約と実装が整合しない場合、execution_unit へ分割可能であるにもかかわらず case-open が単一 Epic 子 Issue 上限により停止した場合を含む）
-
-**停止時タイミング情報の追記**: 停止報告に `case_auto_started_at`（開始時刻）、停止時刻（JST、人間が読みやすい形式: 例 `2026-06-21 15:30:00 JST`）、経過時間（停止時刻 − 開始時刻、人間が読みやすい形式: 例 `12分34秒`、全体合計）、Step 4 で記録した工程別タイムスタンプ内訳（停止時点までの工程分）を含めること
+**停止時タイミング情報の追記**: 停止報告に `case_auto_started_at`、停止時刻（JST、人間が読みやすい形式）、経過時間、Step 4 で記録した工程別タイムスタンプ内訳（停止時点までの工程分）を含める
 
 ### Step 7-1: 停止理由分類
 
-Step 7 の停止条件を検出した場合、停止理由を以下の分類で報告する。分類は再開コマンド選択とユーザー通知の精度向上が目的であり、HITL 境界の変更ではない。停止条件11項目を以下の分類軸へ整理する:
-
-| 分類 | 対応停止条件 | 定義 |
-|---|---|---|
-| req-define 合意要件からの逸脱 | (1) | case-open または後続工程が合意済み要件、対象外、受け入れ条件を変更した場合、合意されていない機能要件または制約を追加した場合、合意済み OU を欠落・統合・分割して要件の意味を変更した場合 |
-| command 契約・実装不整合 | (11) | execution_unit へ分割可能であるにもかかわらず case-open が単一 Epic 子 Issue 上限により停止した場合、case-open または後続工程の実装が契約へ整合していない場合、構成生成事前検証が実装されていない場合 |
-| 要件未合意のスコープ拡大 | (2) | 合意されていないスコープが実行中に追加された場合 |
-| repo 外実体変更 | (3)(4)(5)(6) | DB マイグレーション実行、デプロイ/apply、クラウドリソース操作、外部SaaS設定変更、課金、権限、認証情報変更が必要な場合 |
-| CI/test/lint 失敗 | (7)(8) | コンフリクト解消モデルの Level 2 まで試行しても自己修復不能な場合 |
-| branch 削除検出 | (9) | 作成元不明 branch / user-owned branch / 他作業 branch の削除を検出した場合 |
-| 未コミット変更の帰属不明 | (10) | 変更の由来が不明で安全に続行できない場合 |
-
-execution_unit 分割可能性があるにもかかわらず case-open が停止した場合、「req-define 合意要件からの逸脱」ではなく「command 契約・実装不整合」として報告する。これは case-open の契約・実装不整合であり、要件doc 側の問題ではない。
+Step 7 の停止条件を以下の分類軸で報告する（HITL 境界の変更ではなく、再開コマンド選択とユーザー通知の精度向上が目的）: req-define 合意要件からの逸脱 ((1))、command 契約・実装不整合 ((11))、要件未合意のスコープ拡大 ((2))、repo 外実体変更 ((3)(4)(5)(6))、CI/test/lint 失敗 ((7)(8))、branch 削除検出 ((9))、未コミット変更の帰属不明 ((10))。execution_unit 分割可能性があるにも関わらず case-open が停止した場合、「req-define 合意要件からの逸脱」ではなく「command 契約・実装不整合」として報告する（case-open の契約・実装不整合であり要件doc 側の問題ではない）。各分類の定義、対応停止条件、再開コマンド候補の詳細は `agentdev-workflow-orchestration` を参照
 
 ### Step 8: 完了報告
 
 最終工程（case-close 委譲）の完了報告をそのまま出力する。Epic Issue を伴う Wave 反復実行時は、完了・blocked・failed 子Issue 一覧を含める（Epic Issue 本文ステータス追跡テーブルから読み取り、case-auto は書き込まない、G16）。停止時は完了済み OU・進行中 OU・未実行 OU・再開可能な次コマンドを報告する
 
-**停止理由分類の完了報告テンプレート拡張**: Step 7 経由で停止した場合、停止報告（完了報告の停止時フォーマット）に Step 7-1 の停止理由分類を含める。停止報告テンプレートに以下の項目を拡張する:
-
-- 停止理由分類
-- 該当停止条件番号（11項目のいずれか）
-- 分類の根拠（具体的な発生状況、対象ファイル、対象 Issue 等の識別子）
-- 再開コマンド候補（分類に基づく推奨再開手段）
-
-**タイミング情報の追記**: 完了報告生成時刻（Step 8 開始時点）を JST で記録する。case-close の完了報告（テンプレート）は変更せず、case-auto が以下を追記すること:
-
-- 開始時刻: Step 1 で記録した `case_auto_started_at`
-- 終了時刻: 完了報告生成時刻
-- 所要時間: 終了時刻 − 開始時刻（人間が読みやすい形式: 例 `12分34秒`、全体合計）
-- **工程別タイムスタンプ内訳（L1）**: Step 4 で記録した工程別（req-save+spec-save 統合委譲 / case-open / case-run / case-close）の起動前後タイムスタンプ・工程別所要時間。スキップした工程（例: SPEC artifact_actions がない場合の spec-save スキップ時、統合委譲は req-save 単体で実行）は除外可。case-run の L2 内訳は case-run result から読み取って含める
-- **インライン実行の記録**: case-run をインライン実行した旨を実行結果に記録
-
-停止条件による中断時（Step 7 経由）の報告にも、上記と同じ形式で開始時刻・停止時刻・経過時間・工程別タイムスタンプ内訳を含めること（停止時刻を終了時刻として扱う、停止時点までの工程別内訳のみ）
-
-**OU処理ループ**: Standard flow の case-close 完了後に未処理 OU が残存する場合は次 OU の処理を Step 2 から開始（OU処理順序は Step 4「OU処理順序」サブセクションに準拠）。全 OU の処理が完了した場合のみ全体完了報告を出力する。OU処理中に停止条件（Step 7）を検出した場合も完了済み OU・進行中 OU・未実行 OU・再開可能な次コマンドを報告する
-
-**orchestration stage 別結果・フォールバック理由・破棄回復記録**: 完了報告には orchestration stage 1（case-open 順次実行）、stage 2（case-run 並列実行）、stage 3（case-close 順次実行）の各 orchestration stage の実行結果を含める。orchestration stage 2 を順次フォールバックで実行した場合はその理由を記録する。orchestration stage 2 の bg task 破棄を検知して回復した場合は、検知した状態区分（commit 済みで PR 未作成、未コミット変更残存）と回復結果を記録する。
-
-**結果状態の4次元報告**: 完了報告（停止時フォーマットを含む）には Step 4「結果状態の4次元集約」の4状態次元を次の形式で含めること。warn を pass へ変換して集約しないこと。
-
-- **(1) 工程結果**: 各工程（req-save+spec-save / case-open / case-run / case-close）の `pass/warn/fail` を工程別に列挙
-- **(2) artifact_action 適用結果**: 定義適用工程（req-save+spec-save）の action id ごとに `applied/skipped/failed/no-op` を列挙
-- **(3) 定義適用工程の完了状態**: `定義適用完了` / `警告付き工程完了` / `定義適用未完了` のいずれかとその根拠（warn の有無、必須 action の skipped/failed 有無）。必須 action に `skipped/failed` が1件以上ある場合は `定義適用未完了` と報告し、`定義適用完了`/`警告付き工程完了` と報告しない
-- **(4) OU ライフサイクル完了状態**: Issue 作成、PR 作成、PR マージ、Issue クローズの各事象ごとに `完了/未完了` を列挙。(3) が定義適用完了/警告付き工程完了であっても (4) のいずれかが未完了なら OU 完了とは報告しない
-
-Phase 0 成功（(3) の定義適用完了/警告付き工程完了）と OU 完了（(4) の全ライフサイクル事象完了）は別々に報告する。一方を他方へすり替えて報告しない。
+完了報告には以下を含める（停止時フォーマットを含む）: 停止理由分類（Step 7-1 経由）、開始時刻・終了時刻・所要時間（人間が読みやすい形式）、工程別タイムスタンプ内訳（L1、req-save+spec-save 統合委譲 / case-open / case-run / case-close、スキップした工程は除外可、case-run の L2 内訳は case-run result から読み取って含める）、インライン実行の記録（case-run をインライン実行した旨）、orchestration stage 別結果・フォールバック理由・破棄回復記録（stage 1 case-open / stage 2 case-run / stage 3 case-close、stage 2 を順次フォールバック時は理由、bg task 破棄を検知して回復した場合は状態区分と回復結果）、結果状態の4次元報告（(1) 工程結果 pass/warn/fail / (2) artifact_action 適用結果 applied/skipped/failed/no-op / (3) 定義適用工程の完了状態: 定義適用完了・警告付き工程完了・定義適用未完了 / (4) OU ライフサイクル完了状態: Issue 作成・PR 作成・PR マージ・Issue クローズ の各完了/未完了、warn を pass へ変換して集約しない、Phase 0 成功と OU 完了は別々に報告）。**OU処理ループ**: Standard flow の case-close 完了後に未処理 OU が残存する場合は次 OU の処理を Step 2 から開始（全 OU 処理完了時のみ全体完了報告）
 
 ## コンフリクト解消モデル（3レベルエスカレーション）
 
-PR マージコンフリクト発生時（case-close Step 4-2 からのエスカレーション受領時）は、以下3レベルのエスカレーションで解消を図る。各レベルを試行しても解消できない場合のみ次のレベルへ進む。**機械的競合（rebase で自動解決可能）は停止条件に含まず**、Level 1 で case-close が解消する（Level 1 は case-close Step 4-2 の責務、本節では Level 2/3 の case-auto 責務を定義する）。
-
-| Level | 実行主体 | 解消手法 | 失敗時 |
-|---|---|---|---|
-| Level 1 | case-close | `git rebase` による機械的解消。自動解決時は再マージ | case-auto へエスカレーション |
-| Level 2 | case-auto | 両PRのdiffを読み取りコンフリクト箇所を特定し、コンフリクト文脈を付けてインライン case-run を再実行。最大2回（元の並列実行を含む計3回の case-run 実行、AG-005） | Level 3 へ |
-| Level 3 | case-auto | マージ順序変更、blocked 単位の隔離 | 停止 |
-
-### Level 2: コンフリクト文脈付きインライン case-run 再実行（AG-005）
-
-case-close（Step 4-2）からのエスカレーションを受領した場合、以下を実行する:
-
-1. **コンフリクト箇所特定**: コンフリクト発生した両PR（先にマージされたPR、コンフリクトしたPR）の diff を読み取り、コンフリクト箇所（ファイル、行、変更意図）を特定する
-2. **コンフリクト文脈の構築**: コンフリクト箇所、両PRの変更意図、解消方向性のヒントを「コンフリクト文脈」として構築する。実装の正解を与えず、解消に必要な情報を提供する
-3. **インライン case-run 再実行**: コンフリクト文脈を付けてインライン case-run を再実行する（case-run への再委譲ではなく、AG-005）。委譲 prompt にコンフリクト文脈を明示し、当該 Issue の再実装を実行担当サブエージェントへ委譲する
-4. **再実行上限カウンタ**: 再実行回数をカウントする。**最大2回**（元の並列実行を含む計3回の case-run 実行）を上限とする。上限到達時は Level 3 へ進む
-
-**発生元非依存**: case-auto はコンフリクト解消に対して常に全力で解消を図る。コンフリクトの発生元（同一 case-auto 内の並列実行、別 case-auto 跨ぎ）に関わらず、アクセス可能な文脈（両PRのdiff、Issue本文、PR本文、関連REQ/ADR/SPEC）を総動員してコンフリクト文脈を構築する
-
-### Level 3: オーケストレーション級判断
-
-Level 2 のインライン case-run 再実行を上限回数試行してもコンフリクトが解消しない場合、以下のオーケストレーション級判断を試みる:
-
-- **マージ順序変更**: コンフリクトしている複数 PR のマージ順序を変更し、コンフリクトを回避できるか検討する
-- **blocked 単位の隔離**: コンフリクト解消不能な execution_unit を blocked として隔離し、他の ready execution_unit は継続実行する
-
-### 停止条件の段階化
-
-Level 1（case-close rebase）→ Level 2（case-auto インライン case-run 再実行、最大2回）→ Level 3（オーケストレーション級判断）の順に試行し、**すべてを試行しても解消できない場合のみ停止**する。操作的定義: Level 2 のインライン case-run 再実行を上限回数（2回）試行してもコンフリクトが解消しない場合。Level 1 で解消できる機械的競合は case-auto の停止条件から除外する（Step 7(8) の停止条件参照）
+PR マージコンフリクト発生時（case-close Step 4-2 からのエスカレーション受領時）は、以下3レベルのエスカレーションで解消を図る。各レベルを試行しても解消できない場合のみ次のレベルへ進む。**機械的競合（rebase で自動解決可能）は停止条件に含まず**、Level 1 で case-close が解消する（Level 1 は case-close Step 4-2 の責務、本節では Level 2/3 の case-auto 責務を定義する）。Level 1（case-close、`git rebase` による機械的解消、自動解決時は再マージ、失敗時 case-auto へエスカレーション）、Level 2（case-auto、両PRのdiffを読み取りコンフリクト箇所を特定しコンフリクト文脈を付けてインライン case-run を再実行、最大2回＝元の並列実行を含む計3回の case-run 実行 AG-005、失敗時 Level 3 へ）、Level 3（case-auto、マージ順序変更、blocked 単位の隔離、失敗時停止）。Level 2 コンフリクト文脈付きインライン case-run 再実行（AG-005）、Level 3 オーケストレーション級判断、発生元非依存、停止条件の段階化の詳細は `agentdev-workflow-orchestration` を参照
 
 ## ガードレール
 

--- a/src/opencode/commands/agentdev/case-close.md
+++ b/src/opencode/commands/agentdev/case-close.md
@@ -19,12 +19,7 @@ last-write-wins 競合防止は case-close の単一書き手で維持される�
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-close.yaml`）を読み込む（ADR）。
-
-- extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
-- extension が存在しない場合は標準動作で続行する
-- extension が破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する
-- 詳細な読み込み契約は `agentdev-project-extensions` skill 参照
+本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-close.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
 ## 入力
 
@@ -40,59 +35,13 @@ last-write-wins 競合防止は case-close の単一書き手で維持される�
 
 ### Step 1: Issue番号解決
 
-ユーザー入力またはセッション内会話から番号を取得。
-複数候補時は直近を優先して確認。
-検出不可時はユーザーに指定を求めて停止
+ユーザー入力またはセッション内会話から番号を取得。複数候補時は直近を優先して確認。検出不可時はユーザーに指定を求めて停止
 
- - **Epic Issue 判定**: 解決した Issue番号の本文を `agentdev-gh-cli` の安全な読み取り手順で取得し、ステータス追跡テーブル（Wave/子Issue 構成、`agentdev-epic-tracker` の新4列/旧4列形式）が存在するか確認。テーブル存在時は **Epic Wave クローズ**（Step E1〜E6）へ分岐。テーブル不存在時は **単一 Issue クローズ**（Step 1-1〜）へ進む（後方互換）
+**Epic Issue 判定**: 解決した Issue番号の本文を `agentdev-gh-cli` の安全な読み取り手順で取得し、ステータス追跡テーブル（`agentdev-epic-tracker` の新4列/旧4列形式）が存在するか確認。テーブル存在時は **Epic Wave クローズ**（Step E1〜E6）へ分岐。テーブル不存在時は **単一 Issue クローズ**（Step 1-1〜）へ進む（後方互換）
 
-**Epic Wave クローズ**（`case-close #epic` 受領時、Step 1 から分岐）:
+### Epic Wave クローズ（`case-close #epic` 受領時、Step 1 から分岐）
 
-`case-close` が Epic Issue番号を受領した場合の Wave 単位クローズフロー。
-現在 Wave の PR作成済み子Issue を一括マージ、クローズし、Epic status table を更新する。
-最終 Wave 判定後に Epic Issue クローズ または 残 Wave 通知を行う。
-
-**E1. Epic Issue 本文読込**: `agentdev-gh-cli` の安全な読み取り手順で Epic Issue 本文を取得。ステータス追跡テーブル（新4列形式: `#`/ `Issue`/ `ステータス`/ `内容`、または旧4列形式）を解析し、Wave 構成、各子Issue のステータス（`pending`/ `ready`/ `running`/ `completed`/ `blocked`/ `failed`）、PR番号リンクを抽出
-
-**E2. 現在 Wave 特定**: ステータス追跡テーブルから、`running` ステータスの子Issue が属する Wave を「現在 Wave」として特定。`running` が存在しない場合、Wave 番号昇順で最も若い未完了 Wave（`completed` 以外の子Issue を含む Wave）を現在 Wave とする
-
-**E3. PR作成済み子Issue 特定**: 現在 Wave 内の `running` ステータス子Issue を「PR作成済み子Issue」として特定。
-各子Issue に紐づく PR 番号を子Issue 本文、PR 一覧取得手続き（`agentdev-gh-cli`、検索条件: `Closes #N`）等で特定。
-`running` 以外のステータス（`pending`/ `ready`/ `blocked`/ `failed`）は本フローの対象外
-
-**E4. 各子Issue の PR マージ、子Issue クローズ（準並列化、REQ）**: E3 で特定した子Issue を準並列化で処理する。
-並列実行可能な処理（PR情報取得、Issue本文読取、完了条件チェック事前評価等）と直列集約が必要な処理（squash merge、Epic本文ステータス追跡テーブル更新等）を分離する。
-個別リスト（並列対象/直列集約対象）は case-close command SPEC（extension 経由）Step E4 を参照:
- - **PR マージ**: PR merge 手続き（squash 方式、`agentdev-gh-cli`）を実行（Step 4 の squash merge リトライ、フォールバック手順に準拠）
- - **子Issue クローズ**: Issue close 手続き（理由: completed、`agentdev-gh-cli`）
- - **完了条件チェックボックス評価**: QG-4 に従い子Issue 本文の完了条件を最終評価、更新
- - **Capture 回収**: 各子Issue の PR 本文から intake/ learning を分離回収（Step 10 相当、Epic 横断回収）
- - **コンフリクト解消**: rebase による機械的コンフリクト解消は停止条件外とする（REQ Level1）。rebase で解消不能なコンフリクトは実装変更を行わず case-auto へエスカレーションする（REQ、REQ Level2/3、Step 4-2 参照）
-
-**E5. Epic status table 更新（単一書き手: case-close）**: E4 でクローズした各子Issue のステータスを `running` → `completed ([PR#N](URL))` に更新。`agentdev-epic-tracker` スキルの正規表現パターン（running → completed）に従い、`agentdev-issue-management` の安全手順、`agentdev-gh-cli` の VERIFY 操作で本文を再取得し検証
- - **Epic Issue 本文ステータス追跡テーブルの更新は case-close のみが実施する**（単一書き手制約）。case-run は読み取るのみ（書き込まない）。case-auto は Wave 反復制御のみ（直接書き込まない）
-
-**E5b. Epic Issue 完了条件チェックボックス最終評価・更新**: E5（Epic status table 更新）の後、E6（最終 Wave 判定）の前に実施する。Epic Issue 本文の `## 完了条件` セクションを読み込み、完了条件チェックボックスを QG-4 に従い評価・更新する（完了条件チェックボックス評価の case-close 専任責務、G08 Epic Wave 経路への明示適用）。単一 Issue クローズ（Step 2）の QG-4 手順と同等の評価・更新手順を Epic Issue 本文に対して実行する
-  - **評価対象スコープ（QG-4 観点8）**: Wave 種別に応じて評価スコープを切り替える
-    - **中間 Wave**: 当該 Wave でマージされた PR の対象範囲に属する完了条件のみ `[ ]` → `[x]` に更新する（PR 対象範囲スコープ）。他 Wave の完了条件は `[ ]` のまま残す（対象外 Wave の完了条件は評価対象外）。PR 対象範囲の判定は Step 2「PR 対象範囲 vs 全体 評価スコープ判定（QG-4 観点8）」と同一の QG-4 観点8 判定マトリクスに従う。E3 で特定した当該 Wave の子Issue の PR 変更ファイル一覧（PR 変更ファイル一覧取得、`agentdev-gh-cli`）を入力とする
-   - **最終 Wave**: Epic Issue 本文の全完了条件を評価する（全体評価スコープ）。実装完了している完了条件を `[ ]` → `[x]` に更新する。各完了条件の評価スコープ（PR 対象範囲 or 全体）は Step 2 の QG-4 観点8 判定マトリクスに従い決定し、「全体」スコープの完了条件は再 grep/ 再検査/ 再計測を実施し最新証拠を取得する
- - **未達項目の自律解決判定**: 達成不可項目（実装完了していない完了条件）は Step 2 の「達成不可項目を自律解決判定（変更対象分類×検証種別分類）」に準じて処理する。中間 Wave で他 Wave 由来の未達は評価対象外のため自律解決の対象としない
- - **Epic Issue 本文更新手続き（`agentdev-gh-cli`）**: 評価結果を Epic Issue 本文へ反映 → VERIFY。Windows 環境の WRITE 手続きではコンソールエンコーディング初期化（`agentdev-gh-cli` の「Windows 環境 WRITE 手続き」）を必須前置する（REQ）
-  - **再読込 VERIFY**: Epic Issue 本文更新後に本文を再読込し、対象完了条件（評価スコープに属する完了条件）の `- [ ]` が0件であることを確認する。最大2回まで実施する
-   1. 1回目の再読込で対象完了条件の `- [ ]` が0件なら Step E6（最終 Wave 判定）へ進む
-   2. 1回目で `- [ ]` が残る場合は更新を再試行し、再度再読込（2回目）する
-   3. 2回目でも `- [ ]` が残る場合は構造化エラーで停止する（後述「未達項目残存時の停止」）
-  - **未達項目残存時の停止（G08 Epic Wave 経路への明示適用）**: 最終 Wave で実装完了していない完了条件（`- [ ]`）が残る場合、case-close は構造化エラーで停止する。中間 Wave で他 Wave の完了条件が `[ ]` のまま残ることは停止条件ではない（対象外 Wave の完了条件は評価対象外のため）。停止時の出力に以下を含める:
-   - 残存する未達完了条件の一覧（`- [ ]` の完了条件テキスト）
-   - 対応する子Issue のステータス（`completed` / `blocked` / `failed`）。Epic Issue 本文のステータス追跡テーブルから読み取る
-   - 再開コマンド候補（未達完了条件を完遂するための次アクション。例: 未対応子Issue の `/agentdev/case-run #N`、blocked 子Issue の `/agentdev/case-update #N`、要件再検討時の `/agentdev/req-define`）
-
-**E6. 最終 Wave 判定**: ステータス追跡テーブル全体を再確認し、全子Issue が `completed` かを判定（`blocked`/ `failed` は終了状態だが `completed` とはみなさない）:
- - **E6a. 最終 Wave（全子Issue completed）**: Epic Issue 自体を Issue close 手続き（理由: completed、`agentdev-gh-cli`）でクローズ→ Epic レベルの最終処理（Step 10/ Step 11 相当の Epic 横断 capture 回収、`.agentdev/` 永続化、学びの検知）→ Epic 完了報告（Step 12 相当）
- - **E6b. 最終 Wave 以外**: 残 Wave 状況を通知して停止:
- - 完了 Wave 一覧（Wave 番号、子Issue 番号、PR 番号）
- - 残 Wave 一覧（Wave 番号、対象子Issue 番号、各ステータス）
- - 次実行可能 Issue（依存が満たされた `pending` 子Issue のうち最も若い番号、存在しない場合は「次 Wave の case-run 完了待ち」と明記）
+現在 Wave の PR作成済み子Issue を一括マージ、クローズし、Epic status table を更新する。最終 Wave 判定後に Epic Issue クローズ または 残 Wave 通知を行う。E1（Epic Issue 本文読込、ステータス追跡テーブル解析）、E2（現在 Wave 特定）、E3（PR作成済み子Issue 特定）、E4（各子Issue の PR マージ・子Issue クローズ・完了条件チェックボックス評価・Capture 回収・コンフリクト解消の準並列化、REQ）、E5（Epic status table 更新、単一書き手 case-close のみ）、E5b（Epic Issue 完了条件チェックボックス最終評価・更新、QG-4 観点8、中間 Wave vs 最終 Wave 評価スコープ切替）、E6（最終 Wave 判定: 全子Issue completed なら Epic クローズ、以外は残 Wave 通知）の詳細手順、判定基準、再読込 VERIFY、未達項目残存時の停止条件は `agentdev-epic-tracker` を正とする
 
 **単一 Issue クローズ**（従来フロー、後方互換）:
 
@@ -100,92 +49,30 @@ last-write-wins 競合防止は case-close の単一書き手で維持される�
 
 ### Step 2: 前提確認
 
-達成判定、完了ゲート（QG-4）→ `agentdev-quality-gates` の QG-4（Final Acceptance Gate）に従い、Issue本文の完了条件チェックボックスを最終評価、更新する。判定基準、検査観点は同スキル（`agentdev-quality-gates`）の QG-4 を参照:
-  - **完了条件チェックボックス評価、更新は case-close の責務**（QG-4）。case-run、実行担当サブエージェント、外部実行バックエンドは完了条件チェックボックスを更新しない。case-close は case-run/ 実行担当サブエージェントとは**別コンテキスト**で、PR 作成後に独立して完了条件を再読込して最終完了判定する
-  - **PR 対象範囲 vs 全体 評価スコープ判定（QG-4 観点8）**: unchecked 完了条件を達成判定する前に、各完了条件の評価スコープ（PR 対象範囲 or 全体）を QG-4 観点8「PR 対象範囲 vs 全体 判定マトリクス」に従い決定する。境界ケース #1532/TS-006 由来。手順:
-    1. Issue 本文の完了条件チェックボックスから評価対象（ファイル/ ID/ 集計値/ 横断是正/ SPEC）を分類する
-    2. PR 変更ファイル一覧取得手続き（`agentdev-gh-cli`）で PR 変更ファイル一覧を取得する
-    3. QG-4 観点8 の判定マトリクスを適用し、各完了条件の評価スコープ（PR 対象範囲 or 全体）を決定する
-    4. スコープが「全体」の完了条件は、再 grep/ 再検査/ 再計測を実施し最新証拠を取得する
-    5. Issue 本文にスコープ明示がない場合、case-open 起票時点（Step 2-1b）で明示されていることを前提とする。未明示の場合はユーザー判断を仰ぐ
-  - unchecked項目を達成判定（証拠ソース、`agentdev-workflow-orchestration` のプロトコルに従い）し `[x]` に更新
-  - 達成不可項目を自律解決判定（変更対象分類×検証種別分類）
-  - Issue 本文更新手続き（`agentdev-gh-cli`）で完了条件を反映 → VERIFY
-  - **事後確認（再読込 VERIFY）**: 更新後にIssue本文を再読込し、完了条件セクションの全 `- [ ]` が `[x]` に反映されていることを確認。未反映の場合は再更新（最大2回）し、それでも失敗する場合は構造化エラーで停止
-  - 未達項目が残る場合 → 構造化エラーで停止（G08）
-  - **test strategy 処理完了確認（REQ）**: Issue 本文のテスト戦略セクションに含まれる全 test strategy 項目（verification / pass_criteria / on_failure の3要素構造）が「合格」または PR 本文の `## Findings / Capture候補` セクションへの Findings 記録済み（record-in-findings）であることを確認する。判定基準、検査観点は QG-4 の「test strategy 処理完了」検査観点（`qg-4-final-acceptance.md`）を参照。未処理の test strategy 項目が残る場合、完了扱いとせず構造化エラーで停止する（G08）。Issue 本文にテスト戦略セクションが存在しない場合は本確認を skip する
-  - PR存在確認
+達成判定、完了ゲート（QG-4）→ `agentdev-quality-gates` の QG-4（Final Acceptance Gate）に従い、Issue本文の完了条件チェックボックスを最終評価、更新する。判定基準、検査観点は同スキル（`agentdev-quality-gates`）の QG-4 を参照
+
+- **完了条件チェックボックス評価、更新は case-close の責務**（QG-4）。case-run、実行担当サブエージェント、外部実行バックエンドは完了条件チェックボックスを更新しない。case-close は case-run/ 実行担当サブエージェントとは**別コンテキスト**で、PR 作成後に独立して完了条件を再読込して最終完了判定する
+- **PR 対象範囲 vs 全体 評価スコープ判定（QG-4 観点8）**: unchecked 完了条件を達成判定する前に、各完了条件の評価スコープ（PR 対象範囲 or 全体）を QG-4 観点8「PR 対象範囲 vs 全体 判定マトリクス」に従い決定する（境界ケース #1532/TS-006 由来）。手順、再 grep/再検査/再計測、事後確認（再読込 VERIFY）、未達項目残存時の停止（G08）、test strategy 処理完了確認（REQ、未処理項目が残る場合は構造化エラーで停止）の詳細は `agentdev-quality-gates` の QG-4 を参照。PR 存在確認
 
 ### Step 3: docs/ 検証
 
-機能追加固有の検証（REQ作成、インデックス記載、spec更新、ADR作成）および全work_type共通の関連ドキュメント整合性確認。
-DOC-MAP整合性確認。
-不足時は警告表示してユーザー判断を仰ぐ。
-PR 本文の `## SPEC確定候補` セクションから SPEC 確定フロー（Step 3-2）を実行する
-  - **文書分類ポリシー適合確認**: document-model SPEC（extension 経由）の Document Classification Policy に基づき、最終ドキュメント状態が分類ポリシーに適合していることを確認する
+機能追加固有の検証（REQ作成、インデックス記載、spec更新、ADR作成）および全work_type共通の関連ドキュメント整合性確認、DOC-MAP整合性確認。不足時は警告表示してユーザー判断を仰ぐ。PR 本文の `## SPEC確定候補` セクションから SPEC 確定フロー（Step 3-2）を実行する。**文書分類ポリシー適合確認**: document-model SPEC（extension 経由）の Document Classification Policy に基づき、最終ドキュメント状態が分類ポリシーに適合していることを確認する
 
-**Step 3-1**: close 時 SPEC/ commands/ skills 更新漏れの局所確認（実装完了、PRマージ前に、今回の変更に伴う以下の更新漏れを局所的に確認する）:
- - SPEC 本文と実装の最終矛盾確認
- - 変更に伴う command 定義の更新漏れ
- - 変更に伴う skill 責務境界の変更漏れ
- - 更新漏れを検出した場合は警告表示してユーザー判断を仰ぐ
- - **局所予防の範囲**: この確認は close 時の局所的な漏れ検出であり、`/agentdev/inspect-docs` の全体意味レビューの代替ではない
-  - **extensions 整合性検査（IR-056、REQ）**: 当該 PR が `.opencode/commands/agentdev/**/*.md`、`.opencode/skills/agentdev-*/SKILL.md`、`.opencode/skills/agentdev-*/references/**/*.md`、`.agentdev/extensions/**` のいずれかを変更した場合、`check_extensions.ts` を strict 実行し、IR-056 違反がないことを確認する。違反時はマージを停止しユーザー判断を仰ぐ
-   - **targeted docs guard（REQ）**: 変更ファイルと連動ファイルに対し targeted docs guard を実行する。PR 変更ファイル一覧は PR 補助データ読込手続き（`agentdev-gh-cli`、PR 変更ファイル一覧取得）で取得する（case-close はマージ後 main 環境で実行されるため `--files` を使用。`--base-ref` は worktree 環境（マージ前、case-run 等）向け）。実行コマンド:
+**Step 3-1**: close 時 SPEC/ commands/ skills 更新漏れの局所確認（実装完了、PRマージ前に、SPEC 本文と実装の最終矛盾確認、command 定義の更新漏れ、skill 責務境界の変更漏れを確認、更新漏れ検出時は警告表示してユーザー判断、局所予防の範囲で `/agentdev/inspect-docs` の全体意味レビューの代替ではない）。**extensions 整合性検査（IR-056、REQ）**: 当該 PR が `.opencode/commands/agentdev/**/*.md`、`.opencode/skills/agentdev-*/SKILL.md`、`.opencode/skills/agentdev-*/references/**/*.md`、`.agentdev/extensions/**` のいずれかを変更した場合、`check_extensions.ts` を strict 実行し、IR-056 違反がないことを確認する。違反時はマージを停止しユーザー判断を仰ぐ。**targeted docs guard（REQ）**: 変更ファイルと連動ファイルに対し targeted docs guard を実行（case-close はマージ後 main 環境で実行されるため `--files` を使用）。実行コマンド `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-close --files <PR 変更ファイル一覧> --json`（`<PR 変更ファイル一覧>` は space 区切り推奨、comma 区切り、混在も可）。JSON 出力の `failures` に strict severity が含まれる場合はマージを停止し対象ファイルを修正して再実行。`full_docs_check_recommended` が true の場合は `/repo/docs-check`（全体監査）の実行をユーザーに提案する。draft→accepted 等の SPEC status 変更時は `spec_readme_update_required` を Step 3-2 SPEC 確定フローに反映する。**files_checked 空時の確認（REQ）**: targeted docs guard の JSON 出力で `files_checked` が空の場合、検査見逃しリスクとして扱い、`warnings` 配列の警告を確認、`--files` 指定の妥当性を確認、必要に応じて再実行または手動確認、空の理由が正当であることを確認してから続行する
 
-    ```bash
-    bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
-      --workflow case-close --files <PR 変更ファイル一覧> --json
-    ```
-
-   `<PR 変更ファイル一覧>` の区切り形式は space 区切り（推奨、例: `--files docs/a.md docs/b.md docs/c.md`）、または comma 区切り（例: `--files docs/a.md,docs/b.md,docs/c.md`）。両形式の混在も可。
-
-   JSON 出力の `failures` に strict severity が含まれる場合はマージを停止し、対象ファイルを修正して再実行する。`full_docs_check_recommended` が true の場合は `/repo/docs-check`（全体監査）の実行をユーザーに提案する。draft→accepted 等の SPEC status 変更時は `spec_readme_update_required` を Step 3-2 SPEC 確定フローに反映する
-   - **files_checked 空時の確認（REQ）**: targeted docs guard の JSON 出力で `files_checked` が空の場合、検査見逃しリスクとして扱う。`warnings` 配列に検査対象ファイル未検出の警告が出力されるため、以下を確認する。確認を経ずに `files_checked` 空のまま完了扱いとしない:
-     1. 警告を検査見逃しのリスクとして認識する
-     2. `--files` 指定の妥当性を確認する（PR 変更ファイル一覧の再取得、パス指定の確認）
-     3. 必要に応じて `--files` を修正して再実行、または対象ファイルを手動確認する
-     4. 空の理由が正当（対象ファイルが本当に変更されていない等）であることを確認してから続行する
-
-**Step 3-2**: SPEC 確定フロー。
-PR 本文の `## SPEC確定候補` セクション（case-run/ driver が記録）を読み取り、SPEC の確定、昇格を処理する。
-セクションが存在しない、空の場合はスキップする:
- - **SPEC確定候補の提示**: SPEC確定候補一覧（対象 SPEC、内容、分類）をユーザーに提示する
- - **確定判断**: 各候補について以下のいずれかをユーザー承認のもと選択する:
- - (a) **case-close 内で SPEC 昇格**: 対象 SPEC の `status` を `draft` → `accepted` に昇格する（編集スコープ: `docs/specs/**`）。実装が SPEC 内容を検証済みであることを確認できた場合
- - (b) **spec-save 再起動の提案**: SPEC確定候補が SPEC ファイル未保存（新規 SPEC 候補、追記候補）の場合、`/agentdev/spec-save` の再実行を提案し case-close は完了させる
- - (c) **見送り**: 確定不要と判断した場合、候補を Findings/ Capture候補 に準じて記録し後続へ委ねる
- - **SPEC status 昇格タイミング（draft → accepted）**: 以下の両方を満たした場合に昇格させる:
- - 対象 SPEC が `status: draft` であること
- - 今回の実装（PR）が当該 SPEC の内容を検証（実装と整合）したことを case-close Step 3 の docs/検証で確認できたこと
-  - 昇格時は SPEC frontmatter `status` を `accepted` に更新し、`updated` 日付を更新する
+**Step 3-2**: SPEC 確定フロー。PR 本文の `## SPEC確定候補` セクション（case-run/ driver が記録）を読み取り、SPEC の確定、昇格を処理する。セクション不存在・空の場合はスキップ。(a) **case-close 内で SPEC 昇格**: 対象 SPEC の `status` を `draft` → `accepted` に昇格（編集スコープ: `docs/specs/**`、実装が SPEC 内容を検証済みの場合）。(b) **spec-save 再起動の提案**: SPEC確定候補が SPEC ファイル未保存の場合、`/agentdev/spec-save` の再実行を提案し case-close は完了させる。(c) **見送り**: 確定不要と判断した場合、候補を Findings/ Capture候補 に準じて記録し後続へ委ねる。SPEC status 昇格タイミング（draft → accepted）の詳細、frontmatter `status` と `updated` の更新、SPEC 確定候補処理の詳細は `agentdev-spec-file-manager/references/spec-lifecycle-application.md` を参照
 
 ### case-close が使用する検査ツール
 
-case-close が使用する検査ツール（integrity 契約 SPEC「Workflow × 使用ツールマトリックス」参照）:
-
-- check_changed_docs.ts（--workflow case-close、--files <PR 変更ファイル一覧>）: Step 3-1 targeted docs guard で実行（AG-003）
-- check_extensions.ts（IR-056）: `.opencode/commands/agentdev/**/*.md`, `.opencode/skills/agentdev-*/SKILL.md`, `.opencode/skills/agentdev-*/references/**/*.md`, `.agentdev/extensions/**` のいずれかを変更した場合に実行（Step 3-1）
-- test_strategy: QG-4 完了条件確認
-
-※上記は全て肯定表現である。
+case-close が使用する検査ツール（integrity 契約 SPEC「Workflow × 使用ツールマトリックス」参照）: check_changed_docs.ts（--workflow case-close、--files <PR 変更ファイル一覧>、Step 3-1 targeted docs guard で実行、AG-003）、check_extensions.ts（IR-056、`.opencode/commands/agentdev/**/*.md`, `.opencode/skills/agentdev-*/SKILL.md`, `.opencode/skills/agentdev-*/references/**/*.md`, `.agentdev/extensions/**` のいずれかを変更した場合に実行、Step 3-1）、test_strategy（QG-4 完了条件確認）。上記は全て肯定表現である
 
 ### Step 4: PRマージ
 
-**Step 4-0: squash merge 前の mergeable UNKNOWN ポーリング**。
-`agentdev-gh-cli` の「squash merge 前の mergeable UNKNOWN ポーリング」手続きに従い、対象 PR の `mergeable` 状態事前確認、`UNKNOWN` ポーリング待機、上限超過時の構造化エラー停止、待機中の `CONFLICTING` 遷移検出を自動分岐させ、コンフリクト解消パス（Step 4-2）へ即時接続する。ポーリング間隔・上限値は gh-cli 手続き側が所有する（AG-001）。
+**Step 4-0**: squash merge 前の mergeable UNKNOWN ポーリング。`agentdev-gh-cli` の「squash merge 前の mergeable UNKNOWN ポーリング」手続きに従い、対象 PR の `mergeable` 状態事前確認、`UNKNOWN` ポーリング待機、上限超過時の構造化エラー停止、待機中の `CONFLICTING` 遷移検出を自動分岐させ、コンフリクト解消パス（Step 4-2）へ即時接続する。ポーリング間隔・上限値は gh-cli 手続き側が所有する（AG-001）。PR merge 手続き（squash 方式、`agentdev-gh-cli`）を実行 → HEAD commit hash 記録（`agentdev-git-worktree` skill に従い）。**Squash merge 失敗時のリトライ**: `agentdev-gh-cli` の「squash merge リトライ手続き」に従う（待機間隔・最大試行回数は gh-cli 手続き側が所有、AG-001、各試行のログ記録、全試行失敗時のフォールバックは template `.opencode/commands/agentdev/templates/case-close/standard.md` 参照）。対応記録コメントを Issue に追加（テンプレート: `.opencode/skills/agentdev-workflow-templates/templates/issue_comment_*.md` から Read して `agentdev-gh-cli` の VERIFY 操作に従って内容検証）。**`--delete-branch` 使用禁止**: PR マージ時に `--delete-branch` オプションを使用しない（アクティブ worktree に checkout されたブランチで local 削除が失敗し remote 削除フェーズへ到達しないため）。ブランチ削除は Step 7 で独立実施する（REQ）
 
-  - PR merge 手続き（squash 方式、`agentdev-gh-cli`）を実行 → HEAD commit hash 記録（`agentdev-git-worktree` skill に従い）
-  - **Squash merge 失敗時のリトライ**: `agentdev-gh-cli` の「squash merge リトライ手続き」に従う。待機間隔・最大試行回数は gh-cli 手続き側が所有する（AG-001）。各試行のログ記録、全試行失敗時のフォールバック（template `.opencode/commands/agentdev/templates/case-close/standard.md` 参照）も同手続きに従う
-  - 対応記録コメントをIssueに追加 → テンプレート: `.opencode/skills/agentdev-workflow-templates/templates/issue_comment_*.md` から Readして `agentdev-gh-cli` の VERIFY 操作に従って内容検証
-  - **`--delete-branch` 使用禁止**: PR マージ時に `--delete-branch` オプションを使用しない。アクティブ worktree に checkout されたブランチで `--delete-branch` を使用すると local 削除が失敗し remote 削除フェーズへ到達しない。ブランチ削除は Step 7 で独立実施する（REQ）
+**Step 4-1**: Squash merge 後のローカル先行 commit 検出、処理（REQ）。squash merge 完了後、ローカルに remote 未 push の先行 commit が存在する場合、`agentdev-git-worktree` の「Squash merge 後分岐ハンドリング手順（REQ）」に従い、ローカル先行 commit 検出、内容重複確認、reset を実行する。本処理により `git pull --ff-only` 失敗を予防する
 
-**Step 4-1: Squash merge 後のローカル先行 commit 検出、処理（REQ）**。
-squash merge 完了後、ローカルに remote 未 push の先行 commit が存在する場合、`agentdev-git-worktree` の「Squash merge 後分岐ハンドリング手順（REQ）」に従い、ローカル先行 commit 検出、内容重複確認、reset を実行する。本処理により `git pull --ff-only` 失敗を予防する
-
-**Step 4-2: コンフリクト解消 rebase パス（REQ/002、REQ/025）**。
-squash merge がコンフリクトで失敗した場合（Step 4 のリトライ全失敗後、エラー原因がコンフリクトの場合）に実行する機械的解消パス（コンフリクト解消モデル Level 1）。
-`agentdev-git-worktree` の「コンフリクト解消 rebase パス（REQ）」に従い、rebase による機械的解消を試みる。**実装変更は行わず** rebase のみ試みる。rebase 自動解決時は squash merge（Step 4）へ戻り再マージ、rebase コンフリクト発生時は case-auto へエスカレーションして停止する（コンフリクト解消モデル Level 2/3 は case-auto の責務）
+**Step 4-2**: コンフリクト解消 rebase パス（REQ/002、REQ/025）。squash merge がコンフリクトで失敗した場合（Step 4 のリトライ全失敗後、エラー原因がコンフリクトの場合）に実行する機械的解消パス（コンフリクト解消モデル Level 1）。`agentdev-git-worktree` の「コンフリクト解消 rebase パス（REQ）」に従い、rebase による機械的解消を試みる（**実装変更は行わず** rebase のみ）。rebase 自動解決時は squash merge（Step 4）へ戻り再マージ、rebase コンフリクト発生時は case-auto へエスカレーションして停止する（コンフリクト解消モデル Level 2/3 は case-auto の責務）
 
 ### Step 5: Post-merge テスト戦略検証
 
@@ -197,61 +84,29 @@ Issue close 手続き（理由: completed、`agentdev-gh-cli`）
 
 ### Step 7: ブランチ、worktree削除
 
-`agentdev-git-worktree` の worktree削除手順に従う:
- - 未コミット変更検出（`agentdev-git-worktree` skill に従い）
- - squash merge 済みの場合 → 当該 worktree が隔離されている（専用 worktree + branch で index が独立）場合のみ `git checkout .` で破棄可。**共有作業ツリー（main worktree）では `git checkout .` は禁止**（他セッション変更の無差別破壊）。本 Step は worktree 削除フェーズ内の隔離 worktree でのみ実行する
-  - runtime workspace のクリーンアップは harness の責務。case-close は関与しない
- - worktree remove → Permission denied 時は停止（リトライは skill 定義に従う）
- - ローカルブランチ削除（squash merge 後の条件付き `-D` は skill 定義に従う）
- - リモートブランチ削除
- - 削除失敗時は警告表示して停止すること
+`agentdev-git-worktree` の worktree削除手順に従う: 未コミット変更検出（`agentdev-git-worktree` skill に従い）。squash merge 済みの場合 → 当該 worktree が隔離されている（専用 worktree + branch で index が独立）場合のみ `git checkout .` で破棄可。**共有作業ツリー（main worktree）では `git checkout .` は禁止**（他セッション変更の無差別破壊）。本 Step は worktree 削除フェーズ内の隔離 worktree でのみ実行する。runtime workspace のクリーンアップは harness の責務、case-close は関与しない。worktree remove → Permission denied 時は停止（リトライは skill 定義に従う）。ローカルブランチ削除（squash merge 後の条件付き `-D` は skill 定義に従う）。リモートブランチ削除。削除失敗時は警告表示して停止すること
 
 ### Step 8: 親Epic Issue更新
 
-`agentdev-epic-tracker` スキル参照:
- - Issue本文から Parent Issue番号を特定（`Parent: #{N}` パターン）
- - Parent なし → スキップ
- - ステータストラッキング表を更新 → `agentdev-gh-cli` VERIFY
- - 子Issue状態事前取得: Issue 補助データ読込手続き（`agentdev-gh-cli`）で全子Issueの OPEN/CLOSED 状態を一覧取得しログ出力（例: `子Issue状態一覧: #N1 (OPEN), #N2 (CLOSED), ...`）
- - Epic自動クローズ判定: 全子Issue CLOSED → 自動クローズ。1件以上 OPEN → スキップ
+`agentdev-epic-tracker` スキル参照: Issue本文から Parent Issue番号を特定（`Parent: #{N}` パターン）。Parent なし → スキップ。ステータストラッキング表を更新 → `agentdev-gh-cli` VERIFY。子Issue状態事前取得: Issue 補助データ読込手続き（`agentdev-gh-cli`）で全子Issueの OPEN/CLOSED 状態を一覧取得しログ出力。Epic自動クローズ判定: 全子Issue CLOSED → 自動クローズ。1件以上 OPEN → スキップ
 
 ### Step 9: 実行前同期
 
-**Step 9-1**: Step 1-1（重複ファイルチェック）再実行。
-`git pull --ff-only` 直前に、`agentdev-git-worktree` の「PR merge 前重複ファイルチェック」プロシージャを再実行する（L-013、PR #1128 由来）。
-  - 共有 main worktree で Step 1-1 実行時点から Step 9 実行までの間に並列セッションが加えた未コミット変更を検知するためである
-  - 重複ファイルを検出した場合、構造化エラーで停止しユーザーによる対応（stash/commit/checkout）を促すこと
-
-**Step 9-2: git main 同期リスク事前検出、代替同期手順選択（REQ）**。
-`agentdev-git-worktree` の「git main 同期リスク事前検出プロシージャ（REQ）」に従い、worktree 状態（dirty tree）・並列実行による ref lock 競合・非 main ブランチ占有の3リスク事前検出と代替同期手順選択を実行する。暗黙の手順順序依存を明示的な事前チェックに置き換える（3件の pull 失敗事象に基づく）。
-
-`agentdev-git-worktree` に従い `git pull --ff-only` を実行。ローカル変更事前チェック、hash検証、不一致時は評価、承認のやり直し
+**Step 9-1**: Step 1-1（重複ファイルチェック）再実行。`git pull --ff-only` 直前に、`agentdev-git-worktree` の「PR merge 前重複ファイルチェック」プロシージャを再実行する（L-013、PR #1128 由来、共有 main worktree で Step 1-1 実行時点から Step 9 実行までの間に並列セッションが加えた未コミット変更を検知するため）。重複ファイルを検出した場合、構造化エラーで停止しユーザーによる対応（stash/commit/checkout）を促すこと。**Step 9-2**: git main 同期リスク事前検出、代替同期手順選択（REQ）。`agentdev-git-worktree` の「git main 同期リスク事前検出プロシージャ（REQ）」に従い、worktree 状態（dirty tree）・並列実行による ref lock 競合・非 main ブランチ占有の3リスク事前検出と代替同期手順選択を実行する。`agentdev-git-worktree` に従い `git pull --ff-only` を実行（ローカル変更事前チェック、hash検証、不一致時は評価・承認のやり直し）
 
 ### Step 10: 学びの検知、抽出
 
-`agentdev-learning-capture` スキル（manual reference）に従い、エージェントが自ら学びの有無を判断:
- - ユーザーに学びの有無を問うことは禁止
- - 学びあり → `.agentdev/learning/inbox.md` に直接追記 → 通知
- - 採用済み成果物取り込み判定 → `agentdev-learning-pipeline`（manual reference）の deferred ルール
- - **Capture 回収責務**: PR 本文の `## Findings / Capture候補` セクションから intake/ learning を分離回収する。intake 候補は `.agentdev/intake/inbox/` に保存し、learning 候補は `.agentdev/learning/inbox.md` に保存する。Epic 横断回収
- - **Capture 境界**: intake/ learning 境界は `agentdev-workflow-orchestration` を参照
- - intake と learning を別々の成果物として扱う
- - **一時会話コンテキスト不入力**: case-run の一時会話コンテキスト（ローカル変数、中間ファイル等）を capture の入力として使用しない。capture 情報の入力源は PR 本文のみ
+`agentdev-learning-capture` スキル（manual reference）に従い、エージェントが自ら学びの有無を判断（ユーザーに学びの有無を問うことは禁止）。学びあり → `.agentdev/learning/inbox.md` に直接追記 → 通知。採用済み成果物取り込み判定 → `agentdev-learning-pipeline`（manual reference）の deferred ルール。**Capture 回収責務**: PR 本文の `## Findings / Capture候補` セクションから intake/ learning を分離回収する（intake 候補は `.agentdev/intake/inbox/`、learning 候補は `.agentdev/learning/inbox.md`、Epic 横断回収）。**Capture 境界**: intake/ learning 境界は `agentdev-workflow-orchestration`（capture-boundaries）を参照。intake と learning を別々の成果物として扱う。**一時会話コンテキスト不入力**: case-run の一時会話コンテキスト（ローカル変数、中間ファイル等）を capture の入力として使用しない。capture 情報の入力源は PR 本文のみ
 
 ### Step 11: ドメイン状態永続化
 
 `agentdev-git-worktree` に従い `.agentdev/` 配下を commit/push。learning と intake を同一 commit に含める
 
-> **auto-close 回避の留意点**: 本コマンド名 `case-close` は "close" を含む複合語である。コミットメッセージに `(case-close #N)` 等のコマンド名と Issue 番号の近接表記を用いると、GitHub が "close" を auto-close キーワードと誤認し Issue を意図せずクローズするリスクがある。コミットメッセージのフォーマットは `agentdev-conventional-commits` skill の「GitHub auto-close 回避ガイドライン」に従い、コマンド名と Issue 番号を分離し `#` 記号による近接参照を避けること（例: `case-close for Issue N`）。
+> **auto-close 回避の留意点**: 本コマンド名 `case-close` は "close" を含む複合語。コミットメッセージに `(case-close #N)` 等のコマンド名と Issue 番号の近接表記を用いると、GitHub が "close" を auto-close キーワードと誤認し Issue を意図せずクローズするリスクがある。コミットメッセージのフォーマットは `agentdev-conventional-commits` skill の「GitHub auto-close 回避ガイドライン」に従い、コマンド名と Issue 番号を分離し `#` 記号による近接参照を避けること（例: `case-close for Issue N`）
 
 ### Step 12: 完了報告
 
-完了報告templateに従って出力。結果状態に応じた種別を選択:
- - 全系統成功 → .opencode/commands/agentdev/templates/case-close/standard.md
- - .agentdev push失敗 → .opencode/commands/agentdev/templates/case-close/`agentdev-push-failed`.md
- - ブランチ、worktree削除失敗 → .opencode/commands/agentdev/templates/case-close/worktree-cleanup-failed.md
- - GitHub完了後に .agentdev push失敗の場合は standard 種別 を使用してはならない
- - **結果状態の分離報告**: GitHub側完了状態、`.agentdev` 永続化状態、ブランチ削除状態を独立して報告
+完了報告templateに従って出力。結果状態に応じた種別を選択: 全系統成功 → `.opencode/commands/agentdev/templates/case-close/standard.md`、`.agentdev` push失敗 → `agentdev-push-failed.md`、ブランチ・worktree削除失敗 → `worktree-cleanup-failed.md`。GitHub完了後に `.agentdev` push失敗の場合は standard 種別 を使用してはならない。**結果状態の分離報告**: GitHub側完了状態、`.agentdev` 永続化状態、ブランチ削除状態を独立して報告
 
 ## ガードレール
 
@@ -262,27 +117,18 @@ Issue close 手続き（理由: completed、`agentdev-gh-cli`）
 - G05: ブランチ、worktree削除は必ず実行。失敗時は警告表示して停止
 - G06: `git pull --ff-only` は必ず実行。pull前ローカル変更チェック、hash検証必須
 - G07: PRのCI通過確認。CI失敗時は case-run に差し戻す
- - G08: 未達チェックボックスが残る場合、構造化エラーで停止。チェックボックス更新後は必ず再読込して反映を確認
+- G08/G20: 未達チェックボックスが残る場合、構造化エラーで停止。チェックボックス更新後は必ず再読込して反映を確認。完了条件チェックボックスの評価・更新は case-close の専任責務（case-run/ driver/ 外部実行バックエンドは更新しない、別コンテキストで再読込し最終完了判定、更新後に再読込 VERIFY 必須）
 - G09: 機能追加で docs/ 更新がない場合、警告表示して停止確認
 - G10: テスト戦略チェックボックスを必ず更新
-- G11: コメントテンプレートの【必須】セクション確認
-- G12: GitHub Issue/PR 操作は `agentdev-gh-cli` の手続きへ委譲（gh コマンド直接記述禁止、REQ）
+- G11: コメントテンネートの【必須】セクション確認
+- G12/G14: GitHub Issue/PR 操作は `agentdev-gh-cli` の手続きへ委譲（gh コマンド直接記述禁止、REQ、gh CLI出力読み取りは `agentdev-gh-cli` の安全な手順に従う）
 - G13: 学びの検知はエージェント自律。ユーザーに問わない
-- G14: gh CLI出力読み取りは `agentdev-gh-cli` の安全な手順に従う
-- G15: intake と learning を混合した単一成果物にしない（`agentdev-workflow-orchestration` の capture 境界に準拠）
-- G16: 今回の完了条件に含まれる未対応事項を intake に逃がして完了扱いにしない
-- G17: Step 11 の commit は並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、明示パス（`git add <path>`/ `git rm <path>`）でステージし、`git commit -- <paths>`（--only pathspec 形式）で実行する。`git add` は capture 成果物の専用サブディレクトリ（`.agentdev/learning/`、`.agentdev/intake/`）または明示パスに限定し、`.agentdev/` 全体の一括スコープにしないこと。他パスを巻き込まない
-- G18: learning と intake を同一 commit に含める
+- G15/G16/G18: intake と learning を混合した単一成果物にしない（`agentdev-workflow-orchestration` capture 境界準拠）。learning と intake を同一 commit に含める。今回の完了条件に含まれる未対応事項を intake に逃がして完了扱いにしない
+- G17: Step 11 の commit は並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、明示パス（`git add <path>`/ `git rm <path>`）でステージし、`git commit -- <paths>`（--only pathspec 形式）で実行する。`git add` は capture 成果物の専用サブディレクトリ（`.agentdev/learning/`、`.agentdev/intake/`）または明示パスに限定し、`.agentdev/` 全体の一括スコープにしないこと
 - G19: Step 12 は結果状態を分離して報告。`.agentdev` push失敗時は完了扱いにしない
-- G20: 完了条件チェックボックスの評価、更新は case-close の専任責務。case-run/ driver/ 外部実行バックエンドは更新しない。case-close は別コンテキストで Issue 本文を再読込して最終完了判定し、更新後に再読込 VERIFY を必ず実施する
-- G21: case-close の capture 責務は「回収・保存」（recover and save）。PR 本文から intake/ learning を分離回収しドメイン状態に保存する。capture 境界（capture-boundaries）の詳細は `agentdev-workflow-orchestration` 参照
-- G22: SPEC status 昇格（draft → accepted）は case-close の責務。昇格は対象 SPEC が `draft` かつ今回の実装が SPEC 内容を検証済みの場合のみ実施する。spec-save は accepted を付与しない
-- G23: SPEC確定候補の処理（Step 3-2）は PR 本文の `## SPEC確定候補` セクションを入力とし、`## Findings / Capture候補` とは区別して扱う
-- G24: Epic Issue 本文ステータス追跡テーブルの更新は case-close のみが実施する（単一書き手制約）。case-run は Epic Issue 本文を読み取るのみで書き込まない。case-auto は Wave 反復制御のみ行い Epic Issue 本文に直接書き込まない。last-write-wins 競合防止は case-close の単一書き手で維持される
-- G25: Epic Wave クローズ（Step E1〜E6）は Epic Issue番号入力時（ステータス追跡テーブル存在時）のみ実行。単一 Issue番号入力時は従来フロー（単一 Issue クローズ Step 1-1〜）を維持する（後方互換）
-- G26: Epic Wave クローズ時の PR マージ、子Issue クローズは現在 Wave の `running` 子Issue のみを対象とする。`pending`/ `ready`/ `blocked`/ `failed` は対象外。`blocked`/ `failed` を `completed` に上書きしない（べき等性、`agentdev-epic-tracker` 準拠）
-- G27: squash merge 実行前に PR の mergeable 状態を事前確認し、UNKNOWN の場合は mergeable になるまでポーリング待機すること。待機間隔・上限は `agentdev-gh-cli` の mergeable UNKNOWN ポーリング手続きが所有する（AG-001）。上限超過時はマージを中止し構造化エラーで停止する。ポーリングを省略して UNKNOWN 状態のままマージを試行してはならない
-- G28: `git pull --ff-only` 実行前に worktree 状態（dirty tree）・並列実行による ref lock 競合・非 main ブランチ占有の3リスクを事前検出し、検出時に安全な代替同期手順を選択すること（REQ）。暗黙の手順順序依存で pull を継続してはならない
+- G21/G22/G23: case-close の capture 責務は「回収・保存」（PR 本文から intake/ learning を分離回収しドメイン状態に保存、capture 境界は `agentdev-workflow-orchestration` 参照）。SPEC status 昇格（draft → accepted）は case-close の責務（対象 SPEC が `draft` かつ今回の実装が SPEC 内容を検証済みの場合のみ、spec-save は accepted を付与しない）。SPEC確定候補の処理（Step 3-2）は PR 本文の `## SPEC確定候補` を入力とし `## Findings / Capture候補` とは区別
+- G24/G25/G26: Epic Issue 本文ステータス追跡テーブルの更新は case-close のみ（単一書き手制約、case-run は読み取りのみ、case-auto は Wave 反復制御のみ直接書き込まない、last-write-wins 競合防止は case-close の単一書き手で維持）。Epic Wave クローズ（Step E1〜E6）は Epic Issue番号入力時（ステータス追跡テーブル存在時）のみ実行、単一 Issue番号入力時は従来フローを維持（後方互換）。Epic Wave クローズ時の PR マージ・子Issue クローズは現在 Wave の `running` 子Issue のみ対象（`pending`/ `ready`/ `blocked`/ `failed` は対象外、`blocked`/ `failed` を `completed` に上書きしない、べき等性、`agentdev-epic-tracker` 準拠）
+- G27/G28: squash merge 実行前に PR の mergeable 状態を事前確認し UNKNOWN の場合は mergeable になるまでポーリング待機（待機間隔・上限は `agentdev-gh-cli` の mergeable UNKNOWN ポーリング手続きが所有、AG-001、上限超過時はマージ中止し構造化エラーで停止、ポーリング省略して UNKNOWN 状態のままマージ試行禁止）。`git pull --ff-only` 実行前に worktree 状態（dirty tree）・並列実行による ref lock 競合・非 main ブランチ占有の3リスクを事前検出し、検出時に安全な代替同期手順を選択（REQ、暗黙の手順順序依存で pull を継続しない）
 
 
 

--- a/src/opencode/commands/agentdev/case-open.md
+++ b/src/opencode/commands/agentdev/case-open.md
@@ -4,13 +4,9 @@ description: 要件定義をもとにGitHub Issueを作成する
 
 # Case登録
 
-要件定義（req-define）の結果をもとにGitHub Issueを作成する。
-①壁打ち→②構造的実行フェーズの境界。
+要件定義（req-define）の結果をもとにGitHub Issueを作成する。①壁打ち→②構造的実行フェーズの境界。
 
-**draft-data 入力**: case-open は構造化 `draft-data`（`# draft-data` fenced YAML block）を入力として読み取る。
-draft 全体の `agreed_items`、`artifact_actions`、`operation_units` を処理対象とし、OU ごとにスライスせず draft 全体の合意結果を取り扱う。
-`auto_gate.auto_ready` が false、または未解決質問、未解決衝突、repo外操作、停止理由が残る場合は停止する。
-`conflict_resolutions` に記録済みの衝突については同じ内容をユーザーへ再確認しない。
+**draft-data 入力**: case-open は構造化 `draft-data`（`# draft-data` fenced YAML block）を入力として読み取る。draft 全体の `agreed_items`、`artifact_actions`、`operation_units` を処理対象とし、OU ごとにスライスせず draft 全体の合意結果を取り扱う。`auto_gate.auto_ready` が false、または未解決質問、未解決衝突、repo外操作、停止理由が残る場合は停止する。`conflict_resolutions` に記録済みの衝突については同じ内容をユーザーへ再確認しない
 
 ## 入力
 
@@ -22,192 +18,54 @@ draft 全体の `agreed_items`、`artifact_actions`、`operation_units` を処�
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-open.yaml`）を読み込む（ADR）。
-
-- extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
-- extension が存在しない場合は標準動作で続行する
-- extension が破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する
-- 詳細な読み込み契約は `agentdev-project-extensions` skill 参照
+本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-open.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
 ## 手順
 
 ### Step 1: 前工程からの引き継ぎ停止判定
 
-要件docまたは RU に `agentdev_handoff: true` が含まれる場合、リポジトリ種別に応じて以下の判定を行う:
+要件doc または RU に `agentdev_handoff: true` が含まれる場合、リポジトリ種別に応じて分岐（詳細は `agentdev-workflow-lifecycle` runtime-package-boundary 参照）: self-hosting リポジトリ（ジャンクション or 実ディレクトリ）では履歴メタデータとして処理を継続、consumer リポジトリ（コピー配置等）では Issue を作成せず停止し agent-dev-flow repository への手動取り込み対象として報告
 
-- **self-hosting リポジトリ**（`.opencode/commands/agentdev/` がジャンクションまたは実ディレクトリ）: `agentdev_handoff: true` を取り込み元の履歴メタデータとして扱い、通常の req/case workflow 入力として処理を継続する（停止しない）
-- **consumer リポジトリ**（ジャンクションではなくコピー配置等）: Issue を作成せず停止し、agent-dev-flow repository への手動取り込み対象として報告する
-
-リポジトリ種別の判定基準は `agentdev-workflow-lifecycle`（runtime-package-boundary 参照）に従う
-
-**Step 1-1**: OU 選択ゲート（ドラフトに `operation_units` セクションがある場合、処理対象 OU を決定する）:
-- OU ID 指定あり → 当該 OU のみを処理対象とする例外経路。指定された OU の req-save result を読み取り、その OU だけを Issue 化する
-- OU ID 指定なし → draft 全体の OU 群を処理対象とする既定経路
-  - OU 1 件 → 当該 OU を自動選択して処理
-  - OU 2 件以上 → draft 全体の OU 群から execution_unit 構成を生成し、複数 Standard Issue / 複数 Epic Issue / 混在を生成する（Step 3-1 の自律構成生成へ分岐）。旧「OU 一覧表示停止」は廃止
-- `operation_units` セクションがない場合 → 従来どおり全要件docを処理する（後方互換）
+**Step 1-1**: OU 選択ゲート（`operation_units` セクションがある場合）。OU ID 指定あり → 当該 OU のみを処理対象とする例外経路。OU ID 指定なし → OU 1件なら自動選択、2件以上なら execution_unit 構成を生成し Step 3-1 へ分岐。`operation_units` セクションがない場合は従来どおり全要件docを処理（後方互換）
 
 ### Step 2: 要件docからIssue本文を生成
 
-詳細は `agentdev-issue-management` を参照。委譲接続点: サブエージェントはREQ読解、テンプレート充足検査、完了条件候補抽出のみを返し、親エージェントが本文確定とIssue作成を行う。本文候補の受け渡しは `agentdev-issue-management` の「委譲接続点と本文受け渡し」セクションに従いファイルパス経由で行う（G25）
+詳細、委譲接続点（サブエージェントはREQ読解、テンプレート充足検査、完了条件候補抽出のみを返し、親エージェントが本文確定とIssue作成）は `agentdev-issue-management` を参照。本文候補の受け渡しは `agentdev-issue-management` の「委譲接続点と本文受け渡し」セクションに従いファイルパス経由で行う（G25）
 
-**Step 2-1**: 完了条件網羅性検証（QG-2）。
-Issue本文生成後、Issue作成前に、`agentdev-quality-gates` の QG-2（Acceptance Criteria Coverage Gate）に従い、完了条件が対象 REQ/ADR/SPEC の必達要件を網羅しているかを検証する。
-判定基準、検査観点は同スキル（`agentdev-quality-gates`）の QG-2 を参照。
-fail 時は Issue 作成前に req-define 差し戻しを推奨
+**Step 2-1/2-1a/2-1b**: QG-2 完了条件網羅性検証。Issue本文生成後、Issue作成前に `agentdev-quality-gates` の QG-2 に従い完了条件が対象 REQ/ADR/SPEC の必達要件を網羅しているかを検証（fail 時は req-define 差し戻し推奨）。**2-1a**: 数値閾値到達可能性検証（QG-2 観点6、#1538/TS-007 由来、要件定義者が明示した閾値のみ受け付け、自動推論しない）。**2-1b**: スコープ明示（本 Issue 対象範囲 vs 全体、#1532/TS-006 由来、QG-4 観点8 判定マトリクスの入力前提、識別子中心、横断評価は「全体」デフォルト）
 
-**Step 2-1a**: 完了条件の数値閾値到達可能性検証（QG-2 観点6）。
-完了条件に数値閾値（LF 数、行数、ファイル数、件数等）を含む場合、当該閾値が同種既存成果物の実測値と比較して対象成果物の自然な構造で到達可能であることを検証する。
-test strategy 策定ガイド（`agentdev-req-analysis` の「test strategy 数値閾値ガイド」）に基づく策定が前提。境界ケース #1538/TS-007 由来。
-- 検出時点で閾値の根拠（同種既存例の実測値、中央値/最小値/最大値）が記載されていない場合、要件定義者に根拠明示を確認する
-- case-open は自動推論を行わず、要件定義者が明示した閾値のみを受け付ける
+**Step 2-2**: test_strategy 埋め込み（REQ）。draft-data の `test_strategy` を読み取り、Issue 本文の「テスト戦略」セクションに 3 要素構造（`verification` / `pass_criteria` / `on_failure`）で反映（スキーマは req-define command SPEC extension 経由）。未定義の場合はテンプレートのプレースホルダをそのまま残す
 
-**Step 2-1b**: 完了条件のスコープ明示（本 Issue 対象範囲 vs 全体）。
-完了条件が横断評価（全成果物を横断する評価）を含む場合、各完了条件の評価スコープ（本 Issue 対象範囲 or リポジトリ全体/当該 SPEC/REQ 全体）を要件定義者が明示したかを確認する。QG-4 の「PR 対象範囲 vs 全体 判定マトリクス」（`qg-4-final-acceptance.md` 観点8）に対応する入力前提。境界ケース #1532/TS-006 由来。
-- スコープ明示がない場合、case-open は要件定義者に確認する（自動推論しない）
-- スコープは識別子中心（ファイルパス、REQ ID、NG ID、IR ID）で明示する（Step 2-3 記載粒度ガイドライン準拠）
-- 横断評価の完了条件は「全体（再 grep、再検査）」をスコープとすることをデフォルトとする
-
-**Step 2-2**: test_strategy 埋め込み（REQ）。
-draft-data の `test_strategy` を読み取り、Issue 本文の「テスト戦略」セクションに埋め込む。
-各項目を 3 要素構造（`verification`（検証手順）、`pass_criteria`（合格基準）、`on_failure`（不合格時の処置））で反映する。
-3 要素のスキーマは req-define command SPEC（extension 経由で解決）の「draft-data test_strategy フィールドスキーマ」に従う。
-draft-data に `test_strategy` が未定義の場合は、テンプレートのプレースホルダをそのまま残す
-
-**Step 2-3**: 完了条件・事前状態の記載粒度ガイドライン（識別子中心・件数補助値、REQ）。
-Issue 本文の完了条件・事前状態セクションの記載を識別子中心とし、件数等の変動しやすい実測値スナップショットは補助値として扱う。本ガイドラインは case-run の QG-3 前置 staleness check（ファイルパス存在確認、検査結果件数再計測）が識別子ベースで参照解決するための入力前提を整える:
-
-- **記載対象（識別子中心、主軸）**: ファイル相対パス（`.opencode/commands/agentdev/case-run.md` 等）、NG 識別子（`NG-xxx`）、IR ID（`IR-NNN`）、REQ ID（`REQ-NNNN-MMM`）
-- **補助値として許容する実測値**: NG 件数、IR 違反件数等の集計値。識別子リストに付随する参考情報として記載し、完了条件の判定主軸にはしない
-- **理由**: 件数・集計値は Issue 作成時点のスナップショットであり実装進行中に変動する。識別子は安定しており、後続 case-run の staleness check が識別子ベースで参照解決を行えるようにするため
-
-記載例:
-
-```
-## 完了条件（識別子中心）
-
-- [ ] `src/opencode/commands/agentdev/case-run.md` に staleness check Step が追加されていること
-- [ ] NG-123 が解消されていること
-- [ ] IR-053 違反が 0 件であること（参考: 現行 3 件）
-```
-
-**Step 2-4**: 完了条件展開前の最新状態再確認（REQ）。
-Step 2 の Issue 本文生成（完了条件展開）に先立ち、対象パスで最新状態の再確認を行う。検出時点スナップショットと起票時点の最新状態に差異がある場合、最新状態を優先する。本手順は Step 2-3 の記載粒度ガイドラインと連動し、case-run の QG-3 前置 staleness check が識別子ベースで参照解決するための入力前提を整える。
-
-再確認を必須とするタイミング:
-
-- **同日内複数 PR マージ後の Issue 起票**: 同一日内に複数 PR がマージされた後、当該マージにより `docs/requirements/REQ-*.md`、`docs/adr/ADR-*.md`、`docs/specs/**/*.md` の内容が変動する可能性があるため、起票前に最新状態を再確認する
-- **順次 Wave 実行時の後続 Wave Issue 起票**: 複数 Wave が順次実行される場合、先行 Wave のマージ完了後に後続 Wave の Issue を起票する際、件数等の実測値が変動している可能性があるため再確認する
-
-再確認は識別子（ファイルパス、REQ ID、NG ID、IR ID）の存在確認を主軸とし、件数等の実測値は補助値として扱う（Step 2-3 の記載粒度ガイドライン準拠）。
-
-**Step 2-5**: review_dispositions の読取、evidence 再確認、証跡転記（AG-008）。
-draft-data の `review_dispositions` を読み取り、default branch 最新化後に各 disposition の evidence（`path`、`section`）の実在性と最新性を再確認する。本手順は review_dispositions の consumer 契約（case-open command SPEC（extension 経由）の「review_dispositions の consumer 契約」節参照）に従う。
-
-- **読取**: draft-data の `review_dispositions` を読み取る。フィールド欠落時は後方互換（AG-001）として処理を継続する
-- **evidence 再確認**: default branch 最新化後に各 disposition の `evidence.path` と `evidence.section` の実在性を再確認する。再確認時の commit SHA を当該 disposition の `evidence.checked_at_commit` へ記録する
-- **停止条件**: evidence の path または section が存在しない場合（失効）、Issue を作成せず停止する。当該 disposition を `stale_target` へ更新するか再評価対象として扱い、ユーザーへ停止理由を報告する。`covered` のまま失効した根拠で起票しない
-- **証跡転記**: 再確認した disposition を Issue 本文の「レビュー判断」セクションへ恒久証跡として転記する。転記規則（単一 Standard Issue / Epic flow / 複数 Standard Issue）は case-open command SPEC（extension 経由）の「review_dispositions の消費と証跡転記」節に従う
-- **再確認禁止**: 記録済みの判断（disposition、reason）をユーザーへ再確認しない。case-open は evidence の実在性と最新性の確認のみを行う
+**Step 2-3/2-4/2-5**: 識別子中心の記載粒度ガイドライン（2-3、case-run の QG-3 前置 staleness check の入力前提、詳細・記載例は `agentdev-issue-management` 参照）、完了条件展開前の最新状態再確認（2-4、同日内複数 PR マージ後・順次 Wave 実行時の後続 Wave Issue 起票で必須、識別子存在確認を主軸）、review_dispositions の読取・evidence 再確認・証跡転記（2-5、AG-008、consumer 契約は case-open command SPEC extension 経由、evidence 失効時は停止し `stale_target` へ更新）の各詳細は `agentdev-issue-management`、case-open command SPEC（extension 経由）を参照
 
 ### Step 3: マルチREQ入力判定
 
-入力要件doc数を確認
-- 単一REQ → Step 4
-- 複数REQ または draft-meta `scale: large` → **マルチREQ Epic flow**（Step 5〜）
-- **OU モード時**: Step 1-1 で選択した OU が複数または `scale: large` を含む場合 → Epic flow に分岐（Step 3-1 で自律的に構成を生成）
+入力要件doc数を確認。単一REQ → Step 4。複数REQ または draft-meta `scale: large` → **マルチREQ Epic flow**（Step 5〜）。OU モード時: Step 1-1 で選択した OU が複数または `scale: large` を含む場合 → Epic flow に分岐（Step 3-1 へ）
 
-**Step 3-1**: 自律構成生成（OU モード、複数REQ時）。
-ドラフトの `operation_units` セクションを読み取り、要件分析に基づいて Epic/ Wave/ Issue 構造を自律生成する。
-req-define の出力（operation_units の `depends_on`, `recommended_order` 等）は参考情報とし、case-open が最終構造を決定する:
-- 複数 OU が存在する場合、要件分析に基づいて Epic Issue および子 Issue 構造を生成する
-- **独立 OU の自動 Epic 化（REQ）**: 複数の独立 OU（`depends_on` 空、L0 相当）を検出した場合、自動的に Epic Issue 化し Wave 1 に全 OU を配置する。これにより Standard flow は「真に単一 OU のみ」に縮退し、Standard/Epic 二系統を単一 Wave 実行モデルに統一する。独立 OU が1件のみの場合は Standard flow（Epic 化しない、G20）
-- **停止条件**: 要件が曖昧で Issue 構造を生成できない場合、または operation_units の要件に矛盾が含まれる場合は停止し、要件の明確化を求める
-- **禁止事項**: 機能要件、非機能要件、制約、対象外、受け入れ条件を新規に作成しない。実装順序、Issue分解についてユーザー確認を求めない
-- **Wave テーブル「実行方法」列の生成**: case-open は各子Issue の実行方法（並列/直列）を技術的依存関係レベルに基づいて Wave テーブルに明記する。判定基準は workflow-contracts SPEC（extension 経由）Wave スケジューリングセクションの依存レベル定義に基づく:
- - L0（完全独立）、L1（Specs共有）→「並列」
- - L2（ファイル衝突）、L3（明示的依存）→「直列」
-- **構成生成事前検証（preflight）**: 自律構成生成の完了後、Step 4-1（構成生成事前検証）を実施する。構成不備を検出した場合は GitHub Issue 作成前に停止する
+**Step 3-1**: 自律構成生成（OU モード、複数REQ時）。ドラフトの `operation_units` を読み取り要件分析に基づき Epic/Wave/Issue 構造を自律生成（req-define 出力は参考情報、case-open が最終構造を決定）。独立 OU の自動 Epic 化（REQ、複数の独立 OU `depends_on` 空 L0 相当を検出時、Wave 1 に全 OU 配置、独立 OU 1件のみなら Standard flow G20）。Wave テーブル「実行方法」列（L0/L1 → 並列、L2/L3 → 直列）。停止条件、禁止事項、構成生成事前検証（preflight）の詳細は `agentdev-epic-tracker` を参照
 
 ### Step 4: 規模判定（Step 3 で単一REQの場合）
 
-- `scale: large` → **単一REQ Epic flow**（Step 5〜）
-- `scale: standard`/ フィールドなし → **Standard flow**（Step 10〜）
+`scale: large` → **単一REQ Epic flow**（Step 5〜）。`scale: standard`/フィールドなし → **Standard flow**（Step 10〜）。**Step 4-1**: 構成生成事前検証（preflight、Step 3-1 通過時および Step 4 通過時に実施）。Standard/Epic/混在構成の全ルートで GitHub Issue 作成前に共通の事前検証（5項目: 各 Epic の子 Issue 数が10件以下、各 Wave の同時実行対象が5件以下、各 Standard Issue と子 Issue が1つの OU に対応、必須依存関係が維持、全 OU が execution_unit へ割当・欠落重複なし）。検証で上限超過または構成不備を検出した場合は Issue 作成呼び出しを行わず停止する。検証失敗時はドラフト削除、RU ファイル削除を実施せず再開可能な状態で停止
 
-**Step 4-1**: 構成生成事前検証（preflight、Step 3-1 通過時および Step 4 通過時に実施）。
-Standard flow、Epic flow、混在構成の全ルートで、GitHub Issue 作成前に共通の事前検証を実施する。execution_unit 構成の確定後、最初の GitHub Issue 作成呼び出し（Epic Issue 作成、Standard Issue 作成、子 Issue 作成を含む）の前に完了する。検証項目（5項目）:
-
-1. 各 Epic の子 Issue 数が10件以下であること
-2. 各 Wave の同時実行対象が5件以下であること
-3. 各 Standard Issue および各子 Issue が1つの OU と対応していること
-4. 必須依存関係（連結成分のエッジ）が維持されていること
-5. 全 OU がいずれか1つの execution_unit へ割り当てられ、欠落・重複がないこと
-
-検証で上限超過または構成不備を検出した場合、GitHub Issue 作成呼び出しを行わず停止する。Epic Issue、Standard Issue、子 Issue のいずれかを作成済みの状態での検証失敗を許容しない。検証失敗時は要件doc（draft）の削除、RU ファイルの削除を実施せず、再開可能な状態で停止する。
-
-**共通ルール**（全Step適用）:
-- **VERIFY**: gh CLI書込後は毎回 `agentdev-gh-cli` の VERIFY操作に従い検証
-- **テンプレート準拠**: テンプレート読込後は毎回【必須】セクションの完備を確認（【任意】は内容がある場合のみ含める）、欠落時は再生成
+**共通ルール**（全Step適用）: VERIFY（gh CLI 書込後は毎回 `agentdev-gh-cli` VERIFY 操作で検証）、テンプレート準拠（テンプレート読込後は毎回【必須】セクションの完備を確認、【任意】は内容がある場合のみ含める、欠落時は再生成）
 
 ### Step 5: テンプレート読込（Epic flow）
 
-`agentdev-workflow-templates` の選定ルールに従いテンプレートを読み込む。詳細は `agentdev-issue-management` を参照
+`agentdev-workflow-templates` の選定ルールに従いテンプレートを読み込む。詳細は `agentdev-issue-management` を参照。Epic flow は Step 3 または Step 4 のルーティングにより開始。マルチREQ/ 単一REQ の差分（分解ソース、Waveテーブル列、子Issue数上限、子Issue内容ソース、子Issue追加要素）の詳細は `agentdev-epic-tracker` を参照
 
-Epic flow は Step 3 または Step 4 のルーティングにより開始。マルチREQ/ 単一REQ の差分:
+### Step 6〜9: Epic flow（Step 5 通過後）
 
-| 差分項目 | マルチREQ | 単一REQ |
-|----------|-----------|---------|
-| 分解ソース | 各REQ doc単位 | draft-meta `decomposition` |
-| Waveテーブル列 | Wave/Issue/実行方法/前提/対象REQ | Wave/Issue/実行方法/前提 |
-| 子Issue数上限 | G15（最大10） | G05（最大10） |
-| 子Issue内容ソース | 各REQ docから生成 | decomposition内容から生成 |
-| 子Issue追加要素 | Wave番号+依存記載、REQ doc番号明示（traceability）、孫Issue判定 | なし |
+- **Step 6**: Epic Issue本文を生成。Step 3-1 の自律構成分析結果に基づき Epic 本文を構築。詳細、委譲接続点は `agentdev-issue-management` を参照
+- **Step 7**: Epic Issueを作成。ラベル `enhancement`, `feature`, `epic`。Issue 作成手続き（`agentdev-gh-cli`）で本文を書き込み → VERIFY。Issue番号を `{epic_number}` として記録
+- **Step 8**: 子Issueを作成。Issue 化単位は OU 単位（G14、G21）。子Issue 本文に `Parent: #{epic_number}`（G03）、対象 OU ID、紐づく REQ/ADR/SPEC 識別子を記載。子Issue 本文案作成、検査、Issue 作成は最大5件まで並列化（3つの「5件」文脈のうち case-run Wave 内子 Issue 並列上限と同一、後述）。Epic Issue 作成、Wave 1 配置、Epic 本文ステータス追跡テーブル更新は親が直列集約（REQ、G04 集約更新で維持）。詳細、委譲接続点は `agentdev-issue-management` を参照。**前工程完了度属性の埋め込み（REQ）**: 各子 Issue 本文の「## 補足情報」セクションに「前工程完了度」属性を埋め込む（3段階: 完全完了/ 検証のみ/ 補完あり、epic-wave-model SPEC extension 経由）
+- **Step 9**: Epic Issue本文を更新。詳細、委譲接続点は `agentdev-issue-management` を参照。**Step 9-1**: OU 結果の書き戻し（`operation_units` セクションがある場合、作成した Issue/Epic 番号を当該 OU の `result` に書き戻す）。**Epic flow 完了後、共通終了処理（Step 13〜15）を必ず実行すること**
 
-### Step 6: Epic Issue本文を生成（Epic flow）
+### Step 10〜12: Standard flow（Step 4 通過後）
 
-Step 3-1 の自律構成分析結果（Epic/ Wave/ Issue 構造、依存関係）に基づいて Epic 本文を構築する。
-詳細は `agentdev-issue-management` を参照。
-委譲接続点: サブエージェントは分解候補、依存候補、子Issue数検査を pass/warn/fail/partial で返し、親エージェントがEpic本文と停止判断を確定する。本文候補の受け渡しは `agentdev-issue-management` の「委譲接続点と本文受け渡し」セクションに従いファイルパス経由で行う（G25）
-
-### Step 7: Epic Issueを作成（Epic flow）
-
-- ラベル: `enhancement`, `feature`, `epic`
-- Issue 作成手続き（`agentdev-gh-cli`）で本文を書き込み → VERIFY。Issue番号を `{epic_number}` として記録
-
-### Step 8: 子Issueを作成（Epic flow）
-
-Issue 化単位は REQ doc 単位ではなく OU 単位とする（G14、G21）。各子 Issue は対応 OU 経由で REQ/ADR/SPEC へのトレーサビリティを保持する。子Issue 本文に `Parent: #{epic_number}`（G03）、対象 OU ID、紐づく REQ/ADR/SPEC 識別子を記載し、OU 単位でトレーサビリティを確保する。
-子Issue 本文案作成、検査、Issue 作成は最大5件まで並列化できる。この「5件」は case-run Wave 内子 Issue 並列上限と同一の実行安全境界であり、Phase 2 同時起動数、execution_unit 全体並列上限なしとは別文脈である（「並列上限と3つの『5件』文脈」セクション参照）。
-Epic Issue 作成、Wave 1 配置、Epic 本文ステータス追跡テーブル更新は親が直列集約する（REQ）。
-G04「全子Issue 作成完了後にテーブル更新（部分更新禁止）」は集約更新で維持する。
-詳細は `agentdev-issue-management` を参照。
-委譲接続点: サブエージェントは子Issue本文候補とテンプレート充足検査のみを返し、親エージェントが `gh` 実行とVERIFYを行う。本文候補の受け渡しは `agentdev-issue-management` の「委譲接続点と本文受け渡し」セクションに従いファイルパス経由で行う（G25）
-
-**前工程完了度属性の埋め込み（REQ）**: 各子 Issue 本文の「## 補足情報」セクションに「前工程完了度」属性を埋め込むこと。
-属性値は epic-wave-model SPEC（extension 経由）の「前工程完了度3段階分類（REQ）」に従い、operation_units の `operation` 値（create/append/update/spec-create/spec-update）や artifact_actions の内容から判定する。
-3段階: 完全完了（req-save/spec-save 完了、追加作業不要）/ 検証のみ（acceptance criteria 順位検証のみ実施）/ 補完あり（前工程に残余あり、補完実装の可能性）。
-
-### Step 9: Epic Issue本文を更新（Epic flow）
-
-詳細は `agentdev-issue-management` を参照。委譲接続点: サブエージェントは置換漏れ検査のみを返し、親エージェントが本文更新とVERIFYを行う。本文候補の受け渡しは `agentdev-issue-management` の「委譲接続点と本文受け渡し」セクションに従いファイルパス経由で行う（G25）
-
-**Step 9-1**: OU 結果の書き戻し（ドラフトに `operation_units` セクションがある場合、作成した Issue/ Epic 番号を当該 OU の `result` に書き戻す）
-
-**Epic flow 完了後、共通終了処理（Step 13〜15）を必ず実行すること。**
-
-### Step 10: 関連ADR特定（Standard flow）
-
-`docs/adr/README.md` から関連ADRを特定（単一REQ Epic flowの内容反映にも活用）
-
-### Step 11: ラベル付与（Standard flow）
-
-`agentdev-workflow-lifecycle` に従う
-
-### Step 12: GitHub Issue作成（Standard flow）
-
-Issue 作成手続き（`agentdev-gh-cli`）→ VERIFY
-
-**Step 12-1**: OU 結果の書き戻し（Standard flow）。ドラフトに `operation_units` セクションがある場合、作成した Issue 番号を当該 OU の `result` に書き戻す
+- **Step 10**: 関連ADR特定（`docs/adr/README.md` から、単一REQ Epic flow の内容反映にも活用）
+- **Step 11**: ラベル付与（`agentdev-workflow-lifecycle` に従う）
+- **Step 12**: GitHub Issue作成。Issue 作成手続き（`agentdev-gh-cli`）→ VERIFY。**Step 12-1**: OU 結果の書き戻し（`operation_units` セクションがある場合、作成した Issue 番号を当該 OU の `result` に書き戻す）
 
 ### Step 13: コメント追加（共通終了処理）
 
@@ -215,48 +73,29 @@ Issue 作成手続き（`agentdev-gh-cli`）→ VERIFY
 
 ### Step 14: ドラフト削除（共通終了処理）
 
-ドラフトが存在する場合、`.agentdev/drafts/req-draft-{topic-slug}.md` を削除（Standard/ Epic 全フロー共通）。
-削除は並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、`git rm <draft-path>` で明示パスをステージし、同一ステップ内で `git commit -- <draft-path>` により即時コミットする（Form Zero）。
-未ステージの削除を作業ツリーに残存させないこと
+ドラフトが存在する場合、`.agentdev/drafts/req-draft-{topic-slug}.md` を削除（Standard/Epic 全フロー共通）。削除は並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、`git rm <draft-path>` で明示パスをステージし、同一ステップ内で `git commit -- <draft-path>` により即時コミットする（Form Zero）。未ステージの削除を作業ツリーに残存させないこと
 
-**Step 14-1**: RU ファイル削除（Standard/ Epic 全フロー共通）。
-詳細は `agentdev-req-file-manager` を参照。
-委譲接続点。
-親エージェントのみが削除、同期確認を行う。
-サブエージェントへ委譲する場合は削除対象候補の抽出までとする。
-削除は並列実行安全ステージングプロシージャに従い `git rm <RU-path>` で明示パスをステージし、同一ステップ内で `git commit -- <RU-path>` により即時コミットする（Form Zero）
+**Step 14-1**: RU ファイル削除（Standard/Epic 全フロー共通）。詳細、委譲接続点は `agentdev-req-file-manager` を参照。削除は並列実行安全ステージングプロシージャに従い `git rm <RU-path>` で明示パスをステージし、同一ステップ内で `git commit -- <RU-path>` により即時コミットする（Form Zero）
 
-**Step 14-2**: draft/ RU 削除残存検証（Standard/ Epic 全フロー共通）。
-Step 14/ 14-1 の削除後、当該ファイルが作業ツリー、index に残存していないことを検証する（`git status --porcelain -- <draft-path> <RU-path>` が空であること、またはファイル非存在確認）。
-残存を検出した場合、即座に停止し残存ファイル一覧を報告する。
-本検証は Standard flow と Epic flow の双方で実施する（Epic flow 限定のクリーンアップ検証ゲートを Standard flow にも拡張）
+**Step 14-2**: draft/RU 削除残存検証（Standard/Epic 全フロー共通）。Step 14/14-1 の削除後、当該ファイルが作業ツリー、index に残存していないことを検証（`git status --porcelain -- <draft-path> <RU-path>` が空、またはファイル非存在確認）。残存を検出した場合、即座に停止し残存ファイル一覧を報告。Standard flow と Epic flow の双方で実施
 
-**Step 14-3**: draft/ RU 削除 commit 後の即時 push（REQ）。
-Step 14/ 14-1 の削除コミット後に `git push` を即時実行する。
-case-run 引き継ぎ時の `git pull --ff-only` 失敗を防止するため、削除 commit と Issue 作成、完了報告の中間で作業ツリー状態を origin に確定させる。
-push 失敗時は構造化エラーメッセージを表示して停止する
+**Step 14-3**: draft/RU 削除 commit 後の即時 push（REQ）。Step 14/14-1 の削除コミット後に `git push` を即時実行（case-run 引き継ぎ時の `git pull --ff-only` 失敗を防止するため）。push 失敗時は構造化エラーメッセージを表示して停止する
 
 ### Step 15: 完了報告（共通終了処理）
 
-テンプレート種別:
-- Standard → `templates/case-open/standard.md`
-- 単一REQ Epic → `templates/case-open/epic.md`
-- マルチREQ Epic → `templates/case-open/multi-req-epic.md`
-
-**Capture結果 小節**: 完了報告テンプレートの `結果` 内に `Capture結果` 小節を含める。case-open 実行中に実観測した deviation を `agentdev-learning-capture` skill または `agentdev-intake-pipeline`（自動capture向け item 生成操作）へ委譲して保存した場合、保存した capture 成果物のパス・分類（intake/learning）・保存結果（成功/失敗、失敗時は理由）のみを含める。capture 本体は含めない。capture 成果物が無い場合は `Capture結果` 小節を省略する（共通意味契約は `artifact-contracts` SPEC「Capture結果 小節（共通意味契約）」節参照）
+テンプレート種別: Standard → `templates/case-open/standard.md`、単一REQ Epic → `templates/case-open/epic.md`、マルチREQ Epic → `templates/case-open/multi-req-epic.md`。**Capture結果 小節**: case-open 実行中に実観測した deviation を `agentdev-learning-capture` skill または `agentdev-intake-pipeline`（自動capture向け item 生成操作）へ委譲して保存した場合、保存した capture 成果物のパス・分類・保存結果のみを含める（capture 本体は含めない、成果物が無い場合は省略、共通意味契約は `artifact-contracts` SPEC「Capture結果 小節」節参照）
 
 ## ガードレール
 
 ### フェーズ制約
 - G01: ADR、specsの内容はIssue本文の生成に反映すること
-- G02: Standard flowの動作、出力形式はEpic flow追加による影響を受けない
 
 ### 実行制約
 - G03: 子Issue本文の先頭行に `Parent: #{epic_number}` を必ず含める（親子関係の追跡用）
 - G04: 全子Issueの作成完了後にEpic本文のステータス追跡テーブルを更新する（部分更新は禁止）
 - G05: 子Issueは最大10件まで（Epic 1件あたり）。Step 8 で子Issue数を確認し、超過時はEpic、子Issueいずれも作成せずエラーで停止
-- G14: Wave単位のみの子Issue構造を作成してはならない。子Issue は OU 単位で作成し、対応 OU 経由で REQ/ADR/SPEC へのトレーサビリティを保持すること。子 Issue を REQ 文書単位で対応付ける規定は廃止
-- G15: マルチREQ Epic flowは、複数REQドキュメント入力時またはdraft-metaに`scale: large`が設定されている場合にのみ実行する
+- G14: Wave単位のみの子Issue構造を作成してはならない。子Issue は OU 単位で作成し、対応 OU 経由で REQ/ADR/SPEC へのトレーサビリティを保持すること
+- G15/G16: マルチREQ Epic flow は複数REQドキュメント入力時または draft-meta に `scale: large` 設定時のみ実行。単一REQ Epic flow は `scale: large` 明示時のみ
 
 ### 品質ゲート
 - G06: req-define未実行の場合は警告
@@ -265,44 +104,29 @@ push 失敗時は構造化エラーメッセージを表示して停止する
 - G09: テンプレートの【必須】セクションが全て本文に含まれていることを確認してから Issue 作成手続き（`agentdev-gh-cli`）を実行。欠落時は再生成
 - G10: `完了条件` セクションはテンプレートの【必須】セクション。準拠検証で必ず確認
 
-### 判断、承認制約
-- G11: 単一REQ Epic flowは draft-metaの `scale: large` が明示的に設定されている場合のみ実行
-- G16: マルチREQ Epic flowは複数REQドキュメント入力時またはdraft-metaに`scale: large`が設定されている場合のみ実行
-
 ### 委譲、参照制約
 - G12: gh CLI出力を読み取る際は `agentdev-gh-cli` の安全な読み取り手順に従うこと
 - G13: work_type 判定基準と固有ルールは `agentdev-workflow-lifecycle` を参照
 
 ### 出力制約
-- G17: 成果物本文（Issue本文、PR本文、commit message、保存対象ファイル本文、テンプレート成果物）はverbatimで返す。「verbatim」とはLF・空行・インデントを含む行構造をbyte単位で保持することを指し、文字列の正規化、改行圧縮、空白挿入・削除をすべて禁止する。委譲接続点（Step 2/6/8/9）と最終 gh CLI 渡し（Step 12/13）の双方に適用する。判定結果、調査過程、中間ログ、読解メモは要約、成果物パス、根拠、親判断事項、capture候補へ圧縮して返す
+- G02: Standard flowの動作、出力形式はEpic flow追加による影響を受けない
+- G17: 成果物本文（Issue本文、PR本文、commit message、保存対象ファイル本文、テンプレート成果物）はverbatimで返す（LF・空行・インデントを含む行構造をbyte単位で保持、正規化・圧縮・空白挿入削除禁止）。委譲接続点（Step 2/6/8/9）と最終 gh CLI 渡し（Step 12/13）の双方に適用。判定結果、調査過程、中間ログ、読解メモは要約、成果物パス、根拠、親判断事項、capture候補へ圧縮して返す
 
- ### deviation capture 制約
-- G18: case-open は自工程で実観測した deviation を `agentdev-learning-capture` skill または `agentdev-intake-pipeline`（自動capture向け item 生成操作）へ委譲して保存する。保存先は Split Rule（`agentdev-workflow-orchestration` 参照）に従う。`intake-capture` command 等、別 command を直接呼ばない
+### deviation capture 制約
+- G18/G22: case-open は自工程で実観測した deviation を `agentdev-learning-capture` skill または `agentdev-intake-pipeline`（自動capture向け item 生成操作）へ委譲して保存する。保存先は Split Rule（`agentdev-workflow-orchestration` 参照）に従い、`intake-capture` command 等、別 command を直接呼ばない。capture 本文は完了報告に含めず保存した成果物のパス・分類・保存結果のみを `Capture結果` 小節へ含める
 
 ### OU 処理制約
-- G19: case-open は自律的な要件分析に基づいて Epic Issue を作成すること。ただし機能要件、非機能要件、対象外、受け入れ条件を新規に作成しないこと
-- G20: case-open は複数 OU が存在する場合、要件分析に基づいて Epic Issue および子 Issue 構造を生成すること。単一 Issue で完結する場合は Epic を作成しないこと
-- G21: case-open の Issue 化単位は REQ doc 単位ではなく OU 単位とすること
-- G22: case-open の capture 責務は自工程 deviation capture のみ。`agentdev-learning-capture` skill または `agentdev-intake-pipeline`（自動capture向け item 生成操作）への委譲で保存し、capture 本文は完了報告に含めず保存した成果物のパス・分類・保存結果のみを `Capture結果` 小節へ含める。境界の詳細は `agentdev-workflow-orchestration` 参照
+- G19/G20/G21: case-open は自律的な要件分析に基づいて Epic Issue または子 Issue 構造を生成（複数 OU 存在時、単一 Issue 完結時は Epic を作成しない）。機能要件、非機能要件、対象外、受け入れ条件を新規作成しない。Issue 化単位は REQ doc 単位ではなく OU 単位
 
 ### 並列実行安全 git 操作制約
-- G23: 共有作業ツリーでスイープ操作（`git add -A`/ `git add .`/ `git add --all`/ `git commit -a`/ `git checkout .`/ `git reset --hard`/ `git stash`/ 非所有パスへの `git checkout -- <path>`/ `git restore <path>`）を実行しないこと。`agentdev-git-worktree` の並列実行安全ステージングプロシージャに従うこと
-- G24: ステージ、コミットは明示パス指定（`git add <path>`/ `git rm <path>`）+ `git commit -- <paths>`（--only pathspec 形式）で行い、共有 index の他セッション変更を排出しないこと。draft/ RU の削除は同一ステップで即時ステージ、コミットし未ステージ残存を許さないこと（Form Zero）。`git add` は `.agentdev/` 全体の一括スコープではなく明示パスに限定すること
+- G23/G24: 共有作業ツリーでスイープ操作（`git add -A`/ `git add .`/ `git add --all`/ `git commit -a`/ `git checkout .`/ `git reset --hard`/ `git stash`/ 非所有パスへの `git checkout -- <path>`/ `git restore <path>`）を実行せず、`agentdev-git-worktree` の並列実行安全ステージングプロシージャに従う。ステージ・コミットは明示パス指定（`git add <path>`/ `git rm <path>`）+ `git commit -- <paths>`（--only pathspec 形式）で行い共有 index の他セッション変更を排出しない。draft/RU 削除は同一ステップで即時ステージ・コミットし未ステージ残存を許さない（Form Zero）。`git add` は `.agentdev/` 全体の一括スコープではなく明示パスに限定
 
 ### 本文 verbatim・ファイル経由制約
-- G25: case-open は Issue 本文（Standard/Epic/子Issue/完了報告コメント全て）を文字列変数で持ち回らず、`[System.IO.File]::WriteAllText`（UTF8Encoding($false)）による UTF-8 BOM なし LF 一時ファイル経由で `gh --body-file` へ渡す。テンプレート読込→変数置換→ファイル保存→gh CLI 渡しまでをファイル経由で固定し、親エージェントの本文再構成（空行圧縮、見出し前後のスペース化、改行正規化）を禁止する
+- G25: Issue 本文（Standard/Epic/子Issue/完了報告コメント全て）は文字列変数で持ち回らず `[System.IO.File]::WriteAllText`（UTF8Encoding($false)）による UTF-8 BOM なし LF 一時ファイル経由で `gh --body-file` へ渡す。テンプレート読込→変数置換→ファイル保存→gh CLI 渡しまでファイル経由で固定し、親エージェントの本文再構成を禁止
 
 ## 並列上限と3つの「5件」文脈
 
-case-open、case-auto、case-run で参照される「5件」上限は文脈ごとに区別される（epic-wave-model SPEC「並列上限と停止条件の整理」セクション参照）。混同を避けるため以下の3文脈を明示する:
-
-| 文脈 | 上限 | 根拠 |
-|---|---|---|
-| case-run Wave 内子 Issue 並列 | 5件 | 同一 Wave 内の case-run サブエージェント並列起動上限 |
-| case-auto Phase 2 同時起動数 | 5件 | Phase 分離モデルにおける case-run bg task 同時起動数 |
-| execution_unit 全体並列 | 上限なし | 必須依存がない execution_unit 群は全て並列実行可能 |
-
-case-open の Step 8「子 Issue 作成の並列化」は1つ目の文脈（case-run Wave 内子 Issue 並列上限）に該当する。3つの「5件」は別文脈であり、混同しない。
+case-open、case-auto、case-run で参照される「5件」上限は文脈ごとに区別される（epic-wave-model SPEC「並列上限と停止条件の整理」セクション参照）: (1) case-run Wave 内子 Issue 並列（5件、同一 Wave 内 case-run サブエージェント並列起動上限）(2) case-auto Phase 2 同時起動数（5件、Phase 分離モデルにおける case-run bg task 同時起動数）(3) execution_unit 全体並列（上限なし、必須依存がない execution_unit 群は全て並列実行可能）。case-open の Step 8「子 Issue 作成の並列化」は(1)に該当。3文脈は別なので混同しない
 
 
 

--- a/src/opencode/commands/agentdev/case-run.md
+++ b/src/opencode/commands/agentdev/case-run.md
@@ -4,26 +4,13 @@ description: 単一 Issue または単一 Wave（Epic Issue 指定時: 現在 re
 
 # 実装パイプライン
 
-Case に対して実装実行を実行担当サブエージェント経由で委譲し、その result を処理する。
-case-run 本体は orchestration に専念し、実装実行そのものは行わない。
-常に git worktree を使用。
+Case に対して実装実行を実行担当サブエージェント経由で委譲し、その result を処理する。case-run 本体は orchestration に専念し、実装実行そのものは行わない。常に git worktree を使用
 
-**スコープ**: case-run は単一 Issue または単一 Wave を処理する。
-Epic 全体（複数 Wave）の処理、Wave 境界（PR マージ）は case-close の責務であり、case-run は扱わない。
-1 Wave の実行（PR作成まで）で return する。
-複数 Issue の一括実行、Wave 順序制御にまたがるオーケストレーションは case-auto の責務（workflow-contracts SPEC SC-008、extension 経由で解決）。
-
-3フェーズ構成で各フェーズは独立して再実行可能（べき等性）。
-フェーズ間エラー時は Step 1 の再開判定から再開できる。
+**スコープ**: case-run は単一 Issue または単一 Wave を処理する。Epic 全体（複数 Wave）の処理、Wave 境界（PR マージ）は case-close の責務であり、case-run は扱わない。1 Wave の実行（PR作成まで）で return する。複数 Issue の一括実行、Wave 順序制御にまたがるオーケストレーションは case-auto の責務（workflow-contracts SPEC SC-008、extension 経由で解決）。3フェーズ構成で各フェーズは独立して再実行可能（べき等性）。フェーズ間エラー時は Step 1 の再開判定から再開できる
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-run.yaml`）を読み込む（ADR）。
-
-- extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
-- extension が存在しない場合は標準動作で続行する
-- extension が破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する
-- 詳細な読み込み契約は `agentdev-project-extensions` skill 参照
+本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-run.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
 ## 入力
 
@@ -38,139 +25,59 @@ Epic 全体（複数 Wave）の処理、Wave 境界（PR マージ）は case-cl
 
 ## フェーズ構成（case-run internal lifecycle）
 
-本節の「フェーズ」は case-run internal lifecycle（単一 Issue または Wave 内の準備、実装、提出）を指す。case-auto が管理する orchestration stage（command 間進行、stage 1 case-open / stage 2 case-run / stage 3 case-close）とは別の概念である（responsibility-boundary-purification SPEC「case 実行責務の 4 用語と所有者」参照）。case-run は case-run internal lifecycle のみを所有し、orchestration stage を複製しない。
-
-| フェーズ | Steps | 再開条件 |
-|---|---|---|
-| 準備フェーズ | 2-5 | worktree+ブランチが存在しない |
-| 実行担当サブエージェント委譲フェーズ | 6-7 | PRが未作成 または 実行担当サブエージェント result 未確定 |
-| クリーンアップフェーズ | 8 | 実行担当サブエージェント result = completed-pr |
+本節の「フェーズ」は case-run internal lifecycle（単一 Issue または Wave 内の準備、実装、提出）を指す。case-auto が管理する orchestration stage（command 間進行、stage 1 case-open / stage 2 case-run / stage 3 case-close）とは別の概念（responsibility-boundary-purification SPEC「case 実行責務の 4 用語と所有者」参照）。case-run は case-run internal lifecycle のみを所有し、orchestration stage を複製しない。3フェーズ: 準備フェーズ（Steps 2-5、再開条件: worktree+ブランチが存在しない）、実行担当サブエージェント委譲フェーズ（Steps 6-7、再開条件: PR未作成 or result 未確定）、クリーンアップフェーズ（Step 8、再開条件: result=completed-pr）。各フェーズは独立して再実行可能（べき等性）
 
 ## 手順
 
 ### Step 1: フェーズ判定（再開ポイント検出、実行モード分岐）
 
-`agentdev-workflow-orchestration` に従い、再開フェーズを判定する。
-Issue番号解決、引数パース、妥当性確認、実行パス分岐、成果物チェックの詳細は同skill参照。
+`agentdev-workflow-orchestration` に従い、再開フェーズを判定する（Issue番号解決、引数パース、妥当性確認、実行パス分岐、成果物チェックの詳細は同 skill 参照）。再開が必要なフェーズをユーザーに通知（準備フェーズから開始する場合は省略）。**実行モード分岐**: (1) 単一 Issue 実行モード（引数が非 Epic Issue 番号の場合、当該1 Issue を実行担当サブエージェントに委譲、後述 Step 2-8）、(2) Epic Wave 実行モード（`case-run #epic`、引数が Epic Issue 番号の場合、現在 ready な Wave の子Issue を並列委譲 最大5件、詳細は後述「Epic Wave 実行モード」セクション）。いずれのモードでも他Issue の実装履歴や Epic 全体の実装過程を前提としない
 
-- **再開ポイントの報告**: 再開が必要なフェーズをユーザーに通知。準備フェーズから開始する場合は省略
+**前工程からの引き継ぎ停止判定**: Issue 本文、要件doc本文に `agentdev_handoff: true` が含まれる場合、リポジトリ種別に応じて分岐（詳細は `agentdev-workflow-lifecycle` runtime-package-boundary 参照）: self-hosting リポジトリ（ジャンクション or 実ディレクトリ）では履歴メタデータとして通常の case workflow を実施、consumer リポジトリ（コピー配置等）では実装を開始せず停止し agent-dev-flow repository への手動取り込み対象として報告
 
-**実行モード分岐**:
+### Step 2〜4: 抽出・確認・判定
 
-1. **単一 Issue 実行モード**: 引数が非 Epic Issue 番号の場合。当該1 Issue を実行担当サブエージェントに委譲する（委譲 prompt 内で実行 command を指定、後述 Step 2-8）
-
-2. **Epic Wave 実行モード（`case-run #epic`）**: 引数が Epic Issue 番号の場合。
-Epic Issue 本文から現在 ready な Wave の子Issue を特定し、各子Issue を並列委譲する（最大5件、委譲 prompt 内で実行 command を指定）。
-詳細は後述「Epic Wave 実行モード」セクション
-
-いずれのモードでも他Issue の実装履歴や Epic 全体の実装過程を前提としない。
-
-**前工程からの引き継ぎ停止判定**: Issue 本文、要件doc本文に `agentdev_handoff: true` が含まれる場合、リポジトリ種別に応じて分岐する:
-- **self-hosting リポジトリ**（`.opencode/commands/agentdev/` がジャンクションまたは実ディレクトリ）: 停止せず、履歴メタデータとして通常の case workflow として実装を開始する
-- **consumer リポジトリ**（ジャンクションではなくコピー配置等）: 実装を開始せず停止し、agent-dev-flow repository への手動取り込み対象として報告する
-
-リポジトリ種別の判定基準は `agentdev-workflow-lifecycle`（runtime-package-boundary 参照）に従う
-
-### Step 2: Issue本文から要件docと受け入れ基準を抽出
-
-**べき等性**: worktreeとブランチが既に存在する場合、Step 5をスキップして Step 6 へ移行。
-
-`agentdev-req-analysis` のチェックボックス品質基準で検証
-
-### Step 3: 関連ADR特定
-
-`docs/adr/README.md` を読み込み、関連ADRを特定。関連ADRがあれば個別に読み込み、実装がADRの決定事項に矛盾しないことを確認
-
-### Step 4: work_type 判定
-
-`agentdev-workflow-lifecycle` に従い bugfix/feature/maintenance/docs_chore を判定。
-scale は feature のみ standard/large。
-workflow_route は都度導出し保存しない
+- **Step 2**: Issue本文から要件docと受け入れ基準を抽出（べき等性: worktreeとブランチが既に存在する場合、Step 5をスキップして Step 6 へ移行）。`agentdev-req-analysis` のチェックボックス品質基準で検証
+- **Step 3**: 関連ADR特定（`docs/adr/README.md` を読み込み、関連ADRがあれば個別に読み込み、実装がADRの決定事項に矛盾しないことを確認）
+- **Step 4**: work_type 判定（`agentdev-workflow-lifecycle` に従い bugfix/feature/maintenance/docs_chore を判定、scale は feature のみ standard/large、workflow_route は都度導出し保存しない）
 
 ### Step 5: Worktree作成、ブランチ準備
 
-`agentdev-git-worktree` に従って実行。
-`origin/main` をベースとして明示的に指定。
-べき等チェック: worktree既存時は作成スキップ。
-**Wave 実行時、PR merge 後再開時は worktree 作成前に `git fetch origin` を実行し origin/main の鮮度を確認すること**。
-詳細手順は `agentdev-git-worktree` 参照
+`agentdev-git-worktree` に従って実行。`origin/main` をベースとして明示的に指定。べき等チェック: worktree既存時は作成スキップ。**Wave 実行時、PR merge 後再開時は worktree 作成前に `git fetch origin` を実行し origin/main の鮮度を確認すること**。詳細手順は `agentdev-git-worktree` 参照
 
-**L2 タイムスタンプ計測（REQ、REQ）**: 本 Step の開始時刻、終了時刻（JST）を記録し、worktree 設定時間を計測する。計測結果は Step 8 完了報告の L2 内訳に含める
+**L2 タイムスタンプ計測（REQ）**: 本 Step の開始時刻、終了時刻（JST）を記録し、worktree 設定時間を計測する。計測結果は Step 8 完了報告の L2 内訳に含める
 
 **Step 5-1**: 親Epicステータス更新（`agentdev-epic-tracker` 参照）
 
-**Step 5-2**: worktree precondition gate（実行担当サブエージェント起動前の隔離検証）。`agentdev-git-worktree` の「worktree 内判定ヘルパー」に従い、当該 Issue の worktree+ブランチが作成済みであり、現在 worktree 内にいることを検証する。検証失敗時（worktree 未作成、メインリポジトリにいる）は実行担当サブエージェントを起動**せず**停止し、Step 5（Worktree作成、ブランチ準備）へ戻るようユーザーに報告する。Step 6 へ進んではならない。
-
-本 gate は適用範囲対象外「case-run の worktree 隔離フェーズ（構造的に保証済み）」の前提を保護する機構である。worktree 隔離が構造的に保証されているという前提を、実行時に検証して担保する。
+**Step 5-2**: worktree precondition gate（実行担当サブエージェント起動前の隔離検証）。`agentdev-git-worktree` の「worktree 内判定ヘルパー」に従い、当該 Issue の worktree+ブランチが作成済みであり、現在 worktree 内にいることを検証する。検証失敗時（worktree 未作成、メインリポジトリにいる）は実行担当サブエージェントを起動**せず**停止し、Step 5（Worktree作成、ブランチ準備）へ戻るようユーザーに報告する。Step 6 へ進んではならない。本 gate は適用範囲対象外「case-run の worktree 隔離フェーズ（構造的に保証済み）」の前提を保護する機構である
 
 ### Step 5-3: QG-3 前置 staleness check（実装作業開始前、REQ〜034）
 
-`agentdev-quality-gates` の「case-run 前置 staleness check（REQ〜034）」に従い、ファイルパス現行存在確認、検査結果件数再計測、差異検出時の引き渡し・case-update 連携を実行する。本検査は QG-3 本体（Step 6 委譲先が実施する PR 作成直前ゲート）とは独立した前置検査であり、QG-3 deviation 分類運用、QG-3 本体実施要否には影響しない。差異非検出時はそのまま Step 6 へ進む
+`agentdev-quality-gates` の「case-run 前置 staleness check（REQ〜034）」に従い、ファイルパス現行存在確認、検査結果件数再計測、差異検出時の引き渡し・case-update 連携を実行する。本検査は QG-3 本体（Step 6 委譲先が実施する PR 作成直前ゲート）とは独立した前置検査であり、QG-3 deviation 分類運用、QG-3 本体実施要否には影響しない。差異非検出時はそのまま Step 5-4 へ進む
 
 ### Step 5-4: docs/** 変更時の targeted docs guard
 
-PR 対象ファイルに docs/** 変更を含む場合、Step 6（実行担当サブエージェント起動）の委譲前に targeted docs guard を行う。本検査は QG-3 本体・QG-3 前置 staleness check（Step 5-3）とは独立した前置 docs 整合性検査であり、3つの検査は順序依存を持たず、それぞれの実施要否に影響しない。
+PR 対象ファイルに docs/** 変更を含む場合、Step 6（実行担当サブエージェント起動）の委譲前に targeted docs guard を行う。本検査は QG-3 本体・QG-3 前置 staleness check（Step 5-3）とは独立した前置 docs 整合性検査であり、3つの検査は順序依存を持たず、それぞれの実施要否に影響しない
 
-**実行条件**:
+**実行条件**: PR 対象ファイルに docs/** 変更を含む場合に実行する。docs/** 変更を含まない PR（コードのみ、SCRIPT のみ等）ではスキップする（QG-3 限定原則を維持、docs全体grep ではなく変更ファイル限定の targeted 検査）
 
-- PR 対象ファイルに docs/** 変更を含む場合に実行する。docs/** 変更を含まない PR（コードのみ、SCRIPT のみ等）ではスキップする（QG-3 限定原則を維持、docs全体grep ではなく変更ファイル限定の targeted 検査）
+**実行コマンド**: `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref origin/main --json`。変更ファイルは worktree 内の git diff から取得する（`--base-ref origin/main` または `--files <changed-paths>`）。case-run は worktree 環境（マージ前）で実行されるため `--base-ref` を使用する（`--files` は case-close 等、main 環境（マージ後）向け）。case-run プロファイル固有の追加ルールとして `full_docs_check_recommended` 判定は持たない（case-close の責務）
 
-**実行コマンド**:
-
-```bash
-bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
-  --workflow case-run --base-ref origin/main --json
-```
-
-変更ファイルは worktree 内の git diff から取得する（`--base-ref origin/main` または `--files <changed-paths>`）。case-run は worktree 環境（マージ前）で実行されるため `--base-ref` を使用する（`--files` は case-close 等、main 環境（マージ後）向け）。case-run プロファイル固有の追加ルールとして `full_docs_check_recommended` 判定は持たない（case-close の責務）。
-
-**検出結果の記録、連携**:
-
-- 検出結果（failures の strict severity）は PR 本文の `## Findings / Capture候補` セクションに `### docs-integrity` 小見出しで記録する（実行担当サブエージェント責務）
-- case-update へ連携し、Issue 本文の更新を委譲する（case-run 単独では Issue 本文を書き換えない）
+**検出結果の記録、連携**: 検出結果（failures の strict severity）は PR 本文の `## Findings / Capture候補` セクションに `### docs-integrity` 小見出しで記録する（実行担当サブエージェント責務）。case-update へ連携し、Issue 本文の更新を委譲する（case-run 単独では Issue 本文を書き換えない）
 
 ### case-run が使用する検査ツール
 
-case-run が使用する検査ツール（integrity 契約 SPEC「Workflow × 使用ツールマトリックス」参照）:
-
-- check_changed_docs.ts（--workflow case-run）: PR 対象ファイルに docs/** 変更を含む場合、Step 6 委譲前に実行（AG-002、Step 5-4「docs/** 変更時の targeted docs guard」参照）
-- check_extensions.ts（IR-056）: `.opencode/commands/agentdev/**/*.md`, `.opencode/skills/agentdev-*/SKILL.md`, `.opencode/skills/agentdev-*/references/**/*.md`, `.agentdev/extensions/**` のいずれかを変更した場合に実行
-- test_strategy: Issue 完了条件検証
-
-※上記は全て肯定表現である。
+case-run が使用する検査ツール（integrity 契約 SPEC「Workflow × 使用ツールマトリックス」参照）: check_changed_docs.ts（--workflow case-run、PR 対象ファイルに docs/** 変更を含む場合に Step 6 委譲前に実行、AG-002）、check_extensions.ts（IR-056、`.opencode/commands/agentdev/**/*.md`, `.opencode/skills/agentdev-*/SKILL.md`, `.opencode/skills/agentdev-*/references/**/*.md`, `.agentdev/extensions/**` のいずれかを変更した場合に実行）、test_strategy（Issue 完了条件検証）。上記は全て肯定表現である
 
 ### Step 6: 実行担当サブエージェント起動（委譲）
 
-実装実行を adapter skill（`agentdev-case-run-execution-adapter`）を読み込んだ実行担当サブエージェントへ委譲する（委譲 prompt 内で実行 command を指定）。起動手段は AGENTS.md および references/<harness>.md 参照。
-adapter protocol は `agentdev-case-run-execution-adapter` skill 参照。
+実装実行を adapter skill（`agentdev-case-run-execution-adapter`）を読み込んだ実行担当サブエージェントへ委譲する（委譲 prompt 内で実行 command を指定）。起動手段は AGENTS.md および references/<harness>.md 参照。adapter protocol は `agentdev-case-run-execution-adapter` skill 参照
 
-**L2 タイムスタンプ計測（REQ、REQ）**: 委譲起動直前、直後に壁時計タイムスタンプ（JST、REQ の時刻形式に準拠）を記録し、実行担当サブエージェント実行時間を計測する。
-併せて Step 5（Worktree作成）の開始、終了時刻、Step 8（worktree クリーンアップ）の開始、終了時刻を記録し、worktree 設定/クリーンアップ時間を計測する。
-計測した L2 タイムスタンプは Step 7 result、Step 8 完了報告に含める（case-auto が L1 計測で case-run 委譲の壁時計時間を読み取る際の内訳として使用）
+**L2 タイムスタンプ計測（REQ）**: 委譲起動直前・直後に壁時計タイムスタンプ（JST、REQ の時刻形式に準拠）を記録し、実行担当サブエージェント実行時間を計測。併せて Step 5（Worktree作成）と Step 8（worktree クリーンアップ）の開始・終了時刻を記録する。計測した L2 タイムスタンプは Step 7 result、Step 8 完了報告に含める（case-auto が L1 計測で case-run 委譲の壁時計時間を読み取る際の内訳として使用）
 
-**委譲プロンプト**: 実行 command を prompt 内で指定し Issue #N の実装を指示する（command の具体名は AGENTS.md 参照）。
-Issue 本文に req-define 壁打ち合意の実行計画方向性（参考情報）が含まれ得る。
-実行担当サブエージェントはこれを参考情報として扱い、束縛されない。
+**委譲プロンプト、staleness check 結果の引き渡し（REQ）、test strategy 項目の test-fix ループ（REQ）、実行担当サブエージェントの責務（目標分解、各 criterion に observable evidence を要求、品質ゲートの実行、test-fix ループ）、委譲起動失敗・異常終了時の扱い（即 `failed` とせず実装完了・検証未完了として扱う）の詳細は `agentdev-case-run-execution-adapter` スキルを参照**
 
-**staleness check 結果の引き渡し（REQ）**: Step 5-3 で差異を検出した場合、委譲プロンプトに差異内容（対象パス、Issue 本文記載値、現行値）を含める。実行担当サブエージェントは PR 本文の `## Findings / Capture候補` セクションに `### stale-reference` 小見出しで当該差異を記録し、case-update への連携を示す（Issue 本文の単独書き換えは行わない、REQ）。差異非検出時は引き渡し不要。
-
-**test strategy 項目の test-fix ループ（REQ）**: Issue 本文のテスト戦略セクションに test strategy 項目（3要素構造: verification / pass_criteria / on_failure）が含まれる場合、委譲契約は各項目の検証、不合格時の処置（実装修正して再検証、または Findings 記録）、全項目処理までの反復を実行担当サブエージェントに要求する。
-実行担当サブエージェントの具体的責務は `agentdev-case-run-execution-adapter` スキル（REQ）参照。
-
-**実行担当サブエージェントの責務**: 委譲 prompt 内で指定された実行 command による目標分解（Issue を success criteria に分解）、各 criterion に observable evidence を要求、品質ゲート（code review + QA review + gate review）の実行、test strategy 項目の test-fix ループ（各項目ごとの検証、不合格時処置、全項目処理までの反復、REQ）。
-ランタイム作業領域（実行監査トレイル等）は worktree 配下に配置され、worktree 削除時に破棄される。各ツール呼び出しの保護（timeout 等）は harness 側が提供し、配布 command は具体的な待機時間や timeout 値を所有しない。
-
-**委譲起動失敗、異常終了時の扱い**: 実行担当サブエージェントの委譲起動失敗、異常終了時は即 `failed` とせず**実装完了、検証未完了**として扱う。委譲起動不能の場合は `delegation-unavailable` として報告する。
-詳細な事後処理（worktree の `git status` で未コミット変更確認、残留箇所の grep と手動修正）は `agentdev-case-run-execution-adapter` スキル参照。
-
-- **case-run が直接行わない（実行担当サブエージェントの責務）**: work plan生成、実装実行、TDD、乖離検出（QG-3）、specs更新、関連ドキュメント整合性確認、ローカル検証、PR本文作成、PR作成、デプロイ検証
-- **実行担当サブエージェントへの引き渡し**: 割り当てられた1 Issue の Issue番号、worktree root（相対パス指定、worktree内制約）、ブランチ名。実行担当サブエージェントはこの1 Issue のみを実装対象とする（Wave全体や他子Issue のオーケストレーションは含まない）
-- **PR URL 受領**: 実行担当サブエージェントが直接 PR 作成を行い、PR URL を委譲 result として返却する（PR URL フォールバック検索は使用しない）
-- 外部実行ハーネスの plan artifact 等の中間成果物の内部構造に依存した処理、検証を行わない。最終結果は PR URL で受領する
-- 実行担当サブエージェントが Issue 完了条件チェックボックスを更新しない（case-close QG-4 の責務）
-- Findings/ Capture 候補は実行担当サブエージェントが PR 本文の `## Findings / Capture候補` に記録する
-- **外部実行手段の中間成果物**: 外部実行手段の plan artifact 等の中間成果物を AgentDevFlow の永続成果物（Issue/PR/REQ/ADR/SPEC）として扱わない。draft は一時成果物であり、case-open 成功後は invalid post-case reader として参照しない
-- **SPEC確定候補**: 実装時に発見された SPEC レベルの詳細（SPEC に記載すべき schema、enum、判定表、内部アルゴリズム等、実装で判明した仕様詳細）は、実行担当サブエージェントが PR 本文の `## SPEC確定候補` セクションに記録する。`## Findings / Capture候補`（本筋外発見、intake/learning 候補）とは別セクションとし、混在させない。SPEC確定候補は case-close Step 3 で SPEC 確定チェックの入力となり、draft → accepted 昇格または spec-save 再起動の判断材料となる
+**case-run が直接行わない（実行担当サブエージェントの責務）**: work plan生成、実装実行、TDD、乖離検出（QG-3）、specs更新、関連ドキュメント整合性確認、ローカル検証、PR本文作成、PR作成、デプロイ検証。**実行担当サブエージェントへの引き渡し**: 割り当てられた1 Issue の Issue番号、worktree root（相対パス指定、worktree内制約）、ブランチ名。**PR URL 受領**: 実行担当サブエージェントが直接 PR 作成を行い、PR URL を委譲 result として返却する（PR URL フォールバック検索は使用しない）。**外部実行ハーネスの中間成果物**: plan artifact 等の中間成果物を AgentDevFlow の永続成果物として扱わない、最終結果は PR URL で受領する。**完了条件チェックボックス**: 実行担当サブエージェントは完了条件チェックボックスを更新しない（case-close QG-4 の責務）。**Findings/Capture 候補**: 実行担当サブエージェントが PR 本文の `## Findings / Capture候補` に記録する。**SPEC確定候補**: 実装時に発見された SPEC レベルの詳細（schema、enum、判定表、内部アルゴリズム等）は、実行担当サブエージェントが PR 本文の `## SPEC確定候補` セクションに記録する（`## Findings / Capture候補` とは別セクション、混在させない）。SPEC確定候補は case-close Step 3 で SPEC 確定チェックの入力となる
 
 ### Step 7: 実行担当サブエージェント result 処理
 
@@ -192,54 +99,16 @@ Issue 本文に req-define 壁打ち合意の実行計画方向性（参考情�
 
 ## Epic Wave 実行モード（`case-run #epic` 受領時）
 
-以下のフローに基づく。
-Epic Issue 番号を受け取った場合、以下のフローで現在 ready な Wave の子Issue を並列実行する。
-1 Wave の実行（PR作成まで）で return し、Wave 境界（マージ）は扱わない。
-同一コマンド再実行で次 Wave に進む（べき等、Epic Issue 本文から進行状況判定）。
-
-**Epic Issue の入力ソース（REQ/088）**: Epic Issue は本来の Epic flow（マルチREQ、`scale: large`）に加え、Standard flow 起因の独立 OU 自動 Epic 化（case-open が `depends_on` 空、L0 相当の独立 OU を検出して Epic 化）によるものも含む。
-case-run は入力ソースを区別せず、Epic Wave モデル（ADR、最大5件並列委譲）で一様に処理する。
-case-run 側の新規機能追加は不要で、入力としての Epic Issue が増えるのみである。
-
-1. **Epic Issue 本文読込**: Epic Issue 本文から子Issue一覧、Wave 構成、ステータス追跡テーブルを読み取る（永続状態を SSoT とする）
-
-2. **現在 ready な Wave の子Issue 特定**: ステータス追跡テーブルから現在 ready な Wave の子Issue を特定する。
-`ready` がない場合、依存が満たされた `pending` Issue を `ready` に遷移させて選択する。
-ただし前提Issue が blocked/failed の場合は `pending` のまま選択対象外
-
-3. **`git fetch origin` 実行**: 各子Issue の worktree 作成前に `git fetch origin` を実行し、origin/main の鮮度を確認する。詳細手順は `agentdev-git-worktree` 参照
-
-4. **子Issue の worktree 作成**: 各子Issue について Step 5（Worktree作成、ブランチ準備）、Step 5-2（precondition gate）、Step 5-3（QG-3 前置 staleness check）を実行する
-
-5. **各子Issue を並列委譲**: 各子Issue を adapter skill（`agentdev-case-run-execution-adapter`）を読み込んだ実行担当サブエージェントへ並列委譲する。
-委譲の起動手段、実行制御パラメータは AGENTS.md および references/<harness>.md に配置する。
-**最大5件**まで同時起動。
-委譲プロンプトは実行 command を prompt 内で指定し Issue #N の実装を指示する（command の具体名は AGENTS.md 参照）
-
-6. **全委譲完了待機**: 全委譲の完了を待つ。各委譲は Step 7 の result 処理と同じ4状態を返す
-
-7. **結果収集**: 各子Issue の result（completed-pr / blocked / failed / delegation-unavailable）を収集する。子Issue ごとに worktree は独立しており、他子Issue の結果に依存しない（子Issue の結果は親コンテキストではなく永続状態に記録）
-
-8. **return**: 収集した結果（子Issue ごとの PR番号、blocked/failed の理由）を報告して return する。
-Wave 境界（PR マージ）は case-close の責務。
-`completed-pr` となった子Issue を次 Wave へ進めるためには、case-close でマージ後に再度 `case-run #epic` を実行する（べき等）
+Epic Issue 番号を受け取った場合、現在 ready な Wave の子Issue を並列実行する。1 Wave の実行（PR作成まで）で return し、Wave 境界（マージ）は扱わない。同一コマンド再実行で次 Wave に進む（べき等、Epic Issue 本文から進行状況判定）。**Epic Issue の入力ソース（REQ/088）**: Epic Issue は本来の Epic flow（マルチREQ、`scale: large`）に加え、Standard flow 起因の独立 OU 自動 Epic 化（case-open が `depends_on` 空、L0 相当の独立 OU を検出して Epic 化）によるものも含む。case-run は入力ソースを区別せず、Epic Wave モデル（ADR、最大5件並列委譲）で一様に処理する。フロー詳細（Epic Issue 本文読込、現在 ready な Wave の子Issue 特定、`git fetch origin` 実行、子Issue の worktree 作成、各子Issue の並列委譲、全委譲完了待機、結果収集、return）は `agentdev-epic-tracker` を参照。Wave 境界（PR マージ）は case-close の責務。`completed-pr` となった子Issue を次 Wave へ進めるためには、case-close でマージ後に再度 `case-run #epic` を実行する（べき等）
 
 
 ## テスト戦略（TS）標準手順
 
-関数削除を伴う Issue の test strategy 標準手順（L-014、PR #1140 / #1139 Epic #1138 由来）。
-共用関数の包括的削除による破壊的変更を防止する。
-
-- 関数削除を伴う Issue の test strategy に、削除対象関数の全使用箇所 grep 確認手順を追加すること
-- 標準手順: 削除対象関数名で `scripts/` 配下を grep（例: `grep -rn "funcName" scripts/`）し、対象スコープ外の使用箇所が 0 件であることを確認する
-- 対象スコープ外に残存する使用箇所がある場合、削除を中止し Findings に記録する
+関数削除を伴う Issue の test strategy 標準手順（L-014、PR #1140 / #1139 Epic #1138 由来）。共用関数の包括的削除による破壊的変更を防止する。関数削除を伴う Issue の test strategy に、削除対象関数の全使用箇所 grep 確認手順を追加する（標準手順: 削除対象関数名で `scripts/` 配下を grep し、対象スコープ外の使用箇所が 0 件であることを確認、残存する場合は削除を中止し Findings に記録）。詳細は `agentdev-req-analysis` を参照
 
 ## エラー処理
 
-
-エラー発生時の対応は `agentdev-workflow-orchestration` に従う。
-実行担当サブエージェント result が blocked/ failed の場合、Issue コメント（SSoT）を参照して停止理由、再開ポイントをユーザーに報告する。
-実行担当サブエージェント内の自律修正ループ（同一入力の機械的再試行、検証ループ）は `agentdev-case-run-execution-adapter`/ `agentdev-workflow-orchestration` に従う。
+エラー発生時の対応は `agentdev-workflow-orchestration` に従う。実行担当サブエージェント result が blocked/ failed の場合、Issue コメント（SSoT）を参照して停止理由、再開ポイントをユーザーに報告する。実行担当サブエージェント内の自律修正ループ（同一入力の機械的再試行、検証ループ）は `agentdev-case-run-execution-adapter`/ `agentdev-workflow-orchestration` に従う
 
 ## ガードレール
 
@@ -250,30 +119,19 @@ Wave 境界（PR マージ）は case-close の責務。
 - G05: Issue番号省略は同一セッション内で作成済みの場合のみ
 - G06: Issue番号解決に Issue/PR 一覧取得手続き（`agentdev-gh-cli`）等の open issue 一覧取得は禁止
 - G10: work_type 判定基準は `agentdev-workflow-lifecycle` を参照
-- G11: case-run は単一 Issue または単一 Wave（Epic 指定時: 現在 ready な Wave の子Issue を並列実行、最大5件）のみを処理する。Epic 全体（複数 Wave）の一括実行、Wave 境界（PR マージ）は扱わない。Wave 境界は case-close の責務
-- G22: case-run は実装実行を実行担当サブエージェントへ委譲し、自ら work plan生成、実装、乖離検出、specs更新、PR作成を行わない。adapter protocol は `agentdev-case-run-execution-adapter` 参照
-- G23: 実行担当サブエージェント result の4状態（completed-pr/blocked/failed/delegation-unavailable）は `agentdev-case-run-execution-adapter` の result 契約に従う。成功成果は PR 作成である
+- G11/G22/G23/G32: case-run は単一 Issue または単一 Wave（Epic 指定時: 現在 ready な Wave の子Issue を並列実行、最大5件）のみを処理。Epic 全体（複数 Wave）の一括実行、Wave 境界（PR マージ）は扱わない（Wave 境界は case-close の責務）。実装実行を実行担当サブエージェントへ委譲し、自ら work plan生成、実装、乖離検出、specs更新、PR作成を行わない（adapter protocol は `agentdev-case-run-execution-adapter` 参照）。実行担当サブエージェント result の4状態（completed-pr/blocked/failed/delegation-unavailable）は `agentdev-case-run-execution-adapter` の result 契約に従い、成功成果は PR 作成。Epic Wave 実行モードでは1 Wave のみ実行し PR 作成で return する
 - G24: 完了条件チェックボックスの評価、更新は case-close QG-4 の責務。case-run、実行担当サブエージェントは完了条件チェックボックスを更新しない
 - G25: blocked/ failed の詳細本文 SSoT は Issue コメント。completed の SSoT は PR 本文。一時会話コンテキスト、中間ファイルは SSoT としない
-- G26: 外部実行ハーネスの plan artifact 等の中間成果物の内部構造に依存した処理、検証を行わない。最終結果は PR URL で受領する。
-- G29: 外部実行手段の中間成果物を AgentDevFlow の永続成果物として扱わない
-- G30: Step 6（実行担当サブエージェント起動）の前に worktree+ブランチが作成済みであることを検証すること（Step 5-2 precondition gate）。未作成時、メインリポジトリにいる場合は実行担当サブエージェントを起動禁止（適用範囲対象外「case-run の worktree 隔離フェーズ（構造的に保証済み）」の前提保護）
-- G31: 実行担当サブエージェントへの引き渡しで worktree root（相対パス、`.worktrees/{N}-{type}/`）を必ず含め、メインリポジトリパスを渡さないこと
-- G32: Epic Wave 実行モードでは1 Wave のみ実行し PR 作成で return する。Wave 境界（PR マージ）は case-close へ委譲する
-- G33: case-run は実装作業開始前に QG-3 前置 staleness check（ファイルパス現行存在確認、検査結果件数再計測）を実行する（REQ）。本検査は QG-3 本体とは独立した前置検査であり、QG-3 deviation 分類（spec-bug 等）運用を変更しない（REQ）
-- G34: case-run は staleness check で差異を検出した場合、検出結果を Step 6 委譲プロンプトで実行担当サブエージェントに引き渡し、PR 本文の `## Findings / Capture候補` セクションに `### stale-reference` 小見出しで記録する（実行担当サブエージェント責務、REQ）。差異検出時は case-update へ連携する
-- G35: case-run は staleness check で差異を検出した場合でも Issue 本文を単独で書き換えず、case-update の責務として委譲する（REQ）
+- G26/G29: 外部実行ハーネスの plan artifact 等の中間成果物を AgentDevFlow の永続成果物として扱わず、内部構造に依存した処理・検証を行わない。最終結果は PR URL で受領する
+- G30/G31: Step 6（実行担当サブエージェント起動）の前に worktree+ブランチが作成済みであることを Step 5-2 precondition gate で検証すること。未作成時・メインリポジトリにいる場合は実行担当サブエージェントを起動禁止。実行担当サブエージェントへの引き渡しで worktree root（相対パス、`.worktrees/{N}-{type}/`）を必ず含め、メインリポジトリパスを渡さないこと
+- G33/G34/G35: case-run は実装作業開始前に QG-3 前置 staleness check（ファイルパス現行存在確認、検査結果件数再計測）を実行（REQ、QG-3 本体とは独立、QG-3 deviation 分類運用を変更しない）。差異検出時は検出結果を Step 6 委譲プロンプトで実行担当サブエージェントに引き渡し、PR 本文の `## Findings / Capture候補` に `### stale-reference` 小見出しで記録（実行担当サブエージェント責務）。case-update へ連携し、case-run は Issue 本文を単独で書き換えない（case-update の責務）
 
 ### 本筋外発見の退避方針
 
-intake/ learning 境界は `agentdev-workflow-orchestration` を参照する。
-実行担当サブエージェントが PR 本文の `## Findings / Capture候補` に記録する。
+intake/ learning 境界は `agentdev-workflow-orchestration`（capture-boundaries）を参照。実行担当サブエージェントが PR 本文の `## Findings / Capture候補` に記録する
 
 - G14: スコープ拡大禁止。発見は記録し修正は後続処理に委ねる
-- G15: intake 候補を PR 本文の `## Findings / Capture候補` に記録。`.agentdev/intake/inbox/` の直接変更禁止
-- G16: learning 候補を intake 候補と区別して記録
-- G17: intake/learning 候補を混ぜた単一成果物にしない。capture 境界（capture-boundaries）の詳細は `agentdev-workflow-orchestration` 参照（case-run の capture 責務は記録のみ）
-- G21: `.agentdev/learning/inbox.md` の直接変更禁止。capture 情報は PR 本文経由のみ case-close に引き継ぐ
+- G15/G16/G17/G21: intake 候補、learning 候補を区別して記録し混ぜた単一成果物にしない。`.agentdev/intake/inbox/`、`.agentdev/learning/inbox.md` の直接変更禁止。capture 情報は PR 本文経由のみ case-close に引き継ぐ（capture 境界の詳細は `agentdev-workflow-orchestration` 参照、case-run の capture 責務は記録のみ）
 - G27: SPEC確定候補（実装で発見された SPEC レベル詳細）は PR 本文の `## SPEC確定候補` セクションに記録し、`## Findings / Capture候補` とは混在させない。SPEC確定候補の確定、SPEC ファイルへの反映判断は case-close の責務
 
 

--- a/src/opencode/commands/agentdev/intake-promote.md
+++ b/src/opencode/commands/agentdev/intake-promote.md
@@ -56,13 +56,11 @@ intake-promote の内部 review フェーズにおける分類値は以下の 3 
 
 ### Step 2: item の読み込み
 
-各 intake item を読み込み、内容を把握する。委譲接続点: サブエージェントは読解メモ、分類候補、根拠、capture候補のみを返し、親エージェントが分類提示と保存判断を行う
+各 intake item を読み込み、内容を把握する。委譲接続点の詳細は `agentdev-intake-pipeline` を参照
 
 ### Step 3: レビュー、評価
 
-各 item を評価する。
-詳細は `agentdev-intake-pipeline` を参照。
-委譲接続点: サブエージェントは採用/ 保留/ 却下の候補と根拠を pass/warn/fail/partial で返し、親エージェントが最終分類を決める
+各 item を評価する。詳細、委譲接続点は `agentdev-intake-pipeline` を参照
 
 ### Step 4: 分類の提示
 
@@ -99,15 +97,11 @@ intake-promote の内部 review フェーズにおける分類値は以下の 3 
 
 ### Step 9: 実行前同期（git pull）
 
-`git pull --ff-only` を実行する。
-失敗時の扱いは `agentdev-intake-pipeline` を参照。
-委譲接続点: 親エージェントのみが git 操作を行う
+`git pull --ff-only` を実行する。失敗時の扱い、親エージェントのみが git 操作を行う点は `agentdev-intake-pipeline` を参照
 
 ### Step 10: .agentdev/intake 変更の commit と push
 
-`.agentdev/intake/` 配下の変更のみを commit/push する（分類承認後の自動実行、REQ）。
-詳細は `agentdev-intake-pipeline` を参照。
-委譲接続点: 親エージェントのみが commit/push を行う
+`.agentdev/intake/` 配下の変更のみを commit/push する（分類承認後の自動実行、REQ）。詳細、親エージェントのみが commit/push を行う点は `agentdev-intake-pipeline` を参照
 
 
 ### Step 11: 完了報告
@@ -119,10 +113,7 @@ template: .opencode/commands/agentdev/templates/intake-promote/standard.md。
 
 ## エラー処理
 
-| エラー | 対処 |
-|--------|------|
-| git pull --ff-only 失敗 | 構造化エラーメッセージを表示して停止。自動解消しない |
-| git push 失敗 | 構造化エラーメッセージを表示。完了扱いにしない |
+主要なエラー処理（git pull --ff-only 失敗時の停止、git push 失敗時の完了扱い禁止等）は `agentdev-intake-pipeline` を参照。構造化エラーメッセージを表示して停止し、自動解消しない。
 
 ## ガードレール
 

--- a/src/opencode/commands/agentdev/learning-promote.md
+++ b/src/opencode/commands/agentdev/learning-promote.md
@@ -120,11 +120,7 @@ description: inbox.mdから正規化、分類、8軸評価、HITL確定を経て
 
 ### Step 16: 完了報告
 
-template: `.opencode/commands/agentdev/templates/learning-promote/standard.md`。以下を含める:
-- 8軸評価サマリ（加重合計スコア分布）
-- 判定結果（promote/defer/reject/duplicate 件数）
-- 後続ルート（`/agentdev/backlog-review`）
-- git 永続化結果（変更有無、ファイル一覧、commit hash、push 成否）
+template: `.opencode/commands/agentdev/templates/learning-promote/standard.md`。8軸評価サマリ、判定結果（promote/defer/reject/duplicate 件数）、後続ルート（`/agentdev/backlog-review`）、git 永続化結果（変更有無、ファイル一覧、commit hash、push 成否）を含める
 
 ## ガードレール
 
@@ -139,33 +135,14 @@ template: `.opencode/commands/agentdev/templates/learning-promote/standard.md`�
 - G09: 破壊的変更（inbox.md 全体強制クリア、大量エントリ一括削除等）は Step 10 承認とは別に明示承認を維持する（REQ）
 - G10: 無条件の自動REQ化禁止（REQ）: 学びを直接 REQ 化しない。恒久契約（REQ/ADR/SPEC）への昇華可能性を Step 7 で評価し、昇華可能なもののみ `promoted/` へ出力する。昇華不能な知見は living pool（`deferred.md`）で維持する
 
-## ユーザー確認ポイント
+## ユーザー確認ポイント、エラー処理
 
-1. **Step 9-10**: 廃棄判定結果、8軸評価スコアの確認、修正、承認（判断の確定、REQ）
+ユーザー確認ポイント、エラー処理表、各成果物のライフサイクル詳細は `agentdev-learning-pipeline` を参照。主要項目のみ本節に抜粋する:
 
-2. **Step 14**: prune は Step 10 承認と同時に承認済みとみなし自動実行（REQ）。
-staged/rejected/duplicate の追加確認は不要。
-
-## エラー処理
-
-| エラー | 対処 |
-|--------|------|
-| inbox.md が存在しない | エラー終了。「先に `agentdev-learning-capture` skill で学びを追加してください」 |
-| 学びが0件 | 「分析対象の学びがありません」と報告して終了 |
-| クラスタが0件 | 「昇華対象のクラスタがありません」と報告して終了 |
-| ユーザーが承認しない | 「昇華をキャンセルしました」と報告して終了 |
-| 旧フォーマットパース失敗 | 当該エントリをスキップし警告出力、処理継続 |
-| staging領域書込失敗 | エラー内容を報告 |
-| deferred.md prune 失敗 | 採用済み成果物は保持。prune エラー報告し手動 prune 案内 |
-| deferred.md 書込失敗 | inbox.md は変更しない。エラー内容を報告 |
-| git pull --ff-only 失敗 | 構造化エラー表示して停止。自動解消しない |
-| git push 失敗 | 構造化エラー表示。完了扱いにしない |
-
-## 成果物ライフサイクル
-
-各成果物の役割、性格、ライフサイクル詳細は `agentdev-learning-pipeline` を参照。
-
-**learning-promote の責務**: normalize → classify → 8-axis eval → evaluation-report → disposal judgment → HITL → 採用済み成果物生成 → archive move → prune。
-採用済み成果物は `/agentdev/backlog-review` 経由で RU 化後に `/agentdev/req-define` に合流する。
+- **Step 9-10**: 廃棄判定結果、8軸評価スコアの確認、修正、承認（判断の確定、REQ）
+- **Step 14**: prune は Step 10 承認と同時に承認済みとみなし自動実行（REQ）。staged/rejected/duplicate の追加確認は不要
+- **inbox.md 不在**: エラー終了。「先に `agentdev-learning-capture` skill で学びを追加してください」
+- **git pull/push 失敗**: 構造化エラー表示して停止（push 失敗時は完了扱いにしない）
+- **learning-promote の責務**: normalize → classify → 8-axis eval → evaluation-report → disposal judgment → HITL → 採用済み成果物生成 → archive move → prune。採用済み成果物は `/agentdev/backlog-review` 経由で RU 化後に `/agentdev/req-define` に合流する
 
 

--- a/src/opencode/commands/agentdev/req-define.md
+++ b/src/opencode/commands/agentdev/req-define.md
@@ -32,27 +32,13 @@ description: 要件を整理、定義する（機能追加、バグ修正共通�
 
 ## session由来RU 消費契約（参照）
 
-`source_type: chat` かつ `generated_by: session` のRU（session由来RU）を受領した場合、一時成果物ライフサイクル要件と artifact-contracts SPEC「RU アーティファクト契約（session由来RU）」セクションを正規原本として以下を扱う。本コマンドは同契約を再定義しない。
-
-- `logical_key` によるRU案特定: 第1承認済みのRU案を読み込む。第1承認は内容のみを対象とし、第2承認が採番、保存、commit、push を許可する（SPEC「二段階承認」）
-- `session:...` 論理URI の非解決: `sources[].type: chat` で `sources[].path` が `session:...` の場合、ファイル取得、URL取得、外部セッション取得の解決処理へ渡さない（SPEC「session 論理URI」）
-- 必須8セクション読み取り契約: RU 本文8セクション（目的、対象、対象外、正規所有者とアンカー、依存関係、要件化の方向、決定的受け入れ条件、Source Summary）は session 論理URI の解決なしに後工程が判断可能な自足性を前提とする（SPEC「RU 本文必須8セクション」）
-- `tentative_classification` → 最終分類: 暫定値を入力とし、Step 5-2 で document-model SPEC（extension 経由）の文書7分類モデルへ照らして最終分類を確定し、暫定分類を上書きする（SPEC「req-define による最終分類の扱い」）。`tentative_classification` は既存7値のいずれかであり、欠落時は受領しない
-
-各項目の判定基準、検証観点は正規原本（一時成果物ライフサイクル要件 + artifact-contracts SPEC）へ委譲する。
+`source_type: chat` かつ `generated_by: session` のRU（session由来RU）を受領した場合、一時成果物ライフサイクル要件と artifact-contracts SPEC「RU アーティファクト契約（session由来RU）」セクションを正規原本として `logical_key` によるRU案特定、`session:...` 論理URI の非解決、必須8セクション読み取り契約、`tentative_classification` → 最終分類の扱いを扱う。本コマンドは同契約を再定義せず、各項目の判定基準、検証観点は正規原本（一時成果物ライフサイクル要件 + artifact-contracts SPEC）へ委譲する
 
 ## 手順
 
 ### Step 1: セッションコンテキスト検知（引数なし単体実行時のみ）
 
-当該セッション履歴、現在コンテキストを最優先の Requirement Source 候補として評価する。
-`agentdev-req-analysis` に従い、セッション履歴から6項目（要件内容、work_type、scale、ADR、構造化、適用範囲）を推論し、信頼度付きで表示。
-推論結果に応じて以下のルーティングを行う:
-
- - Confirmed のみで要件doc自足可能 → 当該セッション履歴、現在コンテキストを入力として処理を継続（Step 3 以降へ。RU 自動検出に進まない）
- - 部分的に不足し補足質問で解消可能 → RU 自動検出に進まず壁打ち対話を継続（Step 3 へ）
- - 有効な Requirement Source を構成できない → Step 2（RU 自動検出）へ進む
- 引数ありの場合は Step 2 から開始
+`agentdev-req-analysis` に従い、当該セッション履歴・現在コンテキストから6項目（要件内容、work_type、scale、ADR、構造化、適用範囲）を推論し信頼度付きで表示。Confirmed のみで要件doc自足可能なら Step 3 以降へ、部分的不足で補足質問解消可能なら壁打ち（Step 3）へ、有効な Requirement Source 構成不能なら Step 2（RU 自動検出）へ。引数ありの場合は Step 2 から開始
 
 ### Step 2: 明示入力ファイルの読み込み（指定時）
 
@@ -78,68 +64,30 @@ CREATE 前に APPEND/UPDATE 候補を必ず評価すること。
 要件の分割が必要な場合は保存操作ではなく requirements review 候補として扱うこと。
 操作分類結果は `draft-data` の `artifact_actions` に記録
 
- **4-1. 定量的データ検証**: `glob docs/requirements/REQ-*.md`（および副次的に `glob docs/adr/ADR-*.md`）で実ファイルを列挙し、AGENTS.md 等の文書記載レンジ（例: "〜"）と照合すること。
-乖離を発見した場合は文書修正または実ファイル確認により解消すること。
-詳細手順は `agentdev-req-analysis` を参照
+ **4-1. 定量的データ検証**: `glob docs/requirements/REQ-*.md`（および副次的に `glob docs/adr/ADR-*.md`）で実ファイル列挙と AGENTS.md 等の文書記載レンジとの乖離を確認・解消する。詳細は `agentdev-req-analysis` を参照
 
- **4-2. SPLIT 予兆計測（既存REQ）**: APPEND/UPDATE 対象の既存 REQ が特定された場合、当該 REQ の健全性メトリクス（要件行数、関心分類数、成果物種別数）を計測し、req-health-metrics SPEC（extension 経由）の定量閾値に基づき SPLIT シグナルを算出して合意内容に反映すること。
-計測対象は当該 REQ の要件テーブル行（`^| REQ-NNNN-MMM |`）とする。
-SPLIT シグナル合計が 2 以上の場合、APPEND 実施前にユーザーへ SPLIT 要否を提案すること。
-閾値、計算式の詳細は `agentdev-req-analysis` を参照
+ **4-2. SPLIT 予兆計測（既存REQ）**: APPEND/UPDATE 対象の既存 REQ の健全性メトリクス（要件行数、関心分類数、成果物種別数）を計測し、req-health-metrics SPEC（extension 経由）の定量閾値で SPLIT シグナルを算出。合計 2 以上の場合、APPEND 実施前にユーザーへ SPLIT 要否を提案。計測対象は当該 REQ の要件テーブル行（`^| REQ-NNNN-MMM |`）。閾値、計算式の詳細は `agentdev-req-analysis` を参照
 
 ### Step 5: 要件展開
 
-`agentdev-req-analysis` の分析観点に従って網羅。詳細ゲートは `agentdev-req-analysis` を参照
-  - **5-1. 変更影響候補抽出**: 変更影響候補を抽出し、ドラフトに保持する。RU の frontmatter、本文から対象領域キーワードを抽出し、glob/grep で関連 REQ/ADR/SPEC を事前特定してサブエージェント調査委譲の調査優先対象リスト（ヒントでありハードフィルタではない）を構築すること（REQ）。REQ が要求する実ファイル完全列挙は維持すること。詳細手順は `agentdev-req-analysis` の「調査スコープ洗練手順」を参照。委譲接続点: サブエージェントは探索結果、分類候補、根拠のみを返し、親エージェントがドラフト反映を判断する
- - **5-2. 分類ゲート（REQ 最終分類確定ステップ）**: 各要件行候補を「変更後仕様」or「反映作業」に分類する。併せて REQ/SPEC 境界判定を行い、SPEC 等に配置すべき要件行候補を SPEC 保存対象として分離し、`draft-data` の `artifact_actions`（`artifact: spec`）に記録すること。RU 入力の暫定分類（backlog-review が `tentative_classification` に付与）が存在する場合、本ステップで document-model SPEC（extension 経由）の文書7分類モデルに照らして最終分類を確定し、暫定分類を上書きする。委譲接続点: サブエージェントは分類候補、SPEC 候補と根拠のみを返し、親エージェントが要件doc混入可否を判断する
- - **5-3. 文書分類妥当性検証**: 各要件の対象ドキュメント種別を検証する。REQ 要件行として残った行に SPEC 分離基準違反の残留がないか検出し、検出時は当該行を SPEC 保存対象へ移送して `artifact_actions`（`artifact: spec`）に追加すること（安定契約例外 は検出対象外）。委譲接続点: サブエージェントは不適合候補、SPEC 残留候補と根拠のみを返し、親エージェントがflag記録を判断する
- - **5-4. ADR要否確認ゲート**: ADR判断が必要な変更（ADR候補、既存REQ/ADR/SPECとの衝突候補、command/skill/workflow/docsの責務境界変更を含む）を要件が含む場合、`agentdev-architecture-advisory` に従いアーキテクチャ助言サブエージェントへ委譲する。アーキテクチャ助言サブエージェント相談の入力は同 skill が定める標準テンプレート（要件候補、衝突候補、ADR候補、既存ADRとの関連、親エージェントの判断質問）で構築し、アーキテクチャ助言サブエージェント出力を 4 ラベル構造（確定事項/推定事項/ユーザー確認事項/ブロッカー）で要求すること（REQ）。ラベル構造は soft-contract（ADR）とし厳格スキーマ検証を導入せず、最終的なラベル分類は親エージェントが行う。既存文書またはユーザー合意で裏付けられていない内容を要件本文へ確定事項として混入させない。分類結果にブロッカーが含まれる場合、または未決事項が解消されず残る場合、要件doc生成（Step 7）へ進まず壁打ち（Step 3）へ差し戻すこと
- - **5-5. 実行主体分類表（REQ）**: 委譲契約を定義する場合、各委譲について実行主体分類表（adapter skill / command / subagent / harness）を必須として含めること。分類定義は delegation-contracts SPEC（extension 経由）の「実行主体分類表（委譲契約必須項目、REQ）」セクションを参照。委譲を含まない要件では本項目は省略可
- - **5-6. test strategy 定義（REQ, REQ）**: 各合意項目（AG-*）の検証方法を test strategy として定義する。各 test strategy 項目は verification（検証手順）、pass_criteria（合格基準）、on_failure（不合格時の処置）の3要素構造とする。on_failure（不合格時の処置）を持たない検証項目は test strategy に含めないこと。項目識別子は TS-NNN 形式（NNNは3桁ゼロ埋め連番）、各項目属性は id（TS-NNN）、target_item（AG-* への参照）、verification、pass_criteria、on_failure の5属性を持つ。on_failure アクション種別は fix-and-reverify（実装を修正して再検証）/ record-in-findings（Findings に out-of-scope として記録）の2値とし、選択基準は修正可能な実装不良の場合 fix-and-reverify、スコープ外または修正困難な事象の場合 record-in-findings とする。シリアライズ形式の詳細は req-define command SPEC（extension 経由）の「draft-data test_strategy フィールドスキーマ」を参照
+`agentdev-req-analysis` の分析観点に従って網羅。詳細ゲート、委譲接続点は `agentdev-req-analysis` の各 Phase を参照:
+
+- **5-1. 変更影響候補抽出**: 変更影響候補を抽出しドラフトに保持。RU からの対象領域キーワード抽出、glob/grep での関連 REQ/ADR/SPEC 事前特定、サブエージェント調査委譲への調査優先対象リスト（ヒント）構築、実ファイル完全列挙の維持。詳細は `agentdev-req-analysis`「調査スコープ洗練手順」参照
+- **5-2. 分類ゲート（REQ 最終分類確定）**: 各要件行候補を「変更後仕様」/「反映作業」に分類。REQ/SPEC 境界判定を行い SPEC 保存対象を `artifact_actions`（`artifact: spec`）に分離。RU 暫定分類（`tentative_classification`）があれば document-model SPEC（extension 経由）の文書7分類モデルへ照らして最終分類を確定し上書き
+- **5-3. 文書分類妥当性検証**: REQ 要件行に SPEC 分離基準違反残留がないか検出。検出時は SPEC 保存対象へ移送（安定契約例外は対象外）
+- **5-4. ADR要否確認ゲート**: ADR候補・既存REQ/ADR/SPEC との衝突候補・責務境界変更を含む場合、`agentdev-architecture-advisory` へ委譲。出力は 4 ラベル構造（確定事項/推定事項/ユーザー確認事項/ブロッカー）。soft-contract（ADR）。ブロッカーまたは未決事項残存時は壁打ち（Step 3）へ差し戻し
+- **5-5. 実行主体分類表（REQ）**: 委譲契約を定義する場合、各委譲について実行主体分類表（adapter skill / command / subagent / harness）を必須。詳細は delegation-contracts SPEC（extension 経由）参照。委譲を含まない要件では省略可
+- **5-6. test strategy 定義（REQ, REQ）**: 各合意項目（AG-*）の検証方法を test strategy として定義。3要素構造（`verification` / `pass_criteria` / `on_failure`）を必須とし、`on_failure` を持たない検証項目は含めない。項目識別子は `TS-NNN`、`on_failure` アクション種別は `fix-and-reverify` / `record-in-findings` の2値。シリアライズ形式の詳細は req-define command SPEC（extension 経由）の draft-data test_strategy フィールドスキーマ参照
 
 ### Step 6: ADR判断
 
-`agentdev-adr-guidelines`（manual reference）に従ってADR判断を記録（ADRファイル作成は req-save で実行）
-
- **6-1. 既存ADR重複確認**: ADR候補を提示する前に、`docs/adr/README.md` の承認済み ADR 一覧と意味的重複を確認する。
-重複時は新規ADR作成ではなく既存ADRのUPDATEを推奨する。
-委譲接続点: サブエージェントは重複候補と根拠のみを返し、親エージェントがCREATE vs UPDATEを判断する
-
- **6-2. ADR禁止ゲート**: ADR候補を提示する前に、REQ/SPEC相当判定を行う。
-詳細は `agentdev-req-analysis` を参照。
-委譲接続点: サブエージェントは除外候補と根拠のみを返し、親エージェントがADR候補提示可否を判断する
-
- **6-3. ADR判断根拠の記録**: ADR判断後、判断根拠をドラフトに保存する。
-詳細は `agentdev-req-analysis` を参照。
-委譲接続点: 親エージェントのみがドラフトへ記録する
-
- **6-4. 作業手段ADR拒否ゲート**: ADR候補が削除、廃止、移行、統合、再構築、完全削除そのものを主題にしている場合、ADR候補から除外する。
-過去判断の除去は新規ADRではなくretire/supersedeで処理する。
-委譲接続点: サブエージェントは除外候補と根拠のみを返し、親エージェントがADR候補提示可否を判断する
-
- **6-5. ADR 番号指定形式**: req-define は ADR 番号を推測指定せず `new:{topic-slug}` 形式を使用すること。
-draft 内の ADR 参照は `new:{topic-slug}` 形式とし、確定番号は req-save が `agentdev-adr-file-manager` の採番ルール（max+1, 欠番埋め禁止）で確定して置換する。
-`ADR-NNNN` の直接指定は既存 ADR の UPDATE/APPEND 場合のみ許可され、新規 ADR 作成では番号を指定しないこと
+`agentdev-adr-guidelines`（manual reference）に従ってADR判断を記録（ADRファイル作成は req-save で実行）。各副ステップ（6-1: 既存ADR重複確認、6-2: ADR禁止ゲート、6-3: 判断根拠記録、6-4: 作業手段ADR拒否ゲート、6-5: ADR番号指定形式 `new:{topic-slug}`）の詳細、委譲接続点は `agentdev-req-analysis` を参照
 
 ### Step 7: 要件doc生成
 
-テンプレート: `.opencode/commands/agentdev/templates/req-define/req-draft.md` を Read → 構造化 `draft-data` 形式に従って生成。
-draft の原本は人間向け Markdown 本文ではなく構造化された `# draft-data` fenced YAML block である。
-Step 6-2/5-3 で分離した SPEC 候補は `artifact_actions`（`artifact: spec`）として統合し、`## SPEC候補` 補助セクションは出力しない。
-REQ/ADR/SPEC への保存対象は成果物別最上位配列に分散させず、単一の `artifact_actions` 配列に統合する
+テンプレート: `.opencode/commands/agentdev/templates/req-define/req-draft.md` を Read → 構造化 `draft-data` 形式に従って生成。原本は構造化された `# draft-data` fenced YAML block。Step 6-2/5-3 で分離した SPEC 候補は `artifact_actions`（`artifact: spec`）として統合し `## SPEC候補` 補助セクションは出力しない。保存対象は単一の `artifact_actions` 配列に統合する
 
- - **7-1. 定義完全性ゲート（QG-1）**: 要件doc生成後、`agentdev-quality-gates` の QG-1（Definition Integrity Gate）に従い、REQ/SPEC 分類、ADR ゲート、チェックボックス測可能性、必須フィールド完全性、artifact_actions 構成の妥当性を検証する。判定基準、検査観点は同スキル（`agentdev-quality-gates`）の QG-1 を参照。fail 時は壁打ち（Step 3）へ差し戻し
- - **7-2. operation_units 生成**: 複数RU入力時の統合/分離結果（Step 11-2）を基に `draft-data` 内の `operation_units` を生成する。各 OU は `ou_id`, `source_ru`, `target_req`, `target_spec`, `operation`, `scale`, `depends_on`, `recommended_order`, `issue_policy`, `result` フィールドを持つ。単一REQ操作の場合も 1 件の OU として出力する
- - **7-2a. depends_on / recommended_order の定義（REQ）**: `depends_on` には必須依存のみを記録する。必須依存とは、インターフェース契約、データモデル、schema、公開API、検証不能な前提成果物への依存である。弱依存、関連依存、推奨実行順、同一ファイル変更可能性、同一SPECセクション変更可能性、同一機能領域、クリティカルパス優先度は `depends_on` に含めない。推奨実行順は `recommended_order` に記録する
- - `operation` の値は対象 artifact により2系統: REQ 操作は `create`/ `append`/ `update`、SPEC 操作は `spec-create`/ `spec-update`。後方互換性のため既存の `create`/ `append`/ `update` は維持する
-  - `target_req` は REQ 操作（create/append/update）の対象 REQ、`target_spec` は SPEC 操作（spec-create/spec-update）の対象 SPEC パス（例: 既存 SPEC パス `docs/specs/{domain}/<existing>.md`、新規は `target_spec: {operation, domain, slug}` 構造化）。両フィールドは操作種別に応じて使い分け、未使用時は省略可能とする
- - **7-3. artifact_actions 生成**: Step 6-2/5-3 の分類結果、Step 6 の ADR 判断結果を `draft-data` の `artifact_actions` に統合する。1 action = 1 artifact × 1 editing concern 単位とし、同一関心の複数 agreed items は単一 action に複数段落の `content` としてまとめる。各 action は `id`（ACT-REQ-NNN/ ACT-ADR-NNN/ ACT-SPEC-NNN）, `artifact`（req/adr/spec）, `operation`, `target`, `source_items`, `content` を持つ
- - **7-3a. target_area / content 形式（`artifact: spec` の場合、REQ/079）**: `artifact: spec` の action は operation 別に以下の出力形式を規定する。`target_area` の形式（Markdown 見出し行）、見出し階層の解釈規則、複数マッチ、未検出時の挙動は spec-save 側に委譲し、req-define 側は出力形式のみを規定する
-  - `operation: create / spec-create`: `target_area` は任意（省略時は spec-save が既存セクション構造から追加位置を判断）。`content` は新規セクション本文とする
-  - `operation: update / spec-update`: `target_area` は必須（対象セクション見出し、Markdown 見出し行形式。例: `### IR-044`）。`content` は変更後セクション全文（対象セクションの見出し行から次の同レベル見出しの直前までの全内容）とする
-  - **7-3b. SPEC action への分類根拠出力（`artifact: spec` の場合）**: `artifact: spec` の各 action へ `spec_logical_division`（SPEC 論理5区分: `behavior`/`catalog`/`cross_cutting_contract`/`parameter`/`implementation_detail`）と `canonical_owner`（対象 command、skill、workflow 等の関心キー）を最終分類確定値として出力する。出力値は Step 5-2 の最終分類確定ステップで確定した値とし、`artifact-contracts.md`（extension 経由）「分類根拠伝播契約」の伝播フィールド一覧と一致させる。分類値が確定できない場合は `unknown` とし、soft-contract に従い後続 spec-save へ警告付きで引き継ぐ。後続 spec-save が SPEC frontmatter または冒頭宣言節へ宣言を付与するための入力となる
-  - **7-4. test_strategy 生成（REQ）**: Step 5-6 で定義した test strategy を `draft-data` の `test_strategy` セクションに格納する。各項目は id（TS-NNN）、target_item（AG-* への参照）、verification、pass_criteria、on_failure の5属性をYAML形式で保持する。`test_strategy` セクションの各項目は Step 5-6 の定義と完全に一致すること
-  - **7-5. review_dispositions 生成（AG-007）**: 壁打ち過程の採否判断（採用しなかった入力、既存要件で充足済みの入力、一部のみ採用した入力）を `draft-data` の `review_dispositions` へ正規YAMLフィールドとして出力する。各エントリは id（`RD-NNN`）、source_ru、source_item、disposition（`covered`/`partially_covered`/`rejected`/`not_applicable`、必要に応じて `superseded`/`stale_target`）、reason_code、reason、evidence（`path`、`section`、`checked_at_commit`）、related_removed_items を持つ。`evidence.checked_at_commit` は生成時 `null` とする（G08 git 禁止）。1 エントリ = 単一 source_ru + 単一 source_item（重複禁止）。未決事項は disposition で代替せず `auto_gate` の `unresolved_questions` 等へ記録する。根拠不足時は `auto_gate.auto_ready: false` とし `stop_reasons` へ記録する。シリアライズ形式の詳細は req-define command SPEC（extension 経由）の「draft-data review_dispositions フィールドスキーマ」を参照。`review_dispositions` は optional soft-contract であり、欠落時に後続工程が draft を拒否しない
+各副ステップ（7-1: 定義完全性ゲート QG-1、7-2: operation_units 生成、7-2a: depends_on/recommended_order 定義、7-3: artifact_actions 生成、7-3a: target_area/content 形式、7-3b: SPEC action 分類根拠出力、7-4: test_strategy 生成、7-5: review_dispositions 生成）の詳細、フィールドスキーマ、委譲接続点は `agentdev-req-analysis` の req-define detailed gates、および req-define command SPEC（extension 経由）の各フィールドスキーマを参照。`target_spec`、`spec_logical_division`、`canonical_owner`、`on_failure`、`review_dispositions` の出力形式も同 SPEC を正とする
 
 ### Step 8: work_type 判定
 
@@ -147,50 +95,19 @@ REQ/ADR/SPEC への保存対象は成果物別最上位配列に分散させず�
 
 ### Step 9: Scale判断（feature のみ）
 
-`agentdev-workflow-lifecycle` で standard/large を判定。large 時はユーザーと分解計画を協議
- - **9-1. 実装スコープシグナル確認**: ドラフト内に実装詳細セクション（修正候補リスト、検出事項カタログ、影響ファイル一覧等）が存在する場合、`agentdev-workflow-lifecycle` の実装スコープシグナル基準に基づき scale: large への昇格を判定すること。昇格時は昇格理由をユーザーに提示し、Step 9 の分解計画協議を実施すること
+`agentdev-workflow-lifecycle` で standard/large を判定。large 時はユーザーと分解計画を協議。9-1 実装スコープシグナル確認（ドラフト内に修正候補リスト、検出事項カタログ、影響ファイル一覧等の実装詳細セクション存在時に large 昇格判定、昇格理由をユーザー提示）の詳細は `agentdev-workflow-lifecycle` を参照
 
 ### Step 10: ドラフト保存
 
- 全 work_type（feature/ bugfix/ maintenance/ docs_chore）で `.agentdev/drafts/req-draft-{topic-slug}.md` に保存。
-Step 7 の構造化 `draft-data` 形式（`# draft-data` fenced YAML block）で保存する。
-標準データモデル fields（`work_type`, `scale`, `summary`, `auto_gate`, `agreed_items`, `artifact_actions`, `conflict_resolutions`, `operation_units`, `test_strategy`, `review_dispositions`, `case_open_hints`）を保持する。
-`workflow_route` は派生値として保存しない。
-後続コマンドの工程分岐は `work_type` 固定分岐ではなく `artifact_actions` の存在で決定するため、draft の `artifact_actions` に `artifact: req`/ `artifact: adr` entry が含まれれば req-save が、`artifact: spec` entry が含まれれば spec-save が実行される。
-`operation_units` セクションを含める。
-`execution_groups` セクションは出力しない。
-`summary` 等の人間可読セクションは補助的であり、下流処理の正として扱われない
+全 work_type（feature/ bugfix/ maintenance/ docs_chore）で `.agentdev/drafts/req-draft-{topic-slug}.md` に保存。Step 7 の構造化 `draft-data` 形式（`# draft-data` fenced YAML block）で保存する。標準データモデル fields（`work_type`, `scale`, `summary`, `auto_gate`, `agreed_items`, `artifact_actions`, `conflict_resolutions`, `operation_units`, `test_strategy`, `review_dispositions`, `case_open_hints`）を保持する。`workflow_route` は派生値として保存しない。後続工程の分岐は `artifact_actions` の存在で決定する（`artifact: req`/`adr` → req-save、`artifact: spec` → spec-save）。`operation_units` を含め、`execution_groups` は出力しない。`summary` 等の人間可読セクションは補助的であり下流処理の正として扱われない
 
- - **10-1. 実装詳細の分離**: ドラフトに実装詳細（個別ファイルの編集指示、修正候補リスト、検出事項カタログ等）が含まれる場合、当該内容を `artifact_actions` の `content` とは分離されたセクションに配置し、合意内容の判読性を確保すること。実装詳細がドラフト全体の過半を占める場合は、完了条件チェックボックスへの要約をユーザーに提案すること
-
- - **10-2. auto_gate完了ゲート**: ドラフト保存後、`auto_gate.auto_ready` を確認する。`auto_ready:true` の場合は Step 11 へ進む。`auto_ready:false` または未解決 item（`unresolved_questions`/`unresolved_conflicts`/`out_of_repo_operations`/`stop_reasons`）が残る場合、`stop_reasons` をユーザーに提示し、解消方策（作業分散、対象絞り込み、スコープ削除等）を壁打ち（Step 3）で合意する。合意により解消された場合は `auto_ready:true` に更新して Step 11 へ進む。ユーザーが「`auto_ready:false` のまま標準フローで手動実行する」と明示的に選択した場合、当該選択を `conflict_resolutions` に記録して Step 11 へ進む（REQ）。上記いずれにも該当しない（未解決のまま）場合は Step 3（壁打ち）へ差し戻し（REQ）
-
- - **10-2a. 未確定内容の auto_ready 抑止**: Step 10-2 の判定前に、`agreed_items` 各エントリの `content`、`artifact_actions` 各エントリの `content` について未確定内容の有無を検査し、`auto_gate.auto_ready` と `auto_gate.stop_reasons` を確定すること（REQ）。検査は req-define command SPEC（extension 経由）「未確定内容の auto_ready 抑止」節に従う。以下の手順を機械的に実行する:
-  - **(A) 決定的マーカー検査**: `agreed_items`/`artifact_actions` の各 `content` 文字列に対し、`TBD`/`TODO`/`未定`/`後続工程で確定`/`case-run で確定` の5マーカーを大文字小文字区別なしで部分文字列検索する。いずれかを検出した場合、当該 AG-ID または ACT-ID と検出マーカーを `auto_gate.stop_reasons` へ追加し、`auto_gate.auto_ready: false` とする
-  - **(A') 引用・禁止事例の誤検知除外**: マーカーを含む文が「禁止事項や過去事例の引用」（例: 「TBD を残さないこと」「TODO を含めないこと」「未定のまま保存しないこと」「TBD/ TODO/ 未定 を検出する」等）である場合、当該文のマーカーは検出扱いとしない。同一 ID 内に引用以外の未確定マーカーが残る場合は抑止を維持する
-  - **(B) QG-1 意味判定の併用**: (A) の結果に加え、QG-1（Definition Integrity Gate）の意味判定観点（必須フィールド欠落、曖昧要件、測定不能条件）を `agreed_items`/`artifact_actions` 各エントリへ適用する。QG-1 が fail となるエントリがある場合、該当 AG-ID/ ACT-ID と QG-1 該当観点を `auto_gate.stop_reasons` へ追加し、`auto_gate.auto_ready: false` とする
-  - **stop_reasons 記録**: 抑止時の `stop_reasons` 各エントリは、対象 ID（`AG-NNN` または `ACT-{ARTIFACT}-NNN`）、抑止理由（検出マーカーまたは QG-1 該当観点）、該当箇所の要約を含むこと。詳細な記録形式、代表 fixture、引用誤検知除外パターンは req-define command SPEC（extension 経由）「未確定内容の auto_ready 抑止」節を参照
+各副ステップ（10-1: 実装詳細の分離、10-2: auto_gate 完了ゲート、10-2a: 未確定内容の auto_ready 抑止）の詳細、stop_reasons 記録形式、代表 fixture、引用誤検知除外パターンは req-define command SPEC（extension 経由）「未確定内容の auto_ready 抑止」節、および `agentdev-req-analysis` の req-define detailed gates を参照
 
 ### Step 11: 要件doc確認
 
-生成した要件docをユーザーに提示（承認は求めず提示のみ）。
-差し戻し時は壁打ち継続（Step 2 へ）。
-次コマンド実行を確定の意思表示として扱う
+生成した要件docをユーザーに提示（承認は求めず提示のみ）。差し戻し時は壁打ち継続（Step 2 へ）。次コマンド実行を確定の意思表示として扱う
 
- **11-1. 複数RU同時入力受付**: 詳細は `agentdev-req-analysis` を参照
-
- **11-2. 統合/分離判定**: 詳細は `agentdev-req-analysis` を参照。
-委譲接続点: サブエージェントは統合/分離候補と根拠のみを返し、親エージェントが`draft-data`へ記録する。
-併せて生成ドラフト自身の健全性メトリクス（要件行数、関心分類数、成果物種別数）を計測し、req-health-metrics SPEC（extension 経由）の閾値で SPLIT シグナルを算出して合意内容に反映すること。
-新規 CREATE のドラフトであっても、要件行数が 51 行を超える場合は肥大化傾向としてユーザーへ SPLIT 要否を提案すること
-
- **11-3. 操作単位ごとの出力生成**: 詳細は `agentdev-req-analysis` を参照。委譲接続点: 親エージェントがreq-save消費形式を確定する
-
- **11-4. Epic 規模検出時の記録**: 詳細は `agentdev-req-analysis` を参照。委譲接続点: サブエージェントは分解候補のみを返し、親エージェントが`draft-data`の`case_open_hints`へ記録する
-
- **11-5. Wave 候補、依存関係の記録**: 詳細は `agentdev-req-analysis` を参照。委譲接続点: サブエージェントは依存候補のみを返し、親エージェントが順序依存を確定する
-
- **11-6. OU 構造検証**: 生成した `operation_units` セクションについて以下を確認する: (a) 各 OU に `ou_id`, `operation` が設定されている (b) REQ 操作（create/append/update）の OU に `target_req` が、SPEC 操作（spec-create/spec-update）の OU に `target_spec` が設定されている (c) `depends_on` が実在する `ou_id` を参照している (d) `result` セクションが空である（req-save/spec-save/case-open が書き戻すため）
+各副ステップ（11-1: 複数RU同時入力受付、11-2: 統合/分離判定、11-3: 操作単位ごとの出力生成、11-4: Epic 規模検出時の記録、11-5: Wave 候補/依存関係の記録、11-6: OU 構造検証）の詳細、委譲接続点は `agentdev-req-analysis` を参照。11-2 では生成ドラフト自身の健全性メトリクス（要件行数、関心分類数、成果物種別数）を計測し、req-health-metrics SPEC（extension 経由）の閾値で SPLIT シグナルを算出して合意内容に反映する（新規 CREATE ドラフトで要件行数が 51 行超の場合は SPLIT 要否をユーザーへ提案）
 
 ### Step 12: 完了報告
 
@@ -217,8 +134,7 @@ Step 7 の構造化 `draft-data` 形式（`# draft-data` fenced YAML block）で
 - G14: req-define は draft に `operation_units` セクションを出力し、`execution_groups` セクションは出力しないこと（038）。単一REQ操作の場合も 1 件の OU として出力する。Epic/ Wave/ Issue 構成の生成は case-open の責務である
 - G15: SPEC 分離基準に該当する要件行候選は REQ 要件行に残留させず、`draft-data` の `artifact_actions`（`artifact: spec`）へ分離すること。安定契約例外は分離対象外
 - G16: ADR判断が必要な変更（ADR要否確認ゲート）では ADR 判断前に `agentdev-architecture-advisory` を参照する。アーキテクチャ助言サブエージェントは ADR 要否、推奨方向、設計リスク、根拠を返し、最終的な ADR 作成判断は親エージェントが行う
-- G17: アーキテクチャ助言サブエージェントの助言は親エージェントが分類し、未確認事項を要件本文へ混入させない
-- G18: アーキテクチャ助言サブエージェントはファイル編集主体ではない
+- G17: アーキテクチャ助言サブエージェントの助言は親エージェントが分類し、未確認事項を要件本文へ混入させない。同サブエージェントはファイル編集主体ではない
 - G19: test strategy 項目は verification（検証手順）、pass_criteria（合格基準）、on_failure（不合格時の処置）の3要素を完全に持つこと（REQ）。on_failure（不合格時の処置）を持たない検証項目は test strategy に含めないこと（REQ）。3要素のいずれかが欠落する項目を検出した場合、保存前に QG-1 が fail として扱う（REQ）
 
 

--- a/src/opencode/commands/agentdev/req-save.md
+++ b/src/opencode/commands/agentdev/req-save.md
@@ -23,12 +23,7 @@ req-defineで生成された壁打ち成果物をREQ/ADRファイルとしてdoc
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/req-save.yaml`）を読み込む（ADR）。
-
-- extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
-- extension が存在しない場合は標準動作で続行する
-- extension が破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する
-- 詳細な読み込み契約は `agentdev-project-extensions` skill 参照
+本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/req-save.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
 ## 手順
 
@@ -41,95 +36,29 @@ REQ/ADR 対象 artifact_actions がない場合は no-op 完了（後続の case
 
 ### Step 2: ドラフト読込
 
-`.agentdev/drafts/req-draft-*.md` を読み込む → 最新の1件を対象とする。
-見つからない場合はエラーで中止: `壁打ちドラフトが見つかりません。
-先に /agentdev/req-define を実行してください。
-`
-
-- **読込時 hash 記録**: `git rev-parse HEAD` で読込時点の commit hash を記録する
+`.agentdev/drafts/req-draft-*.md` を読み込む → 最新の1件を対象とする。見つからない場合はエラーで中止（先に `/agentdev/req-define` を実行してください）。**読込時 hash 記録**: `git rev-parse HEAD` で読込時点の commit hash を記録する
 
 ### Step 3: ドラフト検証
 
 `draft-data` の必須フィールド（artifact_actions, operation_units, topic_slug）が存在することを確認。欠損時はエラーで中止
 
-**Step 3-1**: 分類ゲート検査。
-CREATE対象REQの要件テーブルを検査する。
-詳細は `agentdev-req-file-manager` を参照。
-委譲接続点: サブエージェントは反映作業候補、理由、移送先候補のみを返し、親エージェントが停止とユーザー指示待ちを判断する
+**Step 3-1**: 分類ゲート検査（CREATE対象REQの要件テーブル検査）、**Step 3-2**: 文書分類適合確認（REQ/ADR 保存前のドキュメント種別確認）。詳細、委譲接続点は `agentdev-req-file-manager` を参照
 
-**Step 3-2**: 文書分類適合確認。
-REQ/ADR 保存前に対象ドキュメント種別を確認する。
-詳細は `agentdev-req-file-manager` を参照。
-委譲接続点: サブエージェントは分類適合の判定材料のみを返し、親エージェントが保存可否を判断する
-
-**Step 3-3**: REQ/ADR artifact_actions 処理ゲート。ドラフトの `artifact_actions` から `artifact: req`/ `artifact: adr` の entry を処理対象とする（draft 全体の REQ/ADR artifact_actions を処理し、OU ごとに分割しない）:
-- `artifact_actions` に REQ/ADR entry がない場合 → no-op 完了（Step 1 で判定済み）
-- `operation_units` が存在する場合 → 処理対象 `artifact_actions` を決定する:
- - OU ID が指定されている場合 → 指定された OU に属する REQ/ADR 対象 `artifact_actions` だけを処理対象とする
- - OU ID 未指定時 → draft 全体の REQ/ADR 対象 `artifact_actions` を処理対象とする（OU 件数によらず、OU が複数存在することだけを理由に停止しない）
-- `artifact_actions` フィールドがない（旧形式 draft）の場合 → 従来どおり全 req-operation を処理する（後方互換）
-- **SPEC artifact_actions の取扱い**: `artifact: spec` の entry は spec-save コマンドの対象であり、req-save は処理しない（スキップする）
+**Step 3-3**: REQ/ADR artifact_actions 処理ゲート。ドラフトの `artifact_actions` から `artifact: req`/ `artifact: adr` の entry を処理対象とする（draft 全体を処理し、OU ごとに分割しない）。`artifact_actions` に REQ/ADR entry がない場合 → no-op 完了。`operation_units` 存在時は OU ID 指定があれば当該 OU 配下のみ、未指定時は draft 全体を処理対象。`artifact_actions` フィールドがない（旧形式 draft）の場合は従来どおり全 req-operation を処理（後方互換）。`artifact: spec` の entry は spec-save コマンドの対象であり処理しない
 
 ### Step 4: REQ ファイル操作
 
-`agentdev-req-file-manager` の判定ロジックと採番ルールに従って実行。
-Step 3-3 で処理対象とした `artifact_actions`（`artifact: req`/ `artifact: adr`）の全 entry を処理する（draft 全体の REQ/ADR artifact_actions を処理し、OU ごとの消費は行わない）。
-`artifact_actions` フィールドがない場合は従来どおり全 req-operation を処理する。
-詳細は `agentdev-req-file-manager` を参照。
-委譲接続点: サブエージェントはCREATE/APPEND/UPDATE候補、SPLIT候補、REQ再構成候補を返し、親エージェントがファイル保存を行う
+`agentdev-req-file-manager` の判定ロジックと採番ルールに従って実行。Step 3-3 で処理対象とした `artifact_actions`（`artifact: req`/`artifact: adr`）の全 entry を処理する（draft 全体を処理し、OU ごとの消費は行わない）。`artifact_actions` フィールドがない場合は従来どおり全 req-operation を処理する（後方互換）。委譲接続点: サブエージェントはCREATE/APPEND/UPDATE候補、SPLIT候補、REQ再構成候補を返し、親エージェントがファイル保存を行う。詳細は `agentdev-req-file-manager` を参照
 
-**決定的処理のスクリプト呼出（REQ、AG-002、design-principles.md 第5節）**: 本 Step の決定的処理（REQ番号採番、要件行ID採番）は `agentdev-req-file-manager/scripts/` の決定的スクリプトを bash 経由で呼び出して実行する（SKILL.md「Scripts（決定的処理）」セクション参照）。frontmatter id↔ファイル名整合性確認は `agentdev-artifact-validation` の公開検証契約で実行する（AG-019、RU-20260722-01 合意）。LLM 推論で代替しない:
+**決定的処理のスクリプト呼出（REQ、AG-002）**: REQ番号採番、要件行ID採番、frontmatter id↔ファイル名整合性確認は `agentdev-artifact-validation` の公開検証契約（RU-20260722-01 合意）および `agentdev-req-file-manager` SKILL.md「Scripts（決定的処理）」で規定する決定的スクリプトを bash 経由で呼び出して実行する。LLM 推論で代替しない。具体的な CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照
 
-```bash
-# REQ番号採番（CREATE 時、max+1、欠番埋め禁止）
-bun .opencode/skills/agentdev-req-file-manager/scripts/src/alloc-req-number.ts docs/requirements
-# → stdout: { ok: true, allocated: "REQ-NNNN", max: N }
-
-# 要件行ID採番（APPEND 時、REQ-NNNN-MMM 形式、max+1）
-bun .opencode/skills/agentdev-req-file-manager/scripts/src/alloc-composite-id.ts docs/requirements/REQ-{NNNN}.md
-# → stdout: { ok: true, allocated: "REQ-NNNN-MMM", req: N, max: M }
-
-# frontmatter id ↔ ファイル名整合性確認（保存前後の検証、agentdev-artifact-validation 公開検証契約）
-bun .opencode/skills/agentdev-artifact-validation/scripts/src/check-frontmatter-consistency.ts docs/requirements req
-# → stdout: { ok: boolean, errors: string[], warnings: string[] }
-```
-
-**Step 4-0**: QG-1（適用結果の整合性検証、REQ/082、AG-003）。
-REQ/ADR ファイル保存前に、`agentdev-quality-gates` の QG-1（Definition Integrity Gate）を「適用結果の整合性検証」として実行する。
-検証項目: 採番結果の整合性（`new:{slug}` → 確定番号の置換漏れなし）、マージ結果の整合性（要件テーブル構造、番号重複なし）、インデックスの整合性（README/DOC-MAP エントリと採番結果の一致）、変更範囲の妥当性（Step 9 で検証）。
-各検証は決定的スクリプトの JSON 結果で機械的に確認する。
-判定基準、検査観点は同スキル（`agentdev-quality-gates`）の QG-1 を参照。
-fail 時は保存を停止し req-define へ差し戻しを推奨。
-**REQ**: req-save の QG-1 は内容の品質（検証可能性、REQ/SPEC 分類適合性等）を再検証せず、内容の品質は req-define の QG-1 の責務とする
-
-**Step 4-1**: 語彙、責務、runtime境界矛盾の防止。
-Step 4 の保存完了後、既知の矛盾を検出可能な範囲で防止する。
-詳細は `agentdev-req-file-manager` を参照。
-委譲接続点: サブエージェントは検査結果と根拠のみを返し、親エージェントがfollow-up扱いを判断する
-
-**Step 4-2**: Catalog entry 確認（APPEND 時）。
-Step 4 で への APPEND 操作を実行した場合、追加した要件行に関連する integrity-rule-catalog SPEC（extension 経由）の catalog entry 有無を確認する。
-catalog entry が未記載の場合、ユーザーに追記を促す。
-req-save 自身は `docs/specs/` 配下を直接編集しない（G02 制約）
-
-**Step 4-3**: 複数 REQ/ADR ファイルの3フェーズ分離（REQ/093）。複数 REQ/ADR ファイルを保存する場合、並列委譲可能な作成フェーズと直列集約フェーズを分離する（詳細は後述「case-auto 並列委譲モデル」セクション参照）
+**Step 4-0**: QG-1（適用結果の整合性検証、REQ/082、AG-003）。REQ/ADR ファイル保存前に `agentdev-quality-gates` の QG-1 を「適用結果の整合性検証」として実行。採番結果、マージ結果、インデックス、変更範囲の妥当性を決定的スクリプトの JSON 結果で機械的に確認。fail 時は保存を停止し req-define へ差し戻し。**REQ**: req-save の QG-1 は内容の品質を再検証せず、それは req-define の QG-1 の責務。**Step 4-1**: 語彙、責務、runtime境界矛盾の防止（Step 4 完了後に既知の矛盾を検出可能な範囲で防止）。**Step 4-2**: Catalog entry 確認（APPEND 時。関連 integrity-rule-catalog SPEC（extension 経由）の catalog entry 有無を確認、未記載時はユーザーへ追記を促す、`docs/specs/` 配下は直接編集しない G02）。**Step 4-3**: 複数 REQ/ADR ファイルの3フェーズ分離（REQ/093、後述「case-auto 並列委譲モデル」参照）。Step 4-1/4-2 の詳細は `agentdev-req-file-manager` を参照
 
 ### Step 5: インデックス、ハブ更新
 
 詳細は `agentdev-req-file-manager` を参照。委譲接続点: 親エージェントのみが `docs/` ファイルを更新する
 
-**エントリ存在確認のスクリプト呼出（REQ、AG-002、AG-019）**: README/DOC-MAP へのエントリ追加後に、当該エントリが正しく登録されたかを決定的スクリプトで検証する。`check-entry-existence` は `agentdev-artifact-validation` の公開検証契約（RU-20260722-01 合意）:
-
-```bash
-# REQ エントリが README/DOC-MAP に存在するか確認
-bun .opencode/skills/agentdev-artifact-validation/scripts/src/check-entry-existence.ts REQ-NNNN \
-  docs/requirements/README.md docs/DOC-MAP.md
-# → stdout: { ok: boolean, errors: string[], warnings: string[], found: string[] }
-
-# stdin JSON 入力（複数 ID 一括確認）も可能
-echo '{"id":"REQ-NNNN","files":["docs/requirements/README.md"]}' | \
-  bun .opencode/skills/agentdev-artifact-validation/scripts/src/check-entry-existence.ts
-```
+**エントリ存在確認のスクリプト呼出（REQ、AG-002、AG-019）**: README/DOC-MAP へのエントリ追加後に `agentdev-artifact-validation` の公開検証契約（RU-20260722-01 合意、`check-entry-existence`）で登録を検証する。具体的な CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照
 
 ### Step 6: ADR ファイル作成
 
@@ -137,146 +66,45 @@ echo '{"id":"REQ-NNNN","files":["docs/requirements/README.md"]}' | \
 
 ### Step 7: docs 変更整合性検証
 
-REQ番号の連続性確認、frontmatter の `id` とファイル名の一致を確認
-
-**決定的処理のスクリプト呼出（REQ、AG-002、AG-019）**: frontmatter id ↔ ファイル名整合性確認は決定的スクリプトで実行する（`agentdev-artifact-validation` 公開検証契約、RU-20260722-01 合意）:
-
-```bash
-# REQ ファイル群の frontmatter id ↔ ファイル名整合性確認
-bun .opencode/skills/agentdev-artifact-validation/scripts/src/check-frontmatter-consistency.ts docs/requirements req
-# → stdout: { ok: boolean, errors: string[], warnings: string[] }
-
-# ADR ファイル群の整合性確認（ADR 保存時）
-bun .opencode/skills/agentdev-artifact-validation/scripts/src/check-frontmatter-consistency.ts docs/adr adr
-```
+REQ番号の連続性確認、frontmatter の `id` とファイル名の一致を確認。frontmatter id ↔ ファイル名整合性確認は `agentdev-artifact-validation` の公開検証契約で決定的スクリプトを実行（REQ/ADR 保存時）。CLI 形式は同 SKILL.md を参照
 
 ### Step 8: DOC-MAP 影響確認
 
-REQ/ADR/SPEC操作が `docs/DOC-MAP.md` に影響するか確認する。
-影響がある場合は DOC-MAP を更新する。
-影響がない場合は「DOC-MAP更新なし」とする。
-DOC-MAP更新は探索経路の更新であり、要件、判断、仕様の更新ではない。
-影響確認ルールの詳細は `agentdev-doc-map` スキルを参照
+REQ/ADR/SPEC操作が `docs/DOC-MAP.md` に影響するか確認。影響がある場合は更新、ない場合は「DOC-MAP更新なし」。DOC-MAP更新は探索経路の更新であり、要件、判断、仕様の更新ではない。影響確認ルールの詳細は `agentdev-doc-map` スキルを参照
 
-**targeted docs guard（REQ）**: 変更された REQ ファイルと連動ファイル（`docs/requirements/README.md`、`docs/DOC-MAP.md`、`docs/README.md`、`AGENTS.md`）に対し targeted docs guard を実行する。実行コマンド:
+**targeted docs guard（REQ）**: 変更 REQ ファイルと連動ファイル（`docs/requirements/README.md`、`docs/DOC-MAP.md`、`docs/README.md`、`AGENTS.md`）に対し `check_changed_docs.ts --workflow req-save --files <changed REQ files> --json` を実行。`failures` に strict severity を含む場合は修正して再実行。`doc_map_update_required` true 時は Step 8 更新要否判定へ反映、`full_docs_check_recommended` true 時は `/repo/docs-check` をユーザーに提案
 
-```bash
-bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
-  --workflow req-save --files <changed REQ files> --json
-```
+**extension 更新要否（REQ）**: REQ/ADR 追加/移動/削除が `.agentdev/extensions/**` へ影響するか確認。該当 REQ/ADR を context に列挙している extension がある場合、paths も更新対象。必要時はユーザーへ指示を仰ぐ（直接編集しない）
 
-JSON 出力の `failures` に strict severity が含まれる場合は保存工程を継続せず、対象ファイルを修正して再実行する。`doc_map_update_required` が true の場合は Step 8 の更新要否判定に反映する。`full_docs_check_recommended` が true の場合は `/repo/docs-check` の実行をユーザーに提案する。
-
-**extension 更新要否の確認（REQ）**: REQ/ADR の追加、移動、削除が `.agentdev/extensions/**` に影響するか確認する。該当 REQ/ADR を context に列挙している command または skill extension がある場合、それらの paths も更新対象となる。extension 更新が必要な場合はユーザーに指示を仰ぐ（req-save 自身は extension を直接編集しない）。
-
-**エントリ存在確認のスクリプト呼出（REQ、AG-002、AG-019）**: DOC-MAP 更新の有無にかかわらず、REQ/ADR エントリが DOC-MAP に存在するかを決定的スクリプトで確認する（`agentdev-artifact-validation` 公開検証契約）:
-
-```bash
-bun .opencode/skills/agentdev-artifact-validation/scripts/src/check-entry-existence.ts REQ-NNNN docs/DOC-MAP.md
-# → stdout: { ok: boolean, errors: string[], warnings: string[], found: string[] }
-```
+**エントリ存在確認（REQ、AG-019）**: DOC-MAP 更新の有無によらず `agentdev-artifact-validation` の公開検証契約（`check-entry-existence`）で REQ/ADR エントリの DOC-MAP 存在を確認する
 
 ### Step 9: 変更範囲検証
 
-**決定的処理のスクリプト呼出（REQ、AG-002、AG-019）**: `git diff --name-only` で変更ファイル一覧を取得し、許可パスリスト（G02）との照合を決定的スクリプトで実行する。`check-change-impact` は `agentdev-artifact-validation` の公開検証契約（RU-20260722-01 合意）。許可範囲外の変更を検出したらエラー内容をユーザーに報告して指示を待つ（変更の自動破棄は行わない）:
+**決定的処理のスクリプト呼出（REQ、AG-019）**: `git diff --name-only` で変更ファイル一覧を取得し、許可パスリスト（G02）との照合を `agentdev-artifact-validation` の公開検証契約（`check-change-impact`、RU-20260722-01 合意）で実行。許可範囲外の変更を検出したらエラー内容をユーザーに報告して指示を待つ（自動破棄しない）。`violations` が空でない場合は G02 違反として報告し指示を待つ
 
-```bash
-# git diff --name-only をファイルに出力し、許可パスリストと照合
-git diff --name-only > /tmp/changed-paths.txt
-cat > /tmp/allowed-paths.txt <<EOF
-docs/requirements/**
-docs/adr/**
-docs/README.md
-.agentdev/drafts/**
-EOF
-bun .opencode/skills/agentdev-artifact-validation/scripts/src/check-change-impact.ts \
-  /tmp/changed-paths.txt /tmp/allowed-paths.txt
-# → stdout: { ok: boolean, errors: string[], warnings: string[], violations: string[] }
-
-# stdin JSON 入力も可能
-echo '{"changed":["docs/requirements/REQ-{NNNN}.md"],"allowed":["docs/requirements/**"]}' | \
-  bun .opencode/skills/agentdev-artifact-validation/scripts/src/check-change-impact.ts
-```
-
-`violations` が空でない場合は G02 違反としてユーザーに報告し、指示を待つ
-
-**Step 9-1**: リモート同期と hash 検証。
-詳細は `agentdev-req-file-manager` を参照。
-委譲接続点: 親エージェントのみが git 操作と読込やり直し判断を行う
-
-**Step 9-2**: RU パス保存禁止。
-詳細は `agentdev-req-file-manager` を参照。
-委譲接続点: サブエージェントはRU由来情報の有無だけを返し、親エージェントがdocs本文から除外する
+**Step 9-1**: リモート同期と hash 検証。**Step 9-2**: RU パス保存禁止。詳細、委譲接続点は `agentdev-req-file-manager` を参照
 
 ### Step 10: ドラフト status 更新
 
-ドラフトの `draft-data` の `status`（frontmatter）を `saved` に更新する。
-commit/push より前に更新し、status変更をcommitに含めることで永続化を保証する。
-push後のstatus更新は永続化されないため不可
+ドラフト `draft-data` の `status`（frontmatter）を `saved` に更新。commit/push より前に更新し commit 対象に含める（push 後の status 更新は永続化されないため禁止）
 
 ### Step 11: コミット、プッシュ
 
-`agentdev-conventional-commits` に従ってコミットメッセージを生成し、mainブランチに push。
-Step 10 で更新したドラフトファイルのstatus変更をcommit対象に含めること。
-並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、`git add <path>` で明示パスステージし、`git commit -- <paths>`（--only pathspec 形式）でコミットする。
-スイープ操作（`git add -A`/ `git add .` 等）は禁止し、共有 index の他セッション変更を排出しないこと
+`agentdev-conventional-commits` に従ってコミットメッセージを生成し、main ブランチに push。Step 10 の status 変更を commit 対象に含める。並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、`git add <path>` で明示パスステージし、`git commit -- <paths>`（--only pathspec 形式）でコミットする。スイープ操作（`git add -A`/ `git add .` 等）は禁止
 
-**Step 11-1**: REQ/ADR artifact_actions 処理結果の保存（ドラフトに複数の `artifact_actions` entry が含まれる場合、以下を保存する）:
-- (a) 保存したREQドキュメントのリスト（REQ番号を含む）
-- (b) 各 artifact_action から保存したREQドキュメントへのマッピング
-- (c) ソースRUからREQ操作へのマッピング
-- (d) case-openで消費可能な形式での保存結果
+**Step 11-1**: REQ/ADR artifact_actions 処理結果の保存（ドラフトに複数 entry がある場合）。保存する内容: (a) 保存したREQドキュメントのリスト（REQ番号含む）(b) 各 artifact_action から保存したREQドキュメントへのマッピング (c) ソースRUからREQ操作へのマッピング (d) case-open で消費可能な形式での保存結果
 
-**OU 結果の書き戻し**: ドラフトに `operation_units` セクションがある場合、各 OU の `result` に保存結果を書き戻す。書き戻し内容: (a) 保存したREQドキュメント一覧 (b) OU 操作と保存先REQ doc の対応 (c) source RUとOU操作の対応 (d) case-open が入力として扱える保存結果
+**OU 結果の書き戻し**: ドラフトに `operation_units` セクションがある場合、各 OU の `result` に (a) 保存したREQドキュメント一覧 (b) OU 操作と保存先REQ doc の対応 (c) source RUとOU操作の対応 (d) case-open が入力として扱える保存結果 を書き戻す
 
-**Step 11-2**: Issue作成の責任分離。
-req-saveはREQドキュメントの保存中にIssueを作成しない。
-Issue作成はcase-openの責任範囲とする
+**Step 11-2**: Issue作成の責任分離。req-save はREQドキュメントの保存中に Issue を作成しない（case-open の責任範囲）
 
 ### Step 12: 完了報告
 
-完了報告templateに従って出力。実行結果に応じた種別を選択:
-- SPLIT検出 → .opencode/commands/agentdev/templates/req-save/split-detected.md（{docmap_status}変数あり）
-- DOC-MAP更新あり（SPLITなし）→ .opencode/commands/agentdev/templates/req-save/docmap-updated.md
-- DOC-MAP確認、更新不要（SPLITなし）→ .opencode/commands/agentdev/templates/req-save/docmap-not-needed.md
-- Epic規模 → .opencode/commands/agentdev/templates/req-save/epic.md
-- 上記以外 → .opencode/commands/agentdev/templates/req-save/standard.md
+完了報告 template に従って出力。実行結果に応じて `templates/req-save/` 配下の種別（`split-detected.md` / `docmap-updated.md` / `docmap-not-needed.md` / `epic.md` / `standard.md`）を選択
 
 ## case-auto 並列委譲モデル（REQ/093）
 
-req-save は複数 REQ/ADR ファイルの変更案作成、検査を並列化できる（REQ）。3 フェーズ分離で実現する:
-
-| フェーズ | 操作 | 該当 Step | 実行方法 |
-|---|---|---|---|
-| 1. 採番バッチ | 最大番号+N を一括確保（G05 一意性維持） | Step 4（`agentdev-req-file-manager` 採番ルール） | 直列 |
-| 2. ファイル作成 | 各 REQ/ADR ファイル作成、変更（独立パス） | Step 4（CREATE/APPEND/UPDATE） | 並列（最大5件） |
-| 3. インデックス更新 | README.md への順序挿入、draft status 更新、commit/push | Step 5 / Step 10 / Step 11 | 直列 |
-
-- G07（commit 前 status 更新）は フェーズ3 で維持する
-- 直列集約対象（採番、index 更新、draft 更新、commit、push）は並列委譲の完了を待ってから実行する（REQ）
-
-## 廃止時の下流横断クリーンアップ（追加候補）
-
-本セクションは REQ/ADR 廃止確定時に、下流（配布 Command/Skill 群、Guide 群、SPEC 群）へ残る旧 ID 参照の横断クリーンアップを実行するステップの**追加候補**を記録する。既存の req-save 手順（Step 1〜12）に代わるものではなく、既存フローを破壊しない追加ステップである。本候補は廃止 REQ/SPEC 由来記述残置検出カテゴリおよび integrity-rule-catalog.md の新規 IR 候補（retired-reference-residual）と整合する。本候補の実行可否、タイミングは別途 SPEC 確定を待って確定する。
-
-### 対象トリガ
-
-- REQ/ADR の廃止確定時（要件行削除、REQ ファイル全体の物理削除、ADR ステータスの Superseded/Deprecated 変更）
-- 廃止 ID に由来する下流参照の有無確認が前提
-
-### クリーンアップ手順（候補）
-
-1. **廃止 ID リスト作成**: 当該 req-save 操作で廃止確定した REQ/ADR ID（例: REQ-NNNN、ADR-NNNN）のリストを作成する
-2. **下流参照検索**: 廃止 ID をソースに配布 Command/Skill 群、Guide 群、SPEC 群を横断検索する。活性 REQ/SPEC への言及は対象外とする（廃止 REQ/SPEC 由来記述残置検出カテゴリ準拠）
-3. **参照更新候補の分類**:
-   - supersede 元への妥当な文脈参照 → finding 扱い（人間確認）。自動更新しない
-   - 廃止 ID のまま残置 → 当該ドキュメントの後継 ID へ更新、または文脈次第で削除
-4. **更新適用範囲**: req-save の G02（`docs/requirements/**`、`docs/adr/**`、`docs/README.md`、`.agentdev/drafts/**`）範囲外のため、本ステップでは候補の提示に留め、更新適用は後続の別工程（case-update、inspect-promote 経由の intake、または手動修正）で実施する
-5. **Findings 記録**: 抽出した参照更新候補を完了報告の follow-up に記録し、intake/inspect 経由で処理可能な状態で残す
-
-### 既存フローとの関係
-
-本ステップは既存の req-save 手順（Step 1〜12）に代わるものではなく、廃止操作時に追加で実行される候補ステップである。本ステップの実行有無、実行タイミングは今後の SPEC 確定を待って確定する。現時点では本候補の記録のみを行い、自動実行は行わない。既存の G02（ファイル操作制約）、G12（Capture 非関与制約）に違反しない範囲で運用される。
+req-save は複数 REQ/ADR ファイルの変更案作成、検査を並列化できる（REQ）。3 フェーズ（1. 採番バッチ[直列] / 2. ファイル作成[並列・最大5件] / 3. インデックス更新[直列]）で分離する。G07（commit 前 status 更新）はフェーズ3で維持し、直列集約対象（採番、index 更新、draft 更新、commit、push）は並列委譲の完了を待ってから実行する（REQ）。詳細は `agentdev-req-file-manager` を参照
 
 ## ガードレール
 
@@ -296,13 +124,7 @@ req-save は複数 REQ/ADR ファイルの変更案作成、検査を並列化�
 
 ### ADR妥当性再検証ゲート
 
-ADR保存の直前に、以下の妥当性を再検証すること:
-- ADRが技術判断（アーキテクチャ上の決定）を含むか確認
-- REQ/SPEC相当の内容のみの場合、保存を停止し理由を報告
-- adr-guidelinesの判定結果を前提として検証する
-- ADR ファイル保存時に `agentdev-adr-file-manager` の採番ルール（max+1, 欠番埋め禁止）で確定した番号を振ること
-- draft 内の全 ADR 参照（`new:{topic-slug}` 形式）を当該確定番号で置換すること
-- 採番は `docs/adr/` 配下の既存 ADR ファイルの最大番号 + 1 とし、欠番があっても埋めないこと
+ADR保存の直前に、以下の妥当性を再検証すること: ADRが技術判断（アーキテクチャ上の決定）を含むか確認、REQ/SPEC相当の内容のみの場合は保存を停止し理由を報告、`adr-guidelines`の判定結果を前提として検証、`agentdev-adr-file-manager` の採番ルール（max+1, 欠番埋め禁止）で確定した番号を振る、draft 内の全 ADR 参照（`new:{topic-slug}` 形式）を当該確定番号で置換、採番は `docs/adr/` 配下の既存 ADR ファイルの最大番号 + 1 とし欠番があっても埋めない
 
 ### 委譲、参照制約
 - G09: 工程分岐は `work_type` 固定分岐ではなく `artifact_actions` の有無で判定する。判定基準の詳細は `agentdev-workflow-lifecycle` を参照

--- a/src/opencode/commands/agentdev/spec-save.md
+++ b/src/opencode/commands/agentdev/spec-save.md
@@ -16,38 +16,21 @@ req-save の G02（SPEC 編集禁止）を緩和するものではなく、SPEC 
 ## 出力
 
 - `docs/specs/**/*.md`（既存 SPEC への追記 or 新規 SPEC 作成）
-- `.agentdev/drafts/req-draft-{topic-slug}.md`（SPEC artifact_actions 消費済みフラグの status 更新）
+- `.agentdev/drafts/req-draft-{topic-slug}.md`（SPEC artifact_actions 消費済みフラグの status 更新、Step 8 で実施）
 
 ## SPEC ライフサイクル
 
-SPEC ファイル frontmatter に `status` フィールドを導入し、ライフサイクルを管理する（3状態: `draft` / `accepted` / `superseded`）:
+SPEC ファイル frontmatter の `status`（`draft` / `accepted` / `superseded`）の遷移契機、CREATE/APPEND/UPDATE 時の適用規則、`superseded` 遷移、SPEC 一覧表登録の詳細は `agentdev-spec-file-manager/references/spec-lifecycle-application.md` を正とする。要点: 新規 SPEC 作成時は `status: draft` を付与、既存 SPEC へ追記時は `status` を変更しない、`draft` → `accepted` 昇格は case-close の責務
 
-| status | 意味 | 遷移契機 |
-|--------|------|----------|
-| `draft` | spec-save で保存された直後の状態。境界違反検査の対象外 | spec-save が新規 SPEC 作成時に付与（既定値） |
-| `accepted` | case-close で SPEC 確定チェックを通過した状態。すべての integrity rule の検査対象 | case-close Step 3 で実装が SPEC 内容を検証した旨を確認時 |
-| `superseded` | 後継 SPEC へ移行した廃止状態。`superseded_by` で後継 SPEC を明示。通常内容検査の対象外 | spec-save または case-close が後継 SPEC への移行を確定した時 |
+## project extensions
 
-既存 SPEC へ追記する場合、当該 SPEC の `status` は変更しない（既存 SPEC の成熟度を尊重）。
-新規 SPEC 作成時のみ `status: draft` を付与する。
-`draft` から `accepted` への昇格は case-close の責務。後継 SPEC への移行を確定する場合、元 SPEC へ `status: superseded` と `superseded_by` を設定する。`superseded_by` を持つ SPEC は通常内容検査の対象から除外する。
-`status` 欠落は後方互換のため `accepted` 相当として扱う。
+本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/spec-save.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。extension に列挙されていない `docs/specs/**` 内部パスを固定知識として読みに行かない。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
 ## 手順
 
 ### Step 1: 事前チェック
 
-本コマンドは project extensions 手順（ADR）に従う:
-1. `.agentdev/extensions/commands/spec-save.yaml` を読み込む（存在しない場合は標準動作で続行）
-2. extension の `context` / `rules` / `checks` / `acceptance_gates` / `must_not` を本コマンドの標準動作に追加・拡張として扱う（上書きではない）
-3. extension が破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する
-4. extension に列挙されていない `docs/specs/**` 内部パスを固定知識として読みに行かない
-
-ドラフトの `draft-data` の `artifact_actions` から `artifact: spec` entry の有無を確認する（全 work_type 対象、`work_type` による判定は廃止）。
-SPEC 対象 artifact_actions がない場合は no-op で完了。
-ドラフトが存在しない場合はエラーで中止: `壁打ちドラフトが見つかりません。
-先に /agentdev/req-define を実行してください。
-`
+ドラフトの `draft-data` の `artifact_actions` から `artifact: spec` entry の有無を確認する（全 work_type 対象、`work_type` による判定は廃止）。SPEC 対象 artifact_actions がない場合は no-op で完了。ドラフトが存在しない場合はエラーで中止（先に `/agentdev/req-define` を実行してください）
 
 
 ### Step 2: SPEC artifact_actions 読込
@@ -60,27 +43,9 @@ SPEC 対象 artifact_actions がない場合は no-op で完了。
 
 ### Step 3: 配置先解決
 
-各 SPEC action の `target`（または `target_spec: {operation, domain, slug}` 構造化）から配置先 SPEC を解決する:
-- 既存 SPEC パス（例: `docs/specs/{domain}/<existing-spec>.md`、または `target_spec: {operation: update, domain, slug}`）→ 当該 SPEC へ追記（`update` 操作）
-- `target_spec: {operation: create, domain, slug}` → 新規 SPEC 作成（`create` 操作）。ファイル名は `docs/specs/{domain}/{slug}.md`
-- 重複候補の統合: 同一 `target` の action は1つの SPEC へ集約する
+各 SPEC action の `target`（または `target_spec: {operation, domain, slug}` 構造化）から配置先 SPEC を解決する。既存 SPEC パス（例: `docs/specs/{domain}/<existing-spec>.md`、または `target_spec: {operation: update, domain, slug}`）→ 当該 SPEC へ追記（`update` 操作）。`target_spec: {operation: create, domain, slug}` → 新規 SPEC 作成（`create` 操作、ファイル名 `docs/specs/{domain}/{slug}.md`）。同一 `target` の action は1つの SPEC へ集約する
 
-**決定的処理のスクリプト呼出（REQ、AG-002、design-principles.md 第5節）**: 配置先 SPEC が既存か新規か、`target_area` が存在するかの判定は各 skill が所有する決定的スクリプトを bash 経由で呼び出して実行する（`agentdev-spec-file-manager` SKILL.md「Scripts（決定的処理）」セクション参照）。
-LLM 推論で代替しない。
-`update` 操作かつ `target_area` 指定時は、配置先候補 SPEC に対して SPEC 固有 script（`agentdev-spec-file-manager` 所有）を実行し、`target_area` 見出しの存在を確認する（結果は Step 5 のセクション置換で再利用）:
-
-```bash
-# 配置先候補 SPEC 内の target_area 見出し検索（agentdev-spec-file-manager 公開操作契約）
-bun .opencode/skills/agentdev-spec-file-manager/scripts/src/search-target-area.ts \
-  "target_area文字列" docs/specs/{domain}/<existing-spec>.md
-# → stdout: { ok: true, matches: [{file, line, text}] }
-# matches 空 → target_area 未検出（Step 5 で follow-up 報告、operation を create 系に切り替え推奨）
-# matches 複数 → warning（G09 で置換拒否の根拠）
-
-# stdin JSON 入力（複数 SPEC 横断検索）も可能。target_area は見出しテキスト部（# プレフィクス不含）
-echo '{"target_area":"パターン","files":["docs/specs/{domain}/<existing-spec>.md"]}' | \
-  bun .opencode/skills/agentdev-spec-file-manager/scripts/src/search-target-area.ts
-```
+**決定的処理のスクリプト呼出（REQ、AG-002）**: 配置先 SPEC が既存か新規か、`target_area` が存在するかの判定は `agentdev-spec-file-manager` SKILL.md「Scripts（決定的処理）」が規定する決定的スクリプト（`search-target-area.ts`）を bash 経由で呼び出して実行する（LLM 推論で代替しない）。CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md および `agentdev-spec-file-manager/references/target-area-matching.md` を参照
 
 ### Step 4: SPEC 分離基準の最終確認
 
@@ -89,66 +54,27 @@ echo '{"target_area":"パターン","files":["docs/specs/{domain}/<existing-spec
 ### Step 5: SPEC ファイル操作
 
 `draft-data` の `artifact_actions`（`artifact: spec`）の全 entry を処理する:
+
 - **create**: 新規 SPEC ファイルを frontmatter（`title`, `status: draft`, `created`, `updated`）付きで作成し、action の `content` をセクションとして記載
-- **update**:
- - `target_area` 指定時（operation が `update`/`spec-update`）: 対象 SPEC ファイル内で `target_area` に一致する見出し行を検索し、セクション置換を行う（REQ）。詳細は後述「target_area ベースのセクション置換ロジック」
- - `target_area` 未指定時: 既存 SPEC ファイルの該当セクションへ action の `content` を追記（後方互換、REQ）
- - frontmatter `updated` を更新。`status` は変更しない
-- 各 action の `target_area`（指定時）に応じた適切なセクション見出しを用いる
+- **update**: `target_area` 指定時（operation が `update`/`spec-update`）は `agentdev-spec-file-manager/references/target-area-matching.md` のセクション置換ロジックで対象セクションを `content` で置換（REQ）。`target_area` 未指定時は既存 SPEC ファイルの該当セクションへ `content` を追記（後方互換、REQ）。frontmatter `updated` を更新、`status` は変更しない
 
-**target_area 見出し検索のスクリプト呼出（REQ、AG-002）**: `update` 操作における `target_area` 見出し検索は決定的スクリプトで実行する。
-Step 3 で得た `search-target-area.ts` の結果（`matches`）を用いてセクション範囲を特定し、`content` で置換する。
-`matches` が空の場合はスキップして follow-up に記録し、複数マッチの場合は G09 に従い置換を拒否する:
+**target_area 見出し検索のスクリプト呼出（REQ、AG-002）**: `update` 操作における `target_area` 見出し検索は `search-target-area.ts` で実行する。Step 3 の結果（`matches`）を用いてセクション範囲を特定し `content` で置換。`matches` 空 → スキップし follow-up 記録、複数マッチ → G09 に従い置換拒否。CLI 形式、stdin JSON 入力、stdout schema は `agentdev-spec-file-manager` SKILL.md、`agentdev-spec-file-manager/references/target-area-matching.md` を参照
 
-```bash
-# target_area 検索（Step 3 と同一スクリプト、Step 5 では置換位置特定に使用）
-bun .opencode/skills/agentdev-spec-file-manager/scripts/src/search-target-area.ts \
-  "target_area文字列" docs/specs/{domain}/<existing-spec>.md
-# → stdout: { ok: true, matches: [{file, line, text}] }
-# matches[0].line から次の同レベル見出し行の直前までをセクションとして特定し、content で置換
-```
+**Step 5-1**: 複数 SPEC action の並列化（REQ/093）。異なる `target` パスの SPEC create/update は並列化可能（最大5件）。同一 SPEC ファイルへの複数 action は順序依存のため直列サブセットとして分離する。詳細は `agentdev-spec-file-manager` を参照
 
-**Step 5-1**: 複数 SPEC action の並列化（REQ/093）。
-異なる `target` パスの SPEC create/update は並列化可能。
-同一 SPEC ファイルへの複数 action は順序依存のため直列サブセットとして分離する。
-詳細は後述「case-auto 並列委譲モデル」セクション参照
-
-**Step 5-2**: SPEC 宣言付与（CREATE/UPDATE）。Step 5 の CREATE/UPDATE 各操作に併せ、req-define が `artifact_actions`（`artifact: spec`）の各 entry へ出力した `spec_logical_division` と `canonical_owner` を読み取り、SPEC frontmatter または冒頭宣言節へ宣言として付与する。
-- **CREATE**: 新規 SPEC の frontmatter または冒頭宣言節へ `spec_logical_division` と `canonical_owner` を宣言として書き込む。宣言なしで CREATE を完了することを禁止する
-- **UPDATE**: 変更対象 SPEC が frontmatter または冒頭宣言節で当該宣言を未宣言の場合、かつ req-define から渡された分類値が `unknown` 以外に確定している場合に、宣言を補完する。分類値が `unknown` または欠落の場合は警告して処理を継続する（宣言欠落だけを理由に保存拒否しない、soft-contract）
-- **既存 SPEC の一括更新**: 行わない。未変更 SPEC へ遡及的に宣言を付与しない（段階適用）
+**Step 5-2**: SPEC 宣言付与（CREATE/UPDATE）。req-define が `artifact_actions`（`artifact: spec`）の各 entry へ出力した `spec_logical_division` と `canonical_owner` を読み取り、SPEC frontmatter または冒頭宣言節へ宣言として付与する。CREATE で宣言なしで完了することを禁止。UPDATE で宣言未宣言かつ分類値が `unknown` 以外に確定の場合は宣言を補完、`unknown` または欠落の場合は警告して処理を継続（soft-contract、宣言欠落だけで保存拒否しない）。既存 SPEC の一括更新は行わず、未変更 SPEC へ遡及的に宣言を付与しない（段階適用）
 
 ### Step 6: インデックス整合
 
-新規 SPEC 作成時は `docs/specs/README.md`（SPEC 一覧）に追加する。既存 SPEC 追記時は README 更新不要
-
-**エントリ存在確認のスクリプト呼出（REQ、AG-002、AG-019）**: 新規 SPEC 作成後に、当該 SPEC が `docs/specs/README.md` に正しく登録されたかを決定的スクリプトで検証する（`agentdev-artifact-validation` 公開検証契約、RU-20260722-01 合意）:
-
-```bash
-# 新規 SPEC が SPEC 一覧に存在するか確認
-bun .opencode/skills/agentdev-artifact-validation/scripts/src/check-entry-existence.ts \
-  patterns docs/specs/README.md
-# → stdout: { ok: boolean, errors: string[], warnings: string[], found: string[] }
-
-# stdin JSON 入力も可能
-echo '{"id":"patterns","files":["docs/specs/README.md"]}' | \
-  bun .opencode/skills/agentdev-artifact-validation/scripts/src/check-entry-existence.ts
-```
+新規 SPEC 作成時は `docs/specs/README.md`（SPEC 一覧）に追加する。既存 SPEC 追記時は README 更新不要。新規 SPEC 作成後に `agentdev-artifact-validation` の公開検証契約（`check-entry-existence`、RU-20260722-01 合意）で登録を検証する。CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照
 
 ### Step 7: DOC-MAP 影響確認
 
 SPEC 操作が `docs/DOC-MAP.md` に影響するか確認し、影響がある場合は更新する（`agentdev-doc-map` スキル参照）。SPEC 新規作成は探索経路の更新対象
 
-**extension 更新要否の確認（REQ）**: SPEC の追加、移動、分割が `.agentdev/extensions/**` に影響するか確認する。移動または分割により extension 参照先 SPEC パスが変わる場合、当該 extension の context paths を更新する。extension 参照先 SPEC を移動した場合はエラーとし、spec-save 自身は移動を完了させずユーザー判断を仰ぐ（IR-056 check #5 strict 違反を防止）。SPEC 新規作成で既存 command/skill の実行時参照が増える場合、対応 extension の `context` への追加をユーザーに提案する（spec-save 自身は extension を直接編集しない）。
+**extension 更新要否の確認（REQ）**: SPEC の追加、移動、分割が `.agentdev/extensions/**` に影響するか確認する。移動または分割により extension 参照先 SPEC パスが変わる場合、当該 extension の context paths を更新する。extension 参照先 SPEC を移動した場合はエラーとし、spec-save 自身は移動を完了させずユーザー判断を仰ぐ（IR-056 check #5 strict 違反を防止）。SPEC 新規作成で既存 command/skill の実行時参照が増える場合、対応 extension の `context` への追加をユーザーに提案する（直接編集しない）
 
-**targeted docs guard（REQ）**: 変更された SPEC ファイルと連動ファイル（`docs/specs/README.md`、`docs/DOC-MAP.md`）に対し targeted docs guard を実行する。実行コマンド:
-
-```bash
-bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts \
-  --workflow spec-save --files <changed SPEC files> --json
-```
-
-JSON 出力の `failures` に strict severity が含まれる場合は保存工程を継続せず、対象ファイルを修正して再実行する。`spec_readme_update_required` または `doc_map_update_required` が true の場合は Step 6/7 の更新要否判定に反映する。`full_docs_check_recommended` が true の場合は `/repo/docs-check` の実行をユーザーに提案する。
+**targeted docs guard（REQ）**: 変更 SPEC ファイルと連動ファイル（`docs/specs/README.md`、`docs/DOC-MAP.md`）に対し `check_changed_docs.ts --workflow spec-save --files <changed SPEC files> --json` を実行。`failures` に strict severity を含む場合は保存工程を継続せず修正して再実行。`spec_readme_update_required` または `doc_map_update_required` が true の場合は Step 6/7 の更新要否判定に反映。`full_docs_check_recommended` が true の場合は `/repo/docs-check` をユーザーに提案
 
 ### Step 8: ドラフト status 更新
 
@@ -156,32 +82,11 @@ JSON 出力の `failures` に strict severity が含まれる場合は保存工�
 
 ### Step 9: 変更範囲検証
 
-**決定的処理のスクリプト呼出（REQ、AG-002、AG-019）**: `git diff --name-only` で変更ファイル一覧を取得し、許可パスリスト（G02）との照合を決定的スクリプトで実行する（`agentdev-artifact-validation` 公開検証契約、RU-20260722-01 合意）。許可範囲外の変更を検出したらエラーで報告し指示を待つ（自動破棄しない）:
-
-```bash
-# git diff --name-only をファイルに出力し、許可パスリストと照合
-git diff --name-only > /tmp/changed-paths.txt
-cat > /tmp/allowed-paths.txt <<EOF
-docs/specs/**
-.agentdev/drafts/**
-EOF
-bun .opencode/skills/agentdev-artifact-validation/scripts/src/check-change-impact.ts \
-  /tmp/changed-paths.txt /tmp/allowed-paths.txt
-# → stdout: { ok: boolean, errors: string[], warnings: string[], violations: string[] }
-
-# stdin JSON 入力も可能
-echo '{"changed":["docs/specs/{domain}/<existing-spec>.md"],"allowed":["docs/specs/**"]}' | \
-  bun .opencode/skills/agentdev-artifact-validation/scripts/src/check-change-impact.ts
-```
-
-`violations` が空でない場合は G02 違反としてユーザーに報告し、指示を待つ
+**決定的処理のスクリプト呼出（REQ、AG-019）**: `git diff --name-only` で変更ファイル一覧を取得し、許可パスリスト（G02）との照合を `agentdev-artifact-validation` の公開検証契約（`check-change-impact`、RU-20260722-01 合意）で実行。許可範囲外の変更を検出したらエラーで報告し指示を待つ（自動破棄しない）。`violations` が空でない場合は G02 違反として報告し指示を待つ。CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照
 
 ### Step 10: コミット、プッシュ
 
-`agentdev-conventional-commits` に従い main ブランチに push。
-Step 8 の status 変更を commit 対象に含める。
-並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、`git add <path>` で明示パスステージし、`git commit -- <paths>`（--only pathspec 形式）でコミットする。
-スイープ操作は禁止し、共有 index の他セッション変更を排出しないこと
+`agentdev-conventional-commits` に従い main ブランチに push。Step 8 の status 変更を commit 対象に含める。並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、`git add <path>` で明示パスステージし、`git commit -- <paths>`（--only pathspec 形式）でコミットする。スイープ操作は禁止
 
 ### Step 11: 完了報告
 
@@ -189,7 +94,7 @@ Step 8 の status 変更を commit 対象に含める。
 
 ## 検証観点
 
-- **品質ゲート（適用結果の整合性検証、AG-004、REQ）**: spec-save の品質ゲートは「適用結果の整合性検証」として実行する。検証項目: `target_area` 置換結果の整合性（Step 5 の `search-target-area.ts` 結果と置換後本体の一致）、SPEC status の整合性（新規作成時 `status: draft` 付与、既存追記時 `status` 変更なし）、インデックスの整合性（`docs/specs/README.md` エントリと新規 SPEC の一致、Step 6 の `check-entry-existence.ts` 結果）、変更範囲の妥当性（Step 9 の `check-change-impact.ts` 結果）。各検証は決定的スクリプトの JSON 結果で機械的に確認する。**REQ**: spec-save の品質ゲートは内容の品質（SPEC 分離基準適合性等）を再検証せず、内容の品質は req-define の QG-1 の責務とする（Step 4 SPEC 分離基準の最終確認は実施するが、これは分離基準の最終チェックであり内容品質の再審査ではない）
+- **品質ゲート（適用結果の整合性検証、AG-004、REQ）**: `target_area` 置換結果の整合性（Step 5 の `search-target-area.ts` 結果と置換後本体の一致）、SPEC status の整合性（新規作成時 `status: draft`、既存追記時 `status` 変更なし）、インデックスの整合性（`docs/specs/README.md` エントリと新規 SPEC の一致、Step 6 の `check-entry-existence.ts` 結果）、変更範囲の妥当性（Step 9 の `check-change-impact.ts` 結果）を各決定的スクリプトの JSON 結果で機械的に確認。**REQ**: spec-save の品質ゲートは内容の品質（SPEC 分離基準適合性等）を再検証せず、それは req-define の QG-1 の責務（Step 4 SPEC 分離基準の最終確認は実施するが、これは分離基準の最終チェックであり内容品質の再審査ではない）
 - **SPEC 分離基準適合性（REQ）**: 各 action の `content` が SPEC に置くべき内容か（Step 4）
 - **frontmatter 完全性**: 新規作成時の `title`, `status: draft`, `created`, `updated`（G05）
 - **宣言付与の整合性**: CREATE で `spec_logical_division` と `canonical_owner` が frontmatter または冒頭宣言節へ付与されていること。UPDATE で宣言未宣言かつ分類値が `unknown` 以外の場合に補完されていること（Step 5-2）
@@ -198,59 +103,11 @@ Step 8 の status 変更を commit 対象に含める。
 
 ## target_area ベースのセクション置換ロジック（REQ/028）
 
-`operation: update` / `operation: spec-update` で action の `target_area` が指定された場合、spec-save は対象 SPEC ファイル内で `target_area` に一致する見出し行を検索し、セクション置換を行う。
-
-### マッチング規則
-
-- 対象 SPEC ファイル内の見出し行を走査し、`target_area` と完全一致する見出し行を検索する（見出しテキスト部分の一致）
-- 当該見出し行から次の同レベル（または上位レベル）見出し行の直前までを「セクション」として特定する
- - 例: `### X` で検索した場合、次の `###` / `##` / `#` 見出し行の直前までを範囲とする
-- 特定したセクションを action の `content` で置換する
-
-### 複数マッチ時の挙動
-
-`target_area` に一致する見出しが複数存在する場合、最初のマッチを採用し warn を出力する。
-
-### 未検出時の挙動
-
-`target_area` に一致する見出しが存在しない場合、当該 action をスキップし、follow-up として「target_area 未検出、operation を spec-create へ切り替えを推奨」を報告する（全体中止しない）。
-
-### 後方互換（target_area 未指定）
-
-`target_area` が未指定の draft（旧形式）、または `operation` が `create`/`spec-create` の場合は従来の「追記」動作を維持する（REQ）。
-`target_area` が指定された場合のみ「置換」動作を適用し、既存 draft の破壊を防ぐ。
+`operation: update` / `operation: spec-update` で action の `target_area` が指定された場合、spec-save は `agentdev-spec-file-manager/references/target-area-matching.md` のマッチング規則に従い、対象 SPEC ファイル内で `target_area` に一致する見出し行を検索しセクション置換を行う。複数マッチ時の挙動（G09 で置換拒否）、未検出時の挙動（スキップし follow-up 報告、operation を spec-create 推奨）、後方互換（target_area 未指定時は従来「追記」動作）の詳細は同 reference を参照
 
 ## case-auto 並列委譲モデル（REQ/093）
 
-spec-save は複数 SPEC ファイルの変更案作成、検査を並列化できる（REQ）:
-
-- 異なる `target` パスの SPEC create/update は L0（完全独立）のため並列可能（最大5件）
-- 同一 SPEC ファイルへの複数 action のみ順序依存のため、直列サブセットとして分離する
-- 直列集約対象（採番、index 更新、draft 更新、commit、push）は並列委譲の完了を待ってから実行する（REQ）
-- 最終的な commit/push は REQ の明示パス指定（`git add <path>` + `git commit -- <paths>`）で一括実行する
-
-## 廃止時の下流横断クリーンアップ（追加候補）
-
-本セクションは SPEC 廃止確定時（SPEC ライフサイクルの `superseded` 遷移、または物理削除）に、下流（配布 Command/Skill 群、Guide 群、REQ 群）へ残る旧 SPEC パス、ID 参照の横断クリーンアップを実行するステップの**追加候補**を記録する。既存の spec-save 手順（Step 1〜11）に代わるものではなく、既存フローを破壊しない追加ステップである。本候補は廃止 REQ/SPEC 由来記述残置検出カテゴリおよび integrity-rule-catalog.md の新規 IR 候補（retired-reference-residual）と整合する。本候補の実行可否、タイミングは別途 SPEC 確定を待って確定する。
-
-### 対象トリガ
-
-- SPEC の廃止確定時（`status: superseded` 遷移、物理削除）
-- 廃止 SPEC パス、ID に由来する下流参照の有無確認が前提
-
-### クリーンアップ手順（候補）
-
-1. **廃止 SPEC リスト作成**: 当該 spec-save 操作で廃止確定した SPEC パス、ID のリストを作成する。`superseded_by` frontmatter で後継 SPEC が明示されている場合は後継パスも併記する
-2. **下流参照検索**: 廃止 SPEC パス、ID をソースに配布 Command/Skill 群、Guide 群、REQ 群を横断検索する。活性 SPEC への言及は対象外とする（廃止 REQ/SPEC 由来記述残置検出カテゴリ準拠）
-3. **参照更新候補の分類**:
-   - supersede 元への妥当な文脈参照（`superseded_by` で後継を明示する記述等） → finding 扱い（人間確認）。自動更新しない
-   - 廃止 SPEC パスのまま残置 → 当該ドキュメントの後継 SPEC パスへ更新、または文脈次第で削除
-4. **更新適用範囲**: spec-save の G02（SPEC ファイル、ドラフト status 更新用、SPEC インデックス、DOC-MAP の各編集許可範囲）範囲外のため、本ステップでは候補の提示に留め、更新適用は後続の別工程（case-update、inspect-promote 経由の intake、または手動修正）で実施する
-5. **Findings 記録**: 抽出した参照更新候補を完了報告の follow-up に記録し、intake/inspect 経由で処理可能な状態で残す
-
-### 既存フローとの関係
-
-本ステップは既存の spec-save 手順（Step 1〜11）に代わるものではなく、廃止操作時に追加で実行される候補ステップである。本ステップの実行有無、実行タイミングは今後の SPEC 確定を待って確定する。現時点では本候補の記録のみを行い、自動実行は行わない。既存の G02（ファイル操作制約）、G09（SPEC 実行時非依存）に違反しない範囲で運用される。
+spec-save は複数 SPEC ファイルの変更案作成、検査を並列化できる（REQ）。異なる `target` パスの SPEC create/update は L0（完全独立）のため並列可能（最大5件）。同一 SPEC ファイルへの複数 action のみ順序依存のため直列サブセットとして分離する。直列集約対象（採番、index 更新、draft 更新、commit、push）は並列委譲の完了を待ってから実行する（REQ）。最終的な commit/push は明示パス指定（`git add <path>` + `git commit -- <paths>`）で一括実行する。詳細は `agentdev-spec-file-manager` を参照
 
 ## ガードレール
 
@@ -280,9 +137,4 @@ spec-save は複数 SPEC ファイルの変更案作成、検査を並列化で�
 
 ## エラー処理
 
-- ドラフト不備（`artifact_actions` 形式不正）→ エラーで中止し req-define 差し戻しを推奨
-- 配置先 SPEC が特定できない場合 → 当該候補をスキップし follow-up に明示（全体中止しない）
-- 変更範囲検証違反 → ユーザーに報告し指示を待つ（自動破棄禁止）
-
-
-
+ドラフト不備（`artifact_actions` 形式不正）→ エラーで中止し req-define 差し戻し推奨。配置先 SPEC 特定不能 → 当該候補をスキップし follow-up 明示（全体中止しない）。変更範囲検証違反 → ユーザーに報告し指示を待つ（自動破棄禁止）


### PR DESCRIPTION
## 概要

Issue #1929（WP-4: OpenCode command 薄型化）の実装 PR。

移行計画 `.omo/plans/agentdev-migration-2026-08-05.md` §8（WP-4 command 薄型化）に従い、主要7 command と二次3 command の計10ファイルを薄型化した。§8.1 不変条件（command に残すもの / command から移すもの / 目標100行/全150行以内/主要7 command 100-140行）を厳守し、公開動作（入力・出力・状態遷移・停止条件）を維持したまま詳細を既存 skill/reference へ移管した。

## 変更サマリ

### 主要7 command（§8.2）

| command | 前 | 後 | 主な移管先 |
|---|---|---|---|
| `case-auto.md` | 389 | 122 | Wave反復・OU順序・4次元集約・コンフリクト解消モデル・停止理由分類・orchestration stage・子task回復 → `agentdev-workflow-orchestration`、委譲プロトコル → `agentdev-case-run-execution-adapter` |
| `case-run.md` | 280 | 138 | staleness check/targeted docs guard → `agentdev-quality-gates`、Epic Wave 実行 → `agentdev-epic-tracker`、test-fix loop/result envelope → `agentdev-case-run-execution-adapter` |
| `case-close.md` | 288 | 134 | Epic Wave close E1-E6 → `agentdev-epic-tracker`、SPEC 確定フロー → `agentdev-spec-file-manager/references/spec-lifecycle-application.md`、mergeable ポーリング/rebase → `agentdev-gh-cli`/`agentdev-git-worktree` |
| `case-open.md` | 308 | 132 | Issue本文生成・QG-2・識別子中心ガイドライン → `agentdev-issue-management`、自律構成生成・preflight → `agentdev-epic-tracker` |
| `req-define.md` | 224 | 140 | Step 5-x/7-x 詳細・draft-data フィールドスキーマ → `agentdev-req-analysis`、session由来RU → artifact-contracts SPEC |
| `req-save.md` | 317 | 139 | 決定的スクリプト呼出 CLI 例 → `agentdev-artifact-validation` SKILL.md、3フェーズ分離 → `agentdev-req-file-manager`、廃止時クリーンアップ（追加候補）削除 |
| `spec-save.md` | 288 | 140 | target_area セクション置換 → `agentdev-spec-file-manager/references/target-area-matching.md`、SPEC lifecycle → `spec-lifecycle-application.md`、廃止時クリーンアップ（追加候補）削除 |

### 二次3 command（§8.3）

| command | 前 | 後 | 主な移管先 |
|---|---|---|---|
| `backlog-review.md` | 176 | 136 | RU フォーマット詳細 → `agentdev-backlog-integration`、session由来RU → artifact-contracts SPEC |
| `learning-promote.md` | 171 | 148 | エラー処理表・ユーザー確認ポイント → `agentdev-learning-pipeline` |
| `intake-promote.md` | 159 | 150 | エラー処理・委譲接続点詳細 → `agentdev-intake-pipeline` |

## TS-005 検証結果

TS-005（Issue #1929 Test Strategy）完了条件を以下の通り満たす:

1. **全公開 command が150行以内**: 10/10 ファイル達成（最大: intake-promote.md 150行、最小: case-auto.md 122行）
2. **主要7 command が100-140行**: 7/7 ファイル達成（最大: req-define.md/spec-save.md 140行、最小: case-auto.md 122行）
3. **高レベル工程・QG・停止条件・副作用境界が維持**: 各 command の Step 見出し・ガードレール・プロジェクト extension・入出力セクションは維持、詳細のみ skill/reference 参照へ
4. **command 内に script の詳細 CLI 例・長い内部アルゴリズム・未採用候補が残らない**:
   - bash コードブロック（`req-save.md` 4箇所、`spec-save.md` 5箇所）を削除し `agentdev-artifact-validation`/`agentdev-spec-file-manager` SKILL.md 参照へ
   - `req-save.md` と `spec-save.md` の「廃止時の下流横断クリーンアップ（追加候補）」セクション（§8.2 で削除指定）を削除
5. **command から参照する skill/reference が実在する**: 既存 skill のみ参照（`agentdev-workflow-orchestration`, `agentdev-case-run-execution-adapter`, `agentdev-epic-tracker`, `agentdev-issue-management`, `agentdev-req-analysis`, `agentdev-req-file-manager`, `agentdev-spec-file-manager`, `agentdev-artifact-validation`, `agentdev-backlog-integration`, `agentdev-learning-pipeline`, `agentdev-intake-pipeline`, `agentdev-quality-gates`, `agentdev-gh-cli`, `agentdev-git-worktree`, `agentdev-workflow-templates`, `agentdev-workflow-lifecycle`, `agentdev-conventional-commits`, `agentdev-project-extensions`, `agentdev-doc-map`, `agentdev-learning-capture`）
6. **command 構造/E2E/fixture/runtime unresolved reference 検査が通る**: 後述「check_integrity.ts 変更」「check_changed_docs.ts」「check_extensions.ts」参照

## AG-005 達成根拠

AG-005（Issue #1929 Acceptance Gate 5）は「移行計画 §8（WP-4 command 薄型化）を完遂」を完了条件とする。以下の通り全項目を達成:

- **§8.1 不変条件**: command に残すもの（公開目的・入力・出力・高レベル工程順序・許可/禁止副作用・QG呼出位置・停止条件・承認境界・SSoT移行・skill委譲境界・完了報告）は全て維持。command から移すもの（詳細分類表・script CLI例・正規表現・サブエージェントprompt全文・内部アルゴリズム・例外回復詳細・長いテンプレート説明・skill既検証手順・未採用候補）は移管または削除
- **§8.2 主要7 command**: 移管先表に従って thinning 実施
- **§8.3 二次3 command**: 150行以内へ縮約
- **§8.4 実施方法 7ステップ**: 各 command について現状把握 → section 正規所有者割当 → 100-140行再構成 → 既存 skill/reference 統合（重複なし）→ skill 名と読込条件明確 → 構造/参照/行数検証 → 公開動作差分照合（維持）を実施
- **§8.5 完了条件 6項目**: 上記 TS-005 検証結果と同様、全項目達成

## check_integrity.ts 変更

### 実行コマンド
`bun run .opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts`（source profile 既定）

### Before（HEAD: 18002bfe）

| レベル | 件数 |
|---|---|
| OK | 214 |
| NG | 3 |
| Warning | 0 |
| Info | 118 |

- NG 内訳: IndexGenerationConsistency 3件（IR-061 既知、WP-6 で解消予定）
- EXITCODE=1（IR-061 既知3件に起因、CONTEXT 記載の follow-up）

### After（HEAD: 90592b53）

| レベル | 件数 |
|---|---|
| OK | 209 |
| NG | 5 |
| Warning | 0 |
| Info | 115 |

- NG 内訳:
  - IndexGenerationConsistency 3件（IR-061 既知、WP-6 で解消予定、delta 0）
  - RuntimeReference 2件（IR-055 delta、新規 unmanaged NG）:
    - `src/opencode/commands/agentdev/case-close.md:61` の `repo-agentdev-integrity` 参照（圧縮で行移動、baseline 比較で delta 扱い）
    - `src/opencode/commands/agentdev/case-run.md:64` の `repo-agentdev-integrity` 参照（同上）
- EXITCODE=1（IR-061 既知3 + IR-055 delta 2）

### Delta（before -> after）

| レベル | delta | 備考 |
|---|---|---|
| OK | -5 | RuntimeReference baseline-known の一部行が移動、Info へ再分類された分など |
| NG | +2 | IR-055 delta 2件（case-close.md/case-run.md の `repo-agentdev-integrity` 参照行が圧縮で移動） |
| Warning | 0 | 変更なし |
| Info | -3 | baseline 扱いへの再分類等 |

CaptureBoundary チェックは before 3 OK → after 5 OK（0 NG を維持、case-run/case-close への `capture-boundaries` 参照復元により追加 OK 2件）。Command/ReferencePath/DocumentDrift/CaptureBoundary 等の主要カテゴリは健全。

## check_changed_docs.ts 実行結果

### 実行コマンド
`bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref origin/main --json`

### 結果
```json
{
  "workflow": "case-run",
  "files_checked": [],
  "coupled_files_checked": [],
  "failures": [],
  "warnings": ["対象ファイルが検出されませんでした（--base-ref 指定）。git diff 結果が空、または workflow profile の対象外です。"],
  "doc_map_update_required": false,
  "spec_readme_update_required": false,
  "requirements_readme_update_required": false,
  "full_docs_check_recommended": false,
  "extensions_check_required": false,
  "docInputsCheckRequired": true,
  "declared_files_check": null
}
```

EXITCODE=0。本 PR は `src/opencode/commands/agentdev/**/*.md` のみ変更で `docs/**` 変更を含まないため、検査対象ファイルなし（期待通り）。

## check_extensions.ts（IR-056）実行結果

### 実行コマンド
`bun run .opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts`

### 結果
- `ok: true`
- `stats`: command_extensions=16, skill_extensions=13, public_commands=16, public_skills=32, doc_inputs_residual_files=0
- `failures`: 0件
- EXITCODE=0

本 PR は `.opencode/commands/agentdev/**/*.md` を変更したため IR-056 検査対象。違反なし。

## 残リスク / follow-up

### IR-055 delta 2件（要 follow-up）

`case-run.md:64` と `case-close.md:61` の `repo-agentdev-integrity` 参照が圧縮によって元の行位置から別行へ移動したため、baseline 比較で新規 delta 扱いとなった（`bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts` 等のスクリプト呼出しパス）。機能的には元から存在する参照（WP-2 PR #1934 でも対応済みの `repo-*` 参照）の行移動のみ。

**対応**: `src/integrity/baselines/*.json`（IR-055 baseline）の該当行エントリを新しい行位置へ更新する必要があるが、TASK MUST NOT DO「baseline / 索引 / 変更前検査結果を修正しない」により本 PR では対処しない。別 Issue（integrity baseline メンテナンス、または WP-6 で一括解消）で対応することを推奨。

### IR-061 既知3件（WP-6 で解消予定）

INDEX generation（docmap-inventory / req-metrics / spec-metrics）の AUTOGEN block 不整合。TASK CONTEXT に記載の通り WP-6 で解消予定。本 PR では対象外。

### worktree junction 未設定（一部テスト失敗、CI では問題なし）

TASK CONTEXT 記載の通り。本 PR では影響なし。

### SPEC確定候補（workflow-status-prohibition 検出アルゴリズム）

TASK CONTEXT 記載の通り spec-save で判断。本 PR では対象外。

## verify 手段

reviewer は以下で検証可能:

```powershell
$OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
# 行数
Get-ChildItem src/opencode/commands/agentdev/*.md | ForEach-Object { "{0,-30} {1,5}" -f $_.Name, (Get-Content -LiteralPath $_.FullName).Count }

# integrity checker
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts

# changed docs (case-run)
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref origin/main --json

# extensions (IR-056)
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
```

## commit hash

- HEAD: `90592b53`
- parent: `18002bfe`（origin/main）
- 変更: 10 files changed, 197 insertions(+), 1418 deletions(-)

Refs: #1924
