### PR TITLE
test(skill): REQ-012 段階2 Consumer 成立確認

### DIFF
--- a/src/opencode/skills/agentdev-artifact-graph/scripts/tests/consumer_exclusion.test.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/tests/consumer_exclusion.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test"
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { buildGraph } from "../lib/graph.ts"
+import { buildGraph, loadGraph } from "../lib/graph.ts"
 import { DEFAULT_INDEXED_PATHS } from "../lib/config.ts"
 
 const roots: string[] = []
@@ -14,6 +14,123 @@ afterEach(async () => {
 async function jsonLines(path: string): Promise<readonly Record<string, unknown>[]> {
   const content = await Bun.file(path).text()
   return content.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
+}
+
+/**
+ * Distribution artifact path patterns that MUST NOT appear in a consumer Graph
+ * (REQ-012-008, TS-006 / AG-005). Any node/provenance path matching one of
+ * these regexes indicates distribution artifact leakage into the Graph.
+ */
+const DISTRIBUTION_PATTERNS: readonly RegExp[] = [
+  /^\.opencode\/commands\/agentdev\//,
+  /^\.opencode\/skills\/agentdev-[^/]+\//,
+  /^\.opencode\/skills\/japanese-tech-writing\//,
+  /^\.agentdev-plugin\//,
+]
+
+function matchesDistributionPattern(path: string): boolean {
+  return DISTRIBUTION_PATTERNS.some((pattern) => pattern.test(path))
+}
+
+/**
+ * Creates a realistic consumer fixture mirroring the layout produced by
+ * `install-consumer-opencode.ps1 -Mode apply`: consumer-owned docs/ plus
+ * AgentDevFlow distribution artifacts (commands, skills, plugin clone).
+ * The distribution directories contain plausible files with frontmatter and
+ * cross-references that would be picked up if indexed_paths leaked.
+ */
+async function createRealisticConsumerFixture(root: string): Promise<void> {
+  const consumerDocs: Record<string, string> = {
+    "docs/requirements/REQ-001.md": `---
+id: REQ-001
+title: Consumer feature
+status: accepted
+---
+# Consumer feature
+
+See [decision](../adr/ADR-001.md).
+`,
+    "docs/adr/ADR-001.md": `---
+id: ADR-001
+title: Consumer architecture
+status: accepted
+---
+# Consumer architecture
+`,
+    "docs/specs/feature.md": `---
+title: Feature spec
+canonical_owner: consumer-team
+---
+# Feature spec
+`,
+  }
+  for (const [relativePath, content] of Object.entries(consumerDocs)) {
+    await mkdir(join(root, relativePath, ".."), { recursive: true })
+    await writeFile(join(root, relativePath), content, "utf8")
+  }
+
+  const commandFiles: Record<string, string> = {
+    ".opencode/commands/agentdev/req-define.md": `---
+description: Define requirements
+---
+# /agentdev/req-define
+Refs: REQ-001
+`,
+    ".opencode/commands/agentdev/case-open.md": `---
+description: Open a case
+---
+# /agentdev/case-open
+`,
+  }
+  for (const [relativePath, content] of Object.entries(commandFiles)) {
+    await mkdir(join(root, relativePath, ".."), { recursive: true })
+    await writeFile(join(root, relativePath), content, "utf8")
+  }
+
+  const skillFiles: Record<string, string> = {
+    ".opencode/skills/agentdev-artifact-graph/SKILL.md": `---
+name: agentdev-artifact-graph
+description: Build Artifact Graph
+---
+# agentdev-artifact-graph
+Refs: REQ-012, ADR-007
+`,
+    ".opencode/skills/agentdev-doc-writing/SKILL.md": `---
+name: agentdev-doc-writing
+description: Review docs
+---
+# agentdev-doc-writing
+`,
+    ".opencode/skills/japanese-tech-writing/SKILL.md": `---
+name: japanese-tech-writing
+description: Japanese writing norms
+---
+# japanese-tech-writing
+`,
+  }
+  for (const [relativePath, content] of Object.entries(skillFiles)) {
+    await mkdir(join(root, relativePath, ".."), { recursive: true })
+    await writeFile(join(root, relativePath), content, "utf8")
+  }
+
+  const pluginFiles: Record<string, string> = {
+    ".agentdev-plugin/src/opencode/commands/agentdev/req-save.md": `---
+description: Save requirements
+---
+# /agentdev/req-save
+`,
+    ".agentdev-plugin/src/opencode/skills/agentdev-gh-cli/SKILL.md": `---
+name: agentdev-gh-cli
+description: GitHub CLI I/O
+---
+# agentdev-gh-cli
+`,
+    ".agentdev-plugin/scripts/install-consumer-opencode.ps1": `# install script`,
+  }
+  for (const [relativePath, content] of Object.entries(pluginFiles)) {
+    await mkdir(join(root, relativePath, ".."), { recursive: true })
+    await writeFile(join(root, relativePath), content, "utf8")
+  }
 }
 
 describe("REQ-012-008: consumer environment excludes AgentDevFlow distribution artifacts", () => {
@@ -80,5 +197,80 @@ describe("REQ-012-008: consumer environment excludes AgentDevFlow distribution a
     const output = join(root, ".agentdev", "graph")
     const result = await buildGraph({ root, output })
     expect(result.nodeCount).toBe(0)
+  })
+})
+
+describe("TS-006 (AG-005): consumer Graph excludes all distribution artifact paths", () => {
+  it("realistic consumer fixture produces 0 nodes/edges/provenance from distribution patterns", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ag-ts006-"))
+    roots.push(root)
+    await createRealisticConsumerFixture(root)
+
+    const output = join(root, ".agentdev", "graph")
+    const result = await buildGraph({ root, output })
+    const graph = await loadGraph(output)
+
+    expect(result.nodeCount).toBe(3)
+    expect(result.edgeCount).toBeGreaterThanOrEqual(0)
+
+    const distributionNodeIds = graph.nodes.filter((node) => {
+      const specPath = node.id.startsWith("specification:")
+        ? node.id.slice("specification:".length)
+        : undefined
+      return specPath !== undefined && matchesDistributionPattern(specPath)
+    })
+    expect(distributionNodeIds).toEqual([])
+
+    const distributionProvenance = graph.provenance.filter((entry) =>
+      matchesDistributionPattern(entry.path)
+    )
+    expect(distributionProvenance).toEqual([])
+
+    const allPaths = graph.provenance.map((entry) => entry.path)
+    for (const path of allPaths) {
+      expect(matchesDistributionPattern(path)).toBe(false)
+    }
+
+    const distributionEdgeProvenance = graph.edges.filter((edge) => {
+      const prov = graph.provenance.find((entry) => entry.id === edge.provenance_id)
+      return prov !== undefined && matchesDistributionPattern(prov.path)
+    })
+    expect(distributionEdgeProvenance).toEqual([])
+  })
+
+  it("manifest indexed_paths contains only the 3 default canonical paths", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ag-ts006-manifest-"))
+    roots.push(root)
+    await createRealisticConsumerFixture(root)
+
+    const output = join(root, ".agentdev", "graph")
+    await buildGraph({ root, output })
+    const graph = await loadGraph(output)
+
+    expect(graph.manifest.indexed_paths).toEqual([
+      "docs/requirements",
+      "docs/adr",
+      "docs/specs",
+    ])
+    for (const indexed of graph.manifest.indexed_paths) {
+      expect(matchesDistributionPattern(indexed + "/")).toBe(false)
+    }
+  })
+
+  it("consumer REQ-001 is reachable and distribution artifacts are not", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ag-ts006-reach-"))
+    roots.push(root)
+    await createRealisticConsumerFixture(root)
+
+    const output = join(root, ".agentdev", "graph")
+    await buildGraph({ root, output })
+
+    const nodes = await jsonLines(join(output, "nodes.jsonl"))
+    const nodeIds = nodes.map((node) => String(node["id"] ?? ""))
+    expect(nodeIds).toContain("requirement:REQ-001")
+    expect(nodeIds).toContain("adr:ADR-001")
+    expect(nodeIds).toContain("specification:docs/specs/feature.md")
+    expect(nodeIds.some((id) => id.includes("command:"))).toBe(false)
+    expect(nodeIds.some((id) => id.includes("skill:"))).toBe(false)
   })
 })

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/tests/install_consumer.test.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/tests/install_consumer.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { rm } from "node:fs/promises"
+import { join, resolve } from "node:path"
+import { readdir } from "node:fs/promises"
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..", "..", "..", "..")
+const SKILLS_SOURCE = join(REPO_ROOT, "src", "opencode", "skills")
+const INSTALL_SCRIPT = join(REPO_ROOT, "scripts", "install-consumer-opencode.ps1")
+
+describe("install-consumer-opencode.ps1: agentdev-artifact-graph consumer junction (REQ-012-001)", () => {
+  it("standard skill directory exists at src/opencode/skills/agentdev-artifact-graph/", async () => {
+    const skillExists = await Bun.file(join(SKILLS_SOURCE, "agentdev-artifact-graph", "SKILL.md")).exists()
+    expect(skillExists).toBe(true)
+  })
+
+  it("directory name matches the agentdev-* glob used for dynamic enumeration", async () => {
+    const entries = await readdir(SKILLS_SOURCE)
+    const agentdevSkills = entries.filter((name) => name.startsWith("agentdev-"))
+    expect(agentdevSkills).toContain("agentdev-artifact-graph")
+    expect(agentdevSkills.every((name) => /^agentdev-/.test(name))).toBe(true)
+  })
+
+  it("PowerShell Get-ChildItem -Filter 'agentdev-*' enumerates agentdev-artifact-graph", async () => {
+    const proc = Bun.spawn(
+      ["pwsh", "-NoProfile", "-Command", `Get-ChildItem -LiteralPath '${SKILLS_SOURCE}' -Directory -Filter 'agentdev-*' | Select-Object -ExpandProperty Name`],
+      { stdout: "pipe", stderr: "pipe" },
+    )
+    const exitCode = await proc.exited
+    const stdout = await new Response(proc.stdout).text()
+
+    expect(exitCode).toBe(0)
+    const enumerated = stdout.trim().split(/\r?\n/).filter(Boolean)
+    expect(enumerated).toContain("agentdev-artifact-graph")
+  })
+
+  it("install-consumer-opencode.ps1 source contains the agentdev-* dynamic enumeration logic", async () => {
+    const content = await Bun.file(INSTALL_SCRIPT).text()
+    expect(content).toMatch(/Get-ChildItem.*-Filter\s+'agentdev-\*'/)
+  })
+})
+

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/tests/workflow.test.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/tests/workflow.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it } from "bun:test"
-import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readdir, rename, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
-import { buildGraph } from "../lib/graph.ts"
+import { buildGraph, loadGraph } from "../lib/graph.ts"
 import { prepareWorkflowGraph } from "../lib/workflow.ts"
 import { createFixture } from "./fixture.ts"
 
