### PR TITLE
Artifact Graphを既存Project Extensionsへ統合する

### DIFF
--- a/.agentdev/extensions/commands/case-close.yaml
+++ b/.agentdev/extensions/commands/case-close.yaml
@@ -29,7 +29,10 @@ context:
   - id: discovery-3
     purpose: "docs/specs/integrity/integrity-rule-catalog.md 経由で関連 IR を確認してよい"
 
-rules: []
+rules:
+  - id: artifact-graph-closure-observation
+    when: 鮮度、未解決参照、存在しないノードへの関係、根拠欠落、関係閉包の候補を観測するとき。利用不能時は従来の検査手段で続行する
+    skill: repo-agentdev-artifact-graph
 
 checks:
   - id: autogen-index-regeneration-diff

--- a/.agentdev/extensions/commands/case-open.yaml
+++ b/.agentdev/extensions/commands/case-open.yaml
@@ -18,7 +18,10 @@ context:
       - "docs/specs/commands/req-define.md"
     purpose: Issue 本文の test strategy 項目構造の確認
 
-rules: []
+rules:
+  - id: artifact-graph-impact-candidates
+    when: 起点成果物から変更影響、廃止参照、未解決参照の候補を探索するとき。利用不能時は従来の探索手段で続行する
+    skill: repo-agentdev-artifact-graph
 
 checks: []
 

--- a/.agentdev/extensions/commands/case-run.yaml
+++ b/.agentdev/extensions/commands/case-run.yaml
@@ -13,7 +13,10 @@ context:
       - "docs/specs/workflows/workflow-contracts.md"
     purpose: "case-run 3フェーズ構成と自律修正ループ契約の確認"
 
-rules: []
+rules:
+  - id: artifact-graph-implementation-context
+    when: 実装対象に関係するREQ、SPEC、整合性ルール、周辺成果物の候補を探索するとき。利用不能時は従来の探索手段で続行する
+    skill: repo-agentdev-artifact-graph
 
 checks: []
 

--- a/.agentdev/extensions/commands/req-define.yaml
+++ b/.agentdev/extensions/commands/req-define.yaml
@@ -40,7 +40,10 @@ context:
   - id: discovery-2
     purpose: docs/specs/README.md 経由で SPEC 一覧と status を参照してよい
 
-rules: []
+rules:
+  - id: artifact-graph-candidate-discovery
+    when: 既存REQ、関連ADR・SPEC、構造的所有者重複の候補を探索するとき。利用不能時は従来の探索手段で続行する
+    skill: repo-agentdev-artifact-graph
 
 checks: []
 

--- a/.agentdev/extensions/commands/spec-save.yaml
+++ b/.agentdev/extensions/commands/spec-save.yaml
@@ -18,7 +18,10 @@ context:
   - id: discovery-3
     purpose: "docs/specs/foundations/document-model.md で SPEC ドメイン分類規則を確認してよい"
 
-rules: []
+rules:
+  - id: artifact-graph-candidate-discovery
+    when: 対応REQ、同じ正規所有対象のSPEC、関連command・skill・整合性ルールの候補を探索するとき。利用不能時は従来の探索手段で続行する
+    skill: repo-agentdev-artifact-graph
 
 checks: []
 

--- a/.agentdev/extensions/skills/agentdev-deep-review.yaml
+++ b/.agentdev/extensions/skills/agentdev-deep-review.yaml
@@ -1,0 +1,21 @@
+version: 1
+kind: skill-extension
+id: agentdev-deep-review
+
+context:
+  - id: artifact-graph-spec
+    when: Artifact Graphを論点候補の探索に使用するとき
+    paths:
+      - "docs/specs/local/artifact-graph.md"
+    purpose: 派生索引の利用上の防護と障害耐性の確認
+
+rules:
+  - id: artifact-graph-deliberation-candidates
+    when: 複数規範関係、循環、集中ノード、孤立候補、複数経路から審議論点の候補を探索するとき。利用不能時は従来の探索手段で続行する
+    skill: repo-agentdev-artifact-graph
+
+checks: []
+
+acceptance_gates: []
+
+must_not: []

