### PR TITLE
fix: 機能監査で検出した配布・検査不具合を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 .omo/
 .agentdev/integrity/reports/
 AGENTS.md
+outputs/
+dist/

--- a/.opencode/commands/repo/docs-check.md
+++ b/.opencode/commands/repo/docs-check.md
@@ -28,7 +28,8 @@ agent-dev-flow リポジトリの自己監査コマンド。AgentDevFlow 管理�
 
 **実行ランナー（REQ-0108-054）**: 本 command が呼び出す検査スクリプト群（`check_integrity.ts`、`check_command_format.ts`、`check_extensions.ts`、`check_distribution_boundary.ts`、`check_changed_docs.ts`、`check_templates.ts`、`lint_skills.ts`）は TypeScript 直接実行と `require()` / `import` 混在構文、併設テストの `bun:test` 依存を前提とするため、実行ランナーは **Bun** とする。`node` 等の Bun 以外のランナーで直接起動すると `ReferenceError: require is not defined` 等 ESM 解釈エラーが発生する。スクリプトは `bun run <script-path>` 形式で起動すること。
 
-`repo-agentdev-integrity` の検査スクリプト（`.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts`）を `bun run` で実行。検査カテゴリ・対象パス・検出結果の分類は SKILL.md（.opencode/skills/repo-agentdev-integrity/SKILL.md）の検査カテゴリ定義を authoritative source とする。command 定義ファイルフォーマット違反検出（IR-049・`check_command_format.ts`）を含む
+`repo-agentdev-integrity` の検査スクリプト（`.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts`）を `bun run` で実行。検査カテゴリ・対象パス・検出結果の分類は SKILL.md（.opencode/skills/repo-agentdev-integrity/SKILL.md）の検査カテゴリ定義を authoritative source とする
+- **コマンド形式検査（IR-049）**: `check_command_format.ts` を `bun run` で併せて実行する。`--root` にリポジトリルートを指定し、終了コード1は docs-check 全体の失敗として扱う
 - Finding 分類・ルートは SKILL.md の定義に準拠
 - **実行 profile（Issue #1928 / WP-3）**: `check_integrity.ts` は `--profile source|installed|release` を取り、既定は `source`。docs-check は明示しない限り `source`（既定）で実行する。`installed` は配置後検査、`release` は配布アーカイブ検査（`--archive <zip>` 必須）で、いずれも `docs/specs/integrity/integrity-contracts.md`「実行プロファイル分離」と `scripts/package-release-archive.ps1` / `scripts/install-from-archive.ps1` を参照
 - **IR-056（project extensions 整合性）**: `check_extensions.ts`（`.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts`）を `bun run` で併せて実行し、IR-056 として strict に取り扱う（project extensions SPEC、project extensions 読み込み標準 skill）。check_extensions.ts の strict failure は docs-check 全体を fail とする

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.test.ts
@@ -22,6 +22,7 @@ import { execSync } from "child_process";
 const SCRIPT_DIR = import.meta.dir;
 const SCRIPT_FILE = join(SCRIPT_DIR, "check_changed_docs.ts");
 const CLI_UTILS_FILE = join(SCRIPT_DIR, "cli_utils.ts");
+const HISTORY_EXEMPTION_FILE = join(SCRIPT_DIR, "ir057_history_exemption.ts");
 const TEMP_BASE = join("C:", "WINDOWS", "TEMP", "opencode");
 const RUN_ID = `changed-docs-test-${crypto.randomUUID().slice(0, 8)}`;
 const TEMP_ROOT = join(TEMP_BASE, RUN_ID);