@@ -100,5 +100,68 @@ describe("fail-open: Graph missing/stale/failure does not halt workflow (REQ-012
 
     expect(exitCode).toBe(0)
     expect(isRecord(output) ? output["status"] : undefined).toBe("unavailable")
+  })
+})
+
+describe("TS-007 (AG-006): Graph missing does not halt workflow; fallback discovery works", () => {
+  it("renaming .agentdev/graph/ away lets prepare_graph regenerate (workflow continues)", async () => {
+    const fixture = await setup()
+    await buildGraph(fixture)
+
+    await rename(fixture.output, `${fixture.output}.bak`)
+    const graphDirExists = await readdir(join(fixture.root, ".agentdev")).then(
+      (entries) => entries.includes("graph"),
+      () => false,
+    )
+    expect(graphDirExists).toBe(false)
+
+    const result = await prepareWorkflowGraph(fixture)
+    expect(result.status).toBe("ready")
+    if (result.status !== "ready") throw new TypeError("expected ready")
+    expect(result.freshness).toBe("regenerated")
+
+    await rm(`${fixture.output}.bak`, { recursive: true, force: true })
+  })
+
+  it("discover CLI finds canonical docs via filesystem when no graph exists", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ag-ts007-discover-"))
+    roots.push(root)
+    await createFixture(root)
+
+    const graphExists = await readdir(join(root, ".agentdev")).then(
+      (entries) => entries.includes("graph"),
+      () => false,
+    )
+    expect(graphExists).toBe(false)
+
+    const cli = resolve(import.meta.dir, "..", "src", "query_graph.ts")
+    const proc = Bun.spawn(
+      ["bun", cli, "--root", root, "discover", "sample requirement", "--roots", "docs/requirements"],
+      { stdout: "pipe", stderr: "pipe" },
+    )
+    const exitCode = await proc.exited
+    const output = JSON.parse(await new Response(proc.stdout).text())
+
+    expect(exitCode).toBe(0)
+    expect(isRecord(output) ? output["discovered"] : undefined).toContain("docs/requirements/REQ-001.md")
+  })
+
+  it("consumer not adopting ADF: prepare_graph returns ready with empty but valid graph (REQ-012-014)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ag-ts007-noadf-"))
+    roots.push(root)
+    await writeFile(join(root, "README.md"), "# Not an ADF project\n", "utf8")
+
+    const output = join(root, ".agentdev", "graph")
+    const result = await prepareWorkflowGraph({ root, output })
+    expect(result.status).toBe("ready")
+
+    const graph = await loadGraph(output)
+    expect(graph.nodes).toEqual([])
+    expect(graph.edges).toEqual([])
+    expect(graph.manifest.indexed_paths).toEqual([
+      "docs/requirements",
+      "docs/adr",
+      "docs/specs",
+    ])
   })
 })