--- a/.opencode/skills/repo-agentdev-artifact-graph/SKILL.md
+++ b/.opencode/skills/repo-agentdev-artifact-graph/SKILL.md
@@ -64,9 +64,42 @@ bun .opencode/skills/repo-agentdev-artifact-graph/scripts/query_graph.ts --graph
 問い合わせ結果は候補取得に限って使用する。
 根拠ファイルを読み、別手段で補完または反証してから判断する。
 
+## 標準ワークフローからの補助利用
+
+Project Extension から委譲された場合は、問い合わせ前に次を実行する。
+
+```bash
+bun .opencode/skills/repo-agentdev-artifact-graph/scripts/prepare_graph.ts --root . --output .agentdev/graph
+```
+
+結果の扱いは次のとおりとする。
+
+| status | freshness | 扱い |
+|---|---|---|
+| `ready` | `current` | 現在の派生索引として候補取得に使用する |
+| `ready` | `regenerated` | 再生成した派生索引を候補取得に使用する |
+| `limited` | `stale` | 陳腐化を明示し、既存索引を補助的な候補取得だけに使用する |
+| `unavailable` | `missing` / `invalid` | Artifact Graph を使用せず、従来の探索手段で標準ワークフローを続行する |
+
+`limited` と `unavailable` は標準ワークフローの停止条件ではない。
+生成失敗の理由は実行報告へ残すが、その失敗だけを理由に command または skill を失敗させない。
+
+### 委譲元ごとの候補取得
+
+- `req-define`: 既存REQ、関連ADRとSPEC、構造的所有者重複の候補
+- `spec-save`: 対応REQ、同じ正規所有対象を持つSPEC、関連command、skill、整合性ルールの候補
+- `case-open`: 起点成果物から到達できる変更影響、廃止参照、未解決参照の候補
+- `case-run`: 実装対象に関係するREQ、SPEC、整合性ルール、周辺成果物の候補
+- `case-close`: 鮮度、未解決参照、存在しないノードへの関係、根拠欠落、関係閉包の候補
+- `agentdev-deep-review`: 複数規範関係、循環、集中ノード、孤立、複数経路の論点候補
+
+構造的重複候補は、明示された所有者、識別子、関係の一致から機械的に得た候補を指す。
+文章の意味や責務境界を読んで判断する意味的な責務重複とは区別し、前者だけから後者を確定しない。
+
 ## 責務境界
 
 - `declared` と `derived` の関係だけを生成し、`inferred` は生成しない。
 - `.agentdev/graph/` を手編集または Git 管理しない。
 - グラフ不在や生成失敗を「影響なし」の根拠にしない。
 - グラフから変更対象、要件充足、責務重複を確定しない。