@@ -68,6 +69,7 @@ function copyScripts(fixtureRoot: string): void {
   mkdirp(dest);
   copyFileSync(SCRIPT_FILE, join(dest, "check_changed_docs.ts"));
   copyFileSync(CLI_UTILS_FILE, join(dest, "cli_utils.ts"));
+  copyFileSync(HISTORY_EXEMPTION_FILE, join(dest, "ir057_history_exemption.ts"));
 }
 
 // Required TargetedDocsReport fields (REQ-0158 Phase 2 / AG-002 / Epic #1515 OU-005 TS-013).

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_command_format.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_command_format.ts
@@ -29,7 +29,7 @@ const COMMAND_DIRS = [
 
 const STEP_ZERO_HEADING = /^###\s+Step\s+0\b/;
 const STEP_ZERO_REF = /\bStep\s+0\b/;
-const STEP_HEADING = /^###\s+Step\s+(\d+)(?:-(\d+))?\s*:/;
+const STEP_HEADING = /^###\s+Step\s+(\d+)(?:〜(\d+))?(?:-(\d+))?\s*:/;
 const NUMBERED_LIST_MAIN = /^\d+\.\s/;
 const GUARDRAIL_LINE = /^-\s+(G\d+):/;
 const G01_FORMAT = /^G\d{2}$/;
@@ -110,18 +110,20 @@ export function checkCommandFile(
     }
 
     // Check for non-sequential Step numbers
-    const stepNumbers: { num: number; line: number }[] = [];
+    const stepNumbers: { start: number; end: number; line: number }[] = [];
     for (let i = proc.start; i < proc.end; i++) {
       const match = lines[i].match(STEP_HEADING);
-      if (match && !match[2]) {
+      if (match && !match[3]) {
         // Main step only (no substep)
-        stepNumbers.push({ num: parseInt(match[1]), line: i + 1 });
+        const start = parseInt(match[1], 10);
+        const end = match[2] ? parseInt(match[2], 10) : start;
+        stepNumbers.push({ start, end, line: i + 1 });
       }
     }
     // Check sequential: each step should be prev + 1
     for (let i = 1; i < stepNumbers.length; i++) {
-      const prev = stepNumbers[i - 1].num;
-      const curr = stepNumbers[i].num;
+      const prev = stepNumbers[i - 1].end;
+      const curr = stepNumbers[i].start;
       if (curr !== prev + 1) {
         violations.push({
           file: filePath,
@@ -210,13 +212,15 @@ function globMarkdown(dir: string): string[] {
     .map((f: string) => path.join(dir, f));
 }
 
-export function runCheckCommandFormat(): FormatViolation[] {
+export function runCheckCommandFormat(explicitRoot?: string): FormatViolation[] {
   const allViolations: FormatViolation[] = [];
 
   // Find repo root by looking for .git
-  let repoRoot = process.cwd();
-  while (repoRoot !== "/" && !fs.existsSync(path.join(repoRoot, ".git"))) {
-    repoRoot = path.dirname(repoRoot);
+  let repoRoot = explicitRoot ? path.resolve(explicitRoot) : process.cwd();
+  while (!fs.existsSync(path.join(repoRoot, ".git"))) {
+    const parent = path.dirname(repoRoot);
+    if (parent === repoRoot) break;
+    repoRoot = parent;
   }
 
   for (const dir of COMMAND_DIRS) {
@@ -230,4 +234,29 @@ export function runCheckCommandFormat(): FormatViolation[] {
   }
 
   return allViolations;
+}
+
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("usage: bun run check_command_format.ts [--root <path>] [--json]");
+    process.exit(0);
+  }
+  const rootIndex = args.indexOf("--root");
+  const explicitRoot = rootIndex >= 0 ? args[rootIndex + 1] : undefined;
+  if (rootIndex >= 0 && !explicitRoot) {
+    console.error("check_command_format.ts: --root requires a path");
+    process.exit(2);
+  }
+  const violations = runCheckCommandFormat(explicitRoot);
+  if (args.includes("--json")) {
+    console.log(JSON.stringify({ ok: violations.length === 0, violations }, null, 2));
+  } else if (violations.length === 0) {
+    console.log("check_command_format.ts: OK");
+  } else {
+    for (const violation of violations) {
+      console.log(`${violation.severity} ${violation.file}:${violation.line} ${violation.rule} ${violation.description}`);
+    }
+  }
+  process.exit(violations.length === 0 ? 0 : 1);
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
@@ -185,9 +185,13 @@ export function ok(
   category: string,
   check: string,
   message: string,
-  opts?: CheckResultOptions,
+  file?: string | CheckResultOptions,
+  line?: number,
 ): CheckResult {
-  return { category, check, level: "ok", message, ...opts };
+  if (typeof file === "object") {
+    return { category, check, level: "ok", message, ...file };
+  }
+  return { category, check, level: "ok", message, file, line };
 }
 
 export function ng(

--- a/.opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts
@@ -273,7 +273,7 @@ const commands = getCommandFiles();
 const skillDirs = getSkillDirs();
 const templateFiles = getTemplateFiles();
 
-// Current 17 public agentdev commands (aligns with commands/agentdev/README.md listing)
+// Current 16 public agentdev commands (aligns with commands/agentdev/README.md listing)
 const EXPECTED_COMMANDS = [
   "backlog-review",
   "case-auto",
@@ -282,7 +282,6 @@ const EXPECTED_COMMANDS = [
   "case-run",
   "case-update",
   "inspect-docs",
-  "inspect-extensions",
   "inspect-promote",
   "inspect-skills",
   "intake-capture",
@@ -306,9 +305,6 @@ const COMMAND_COUNT = EXPECTED_COMMANDS.length;
 const REQ_CASE_PIPELINE = ["req-define", "req-save", "spec-save", "case-open", "case-run", "case-update", "case-close"];
 const LEARNING_PIPELINE = ["learning-promote"];
 const INTAKE_PIPELINE = ["intake-capture", "intake-from-github", "intake-promote"];
-
-// Valid agent types
-const VALID_AGENTS = new Set(["sisyphus", "prometheus", "oracle", "metis", "hephaestus", "momus"]);
 
 // ─── REQ-0030-009: Normal-path E2E tests ───────────────────────────────────
 
@@ -347,11 +343,10 @@ describe("REQ-0030-009: E2E workflow tests for all commands", () => {
         expect(hasSteps).toBe(true);
       });
 
-      it("has valid agent type in frontmatter", () => {
+      it("has description-only frontmatter", () => {
         expect(fm).not.toBeNull();
         if (fm) {
-          const agent = fm["agent"] as string;
-          expect(VALID_AGENTS.has(agent)).toBe(true);
+          expect(Object.keys(fm)).toEqual(["description"]);
         }
       });
 
@@ -516,16 +511,16 @@ describe("REQ-0030-009: E2E workflow tests for all commands", () => {
     });
   });
 
-  // ─── Agent type consistency ──────────────────────────────────────────────
+  // ─── Harness separation ──────────────────────────────────────────────────
 
-  describe("Agent type consistency per pipeline", () => {
-    it("all agentdev commands use sisyphus agent", () => {
+  describe("Harness separation per pipeline", () => {
+    it("agentdev commands do not bind a harness-specific agent", () => {
       for (const cmd of EXPECTED_COMMANDS) {
         const content = commands.get(cmd);
         expect(content).toBeDefined();
         if (content) {
           const fm = parseFrontmatter(content);
-          expect(fm?.["agent"]).toBe("sisyphus");
+          expect(fm?.["agent"]).toBeUndefined();
         }
       }
     });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/tests/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/tests/check_integrity.test.ts
@@ -262,7 +262,6 @@ function buildValidFixture(root: string): void {
     [
       "---",
       "description: Test command",
-      "agent: test-agent",
       "---",
       "",
       "Test command body.",
@@ -285,7 +284,6 @@ function buildValidFixture(root: string): void {
       [
         "---",
         `description: ${filename} capture duty stub`,
-        "agent: sisyphus",
         "---",
         "",
         `capture-boundaries 参照。duty: ${body}`,
@@ -293,6 +291,14 @@ function buildValidFixture(root: string): void {
       ].join("\n"),
       "utf-8",
     );
+  }
+
+  const sourceCommandDir = join(root, "src", "opencode", "commands", "agentdev");
+  mkdirp(sourceCommandDir);
+  for (const filename of readdirSync(cmdDir)) {
+    if (filename.endsWith(".md")) {
+      copyFileSync(join(cmdDir, filename), join(sourceCommandDir, filename));
+    }
   }
 
   writeFileSync(
@@ -501,6 +507,9 @@ describe("Issue #657 regression: CLI execution verification", () => {
   describe("valid fixture with 10 guides", () => {
     it("exits with code 0 for valid fixture", () => {
       const r = runCli(VALID_ROOT, ["--json"]);
+      if (r.exitCode !== 0) {
+        console.error(r.stdout || r.stderr);
+      }
       expect(r.exitCode).toBe(0);
     });
 

--- a/docs/specs/foundations/design-principles.md
+++ b/docs/specs/foundations/design-principles.md
@@ -127,7 +127,7 @@ Command / Skill の責任分界の判断理由、詳細契約は v2:ADR-0107（�
 AgentDevFlow の配布物は実行時（runtime: 個別プロジェクトで実行可能）と執筆（authoring: agent-dev-flow リポジトリ開発用）に明確に分離する（REQ-001）。
 
 **実行時配布物**は自己完結し、agent-dev-flow リポジトリの dev メタデータに依存しないことを保証する:
-- Command frontmatter は `description` と `agent` のみ（REQ-002-015, REQ-001）
+- Command の YAML フロントマターは `description` 単一とする（REQ-002-022、ADR-001）
 - Skill `references/` は実行時配布物のみを含める（REQ-001）
 - `docs/specs/` は agent-dev-flow リポジトリ専用のリポジトリ内部設計文書であり、実行時配布物の依存先ではない（REQ-001, REQ-001）
 

--- a/scripts/check-consumer-opencode.ps1
+++ b/scripts/check-consumer-opencode.ps1
@@ -167,6 +167,7 @@ $ghCliLocalSource = Join-Path $LocalSourceDir $LocalModeRedirectSkill
 if (Test-Junction -Path $ghCliProjection) {
     $ghCliTarget = Get-JunctionTarget -Path $ghCliProjection
     if ($ghCliTarget -and (Test-Path -LiteralPath $ghCliTarget) -and
+        (Test-Path -LiteralPath $ghCliLocalSource) -and
         ((Resolve-Path -LiteralPath $ghCliTarget).Path -eq (Resolve-Path -LiteralPath $ghCliLocalSource).Path)) {
         $DetectedLocalMode = $true
     }
@@ -228,6 +229,9 @@ if (Test-Path -LiteralPath $SourceDir) {
     if (Test-Path -LiteralPath $skillsSource) {
         Get-ChildItem -LiteralPath $skillsSource -Directory -Filter 'agentdev-*' |
             ForEach-Object { $targets.Add("skills\$($_.Name)") }
+        if (Test-Path -LiteralPath (Join-Path $skillsSource 'japanese-tech-writing')) {
+            $targets.Add('skills\japanese-tech-writing')
+        }
     }
 
     Write-Host ''
@@ -268,6 +272,7 @@ if (Test-Path -LiteralPath $SourceDir) {
                 if ($junctionRel -notin $targets) {
                     Write-Host "[ORPHAN] Junction not from current source: $junctionRel"
                     $orphansFound = $true
+                    $divergences++
                 }
             }
     }

--- a/scripts/install-from-archive.ps1
+++ b/scripts/install-from-archive.ps1
@@ -15,6 +15,8 @@ param(
 #   5  required directory creation failed / source missing
 
 $ErrorActionPreference = "Stop"
+$Source = [System.IO.Path]::GetFullPath($Source)
+$Target = [System.IO.Path]::GetFullPath($Target)
 
 function Ensure-Directory {
     param([string]$Path)
@@ -22,7 +24,7 @@ function Ensure-Directory {
         try {
             New-Item -ItemType Directory -Path $Path -Force | Out-Null
         } catch {
-            Write-Error "install-from-archive: failed to create directory '$Path': $($_.Exception.Message)"
+            Write-Host "install-from-archive: failed to create directory '$Path': $($_.Exception.Message)" -ForegroundColor Red
             exit 5
         }
     }
@@ -34,7 +36,7 @@ function Place-File {
         $srcHash = (Get-FileHash -LiteralPath $SrcFile -Algorithm SHA256).Hash
         $dstHash = (Get-FileHash -LiteralPath $DstFile -Algorithm SHA256).Hash
         if ($srcHash -ne $dstHash) {
-            Write-Error "install-from-archive: content mismatch (exit 4). Destination file differs from source: $DstFile"
+            Write-Host "install-from-archive: content mismatch (exit 4). Destination file differs from source: $DstFile" -ForegroundColor Red
             exit 4
         }
         return
@@ -44,13 +46,13 @@ function Place-File {
     try {
         Copy-Item -LiteralPath $SrcFile -Destination $DstFile -Force
     } catch {
-        Write-Error "install-from-archive: copy failed '$SrcFile' -> '$DstFile': $($_.Exception.Message)"
+        Write-Host "install-from-archive: copy failed '$SrcFile' -> '$DstFile': $($_.Exception.Message)" -ForegroundColor Red
         exit 5
     }
 }
 
 if (-not (Test-Path -LiteralPath $Source)) {
-    Write-Error "install-from-archive: source directory not found: $Source"
+    Write-Host "install-from-archive: source directory not found: $Source" -ForegroundColor Red
     exit 5
 }
 
@@ -58,11 +60,11 @@ $commandsSrc = Join-Path $Source "commands\agentdev"
 $skillsSrc = Join-Path $Source "skills"
 
 if (-not (Test-Path -LiteralPath $commandsSrc)) {
-    Write-Error "install-from-archive: required source directory missing: $commandsSrc"
+    Write-Host "install-from-archive: required source directory missing: $commandsSrc" -ForegroundColor Red
     exit 5
 }
 if (-not (Test-Path -LiteralPath $skillsSrc)) {
-    Write-Error "install-from-archive: required source directory missing: $skillsSrc"
+    Write-Host "install-from-archive: required source directory missing: $skillsSrc" -ForegroundColor Red
     exit 5
 }
 

--- a/src/opencode/skills/agentdev-gh-cli/scripts/cli_utils.ts
+++ b/src/opencode/skills/agentdev-gh-cli/scripts/cli_utils.ts
@@ -1,0 +1,91 @@
+/** agentdev-gh-cli の検証スクリプトで使う自己完結した CLI 共通処理。 */
+export const EXIT_OK = 0;
+export const EXIT_NG = 1;
+export const EXIT_ERROR = 2;
+
+export type CheckLevel = "ok" | "ng" | "warning" | "info";
+
+export interface CheckResult {
+  category: string;
+  check: string;
+  level: CheckLevel;
+  message: string;
+  file?: string;
+  line?: number;
+}
+
+export interface ScanSummary {
+  ok: number;
+  ng: number;
+  warning: number;
+  info: number;
+}
+
+export interface IntegrityReport {
+  timestamp: string;
+  script: string;
+  scanned: Record<string, number>;
+  summary: ScanSummary;
+  results: CheckResult[];
+}
+
+export function ok(category: string, check: string, message: string): CheckResult {
+  return { category, check, level: "ok", message };
+}
+
+export function ng(category: string, check: string, message: string, file?: string, line?: number): CheckResult {
+  return { category, check, level: "ng", message, file, line };
+}
+
+export function info(category: string, check: string, message: string, file?: string, line?: number): CheckResult {
+  return { category, check, level: "info", message, file, line };
+}
+
+export function computeSummary(results: CheckResult[]): ScanSummary {
+  return {
+    ok: results.filter((result) => result.level === "ok").length,
+    ng: results.filter((result) => result.level === "ng").length,
+    warning: results.filter((result) => result.level === "warning").length,
+    info: results.filter((result) => result.level === "info").length,
+  };
+}
+
+export function formatJsonReport(report: IntegrityReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+export function formatMarkdownReport(report: IntegrityReport): string {
+  const lines = [
+    `# ${report.script} Report`,
+    "",
+    `- OK: ${report.summary.ok}`,
+    `- NG: ${report.summary.ng}`,
+    `- Warning: ${report.summary.warning}`,
+    `- Info: ${report.summary.info}`,
+    "",
+    "## Results",
+    "",
+  ];
+  for (const result of report.results) {
+    lines.push(`- [${result.level.toUpperCase()}] ${result.category} / ${result.check}: ${result.message}`);
+  }
+  return lines.join("\n");
+}
+
+export function determineExitCode(summary: ScanSummary): number {
+  return summary.ng > 0 || summary.warning > 0 ? EXIT_NG : EXIT_OK;
+}
+
+export function findRepoRoot(startPath: string): string {
+  const path = require("path") as typeof import("path");
+  const fs = require("fs") as typeof import("fs");
+  let current = path.resolve(startPath);
+  while (true) {
+    if (fs.existsSync(path.join(current, ".git")) || fs.existsSync(path.join(current, ".opencode"))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return path.resolve(startPath);
+    current = parent;
+  }
+}

--- a/src/opencode/skills/agentdev-gh-cli/scripts/verify_body.ts
+++ b/src/opencode/skills/agentdev-gh-cli/scripts/verify_body.ts
@@ -12,7 +12,7 @@ import {
   formatMarkdownReport,
   determineExitCode,
   findRepoRoot,
-} from "../../agentdev-integrity/scripts/cli_utils";
+} from "./cli_utils.ts";
 
 const SCRIPT_NAME = "verify_body.ts";
 const DESCRIPTION = "GitHub Issue/PR body verifier - validates encoding, markdown structure, and required sections";


### PR DESCRIPTION
## 概要

全65機能のコード監査とユーザーストーリー試験で検出した12件の不具合を修正します。

## 変更内容

- 配布スキルの壊れたモジュール参照を自己完結化
- コマンド・変更文書・原本プロファイルの回帰試験を現行契約へ更新
- コマンド形式検査へCLI入口とStep範囲解析を追加
- 消費側導入確認の未導入時例外、依存スキル判定、孤立検出を修正
- アーカイブ導入の相対パス処理と終了コード契約を修正
- テンプレート検査結果の不正な数値キーを修正
- コマンドのYAMLフロントマター契約を文書間で統一
- 会話用出力と配布試験生成物を追跡対象外へ追加

## 原因

配布境界の変更、ハーネス分離、公開コマンド廃止後に、一部の参照・テストデータ・文書契約・導入確認処理が追随していませんでした。

## 影響

配布・導入・自己監査での誤失敗、誤成功、誤った配置、終了コード不一致を解消します。

## 検証

- 全体試験: 991件合格、0件失敗
- 公開コマンドE2E: 117件合格
- 補助試験群: 60件合格
- verify_body: 12件合格
- 型検査: 3パッケージ合格
- PowerShell構文検査: 合格
- 整合性検査: 409件正常、NG 0件、警告0件
- git diff --check: 合格