### PR DESCRIPTION
## 対象 Issue

Refs: #1950

Parent: #1948

## 概要

REQ-012 段階2 Consumer 成立確認。段階1（PR #1955）で新設した agentdev-artifact-graph 標準配布スキルが consumer 環境で自己完結して動作することを検証した。

主に検証タスク（test fixture + test strategy 実行）。install-consumer-opencode.ps1 は既存の `agentdev-*` 動的 glob で agentdev-artifact-graph を自動 junction するため、スクリプト変更は不要であった。

## 完了条件

- [x] REQ-012-001: 標準配布スキルが consumer 環境で self-hosting 固有 path なしに動作する
- [x] REQ-012-008: consumer 環境で AgentDevFlow 配布物（.opencode/commands/agentdev/, .opencode/skills/agentdev-*/, .agentdev-plugin/**）を indexed_paths に含めず、生成 Graph にこれらパターンのノードが0件
- [x] REQ-012-014: consumer が ADF 運用不採用時、Graph は空で生成され正常状態
- [x] install-consumer-opencode.ps1 連携で agentdev-artifact-graph が consumer へ自動 junction される（既存動的 glob で対応済み、検証追加）

## テスト戦略実行結果

### TS-006 (AG-005): consumer 環境での配布物除外検証

`consumer_exclusion.test.ts` に3テストケースを追加:

1. **realistic consumer fixture**: `install-consumer-opencode.ps1 -Mode apply` 後の構成を模擬（docs/requirements, docs/adr, docs/specs + .opencode/commands/agentdev/ + .opencode/skills/agentdev-*/ + .agentdev-plugin/src/opencode/...）。build_graph 実行後、全 node id、全 provenance path、全 edge provenance が distribution pattern に合致しないことを検証。結果: nodeCount=3（consumer のREQ/ADR/SPECのみ）、distribution ノード0件。
2. **manifest indexed_paths**: 生成 manifest の indexed_paths が3種のみであることを検証。
3. **node reachability**: consumer REQ-001 が到達可能で、command:/skill: ノードが存在しないことを検証。