+- 構造的重複候補を意味的な責務重複の確定結果として扱わない。

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/workflow.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/lib/workflow.ts
@@ -1,0 +1,79 @@
+import { join } from "node:path"
+import { buildGraph, loadGraph, type BuildOptions, type BuildResult } from "./graph.ts"
+import { collectInputs, computeInputDigest } from "./input.ts"
+
+export type WorkflowGraphPreparation =
+  | {
+    readonly status: "ready"
+    readonly freshness: "current" | "regenerated"
+    readonly graphPath: string
+  }
+  | {
+    readonly status: "limited"
+    readonly freshness: "stale"
+    readonly graphPath: string
+    readonly reason: string
+  }
+  | {
+    readonly status: "unavailable"
+    readonly freshness: "missing" | "invalid"
+    readonly graphPath: string
+    readonly reason: string
+  }
+
+export type GraphBuilder = (options: BuildOptions) => Promise<BuildResult>
+
+function reason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export async function prepareWorkflowGraph(
+  options: BuildOptions,
+  build: GraphBuilder = buildGraph,
+): Promise<WorkflowGraphPreparation> {
+  const graphPath = options.output
+  const manifestExists = await Bun.file(join(graphPath, "manifest.json")).exists()
+  let previousDigest: string | undefined
+  if (manifestExists) {
+    try {
+      previousDigest = (await loadGraph(graphPath)).manifest.input_digest
+    } catch (error) {
+      if (!(error instanceof Error)) throw error
+      previousDigest = undefined
+    }
+  }
+
+  let currentDigest: string
+  try {
+    currentDigest = computeInputDigest(await collectInputs(options.root))
+  } catch (error) {
+    if (previousDigest !== undefined) {
+      return { status: "limited", freshness: "stale", graphPath, reason: reason(error) }
+    }
+    return {
+      status: "unavailable",
+      freshness: manifestExists ? "invalid" : "missing",
+      graphPath,
+      reason: reason(error),
+    }
+  }
+
+  if (previousDigest === currentDigest) {
+    return { status: "ready", freshness: "current", graphPath }
+  }
+
+  try {
+    await build(options)
+    return { status: "ready", freshness: "regenerated", graphPath }
+  } catch (error) {
+    if (previousDigest !== undefined) {
+      return { status: "limited", freshness: "stale", graphPath, reason: reason(error) }
+    }
+    return {
+      status: "unavailable",
+      freshness: manifestExists ? "invalid" : "missing",
+      graphPath,
+      reason: reason(error),
+    }
+  }
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/prepare_graph.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/prepare_graph.ts
@@ -1,0 +1,21 @@
+import { resolve } from "node:path"
+import { prepareWorkflowGraph } from "./lib/workflow.ts"
+
+function option(args: readonly string[], name: string): string | undefined {
+  const index = args.indexOf(name)
+  return index < 0 ? undefined : args[index + 1]
+}
+
+export async function main(args: readonly string[] = Bun.argv.slice(2)): Promise<void> {
+  const root = resolve(option(args, "--root") ?? ".")
+  const output = resolve(option(args, "--output") ?? `${root}/.agentdev/graph`)
+  console.log(JSON.stringify(await prepareWorkflowGraph({ root, output })))
+}
+
+if (import.meta.main) {
+  // no-excuse-ok: catch -- CLI boundary reports unexpected invocation failures.
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 2
+  })
+}

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/case_extensions.test.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/case_extensions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test"
+import { join, resolve } from "node:path"
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..", "..", "..")
+const EXTENSION_PATHS = [
+  ".agentdev/extensions/commands/case-open.yaml",
+  ".agentdev/extensions/commands/case-run.yaml",
+  ".agentdev/extensions/commands/case-close.yaml",
+] as const
+
+function delegatesToArtifactGraph(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || !("rules" in value) || !Array.isArray(value.rules)) return false
+  return value.rules.some((entry: unknown) => (
+    typeof entry === "object" && entry !== null && "skill" in entry
+    && entry.skill === "repo-agentdev-artifact-graph"
+  ))
+}
+
+describe("TS-001: case extension integration", () => {
+  it("delegates all three case workflow stages", async () => {
+    // Given
+    const documents = await Promise.all(EXTENSION_PATHS.map(async (path) => (
+      Bun.YAML.parse(await Bun.file(join(REPO_ROOT, path)).text())
+    )))
+
+    // When
+    const delegated = documents.map(delegatesToArtifactGraph)
+
+    // Then
+    expect(delegated).toEqual([true, true, true])
+  })
+})

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/definition_extensions.test.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/definition_extensions.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test"
+import { join, resolve } from "node:path"
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..", "..", "..")
+const EXTENSION_PATHS = [
+  ".agentdev/extensions/commands/req-define.yaml",
+  ".agentdev/extensions/commands/spec-save.yaml",
+] as const
+
+function delegatesToArtifactGraph(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || !("rules" in value) || !Array.isArray(value.rules)) return false
+  return value.rules.some((entry: unknown) => (
+    typeof entry === "object" && entry !== null && "skill" in entry
+    && entry.skill === "repo-agentdev-artifact-graph"
+  ))
+}
+
+describe("TS-001: definition extension integration", () => {
+  it("delegates requirement and specification candidate discovery", async () => {
+    // Given
+    const documents = await Promise.all(EXTENSION_PATHS.map(async (path) => (
+      Bun.YAML.parse(await Bun.file(join(REPO_ROOT, path)).text())
+    )))
+
+    // When
+    const delegated = documents.map(delegatesToArtifactGraph)
+
+    // Then
+    expect(delegated).toEqual([true, true])
+  })
+})

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/review_extension.test.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/review_extension.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test"
+import { join, resolve } from "node:path"
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..", "..", "..")
+const EXTENSION_PATH = ".agentdev/extensions/skills/agentdev-deep-review.yaml"
+
+function delegatesToArtifactGraph(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || !("rules" in value) || !Array.isArray(value.rules)) return false
+  return value.rules.some((entry: unknown) => (
+    typeof entry === "object" && entry !== null && "skill" in entry
+    && entry.skill === "repo-agentdev-artifact-graph"
+  ))
+}
+
+describe("TS-001: review extension integration", () => {
+  it("delegates deliberation candidate discovery without a dedicated extension directory", async () => {
+    // Given
+    const document = Bun.YAML.parse(await Bun.file(join(REPO_ROOT, EXTENSION_PATH)).text())
+
+    // When
+    const delegated = delegatesToArtifactGraph(document)
+
+    // Then
+    expect(delegated).toBe(true)
+    expect(await Bun.file(join(REPO_ROOT, ".agentdev/extensions/artifact-graph")).exists()).toBe(false)
+  })
+})

