### PR TITLE
fix: 機能カタログQAで検出した配布・検査・UX不具合を修正

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts
@@ -165,6 +165,8 @@ function listMarkdownFiles(dirPath: string, recursive: boolean): string[] {
   for (const ent of entries) {
     const full = path.join(dirPath, ent.name);
     if (ent.isDirectory() && recursive) {
+      // node_modules サブツリーは third-party README の fixed_url false positive を防ぐためスキップ
+      if (ent.name === "node_modules") continue;
       result.push(...listMarkdownFiles(full, true));
     } else if (ent.isFile() && ent.name.endsWith(".md")) {
       result.push(full.replace(/\\/g, "/"));
@@ -257,10 +259,7 @@ export function checkDistributionBoundary(repoRoot: string): BoundaryReport {
         }
       }
 
-      // Template lines skip id and path checks.
-      if (isLineExempt(line)) continue;
-
-      // Concrete ID check.
+      // Concrete ID check は常時実行 (旧 LINE_EXEMPTION は同行の実 ID見逃しを生むため廃止、REQ-{NNNN} 等は正規表現が元々非マッチ)
       const idMatches = line.match(CONCRETE_ID_PATTERN);
       if (idMatches && idMatches.length > 0) {
         for (const m of idMatches) {
@@ -275,7 +274,7 @@ export function checkDistributionBoundary(repoRoot: string): BoundaryReport {
         }
       }
 
-      // Concrete docs path check.
+      // Concrete docs path check (isConcreteDocsPath が template/README/glob を弾く)
       const pathCandidates = line.match(DOCS_PATH_PATTERN);
       if (pathCandidates && pathCandidates.length > 0) {
         for (const candidate of pathCandidates) {

--- a/scripts/apply-mechanical-replacement.ps1
+++ b/scripts/apply-mechanical-replacement.ps1
@@ -224,3 +224,5 @@ if ($changedFileNames.Count -gt 0) {
     Write-Output "---"
     foreach ($n in $changedFileNames) { Write-Output "  $n" }
 }
+
+exit 0

--- a/scripts/package-release-archive.ps1
+++ b/scripts/package-release-archive.ps1
@@ -87,6 +87,10 @@ foreach ($d in $skillDirs) {
     Copy-Item -Path (Join-Path $d.FullName "*") -Destination $stageSkillDir -Recurse -Force
 }
 
+# node_modules は配布アーカイブに含めない (サイズ増大・consumer側のnpm installで解決)
+Get-ChildItem -LiteralPath $stageSkills -Recurse -Directory -Filter "node_modules" -ErrorAction SilentlyContinue |
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+
 # install-from-archive.ps1 must travel inside the archive.
 Copy-Item -LiteralPath $installScript -Destination (Join-Path $stageScripts "install-from-archive.ps1") -Force
 

--- a/src/opencode/commands/agentdev/backlog-review.md
+++ b/src/opencode/commands/agentdev/backlog-review.md
@@ -50,9 +50,10 @@ RU-*.md の構造（frontmatter: `source_type`, `generated_by`, `generated_at`, 
 
 引数の有無に応じて対象を切り替える:
 
-**引数なしの場合**: 両ディレクトリから採用済み成果物を検出:
+**引数なしの場合**: 三ディレクトリから採用済み成果物を検出:
 - `.agentdev/intake/promoted/*.md`
 - `.agentdev/learning/promoted/*.md`
+- `.agentdev/inspect/promoted/*.md`
 
 **引数ありの場合**: 指定されたファイルパスのみを対象。
 存在しないパスはエラー報告してスキップ。

--- a/src/opencode/skills/agentdev-gh-cli/SKILL.md
+++ b/src/opencode/skills/agentdev-gh-cli/SKILL.md
@@ -62,7 +62,7 @@ extension（`.agentdev/extensions/skills/`）は標準 SKILL.md を前提とし�
 
 ## 差し替え可能性（ローカル版）
 
-ローカル版は本スキルを差し替え、同一手続き名で Case ファイル（`.agentdev/cases/case-{NNNN}.md`）の読み書きへ読み替える（REQ-0150, ADR-0130 decision #4, #5）。
+ローカル版は本スキルを差し替え、同一手続き名で Case ファイル（`.agentdev/cases/case-{NNNN}.md`）の読み書きへ読み替える（根拠は次段落の SPEC 参照）。
 PR 関連手続きはスキップせず、Case ファイルの対応セクションで代替する。
 手続きと Case ファイルセクションの対応は SPEC `agentdev-gh-cli`.md 参照。
 

--- a/src/opencode/skills/agentdev-workflow-lifecycle/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-lifecycle/SKILL.md
@@ -37,7 +37,7 @@ extension（`.agentdev/extensions/skills/`）は標準 SKILL.md を前提とし�
 - command固有Step番号、command固有実行順序、command固有Phase名
 - 特定コマンドの実行ロジック、手順記述
 - 要件分析手法や壁打ちメソドロジー（`agentdev-req-analysis`参照）
-- 仕様適合性検出、ループバック判定（`agentdev-spec-compliance`参照）
+- 仕様適合性検出、ループバック判定（`agentdev-quality-gates`、`agentdev-workflow-routing`参照）
 - ADR/REQファイルの具体的作成、更新操作（`agentdev-adr-file-manager`/`agentdev-req-file-manager`参照）
 - レビューNG時の対応フロー（`agentdev-workflow-routing`参照）
 - 完了報告フォーマット、チェックボックス更新

--- a/src/opencode/skills/agentdev-workflow-orchestration/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentdev-workflow-orchestration
-description: case-run の状態機械、サブエージェント protocol、self-healing loop、CI 対応 loop、1 Issue オーケストレーションの知識ベース。USE FOR: case-run の再開ポイント判定、自律修正ループ判定、CI 対応、subagent起動、障害伝播。DO NOT USE FOR: 単一Issue の基本的な Step 実行手順（case-run コマンド定義を参照）、work_type 判定（`agentdev-workflow-lifecycle` を参照）、乖離検出（`agentdev-spec-compliance` を参照）、子Issue 選択、Wave 構成生成（case-open/ case-auto を参照）
+description: case-run の状態機械、サブエージェント protocol、self-healing loop、CI 対応 loop、1 Issue オーケストレーションの知識ベース。USE FOR: case-run の再開ポイント判定、自律修正ループ判定、CI 対応、subagent起動、障害伝播。DO NOT USE FOR: 単一Issue の基本的な Step 実行手順（case-run コマンド定義を参照）、work_type 判定（`agentdev-workflow-lifecycle` を参照）、乖離検出（`agentdev-quality-gates` を参照）、子Issue 選択、Wave 構成生成（case-open/ case-auto を参照）
 ---
 
 # case-run オーケストレーションナレッジベース


### PR DESCRIPTION
## 概要

34機能カタログQA (Phase 2 静的レビュー + 非破壊テスト) で検出した7件の配布・検査・UX不具合を修正する。

## 修正一覧

| ID | 対象 | 問題 | 修正 |
|----|------|------|------|
| F-009 | `backlog-review.md` | Step 2 引数なし検出で `.agentdev/inspect/promoted/*.md` が漏れ | 三ディレクトリ (intake/learning/inspect) へ拡張 |
| S-001 | `agentdev-gh-cli/SKILL.md` L65 | 配布スキル本文に concrete ID `REQ-0150, ADR-0130` がハードコード | SPEC 参照へ読み替え表現に変更 |
| S-002 | `agentdev-workflow-lifecycle/SKILL.md` L40 | 存在しない `agentdev-spec-compliance` を参照 | `agentdev-quality-gates`, `agentdev-workflow-routing` へ修正 |
| S-003 | `agentdev-workflow-orchestration/SKILL.md` frontmatter | 同上 | `agentdev-quality-gates` へ修正 |
| F-025 | `check_distribution_boundary.ts` | (1) `LINE_EXEMPTION_HINTS` が行丸ごと skip して concrete ID を見逃す (2) `node_modules` 再帰走査で false positive | (1) 行skipを廃止し各行checkにコメント付与 (2) `listMarkdownFiles` に `node_modules` 除外を追加 |
| S-004 | `apply-mechanical-replacement.ps1` | 末尾に明示的な `exit 0` がなく CI 連携で非明示 | `exit 0` 追加 |
| S-005 | `package-release-archive.ps1` | skill 配下の `node_modules` が ZIP に取り込まれサイズ増大 | skill コピー後に `node_modules` を再帰削除 |

## Phase 4 再テスト結果 (回帰なし)

| 再テスト対象 | 結果 | 根拠 |
|--------------|------|------|
| F-017/F-024 `check_integrity.ts` | PASS | "0 new unmanaged NG (delta)"、exit 0 |
| F-025 `check_distribution_boundary.ts` | PASS | 168 files / hits=0 |
| F-027 `check_templates.ts` | PASS | 全カテゴリ 0 NG |
| F-028 `lint_skills.ts` | PASS | 304 OK / 0 NG |
| F-029 `check_extensions.ts` | PASS | 0 failures |
| F-030 `check-frontmatter-consistency.ts` | PASS | REQ/ADR とも 0 errors |
| F-022 `package-release-archive.ps1` | PASS | ZIP 18.5MB→0.5MB、node_modules=0 |
| F-018 `apply-mechanical-replacement.ps1` | PASS | exit 0 明示、3 edits 適用 |

## 影響範囲

- 配布物 (consumer 環境): `backlog-review.md`, `agentdev-gh-cli/SKILL.md`, `agentdev-workflow-lifecycle/SKILL.md`, `agentdev-workflow-orchestration/SKILL.md`, `apply-mechanical-replacement.ps1`, `package-release-archive.ps1`
- 自己ホスト環境のみ: `check_distribution_boundary.ts` (repo-agentdev-integrity は配布対象外)

## テスト方法

非破壊スクリプト (check_integrity.ts, lint_skills.ts, check_templates.ts 等) と PowerShell スクリプトの実行で検証。詳細は Phase 4 再テスト結果表を参照。

## 関連

QA 成果物 (feature-status.csv, README.md, findings.md, result-*.txt) は `.omo/qa/` (gitignore) に保管。