pass_criteria 達成: indexed_paths は配布物パターンを含まない。生成 Graph にこれらパターンのノードが0件。

### TS-007 (AG-006): Graph 不在時の fail-open と fallback

`workflow.test.ts` に3テストケースを追加:

1. **Graph リネーム → 再生成**: 既存 Graph をリネームして不在状態にし、prepare_graph が `ready`/`regenerated` を返す（workflow 停止しない）ことを検証。
2. **discover CLI fallback**: `.agentdev/graph/` が存在しない状態で discover CLI を起動し、filesystem fallback で docs/requirements/REQ-001.md を発見できることを検証。query_graph.ts CLI は discover のみ loadGraph をスキップする設計が既存。
3. **ADF 不採用時の空 Graph**: docs/ が存在しない consumer で prepare_graph が `ready` を返し、空 Graph（nodes=[], edges=[]）が正常状態であることを検証（REQ-012-014）。

pass_criteria 達成: Graph 不在で workflow が停止しない。fallback 時に filesystem 探索で関連文書を発見できる。

### install-consumer-opencode.ps1 junction 検証

`install_consumer.test.ts`（新規）に4テストケースを追加:

1. 標準スキルディレクトリが `src/opencode/skills/agentdev-artifact-graph/` に存在
2. ディレクトリ名が `agentdev-*` glob に合致
3. PowerShell `Get-ChildItem -Filter 'agentdev-*'` が agentdev-artifact-graph を列挙
4. install-consumer-opencode.ps1 ソースが動的列挙ロジックを含む