--- a/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/workflow_integration.test.ts
+++ b/.opencode/skills/repo-agentdev-artifact-graph/scripts/tests/workflow_integration.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { buildGraph } from "../lib/graph.ts"
+import { prepareWorkflowGraph } from "../lib/workflow.ts"
+import { createFixture } from "./fixture.ts"
+
+const roots: string[] = []
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+async function setup(): Promise<{ readonly root: string; readonly output: string }> {
+  const root = await mkdtemp(join(tmpdir(), "artifact-graph-workflow-"))
+  roots.push(root)
+  await createFixture(root)
+  return { root, output: join(root, ".agentdev", "graph") }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe("TS-011: optional workflow preparation", () => {
+  it("regenerates the graph when it is missing", async () => {
+    // Given
+    const fixture = await setup()
+
+    // When
+    const result = await prepareWorkflowGraph(fixture)
+
+    // Then
+    expect(result.status).toBe("ready")
+    expect(result.freshness).toBe("regenerated")
+  })
+
+  it("regenerates the graph when indexed input is stale", async () => {
+    // Given
+    const fixture = await setup()
+    const initial = await buildGraph(fixture)
+    await writeFile(join(fixture.root, "scripts", "new-input.ts"), "export const changed = true\n", "utf8")
+
+    // When
+    const result = await prepareWorkflowGraph(fixture)
+    const regenerated = JSON.parse(await Bun.file(join(fixture.output, "manifest.json")).text())
+
+    // Then
+    expect(result.status).toBe("ready")
+    expect(result.freshness).toBe("regenerated")
+    expect(isRecord(regenerated) ? regenerated["input_digest"] : undefined).not.toBe(initial.inputDigest)
+  })
+
+  it("limits a stale graph to auxiliary use when regeneration fails", async () => {
+    // Given
+    const fixture = await setup()
+    await buildGraph(fixture)
+    await writeFile(join(fixture.root, "scripts", "new-input.ts"), "export const changed = true\n", "utf8")
+    const failingBuilder = async (): Promise<never> => {
+      throw new TypeError("simulated generation failure")
+    }
+
+    // When
+    const result = await prepareWorkflowGraph(fixture, failingBuilder)
+
+    // Then
+    expect(result.status).toBe("limited")
+    if (result.status !== "limited") throw new TypeError("expected a limited graph result")
+    expect(result.freshness).toBe("stale")
+    expect(result.reason).toContain("simulated generation failure")
+  })
+
+  it("returns unavailable instead of throwing when no graph can be generated", async () => {
+    // Given
+    const fixture = await setup()
+    const failingBuilder = async (): Promise<never> => {
+      throw new TypeError("simulated generation failure")
+    }
+
+    // When
+    const result = await prepareWorkflowGraph(fixture, failingBuilder)
+
+    // Then
+    expect(result.status).toBe("unavailable")
+    if (result.status !== "unavailable") throw new TypeError("expected an unavailable graph result")
+    expect(result.freshness).toBe("missing")
+    expect(result.reason).toContain("simulated generation failure")
+  })
+
+  it("keeps the preparation CLI successful when graph generation is unavailable", async () => {
+    // Given
+    const root = await mkdtemp(join(tmpdir(), "artifact-graph-cli-failure-"))
+    roots.push(root)
+    const invalidRoot = join(root, "root-file")
+    await writeFile(invalidRoot, "not a directory", "utf8")
+    const cli = resolve(import.meta.dir, "..", "prepare_graph.ts")
+
+    // When
+    const process = Bun.spawn(["bun", cli, "--root", invalidRoot], { stdout: "pipe", stderr: "pipe" })
+    const exitCode = await process.exited
+    const output = JSON.parse(await new Response(process.stdout).text())
+
+    // Then
+    expect(exitCode).toBe(0)
+    expect(isRecord(output) ? output["status"] : undefined).toBe("unavailable")
+  })
+})


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

Artifact Graphを既存Project Extensionsへ統合し、標準ワークフローから非停止の補助索引として利用できるようにする。

Refs: #1943

## 実装内容
<!-- 【必須】 -->

- 5 command extensionとagentdev-deep-review skill extensionからrepo-agentdev-artifact-graphへ委譲
- グラフ不在・陳腐化・生成失敗を状態化するprepare_graph.tsを追加
- 陳腐化時の再生成または補助利用限定、生成失敗時の標準ワークフロー継続を実装
- 構造的重複候補と意味的な責務重複を区別する利用防護をSKILL.mdへ追加
- Wave 2統合と障害耐性の自動テストを追加

## 完了条件
<!-- 【必須】 -->

- [x] 5 command extensionと1 skill extensionの全てからrepo-agentdev-artifact-graphへ委譲している
- [x] 配布command原本と配布skill原本にArtifact Graph固有の変更がない
- [x] 専用extensionディレクトリと独自loaderを作成していない
- [x] 派生索引がGit管理対象外である
- [x] グラフ不在時も対象標準ワークフローが継続する
- [x] グラフ陳腐化時は再生成するか、陳腐化を明示して補助利用に限定する
- [x] グラフ生成失敗だけを理由に対象標準ワークフローが恒常的に停止しない
- [x] グラフ結果を変更対象、OU、要件充足、責務重複の確定根拠として使用しない
- [x] 構造的重複候補と意味的な責務重複を区別する

## テスト結果
<!-- 【必須】 -->

- bun test: 16 tests / 519 assertions 合格
- TypeScript typecheck: 合格
- グラフ実表面: missingからregenerated、再実行でcurrent、構造エラー0件
- Project Extensions整合性検査: failure 0 / warning 0

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| bun test | 16 tests / 519 assertions | 全件合格 | ✅ |
| TypeScript typecheck | diagnostics 0 | 0 | ✅ |
| LSP | 24 files / 0 diagnostics | 0 | ✅ |
| Project Extensions整合性 | failure 0 / warning 0 | 0 / 0 | ✅ |
| targeted docs guard | failure 0 / warning 0（docs変更なしのため非発動） | 0 / 0 | ✅ |
| Artifact Graph構造検査 | error 0 | 0 | ✅ |
| QG-3 | pass / no-deviation | pass | ✅ |

### QG-3 証拠

- 変更13ファイルはrepo-local Artifact Graph skillと指定済み6 extensionに限定
- src/opencode/commands/**、src/opencode/skills/**、docs/**、REQ、ADRの差分は0件
- .agentdev/extensions/artifact-graph/は存在せず、.agentdev/graph/**は.gitignore対象
- Issue #1943のTS-001、TS-002、TS-010、TS-011、TS-012を全て検証済み

## Findings/ Capture候補
<!-- 【必須】 -->

### intake

- 発見元: check_graph.ts
  - 内容: 構造エラーは0件だが、未解決参照の観測warningが22件残る。候補探索の完全性には引き続き正規ファイルと別手段による補完・反証が必要
  - 分類: intake
  - 残リスク: Wave 2の非停止統合には影響しないが、未解決参照の抽出精度改善は別課題候補

### learning

該当なし

## SPEC確定候補
<!-- 【任意】 -->

- 標準ワークフロー準備結果の状態契約: ready/current、ready/regenerated、limited/stale、unavailable/missing|invalid
- limitedとunavailableは標準ワークフローの停止条件にせず、limitedは陳腐化を明示した補助利用、unavailableは従来探索へのフォールバックとする

## 関連Issue
<!-- 【必須】 -->

Refs: #1943
