### PR TITLE
feat: Artifact Graphのコア生成・検査・問い合わせを実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .worktrees/
 .omo/
 .agentdev/integrity/reports/
+.agentdev/graph/
 AGENTS.md
 outputs/
 dist/

--- a/.opencode/skills/repo-agentdev-artifact-graph/SKILL.md
+++ b/.opencode/skills/repo-agentdev-artifact-graph/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: repo-agentdev-artifact-graph
+description: Builds and inspects the agent-dev-flow repository-local Artifact Graph. USE FOR: generating the derived graph index, checking graph integrity, querying explicit artifact relations, locating provenance. DO NOT USE FOR: replacing canonical documents, inferring semantic relations, editing graph outputs, consumer repositories.
+---
+
+# repo-agentdev-artifact-graph
+
+AgentDevFlow 本体リポジトリの正規入力から、明示関係を検索する派生索引を生成する。
+生成物は `.agentdev/graph/` に置き、正規情報や確定判断の根拠として扱わない。
+
+## 入力と出力
+
+入力範囲と除外規則は [extraction.yaml](extraction.yaml) を正とする。
+ノード、関係、根拠、生成物のスキーマは [schema.yaml](schema.yaml) を正とする。
+
+生成物は次の5ファイルである。
+
+- `manifest.json`
+- `nodes.jsonl`
+- `edges.jsonl`
+- `provenance.jsonl`
+- `diagnostics.json`
+
+## 生成
+
+リポジトリルートで実行する。
+
+```bash
+bun .opencode/skills/repo-agentdev-artifact-graph/scripts/build_graph.ts --root . --output .agentdev/graph
+```
+
+入力相対パスと内容から `input_digest` を計算する。
+現在時刻を生成物へ含めず、入力、ノード、関係、根拠を安定順に整列する。
+
+## 検査
+
+```bash
+bun .opencode/skills/repo-agentdev-artifact-graph/scripts/check_graph.ts --graph .agentdev/graph
+```
+
+ノード、関係、根拠の ID 重複、存在しないノードへの関係、根拠欠落、禁止された関係カテゴリを検査する。
+終了コードは、正常が0、検査不合格が1、入力または実行エラーが2である。
+
+## 問い合わせ
+
+直接関係または指定深度の関係を取得する。
+
+```bash
+bun .opencode/skills/repo-agentdev-artifact-graph/scripts/query_graph.ts --graph .agentdev/graph neighbors requirement:REQ-001 --depth 2
+```
+
+2ノード間の経路を取得する。
+
+```bash
+bun .opencode/skills/repo-agentdev-artifact-graph/scripts/query_graph.ts --graph .agentdev/graph path requirement:REQ-001 specification:docs/specs/example.md --max-depth 4
+```
+
+ノードまたは関係の根拠 ID を取得する。
+
+```bash
+bun .opencode/skills/repo-agentdev-artifact-graph/scripts/query_graph.ts --graph .agentdev/graph provenance requirement:REQ-001
+```
+
+問い合わせ結果は候補取得に限って使用する。
+根拠ファイルを読み、別手段で補完または反証してから判断する。
+
+## 責務境界
+
+- `declared` と `derived` の関係だけを生成し、`inferred` は生成しない。
+- `.agentdev/graph/` を手編集または Git 管理しない。
+- グラフ不在や生成失敗を「影響なし」の根拠にしない。
+- グラフから変更対象、要件充足、責務重複を確定しない。

--- a/.opencode/skills/repo-agentdev-artifact-graph/extraction.yaml
+++ b/.opencode/skills/repo-agentdev-artifact-graph/extraction.yaml
@@ -1,0 +1,41 @@
+schema_version: "1.0.0"
+indexed_paths:
+  - docs/requirements
+  - docs/adr
+  - docs/specs
+  - src/opencode
+  - .opencode
+  - .agentdev/extensions
+  - scripts
+  - tests
+excluded_paths:
+  - .agentdev/graph/**
+  - .git/**
+  - .worktrees/**
+  - node_modules/**
+  - dist/**
+  - outputs/**
+  - .cache/**
+  - .omo/**
+  - .sisyphus/**
+  - '**/*.tmp'
+mandatory_sources:
+  - frontmatter
+  - structured_field
+  - markdown_link
+  - extension_field
+structured_fields:
+  references:
+    - related_req
+    - related_spec
+    - canonical_owner
+    - context.paths
+  supersedes:
+    - superseded_by
+  delegates_to:
+    - delegates_to
+    - rules.skill
+    - checks.skill
+  governs:
+    - governed_by
+inferred_relations: false