install-consumer-opencode.ps1 は `Get-ChildItem -Filter 'agentdev-*'`（行201）で全 agentdev-* スキルを動的列挙するため、agentdev-artifact-graph は追加コードなしで自動 junction 対象となる。スクリプト修正は不要。

## 検証コマンド

```bash
cd src/opencode/skills/agentdev-artifact-graph/scripts
bun install        # zod, typescript, @types/bun
bun test           # 59 pass, 0 fail
bun run tsc --noEmit  # clean (strict mode)
```

## Findings / Capture候補

### intake

- PR #1955 の Findings で「bun spawnSync windows」が回収済みだが、本 PR の install_consumer.test.ts で `Bun.spawn(["pwsh", ...])` を使用し Windows 環境で PowerShell CLI 起動が成功することを追加確認。cross-platform CLI spawn の知見は PR #1955 で回収済みのため重複回避。

### learning

- install-consumer-opencode.ps1 の統合テストは git clone を伴うため unit test に適さない。代わりに「動的 glob の契約検証」（ディレクトリ命名規則 + PowerShell Get-ChildItem 挙動 + ソースコード grep）の3層検証で網羅する手法を確立。このテスト設計パターンは外部スクリプト（git clone 必須）の契約検証に再利用可能。

## SPEC確定候補

- TS-007 の「fallback 探索で README と rg の組合せで主要関連文書を発見できること」について、標準スキルの discover サブコマンドは filesystem walk + content match で rg 相当の検索を提供する。README 経由の探索は discover に readme パスを含めることで達成される（特別な README 処理ロジックは不要）。この「discover = rg 相当の fallback」の位置づけを SPEC agentdev-artifact-graph.md に明記すると良い。

## 変更ファイル

- `src/opencode/skills/agentdev-artifact-graph/scripts/tests/consumer_exclusion.test.ts`（修正）: DISTRIBUTION_PATTERNS、createRealisticConsumerFixture、TS-006 テスト3件追加
- `src/opencode/skills/agentdev-artifact-graph/scripts/tests/workflow.test.ts`（修正）: TS-007 テスト3件追加
- `src/opencode/skills/agentdev-artifact-graph/scripts/tests/install_consumer.test.ts`（新規）: install-consumer junction 契約検証4件