--- a/.opencode/skills/repo-agentdev-artifact-graph/schema.yaml
+++ b/.opencode/skills/repo-agentdev-artifact-graph/schema.yaml
@@ -1,0 +1,39 @@
+schema_version: "1.0.0"
+node_types:
+  - requirement
+  - adr
+  - specification
+  - integrity_rule
+  - command
+  - skill
+  - extension
+  - source_file
+relation_types:
+  - references
+  - supersedes
+  - defined_in
+  - contains
+  - extends
+  - delegates_to
+  - governs
+relation_categories:
+  generated:
+    - declared
+    - derived
+  reserved:
+    - inferred
+provenance_fields:
+  - path
+  - heading
+  - element_id
+  - matched_text
+  - matched_text_hash
+  - line_start
+  - line_end
+  - extraction_rule
+outputs:
+  - manifest.json
+  - nodes.jsonl
+  - edges.jsonl
+  - provenance.jsonl
+  - diagnostics.json

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/.gitignore
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/build_graph.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/build_graph.ts
@@ -1,0 +1,22 @@
+import { resolve } from "node:path"
+import { buildGraph } from "./lib/graph.ts"
+
+function option(args: readonly string[], name: string): string | undefined {
+  const index = args.indexOf(name)
+  return index < 0 ? undefined : args[index + 1]
+}
+
+export async function main(args: readonly string[] = Bun.argv.slice(2)): Promise<void> {
+  const root = resolve(option(args, "--root") ?? ".")
+  const output = resolve(option(args, "--output") ?? `${root}/.agentdev/graph`)
+  const result = await buildGraph({ root, output })
+  console.log(JSON.stringify(result))
+}
+
+if (import.meta.main) {
+  // no-excuse-ok: catch -- CLI boundary converts failures to exit status.
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 2
+  })
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/bun.lock
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/bun.lock
@@ -1,0 +1,29 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "repo-agentdev-artifact-graph-scripts",
+      "dependencies": {
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
+        "typescript": "^5.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+  }
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/check_graph.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/check_graph.ts
@@ -1,0 +1,22 @@
+import { resolve } from "node:path"
+import { checkGraph } from "./lib/checker.ts"
+import { loadGraph } from "./lib/graph.ts"
+
+function graphPath(args: readonly string[]): string {
+  const index = args.indexOf("--graph")
+  return resolve(index < 0 ? ".agentdev/graph" : (args[index + 1] ?? ".agentdev/graph"))
+}
+
+export async function main(args: readonly string[] = Bun.argv.slice(2)): Promise<void> {
+  const report = checkGraph(await loadGraph(graphPath(args)))
+  console.log(JSON.stringify(report))
+  if (!report.valid) process.exitCode = 1
+}
+
+if (import.meta.main) {
+  // no-excuse-ok: catch -- CLI boundary converts failures to exit status.
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 2
+  })
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/checker.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/checker.ts
@@ -1,0 +1,49 @@
+import type { GraphData } from "./model.ts"
+
+export type CheckReport = {
+  readonly valid: boolean
+  readonly errors: readonly string[]
+  readonly warnings: readonly string[]
+}
+
+function duplicateIds(ids: readonly string[], kind: string): readonly string[] {
+  const seen = new Set<string>()
+  const duplicates = new Set<string>()
+  for (const id of ids) {
+    if (seen.has(id)) duplicates.add(`${kind} has duplicate id: ${id}`)
+    seen.add(id)
+  }
+  return [...duplicates].sort()
+}
+
+export function checkGraph(graph: GraphData): CheckReport {
+  const nodeIds = new Set(graph.nodes.map((node) => node.id))
+  const provenanceIds = new Set(graph.provenance.map((entry) => entry.id))
+  const errors = [
+    ...duplicateIds(graph.nodes.map((node) => node.id), "node"),
+    ...duplicateIds(graph.edges.map((edge) => edge.id), "edge"),
+    ...duplicateIds(graph.provenance.map((entry) => entry.id), "provenance"),
+  ]
+  for (const node of graph.nodes) {
+    if (!provenanceIds.has(node.provenance_id)) {
+      errors.push(`node ${node.id} has missing provenance: ${node.provenance_id}`)
+    }
+  }
+  for (const edge of graph.edges) {
+    if (!nodeIds.has(edge.source)) errors.push(`edge ${edge.id} has missing source: ${edge.source}`)
+    if (!nodeIds.has(edge.target)) errors.push(`edge ${edge.id} has missing target: ${edge.target}`)
+    if (!provenanceIds.has(edge.provenance_id)) {
+      errors.push(`edge ${edge.id} has missing provenance: ${edge.provenance_id}`)
+    }
+    if (edge.category !== "declared" && edge.category !== "derived") {
+      errors.push(`edge ${edge.id} has forbidden category: ${edge.category}`)
+    }
+  }
+  const warnings = graph.diagnostics
+    .filter((entry) => entry.severity !== "error")
+    .map((entry) => `${entry.code}: ${entry.message}`)
+  errors.push(...graph.diagnostics
+    .filter((entry) => entry.severity === "error")
+    .map((entry) => `${entry.code}: ${entry.message}`))
+  return { valid: errors.length === 0, errors: errors.sort(), warnings: warnings.sort() }
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/config.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/config.ts
@@ -1,0 +1,43 @@
+export const INDEXED_PATHS = [
+  "docs/requirements",
+  "docs/adr",
+  "docs/specs",
+  "src/opencode",
+  ".opencode",
+  ".agentdev/extensions",
+  "scripts",
+  "tests",
+] as const
+
+export const EXCLUDED_PATHS = [
+  ".agentdev/graph/**",
+  ".git/**",
+  ".worktrees/**",
+  "node_modules/**",
+  "dist/**",
+  "outputs/**",
+  ".cache/**",
+  ".omo/**",
+  ".sisyphus/**",
+  "**/*.tmp",
+] as const
+
+const EXCLUDED_SEGMENTS = new Set([
+  ".git", ".worktrees", "node_modules", "dist", "outputs", ".cache", ".omo", ".sisyphus",
+])
+
+const INPUT_EXTENSIONS = new Set([
+  ".md", ".yaml", ".yml", ".ts", ".tsx", ".mts", ".cts", ".json", ".jsonc", ".ps1", ".sh",
+])
+
+export function isExcludedPath(path: string): boolean {
+  const parts = path.split("/")
+  if (parts.some((part) => EXCLUDED_SEGMENTS.has(part))) return true
+  if (path === ".agentdev/graph" || path.startsWith(".agentdev/graph/")) return true
+  return path.endsWith(".tmp")
+}
+
+export function isInputFile(path: string): boolean {
+  const dot = path.lastIndexOf(".")
+  return dot >= 0 && INPUT_EXTENSIONS.has(path.slice(dot).toLowerCase())
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/edges.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/edges.ts
@@ -1,0 +1,197 @@
+import { dirname, normalize, relative, resolve } from "node:path"
+import type {
+  Diagnostic, ExtractionRule, GraphEdge, InputFile, Provenance, RelationType,
+} from "./model.ts"
+import { extractMarkdownLinks, headingAt, parseExtensionFields, parseFrontmatter, type ParsedField } from "./parse.ts"
+import { makeProvenance, sha256 } from "./provenance.ts"
+import type { NodeIndex } from "./nodes.ts"
+
+export type EdgeIndex = {
+  readonly edges: readonly GraphEdge[]
+  readonly provenance: readonly Provenance[]
+  readonly diagnostics: readonly Diagnostic[]
+}
+
+type EdgeSeed = {
+  readonly type: RelationType
+  readonly category: "declared" | "derived"
+  readonly source: string
+  readonly target: string
+  readonly input: InputFile
+  readonly field: ParsedField
+  readonly rule: ExtractionRule
+}
+
+function normalizeRepoPath(path: string): string {
+  return normalize(path).replaceAll("\\", "/").replace(/^\.\//, "")
+}
+
+function currentNode(index: NodeIndex, path: string): string | undefined {
+  return index.nodeByPath.get(path)
+}
+
+function resolveAlias(index: NodeIndex, raw: string): string | undefined {
+  const cleaned = raw.replace(/^`|`$/g, "").replace(/^v2:/, "")
+  return index.aliases.get(cleaned) ?? index.aliases.get(cleaned.replace(/^\.\//, ""))
+}
+
+function makeEdge(seed: EdgeSeed): { readonly edge: GraphEdge; readonly provenance: Provenance } {
+  const provenance = makeProvenance({
+    path: seed.input.path,
+    heading: headingAt(seed.input.content, seed.field.line),
+    elementId: `field:${seed.field.key}`,
+    matchedText: seed.field.text,
+    lineStart: seed.field.line,
+    lineEnd: seed.field.line,
+    extractionRule: seed.rule,
+  })
+  const id = `edge:${sha256([seed.type, seed.source, seed.target, provenance.id].join("\0"))}`
+  return {
+    edge: {
+      id,
+      type: seed.type,
+      category: seed.category,
+      source: seed.source,
+      target: seed.target,
+      provenance_id: provenance.id,
+      extraction_rule: seed.rule,
+    },
+    provenance,
+  }
+}
+
+function unresolved(input: InputFile, field: ParsedField, value: string): Diagnostic {
+  return {
+    severity: "warning",
+    code: "unresolved_reference",
+    message: `Reference does not resolve: ${value}`,
+    path: input.path,
+    element_id: `field:${field.key}`,
+  }
+}
+
+function structuredSeeds(input: InputFile, index: NodeIndex): {
+  readonly seeds: readonly EdgeSeed[]
+  readonly diagnostics: readonly Diagnostic[]
+} {
+  const source = currentNode(index, input.path)
+  if (source === undefined || source.startsWith("source_file:")) return { seeds: [], diagnostics: [] }
+  const isExtension = input.path.startsWith(".agentdev/extensions/")
+  const fields = isExtension ? parseExtensionFields(input.content) : parseFrontmatter(input.content)
+  const seeds: EdgeSeed[] = []
+  const diagnostics: Diagnostic[] = []
+  for (const field of fields) {
+    for (const value of field.values) {
+      let type: RelationType | undefined
+      let edgeSource = source
+      let rawTarget = value
+      if (field.key === "superseded_by") type = "supersedes"
+      if (["related_req", "related_spec", "governed_by"].includes(field.key)) type = "governs"
+      if (["canonical_owner", "context.paths"].includes(field.key)) type = "references"
+      if (["delegates_to", "rules.skill", "checks.skill"].includes(field.key)) type = "delegates_to"
+      if (type === undefined) continue
+      const target = resolveAlias(index, rawTarget)
+      if (target === undefined) {
+        diagnostics.push(unresolved(input, field, value))
+        continue
+      }
+      if (field.key === "superseded_by") edgeSource = target
+      if (["related_req", "related_spec", "governed_by"].includes(field.key)) {
+        const ruleNode = source.startsWith("integrity_rule:") ? source : target
+        const governedNode = source.startsWith("integrity_rule:") ? target : source
+        edgeSource = ruleNode
+        rawTarget = governedNode
+      } else {
+        rawTarget = target
+      }
+      seeds.push({
+        type,
+        category: "declared",
+        source: edgeSource,
+        target: rawTarget,
+        input,
+        field,
+        rule: isExtension ? "extension_field" : "structured_field",
+      })
+    }
+  }
+  if (isExtension) {
+    const subject = input.path.split("/")[2]
+    const name = input.path.split("/").at(-1)?.replace(/\.ya?ml$/, "")
+    if (subject !== undefined && name !== undefined) {
+      const target = resolveAlias(index, subject === "commands" ? `command:${name}` : `skill:${name}`)
+      if (target !== undefined) {
+        const line = input.content.split(/\r?\n/).findIndex((candidate) => candidate.startsWith("id:")) + 1
+        const safeLine = line > 0 ? line : 1
+        seeds.push({
+          type: "extends", category: "derived", source, target, input,
+          field: { key: "extension_path", values: [name], line: safeLine, text: input.path },
+          rule: "extension_field",
+        })
+      }
+    }
+  }
+  return { seeds, diagnostics }
+}
+
+function markdownSeeds(root: string, input: InputFile, index: NodeIndex): {
+  readonly seeds: readonly EdgeSeed[]
+  readonly diagnostics: readonly Diagnostic[]
+} {
+  if (!input.path.endsWith(".md")) return { seeds: [], diagnostics: [] }
+  const source = currentNode(index, input.path)
+  if (source === undefined) return { seeds: [], diagnostics: [] }
+  const seeds: EdgeSeed[] = []
+  const diagnostics: Diagnostic[] = []
+  for (const link of extractMarkdownLinks(input.content)) {
+    if (/^[a-z]+:/i.test(link.target) || link.target.startsWith("#")) continue
+    const targetPath = normalizeRepoPath(relative(root, resolve(root, dirname(input.path), link.target.split("#")[0] ?? "")))
+    const target = resolveAlias(index, targetPath)
+    const field = { key: "markdown_link", values: [link.target], line: link.line, text: link.text }
+    if (target === undefined) {
+      diagnostics.push(unresolved(input, field, link.target))
+      continue
+    }
+    seeds.push({ type: "references", category: "declared", source, target, input, field, rule: "markdown_link" })
+  }
+  return { seeds, diagnostics }
+}
+
+function containmentSeeds(inputs: readonly InputFile[], index: NodeIndex): readonly EdgeSeed[] {
+  const provenanceById = new Map(index.provenance.map((entry) => [entry.id, entry]))
+  const inputByPath = new Map(inputs.map((input) => [input.path, input]))
+  const seeds: EdgeSeed[] = []
+  for (const node of index.nodes.filter((candidate) => candidate.type !== "source_file")) {
+    const sourceEvidence = provenanceById.get(node.provenance_id)
+    const input = sourceEvidence === undefined ? undefined : inputByPath.get(sourceEvidence.path)
+    if (sourceEvidence === undefined || input === undefined) continue
+    const sourceFile = `source_file:${sourceEvidence.path}`
+    const field = { key: "file", values: [sourceEvidence.path], line: 1, text: sourceEvidence.path }
+    seeds.push({ type: "defined_in", category: "derived", source: node.id, target: sourceFile, input, field, rule: "filesystem" })
+    seeds.push({ type: "contains", category: "derived", source: sourceFile, target: node.id, input, field, rule: "filesystem" })
+  }
+  return seeds
+}
+
+export function extractEdges(root: string, inputs: readonly InputFile[], index: NodeIndex): EdgeIndex {
+  const seeds: EdgeSeed[] = [...containmentSeeds(inputs, index)]
+  const diagnostics: Diagnostic[] = []
+  for (const input of inputs) {
+    const structured = structuredSeeds(input, index)
+    const markdown = markdownSeeds(root, input, index)
+    seeds.push(...structured.seeds, ...markdown.seeds)
+    diagnostics.push(...structured.diagnostics, ...markdown.diagnostics)
+  }
+  const edgeById = new Map<string, GraphEdge>()
+  const provenanceById = new Map<string, Provenance>()
+  for (const seed of seeds) {
+    const result = makeEdge(seed)
+    edgeById.set(result.edge.id, result.edge)
+    provenanceById.set(result.provenance.id, result.provenance)
+  }
+  return {
+    edges: [...edgeById.values()].sort((left, right) => left.id.localeCompare(right.id)),
+    provenance: [...provenanceById.values()].sort((left, right) => left.id.localeCompare(right.id)),
+    diagnostics: diagnostics.sort((left, right) => `${left.path}:${left.element_id}`.localeCompare(`${right.path}:${right.element_id}`)),
+  }
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/graph.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/graph.ts
@@ -1,0 +1,109 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { EXCLUDED_PATHS, INDEXED_PATHS } from "./config.ts"
+import { extractEdges } from "./edges.ts"
+import { collectInputs, computeInputDigest } from "./input.ts"
+import {
+  EdgeSchema,
+  DiagnosticSchema,
+  ManifestSchema,
+  NodeSchema,
+  OUTPUT_FILES,
+  ProvenanceSchema,
+  type Diagnostic,
+  type GraphData,
+  type GraphEdge,
+  type GraphNode,
+  type Provenance,
+} from "./model.ts"
+import { extractNodes } from "./nodes.ts"
+
+export type BuildOptions = {
+  readonly root: string
+  readonly output: string
+}
+
+export type BuildResult = {
+  readonly files: readonly string[]
+  readonly nodeCount: number
+  readonly edgeCount: number
+  readonly diagnosticCount: number
+  readonly inputDigest: string
+}
+
+function json(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`
+}
+
+function jsonLines(values: readonly unknown[]): string {
+  return values.length === 0 ? "" : `${values.map((value) => JSON.stringify(value)).join("\n")}\n`
+}
+
+function diagnosticsDocument(diagnostics: readonly Diagnostic[]): object {
+  return {
+    summary: {
+      errors: diagnostics.filter((entry) => entry.severity === "error").length,
+      warnings: diagnostics.filter((entry) => entry.severity === "warning").length,
+      observations: diagnostics.filter((entry) => entry.severity === "observation").length,
+    },
+    diagnostics,
+  }
+}
+
+export async function buildGraph(options: BuildOptions): Promise<BuildResult> {
+  const inputs = await collectInputs(options.root)
+  const nodeIndex = extractNodes(inputs)
+  const edgeIndex = extractEdges(options.root, inputs, nodeIndex)
+  const manifest = ManifestSchema.parse({
+    schema_version: "1.0.0",
+    generator_version: "0.1.0",
+    input_digest: computeInputDigest(inputs),
+    indexed_paths: [...INDEXED_PATHS],
+    excluded_paths: [...EXCLUDED_PATHS],
+  })
+  const nodes = nodeIndex.nodes.map((node) => NodeSchema.parse(node))
+  const edges = edgeIndex.edges.map((edge) => EdgeSchema.parse(edge))
+  const provenance = [...new Map(
+    [...nodeIndex.provenance, ...edgeIndex.provenance].map((entry) => [entry.id, ProvenanceSchema.parse(entry)]),
+  ).values()].sort((left, right) => left.id.localeCompare(right.id))
+
+  await mkdir(options.output, { recursive: true })
+  await Promise.all([
+    writeFile(join(options.output, "manifest.json"), json(manifest), "utf8"),
+    writeFile(join(options.output, "nodes.jsonl"), jsonLines(nodes), "utf8"),
+    writeFile(join(options.output, "edges.jsonl"), jsonLines(edges), "utf8"),
+    writeFile(join(options.output, "provenance.jsonl"), jsonLines(provenance), "utf8"),
+    writeFile(join(options.output, "diagnostics.json"), json(diagnosticsDocument(edgeIndex.diagnostics)), "utf8"),
+  ])
+  return {
+    files: OUTPUT_FILES,
+    nodeCount: nodes.length,
+    edgeCount: edges.length,
+    diagnosticCount: edgeIndex.diagnostics.length,
+    inputDigest: manifest.input_digest,
+  }
+}
+
+function parseJsonLines<T>(content: string, parse: (value: unknown) => T): readonly T[] {
+  return content.split(/\r?\n/).filter(Boolean).map((line) => parse(JSON.parse(line)))
+}
+
+function parseDiagnostics(value: unknown): readonly Diagnostic[] {
+  if (typeof value !== "object" || value === null || !("diagnostics" in value) || !Array.isArray(value.diagnostics)) {
+    throw new TypeError("diagnostics.json does not contain diagnostics")
+  }
+  return value.diagnostics.map((entry) => DiagnosticSchema.parse(entry))
+}
+
+export async function loadGraph(output: string): Promise<GraphData> {
+  const [manifestText, nodesText, edgesText, provenanceText, diagnosticsText] = await Promise.all(
+    OUTPUT_FILES.map((name) => readFile(join(output, name), "utf8")),
+  )
+  return {
+    manifest: ManifestSchema.parse(JSON.parse(manifestText ?? "")),
+    nodes: parseJsonLines(nodesText ?? "", (value): GraphNode => NodeSchema.parse(value)),
+    edges: parseJsonLines(edgesText ?? "", (value): GraphEdge => EdgeSchema.parse(value)),
+    provenance: parseJsonLines(provenanceText ?? "", (value): Provenance => ProvenanceSchema.parse(value)),
+    diagnostics: parseDiagnostics(JSON.parse(diagnosticsText ?? "")),
+  }
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/input.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/input.ts
@@ -1,0 +1,51 @@
+import { createHash } from "node:crypto"
+import { readdir, readFile } from "node:fs/promises"
+import type { Dirent } from "node:fs"
+import { join, relative } from "node:path"
+import { INDEXED_PATHS, isExcludedPath, isInputFile } from "./config.ts"
+import type { InputFile } from "./model.ts"
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/")
+}
+
+async function walk(root: string, directory: string): Promise<readonly string[]> {
+  let entries: Dirent[]
+  try {
+    entries = await readdir(directory, { withFileTypes: true })
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return []
+    throw error
+  }
+  const paths: string[] = []
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const fullPath = join(directory, entry.name)
+    const repoPath = normalizePath(relative(root, fullPath))
+    if (isExcludedPath(repoPath)) continue
+    if (entry.isDirectory()) paths.push(...await walk(root, fullPath))
+    if (entry.isFile() && isInputFile(repoPath)) paths.push(repoPath)
+  }
+  return paths
+}
+
+export async function collectInputs(root: string): Promise<readonly InputFile[]> {
+  const paths = new Set<string>()
+  for (const indexedPath of INDEXED_PATHS) {
+    for (const path of await walk(root, join(root, indexedPath))) paths.add(path)
+  }
+  return Promise.all([...paths].sort().map(async (path) => ({
+    path,
+    content: await readFile(join(root, path), "utf8"),
+  })))
+}
+
+export function computeInputDigest(inputs: readonly InputFile[]): string {
+  const hash = createHash("sha256")
+  for (const input of [...inputs].sort((left, right) => left.path.localeCompare(right.path))) {
+    hash.update(input.path)
+    hash.update("\0")
+    hash.update(input.content)
+    hash.update("\0")
+  }
+  return hash.digest("hex")
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/model.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/model.ts
@@ -1,0 +1,95 @@
+import { z } from "zod"
+
+export const NODE_TYPES = [
+  "requirement", "adr", "specification", "integrity_rule",
+  "command", "skill", "extension", "source_file",
+] as const
+export const RELATION_TYPES = [
+  "references", "supersedes", "defined_in", "contains",
+  "extends", "delegates_to", "governs",
+] as const
+export const OUTPUT_FILES = [
+  "manifest.json", "nodes.jsonl", "edges.jsonl", "provenance.jsonl", "diagnostics.json",
+] as const
+export const EXTRACTION_RULES = [
+  "filesystem", "frontmatter", "structured_field", "markdown_link", "extension_field",
+] as const
+
+export const ProvenanceSchema = z.object({
+  id: z.string().min(1),
+  path: z.string().min(1),
+  heading: z.string(),
+  element_id: z.string().min(1),
+  matched_text: z.string(),
+  matched_text_hash: z.string().regex(/^[a-f0-9]{64}$/),
+  line_start: z.number().int().positive(),
+  line_end: z.number().int().positive(),
+  extraction_rule: z.enum(EXTRACTION_RULES),
+})
+
+export const NodeSchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(NODE_TYPES),
+  label: z.string().min(1),
+  status: z.string().optional(),
+  provenance_id: z.string().min(1),
+})
+
+export const EdgeSchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(RELATION_TYPES),
+  category: z.enum(["declared", "derived"]),
+  source: z.string().min(1),
+  target: z.string().min(1),
+  provenance_id: z.string().min(1),
+  extraction_rule: z.enum(EXTRACTION_RULES),
+})
+
+export const ManifestSchema = z.object({
+  schema_version: z.literal("1.0.0"),
+  generator_version: z.literal("0.1.0"),
+  input_digest: z.string().regex(/^[a-f0-9]{64}$/),
+  indexed_paths: z.array(z.string()),
+  excluded_paths: z.array(z.string()),
+})
+
+export const DiagnosticSchema = z.object({
+  severity: z.enum(["error", "warning", "observation"]),
+  code: z.string().min(1),
+  message: z.string().min(1),
+  path: z.string(),
+  element_id: z.string().min(1),
+})
+
+export type NodeType = z.infer<typeof NodeSchema>["type"]
+export type RelationType = z.infer<typeof EdgeSchema>["type"]
+export type ExtractionRule = z.infer<typeof ProvenanceSchema>["extraction_rule"]
+export type Provenance = z.infer<typeof ProvenanceSchema>
+export type GraphNode = z.infer<typeof NodeSchema>
+export type GraphEdge = z.infer<typeof EdgeSchema>
+export type Manifest = z.infer<typeof ManifestSchema>
+
+export type Diagnostic = z.infer<typeof DiagnosticSchema>
+
+export type GraphData = {
+  readonly manifest: Manifest
+  readonly nodes: readonly GraphNode[]
+  readonly edges: readonly GraphEdge[]
+  readonly provenance: readonly Provenance[]
+  readonly diagnostics: readonly Diagnostic[]
+}
+
+export type InputFile = {
+  readonly path: string
+  readonly content: string
+}
+
+export type EvidenceSeed = {
+  readonly path: string
+  readonly heading: string
+  readonly elementId: string
+  readonly matchedText: string
+  readonly lineStart: number
+  readonly lineEnd: number
+  readonly extractionRule: ExtractionRule
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/nodes.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/nodes.ts
@@ -1,0 +1,122 @@
+import { basename } from "node:path"
+import type { GraphNode, InputFile, NodeType, Provenance } from "./model.ts"
+import { firstHeading, headingAt, parseExtensionFields, parseFrontmatter, type ParsedField } from "./parse.ts"
+import { makeProvenance } from "./provenance.ts"
+
+export type NodeIndex = {
+  readonly nodes: readonly GraphNode[]
+  readonly provenance: readonly Provenance[]
+  readonly aliases: ReadonlyMap<string, string>
+  readonly nodeByPath: ReadonlyMap<string, string>
+}
+
+type ArtifactIdentity = {
+  readonly type: Exclude<NodeType, "source_file">
+  readonly id: string
+  readonly label: string
+  readonly status?: string | undefined
+  readonly field?: ParsedField | undefined
+  readonly extractionRule: "frontmatter" | "extension_field"
+}
+
+function field(fields: readonly ParsedField[], key: string): ParsedField | undefined {
+  return fields.find((candidate) => candidate.key === key)
+}
+
+function stem(path: string): string {
+  return basename(path).replace(/\.[^.]+$/, "")
+}
+
+function identifyArtifact(input: InputFile): ArtifactIdentity | undefined {
+  const frontmatter = parseFrontmatter(input.content)
+  const identifier = field(frontmatter, "id")
+  const title = field(frontmatter, "title")?.values[0] ?? (firstHeading(input.content) || stem(input.path))
+  const status = field(frontmatter, "status")?.values[0]
+  const requirement = /^docs\/requirements\/(REQ-\d+)\.md$/.exec(input.path)
+  if (requirement?.[1] !== undefined) {
+    return { type: "requirement", id: `requirement:${requirement[1]}`, label: title, status, field: identifier, extractionRule: "frontmatter" }
+  }
+  const adr = /^docs\/adr\/(?:retired\/)?(ADR-\d+)\.md$/.exec(input.path)
+  if (adr?.[1] !== undefined) {
+    return { type: "adr", id: `adr:${adr[1]}`, label: title, status, field: identifier, extractionRule: "frontmatter" }
+  }
+  const rule = /^docs\/specs\/integrity\/rules\/(IR-\d+)[^/]*\.md$/.exec(input.path)
+  if (rule?.[1] !== undefined) {
+    return { type: "integrity_rule", id: `integrity_rule:${rule[1]}`, label: title, status, field: identifier, extractionRule: "frontmatter" }
+  }
+  if (input.path.startsWith("docs/specs/") && input.path.endsWith(".md") && !input.path.endsWith("/README.md")) {
+    return { type: "specification", id: `specification:${input.path}`, label: title, status, field: title === undefined ? undefined : field(frontmatter, "title"), extractionRule: "frontmatter" }
+  }
+  const command = /^src\/opencode\/commands\/agentdev\/([^/]+)\.md$/.exec(input.path)
+  if (command?.[1] !== undefined && command[1] !== "README") {
+    return { type: "command", id: `command:${command[1]}`, label: command[1], field: field(frontmatter, "description"), extractionRule: "frontmatter" }
+  }
+  const skill = /^(?:src\/opencode|\.opencode)\/skills\/([^/]+)\/SKILL\.md$/.exec(input.path)
+  if (skill?.[1] !== undefined) {
+    const name = field(frontmatter, "name")?.values[0] ?? skill[1]
+    return { type: "skill", id: `skill:${name}`, label: name, field: field(frontmatter, "name"), extractionRule: "frontmatter" }
+  }
+  if (input.path.startsWith(".agentdev/extensions/") && /\.ya?ml$/.test(input.path)) {
+    const extensionFields = parseExtensionFields(input.content)
+    const idField = field(extensionFields, "id")
+    const id = idField?.values[0] ?? input.path
+    return { type: "extension", id: `extension:${id}`, label: id, field: idField, extractionRule: "extension_field" }
+  }
+  return undefined
+}
+
+function addAlias(aliases: Map<string, string>, alias: string, id: string): void {
+  if (alias.length > 0 && !aliases.has(alias)) aliases.set(alias, id)
+}
+
+export function extractNodes(inputs: readonly InputFile[]): NodeIndex {
+  const nodes: GraphNode[] = []
+  const provenance: Provenance[] = []
+  const aliases = new Map<string, string>()
+  const nodeByPath = new Map<string, string>()
+  for (const input of inputs) {
+    const sourceProvenance = makeProvenance({
+      path: input.path, heading: "", elementId: "file", matchedText: input.path,
+      lineStart: 1, lineEnd: 1, extractionRule: "filesystem",
+    })
+    const sourceId = `source_file:${input.path}`
+    nodes.push({ id: sourceId, type: "source_file", label: input.path, provenance_id: sourceProvenance.id })
+    provenance.push(sourceProvenance)
+    nodeByPath.set(input.path, sourceId)
+    addAlias(aliases, input.path, sourceId)
+
+    const artifact = identifyArtifact(input)
+    if (artifact === undefined) continue
+    const line = artifact.field?.line ?? 1
+    const matchedText = artifact.field?.text ?? input.content.split(/\r?\n/)[0] ?? input.path
+    const artifactProvenance = makeProvenance({
+      path: input.path,
+      heading: headingAt(input.content, line),
+      elementId: artifact.field === undefined ? "file" : `field:${artifact.field.key}`,
+      matchedText,
+      lineStart: line,
+      lineEnd: line,
+      extractionRule: artifact.extractionRule,
+    })
+    const node: GraphNode = artifact.status === undefined
+      ? { id: artifact.id, type: artifact.type, label: artifact.label, provenance_id: artifactProvenance.id }
+      : { id: artifact.id, type: artifact.type, label: artifact.label, status: artifact.status, provenance_id: artifactProvenance.id }
+    nodes.push(node)
+    provenance.push(artifactProvenance)
+    nodeByPath.set(input.path, artifact.id)
+    addAlias(aliases, artifact.id, artifact.id)
+    aliases.set(input.path, artifact.id)
+    addAlias(aliases, basename(input.path), artifact.id)
+    addAlias(aliases, stem(input.path), artifact.id)
+    addAlias(aliases, artifact.label, artifact.id)
+    const idValue = artifact.field?.values[0]
+    if (idValue !== undefined) addAlias(aliases, idValue, artifact.id)
+    if (artifact.type === "specification") addAlias(aliases, basename(input.path), artifact.id)
+  }
+  return {
+    nodes: nodes.sort((left, right) => left.id.localeCompare(right.id)),
+    provenance: provenance.sort((left, right) => left.id.localeCompare(right.id)),
+    aliases,
+    nodeByPath,
+  }
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/parse.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/parse.ts
@@ -1,0 +1,135 @@
+export type ParsedField = {
+  readonly key: string
+  readonly values: readonly string[]
+  readonly line: number
+  readonly text: string
+}
+
+export type MarkdownLink = {
+  readonly label: string
+  readonly target: string
+  readonly line: number
+  readonly text: string
+  readonly heading: string
+}
+
+function stripQuotes(value: string): string {
+  const trimmed = value.trim()
+  if (trimmed.length >= 2) {
+    const first = trimmed[0]
+    const last = trimmed.at(-1)
+    if ((first === "\"" || first === "'") && first === last) return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+function parseValues(value: string): readonly string[] {
+  const stripped = stripQuotes(value)
+  if (stripped.startsWith("[") && stripped.endsWith("]")) {
+    return stripped.slice(1, -1).split(",").map(stripQuotes).filter(Boolean)
+  }
+  return stripped.length > 0 ? [stripped] : []
+}
+
+export function parseFrontmatter(content: string): readonly ParsedField[] {
+  const lines = content.split(/\r?\n/)
+  if (lines[0] !== "---") return []
+  const fields: ParsedField[] = []
+  let current: { readonly key: string; readonly line: number; readonly text: string; readonly values: string[] } | undefined
+  for (let index = 1; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line === undefined || line === "---") break
+    const listMatch = /^\s*-\s+(.+)$/.exec(line)
+    if (listMatch?.[1] !== undefined && current !== undefined) {
+      current.values.push(stripQuotes(listMatch[1]))
+      continue
+    }
+    const match = /^([A-Za-z_][A-Za-z0-9_.-]*):\s*(.*)$/.exec(line)
+    if (match?.[1] === undefined || match[2] === undefined) continue
+    if (current !== undefined) fields.push(current)
+    current = {
+      key: match[1],
+      line: index + 1,
+      text: line,
+      values: [...parseValues(match[2])],
+    }
+  }
+  if (current !== undefined) fields.push(current)
+  return fields
+}
+
+export function parseExtensionFields(content: string): readonly ParsedField[] {
+  const lines = content.split(/\r?\n/)
+  const fields: ParsedField[] = []
+  const parents = new Map<number, string>()
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line === undefined || line.trim().length === 0 || line.trimStart().startsWith("#")) continue
+    const indent = line.length - line.trimStart().length
+    const listMatch = /^\s*-\s+(.+)$/.exec(line)
+    if (listMatch?.[1] !== undefined) {
+      const parent = parents.get(indent - 2)
+      if (parent !== undefined) {
+        fields.push({ key: parent, values: [stripQuotes(listMatch[1])], line: index + 1, text: line })
+      }
+      continue
+    }
+    const match = /^\s*([A-Za-z_][A-Za-z0-9_.-]*):\s*(.*)$/.exec(line)
+    if (match?.[1] === undefined || match[2] === undefined) continue
+    const parent = parents.get(indent - 2)
+    const key = parent === undefined ? match[1] : `${parent}.${match[1]}`
+    for (const depth of [...parents.keys()]) {
+      if (depth >= indent) parents.delete(depth)
+    }
+    if (match[2].trim().length === 0) {
+      parents.set(indent, key)
+      continue
+    }
+    fields.push({ key, values: parseValues(match[2]), line: index + 1, text: line })
+  }
+  return fields
+}
+
+export function headingAt(content: string, targetLine: number): string {
+  const lines = content.split(/\r?\n/)
+  let heading = ""
+  for (let index = 0; index < Math.min(targetLine, lines.length); index += 1) {
+    const match = /^#{1,6}\s+(.+)$/.exec(lines[index] ?? "")
+    if (match?.[1] !== undefined) heading = match[1].trim()
+  }
+  return heading
+}
+
+export function extractMarkdownLinks(content: string): readonly MarkdownLink[] {
+  const lines = content.split(/\r?\n/)
+  const links: MarkdownLink[] = []
+  let inFence = false
+  let heading = ""
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? ""
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence
+      continue
+    }
+    const headingMatch = /^#{1,6}\s+(.+)$/.exec(line)
+    if (headingMatch?.[1] !== undefined) heading = headingMatch[1].trim()
+    if (inFence) continue
+    const searchable = line.replace(/`[^`]*`/g, "")
+    for (const match of searchable.matchAll(/\[([^\]]*)\]\(([^)\s]+)(?:\s+[^)]*)?\)/g)) {
+      const label = match[1]
+      const target = match[2]
+      if (label !== undefined && target !== undefined) {
+        links.push({ label, target, line: index + 1, text: match[0], heading })
+      }
+    }
+  }
+  return links
+}
+
+export function firstHeading(content: string): string {
+  for (const line of content.split(/\r?\n/)) {
+    const match = /^#\s+(.+)$/.exec(line)
+    if (match?.[1] !== undefined) return match[1].trim()
+  }
+  return ""
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/provenance.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/provenance.ts
@@ -1,0 +1,28 @@
+import { createHash } from "node:crypto"
+import type { EvidenceSeed, Provenance } from "./model.ts"
+
+export function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex")
+}
+
+export function makeProvenance(seed: EvidenceSeed): Provenance {
+  const matchedTextHash = sha256(seed.matchedText)
+  const stableIdentity = [
+    seed.path,
+    seed.heading,
+    seed.elementId,
+    matchedTextHash,
+    seed.extractionRule,
+  ].join("\0")
+  return {
+    id: `provenance:${sha256(stableIdentity)}`,
+    path: seed.path,
+    heading: seed.heading,
+    element_id: seed.elementId,
+    matched_text: seed.matchedText,
+    matched_text_hash: matchedTextHash,
+    line_start: seed.lineStart,
+    line_end: seed.lineEnd,
+    extraction_rule: seed.extractionRule,
+  }
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/query.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/query.ts
@@ -1,0 +1,101 @@
+import type { GraphData, GraphEdge, Provenance } from "./model.ts"
+
+export type GraphQuery =
+  | { readonly kind: "neighbors"; readonly node: string; readonly depth: number }
+  | { readonly kind: "path"; readonly source: string; readonly target: string; readonly maxDepth: number }
+  | { readonly kind: "provenance"; readonly id: string }
+
+export type QueryResult = {
+  readonly nodes: readonly string[]
+  readonly edges: readonly string[]
+  readonly provenance: readonly Provenance[]
+}
+
+function evidenceFor(graph: GraphData, nodeIds: readonly string[], edgeIds: readonly string[]): readonly Provenance[] {
+  const provenanceIds = new Set([
+    ...graph.nodes.filter((node) => nodeIds.includes(node.id)).map((node) => node.provenance_id),
+    ...graph.edges.filter((edge) => edgeIds.includes(edge.id)).map((edge) => edge.provenance_id),
+  ])
+  return graph.provenance.filter((entry) => provenanceIds.has(entry.id)).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function adjacent(edges: readonly GraphEdge[], node: string): readonly { readonly node: string; readonly edge: string }[] {
+  return edges.flatMap((edge) => {
+    if (edge.source === node) return [{ node: edge.target, edge: edge.id }]
+    if (edge.target === node) return [{ node: edge.source, edge: edge.id }]
+    return []
+  }).sort((left, right) => `${left.node}:${left.edge}`.localeCompare(`${right.node}:${right.edge}`))
+}
+
+function provenanceResult(graph: GraphData, id: string): QueryResult {
+  const node = graph.nodes.find((candidate) => candidate.id === id)
+  const edge = graph.edges.find((candidate) => candidate.id === id)
+  const provenanceId = node?.provenance_id ?? edge?.provenance_id
+  return {
+    nodes: node === undefined ? [] : [node.id],
+    edges: edge === undefined ? [] : [edge.id],
+    provenance: provenanceId === undefined ? [] : graph.provenance.filter((entry) => entry.id === provenanceId),
+  }
+}
+
+function neighborResult(graph: GraphData, start: string, maxDepth: number): QueryResult {
+  const visited = new Set([start])
+  const edgeIds = new Set<string>()
+  let frontier = [start]
+  for (let depth = 0; depth < maxDepth && frontier.length > 0; depth += 1) {
+    const next = new Set<string>()
+    for (const current of frontier) {
+      for (const neighbor of adjacent(graph.edges, current)) {
+        edgeIds.add(neighbor.edge)
+        if (!visited.has(neighbor.node)) next.add(neighbor.node)
+      }
+    }
+    for (const node of next) visited.add(node)
+    frontier = [...next].sort()
+  }
+  const nodes = [...visited].sort()
+  const edges = [...edgeIds].sort()
+  return { nodes, edges, provenance: evidenceFor(graph, nodes, edges) }
+}
+
+function pathResult(graph: GraphData, source: string, target: string, maxDepth: number): QueryResult {
+  const queue: { readonly node: string; readonly nodes: readonly string[]; readonly edges: readonly string[] }[] = [
+    { node: source, nodes: [source], edges: [] },
+  ]
+  const visited = new Set([source])
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (current === undefined) break
+    if (current.node === target) {
+      return { nodes: current.nodes, edges: current.edges, provenance: evidenceFor(graph, current.nodes, current.edges) }
+    }
+    if (current.edges.length >= maxDepth) continue
+    for (const neighbor of adjacent(graph.edges, current.node)) {
+      if (visited.has(neighbor.node)) continue
+      visited.add(neighbor.node)
+      queue.push({
+        node: neighbor.node,
+        nodes: [...current.nodes, neighbor.node],
+        edges: [...current.edges, neighbor.edge],
+      })
+    }
+  }
+  return { nodes: [], edges: [], provenance: [] }
+}
+
+export function queryGraph(graph: GraphData, query: GraphQuery): QueryResult {
+  switch (query.kind) {
+    case "neighbors":
+      return neighborResult(graph, query.node, query.depth)
+    case "path":
+      return pathResult(graph, query.source, query.target, query.maxDepth)
+    case "provenance":
+      return provenanceResult(graph, query.id)
+    default:
+      return assertNever(query)
+  }
+}
+
+function assertNever(value: never): never {
+  throw new TypeError(`Unexpected query: ${JSON.stringify(value)}`)
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/package.json
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "repo-agentdev-artifact-graph-scripts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.0",
+    "typescript": "^5.6.0"
+  },
+  "dependencies": {
+    "zod": "^4.0.0"
+  }
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/query_graph.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/query_graph.ts
@@ -1,0 +1,40 @@
+import { resolve } from "node:path"
+import { loadGraph } from "./lib/graph.ts"
+import { queryGraph, type GraphQuery } from "./lib/query.ts"
+
+function value(args: readonly string[], name: string, fallback: string): string {
+  const index = args.indexOf(name)
+  return index < 0 ? fallback : (args[index + 1] ?? fallback)
+}
+
+function parseQuery(args: readonly string[]): GraphQuery {
+  const graphIndex = args.indexOf("--graph")
+  const commandIndex = graphIndex < 0 ? 0 : graphIndex + 2
+  const command = args[commandIndex]
+  if (command === "neighbors") {
+    return { kind: "neighbors", node: args[commandIndex + 1] ?? "", depth: Number(value(args, "--depth", "1")) }
+  }
+  if (command === "path") {
+    return {
+      kind: "path",
+      source: args[commandIndex + 1] ?? "",
+      target: args[commandIndex + 2] ?? "",
+      maxDepth: Number(value(args, "--max-depth", "4")),
+    }
+  }
+  if (command === "provenance") return { kind: "provenance", id: args[commandIndex + 1] ?? "" }
+  throw new TypeError("query must be neighbors, path, or provenance")
+}
+
+export async function main(args: readonly string[] = Bun.argv.slice(2)): Promise<void> {
+  const graph = resolve(value(args, "--graph", ".agentdev/graph"))
+  console.log(JSON.stringify(queryGraph(await loadGraph(graph), parseQuery(args))))
+}
+
+if (import.meta.main) {
+  // no-excuse-ok: catch -- CLI boundary converts failures to exit status.
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 2
+  })
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/build_contract.test.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/build_contract.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { buildGraph } from "../lib/graph.ts"
+import { createFixture } from "./fixture.ts"
+
+const OUTPUT_FILES = [
+  "manifest.json",
+  "nodes.jsonl",
+  "edges.jsonl",
+  "provenance.jsonl",
+  "diagnostics.json",
+] as const
+
+const roots: string[] = []
+
+async function setup(): Promise<{ readonly root: string; readonly output: string }> {
+  const root = await mkdtemp(join(tmpdir(), "artifact-graph-contract-"))
+  roots.push(root)
+  await createFixture(root)
+  return { root, output: join(root, ".agentdev", "graph") }
+}
+
+async function jsonLines(path: string): Promise<readonly Record<string, unknown>[]> {
+  const content = await readFile(path, "utf8")
+  return content.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe("TS-003 and TS-004: graph generation", () => {
+  it("writes five artifacts and all declared node and relation types", async () => {
+    // Given
+    const fixture = await setup()
+
+    // When
+    const result = await buildGraph(fixture)
+
+    // Then
+    expect(result.files).toEqual(OUTPUT_FILES)
+    for (const name of OUTPUT_FILES) {
+      expect(await Bun.file(join(fixture.output, name)).exists()).toBe(true)
+    }
+    const nodes = await jsonLines(join(fixture.output, "nodes.jsonl"))
+    const edges = await jsonLines(join(fixture.output, "edges.jsonl"))
+    expect(new Set(nodes.map((node) => node["type"]))).toEqual(new Set([
+      "requirement", "adr", "specification", "integrity_rule",
+      "command", "skill", "extension", "source_file",
+    ]))
+    expect(new Set(edges.map((edge) => edge["type"]))).toEqual(new Set([
+      "references", "supersedes", "defined_in", "contains",
+      "extends", "delegates_to", "governs",
+    ]))
+    expect(edges.some((edge) => edge["category"] === "inferred")).toBe(false)
+  })
+})
+
+describe("TS-005 and TS-006: extraction and provenance", () => {
+  it("extracts all mandatory structured sources with reachable provenance", async () => {
+    // Given
+    const fixture = await setup()
+
+    // When
+    await buildGraph(fixture)
+
+    // Then
+    const nodes = await jsonLines(join(fixture.output, "nodes.jsonl"))
+    const edges = await jsonLines(join(fixture.output, "edges.jsonl"))
+    const provenance = await jsonLines(join(fixture.output, "provenance.jsonl"))
+    const provenanceById = new Map(provenance.map((entry) => [entry["id"], entry]))
+    const rules = new Set(provenance.map((entry) => entry["extraction_rule"]))
+    for (const rule of ["frontmatter", "structured_field", "markdown_link", "extension_field"]) {
+      expect(rules.has(rule)).toBe(true)
+    }
+    for (const item of [...nodes, ...edges]) {
+      const evidence = provenanceById.get(item["provenance_id"])
+      expect(evidence).toBeDefined()
+      for (const field of [
+        "path", "heading", "element_id", "matched_text", "matched_text_hash",
+        "line_start", "line_end", "extraction_rule",
+      ]) {
+        expect(evidence).toHaveProperty(field)
+      }
+      expect(await Bun.file(join(fixture.root, String(evidence?.["path"]))).exists()).toBe(true)
+    }
+  })
+})

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/checker.test.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/checker.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { checkGraph } from "../lib/checker.ts"
+import { buildGraph, loadGraph } from "../lib/graph.ts"
+import { createFixture } from "./fixture.ts"
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe("graph integrity checks", () => {
+  it("accepts a generated graph and rejects a dangling relation", async () => {
+    // Given
+    const root = await mkdtemp(join(tmpdir(), "artifact-graph-check-"))
+    roots.push(root)
+    await createFixture(root)
+    const output = join(root, ".agentdev", "graph")
+    await buildGraph({ root, output })
+    const graph = await loadGraph(output)
+    const first = graph.edges[0]
+    if (first === undefined) throw new TypeError("fixture graph has no edge")
+
+    // When
+    const valid = checkGraph(graph)
+    const invalid = checkGraph({
+      ...graph,
+      edges: [...graph.edges, { ...first, id: "edge:dangling", target: "missing:node" }],
+    })
+
+    // Then
+    expect(valid.valid).toBe(true)
+    expect(invalid.valid).toBe(false)
+    expect(invalid.errors.some((error) => error.includes("missing:node"))).toBe(true)
+  })
+})

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/determinism.test.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/determinism.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { buildGraph } from "../lib/graph.ts"
+import { createFixture } from "./fixture.ts"
+
+const OUTPUT_FILES = [
+  "manifest.json", "nodes.jsonl", "edges.jsonl", "provenance.jsonl", "diagnostics.json",
+] as const
+const roots: string[] = []
+
+async function setup(suffix: string): Promise<{ readonly root: string; readonly output: string }> {
+  const root = await mkdtemp(join(tmpdir(), `artifact-graph-${suffix}-`))
+  roots.push(root)
+  await createFixture(root)
+  return { root, output: join(root, ".agentdev", "graph") }
+}
+
+async function snapshot(output: string): Promise<readonly Uint8Array[]> {
+  return Promise.all(OUTPUT_FILES.map((name) => readFile(join(output, name))))
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe("TS-007 and TS-008: deterministic output", () => {
+  it("produces byte-identical artifacts across runs at different times", async () => {
+    // Given
+    const fixture = await setup("determinism")
+    await buildGraph(fixture)
+    const first = await snapshot(fixture.output)
+    await Bun.sleep(5)
+
+    // When
+    await buildGraph(fixture)
+    const second = await snapshot(fixture.output)
+
+    // Then
+    expect(second).toEqual(first)
+    expect(JSON.parse(await readFile(join(fixture.output, "manifest.json"), "utf8"))).not.toHaveProperty("generated_at")
+  })
+})
+
+describe("TS-009: digest inputs and exclusions", () => {
+  it("changes for input path or content but ignores graph, Git, cache and temporary files", async () => {
+    // Given
+    const fixture = await setup("digest")
+    await buildGraph(fixture)
+    const first = JSON.parse(await readFile(join(fixture.output, "manifest.json"), "utf8"))
+    await mkdir(join(fixture.root, ".git"), { recursive: true })
+    await mkdir(join(fixture.root, "node_modules", "cache"), { recursive: true })
+    await writeFile(join(fixture.root, ".git", "ignored"), "changed", "utf8")
+    await writeFile(join(fixture.root, "node_modules", "cache", "ignored.tmp"), "changed", "utf8")
+
+    // When
+    await buildGraph(fixture)
+    const excluded = JSON.parse(await readFile(join(fixture.output, "manifest.json"), "utf8"))
+    await writeFile(join(fixture.root, "scripts", "sample.ts"), "export const sample = false\n", "utf8")
+    await buildGraph(fixture)
+    const changed = JSON.parse(await readFile(join(fixture.output, "manifest.json"), "utf8"))
+
+    // Then
+    expect(excluded.input_digest).toBe(first.input_digest)
+    expect(changed.input_digest).not.toBe(first.input_digest)
+    expect(changed.excluded_paths).toEqual(expect.arrayContaining([
+      ".agentdev/graph/**", ".git/**", "node_modules/**", "**/*.tmp",
+    ]))
+  })
+})

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/fixture.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/fixture.ts
@@ -1,0 +1,77 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+const FILES = {
+  "docs/requirements/REQ-001.md": `---
+id: REQ-001
+title: Sample requirement
+governed_by: [IR-001]
+---
+# Sample requirement
+
+See [decision](../adr/ADR-001.md).
+`,
+  "docs/adr/ADR-001.md": `---
+id: ADR-001
+title: Old decision
+status: superseded
+superseded_by: ADR-002
+---
+# Old decision
+`,
+  "docs/adr/ADR-002.md": `---
+id: ADR-002
+title: Current decision
+status: accepted
+---
+# Current decision
+
+See [specification](../specs/feature.md).
+`,
+  "docs/specs/feature.md": `---
+title: Feature specification
+canonical_owner: sample-skill
+governed_by: [IR-001]
+---
+# Feature specification
+`,
+  "docs/specs/integrity/rules/IR-001-sample.md": `---
+id: IR-001
+title: Sample rule
+related_req: [REQ-001]
+related_spec: [feature.md]
+---
+# IR-001: Sample rule
+`,
+  "src/opencode/commands/agentdev/sample.md": `---
+description: Sample command
+delegates_to: [sample-skill]
+governed_by: [IR-001]
+---
+# Sample command
+`,
+  "src/opencode/skills/sample-skill/SKILL.md": `---
+name: sample-skill
+description: Sample skill. USE FOR: tests. DO NOT USE FOR: production.
+---
+# Sample skill
+`,
+  ".agentdev/extensions/commands/sample.yaml": `id: sample-extension
+context:
+  paths:
+    - docs/specs/feature.md
+rules:
+  skill: sample-skill
+checks:
+  skill: sample-skill
+`,
+  "scripts/sample.ts": "export const sample = true\n",
+} as const
+
+export async function createFixture(root: string): Promise<void> {
+  for (const [relativePath, content] of Object.entries(FILES)) {
+    const fullPath = join(root, relativePath)
+    await mkdir(join(fullPath, ".."), { recursive: true })
+    await writeFile(fullPath, content, "utf8")
+  }
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/query_cli.test.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/query_cli.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { buildGraph, loadGraph } from "../lib/graph.ts"
+import { queryGraph } from "../lib/query.ts"
+import { createFixture } from "./fixture.ts"
+
+const roots: string[] = []
+
+async function graphFixture() {
+  const root = await mkdtemp(join(tmpdir(), "artifact-graph-query-"))
+  roots.push(root)
+  await createFixture(root)
+  const output = join(root, ".agentdev", "graph")
+  await buildGraph({ root, output })
+  return { root, output, graph: await loadGraph(output) }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe("graph queries", () => {
+  it("returns depth-limited relations and provenance", async () => {
+    // Given
+    const { graph } = await graphFixture()
+
+    // When
+    const neighbors = queryGraph(graph, { kind: "neighbors", node: "requirement:REQ-001", depth: 2 })
+    const provenance = queryGraph(graph, { kind: "provenance", id: "requirement:REQ-001" })
+
+    // Then
+    expect(neighbors.nodes).toContain("adr:ADR-001")
+    expect(neighbors.edges.length).toBeGreaterThan(0)
+    expect(provenance.provenance.length).toBe(1)
+  })
+
+  it("finds a path between two nodes", async () => {
+    // Given
+    const { graph } = await graphFixture()
+
+    // When
+    const result = queryGraph(graph, {
+      kind: "path", source: "requirement:REQ-001", target: "specification:docs/specs/feature.md", maxDepth: 4,
+    })
+
+    // Then
+    expect(result.nodes[0]).toBe("requirement:REQ-001")
+    expect(result.nodes.at(-1)).toBe("specification:docs/specs/feature.md")
+  })
+})
+
+describe("CLI surface", () => {
+  it("builds, checks and queries the graph through Bun CLIs", async () => {
+    // Given
+    const fixture = await graphFixture()
+    const scriptRoot = join(import.meta.dir, "..")
+
+    // When
+    const build = Bun.spawnSync([
+      "bun", join(scriptRoot, "build_graph.ts"), "--root", fixture.root, "--output", fixture.output,
+    ])
+    const check = Bun.spawnSync(["bun", join(scriptRoot, "check_graph.ts"), "--graph", fixture.output])
+    const query = Bun.spawnSync([
+      "bun", join(scriptRoot, "query_graph.ts"), "--graph", fixture.output,
+      "neighbors", "requirement:REQ-001", "--depth", "1",
+    ])
+
+    // Then
+    expect(build.exitCode).toBe(0)
+    expect(JSON.parse(build.stdout.toString()).files).toHaveLength(5)
+    expect(check.exitCode).toBe(0)
+    expect(JSON.parse(check.stdout.toString()).valid).toBe(true)
+    expect(query.exitCode).toBe(0)
+    expect(JSON.parse(query.stdout.toString()).nodes).toContain("adr:ADR-001")
+  })
+})

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/tsconfig.json
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["*.ts", "lib/**/*.ts", "tests/**/*.ts"]
+}

--- a/docs/specs/quality/spec-health-metrics.md
+++ b/docs/specs/quality/spec-health-metrics.md
@@ -87,11 +87,12 @@ AUTOGENブロックは `AUTOGEN:BEGIN` マーカーから対応する `AUTOGEN:E
 | commands/spec-save.md | 258 | accepted | commands |
 | integrity/integrity-rule-catalog.md | 251 | accepted | integrity |
 | commands/case-close.md | 250 | accepted | commands |
-| README.md | 243 | - | uncategorized |
+| README.md | 244 | - | uncategorized |
 | local/local-case-file.md | 240 | accepted | local |
 | skills/agentdev-gh-cli.md | 214 | accepted | skills |
 | workflows/workflow-contracts.md | 214 | accepted | workflows |
 | workflows/delegation-contracts.md | 210 | accepted | workflows |
+| local/artifact-graph.md | 192 | draft | local |
 | quality/quality-gates.md | 186 | accepted | quality |
 | foundations/design-principles.md | 158 | accepted | foundations |
 | integrity/index-auto-generation.md | 156 | accepted | integrity |


### PR DESCRIPTION
## 概要

Artifact Graph のスキーマ、抽出、決定論的生成、整合性検査、問い合わせ処理をリポジトリ固有 skill として実装する。

## 変更内容

- 8ノード型、7関係型、根拠8項目、入力範囲と除外規則を宣言した。
- YAMLフロントマター、既知の構造化field、Markdownリンク、extension構造化fieldを抽出する。
- 5生成物を安定順で出力し、相対パスと内容から `input_digest` を計算する。
- dangling relation、根拠欠落、ID重複を検査する CLI を追加した。
- 直接関係、指定深度、2ノード間経路、根拠を問い合わせる CLI を追加した。
- `.agentdev/graph/` を Git 管理対象外にした。

## 検証結果

| テスト戦略 | 結果 | 証拠 |
|---|---|---|
| TS-003 | PASS | 5生成物の存在と公開 CLI E2E |
| TS-004 | PASS | 8ノード型、7関係型、`inferred` 非生成 |
| TS-005 | PASS | 4種の必須抽出元を fixture で検証 |
| TS-006 | PASS | 全ノード・全関係から根拠8項目へ到達 |
| TS-007 | PASS | 同一入力2回の5生成物がバイト一致 |
| TS-008 | PASS | 異時刻生成で差分なし、`generated_at` なし |
| TS-009 | PASS | path+content digest と除外対象を検証 |

- `bun test`: 8 tests、502 assertions、全件合格
- `bun run typecheck`: 合格
- LSP diagnostics: 18 TypeScript files、0件
- 新規 skill lint: NG 0件
- 実リポジトリ生成: 721 nodes、1190 edges、構造エラー0件
- `git diff origin/main...HEAD --check`: 合格

## QG-3: Implementation Deviation Gate

- **判定**: pass
- **乖離分類**: `no-deviation`
- **証拠**: 初回QG-3時点では正規SPEC、REQ、ADR、配布物、既存extensionを変更せず、変更先をリポジトリ固有skillと生成物除外設定に限定した。Level 2ではcase-close mandatory index gateの指示に従い、自動生成索引のみを追加した。

## SPEC確定候補

- ノードIDは `<node_type>:<canonical-id-or-relative-path>` とし、`source_file` はリポジトリ相対パスを使用する。
- 関係方向は `artifact --defined_in--> source_file`、`source_file --contains--> artifact`、`current --supersedes--> old`、`integrity_rule --governs--> artifact`、`extension --extends--> command|skill` とする。
- 根拠は `provenance_id` で正規化し、sidecar の各レコードが8項目を保持する。
- 未解決参照は生成失敗にせず warning 診断とし、構造エラーと区別する。
- JSONL は ID 順、JSON は固定キー順と LF 終端で直列化する。

## Findings / Capture候補

### stale-reference

QG-3 前置確認で `HEAD` と `origin/main` は同一基点 `821433c4` であり、正規SPECの差異は検出しなかった。

### docs-integrity

`docs/**` は初回実装で変更なし。Level 2で自動生成索引を追加し、targeted docs guardはfailure 0件、warning 0件で合格した。

### intake

なし。実リポジトリ生成時の未解決参照 warning 22件は、索引対象外パスやディレクトリリンクを含むため、効果検証 Issue #1944 の誤検出評価対象として扱う。

### learning

no-excuse 検査器は TypeScript 7 の `typescript/unstable/*` を要求する一方、新規スクリプトのリポジトリ標準設定は TypeScript 5.9 を解決したため起動できなかった。型検査、LSP、対象限定の禁止構文走査で代替検証した。

## 残リスク

- 未解決参照 warning 22件の真陽性・偽陽性分類は効果検証 Issue #1944 の対象である。
- OpenCode は skill 定義を起動時に読み込むため、利用時は再起動が必要である。

Refs: #1942


## Level 2 コンフリクト解消（case-auto 再実行1回目）

- case-close mandatory index gate が `docs/specs/quality/spec-health-metrics.md` の `WOULD UPDATE` を検出したため、`generate_indexes.ts` で再生成した。
- 差分は `local/artifact-graph.md | 192 | draft | local` の追加と、同じ自動生成表にある `README.md` 計測値の243行から244行への更新である。
- 追加コミット: `fa36f284 chore(index): SPEC健康指標にartifact-graphを反映`
- targeted docs guard: `files_checked` は `docs/specs/quality/spec-health-metrics.md`、failure 0件、warning 0件。
- 再生成後 dry-run: `WOULD UPDATE` 0件。

