### PR TITLE
feat(adversarial-review): REQ-015 経路C intake-promote review 挿入境界の実装 (#1966)

### DIFF
--- a/docs/specs/commands/intake-promote.md
+++ b/docs/specs/commands/intake-promote.md
@@ -112,5 +112,32 @@ intake-promote は change_nature と併せて、observed_evidence（根拠とな
 
 ## adversarial-review 挿入境界（経路C）
 
-経路C の review 挿入境界: 発動条件（暫定分類生成後・ユーザ提示前）を規定する。
+本節は intake-promote における経路C の review 挿入境界を正典として所有する（REQ-015-006）。共通契約（任意性、副作用禁止、accepted finding 反映責務、再 review 条件、停止条件、呼出失敗時取扱い）は adversarial-review SPEC「adversarial-review caller integration 共通契約」節（REQ-014）が正規所有し、本節は経路C 固有の挿入位置、発動条件、戻り先のみを所有する。
+
+### 挿入位置（REQ-015-006）
+
+review 挿入位置は現行 Step 構造へ一意に特定可能である。Step 4「分類の提示」（暫定分類生成）の完了後、Step 5「ユーザー確認」（ユーザ提示）の開始前とする。Step 4 で生成された暫定分類を review 対象とし、Step 5 でユーザへ提示する前に review を経た分類を提示する。候補判断基準と内部手続きの詳細は `agentdev-intake-pipeline` SPEC「adversarial-review 候補判断と内部挿入」節を参照する。
+
+### 発動条件判定 Step と review 呼出 Step の分離（REQ-015-001）
+
+経路C の review 挿入境界は次の2 Step を分離して構成する。
+
+| Step | 役割 |
+|---|---|
+| 発動条件判定 Step | ユーザーの明示指定、暫定分類の意味的完成度、review 対象の存在を判定する |
+| review 呼出 Step | 発動条件を満たす場合に限り adversarial-review を呼び出す |
+
+発動条件判定 Step を満たさない場合は review 呼出 Step へ進まない。command 定義（`.opencode/commands/agentdev/intake-promote.md`）は両 Step を独立した手順（Step 4a, Step 4b）として保持する。
+
+### ユーザー明示指定時の発動（REQ-015-002）
+
+ユーザーが明示的に review を指定した場合、発動条件判定 Step は必ず「発動」と判定し、review 呼出 Step を実行する。明示指定はコマンド起動時の引数、対話中の指示、または extension（`.agentdev/extensions/commands/intake-promote.yaml`）の `rules` により表明される。adversarial-review は任意助言手段であり、明示指定がない限り自動発動しない（REQ-014-001）。
+
+### 条件非該当時の従来フロー維持（REQ-015-003）
+
+発動条件判定 Step で「非発動」と判定された場合、review 呼出 Step をスキップし、Step 4 で生成した暫定分類をそのまま Step 5「ユーザー確認」へ渡す従来フローを維持する。既存の HITL（G06, G07, G08）、自動実行ルール（REQ-003-008）、破壊的変更制約（G18）は変更しない。
+
+### accepted finding の反映と戻り先
+
+review 呼出 Step で accepted finding が得られた場合、呼出元（intake-promote 本体）が暫定分類へ finding を反映し、反映後の分類を Step 5「ユーザー確認」へ渡す（REQ-014-006）。adversarial-review 自身は反映を行わない。unresolved な本質的争点が残る場合、Step 5 のユーザー確認で既存 HITL 経由で扱い、後続の保存、inbox 削除等の不可逆処理へは進まない（REQ-014-009）。呼出失敗時は silent skip を禁止し、利用不能を報告した上で従来フローを維持する（REQ-014-010）。
 

--- a/docs/specs/skills/agentdev-intake-pipeline.md
+++ b/docs/specs/skills/agentdev-intake-pipeline.md
@@ -107,6 +107,29 @@ intake-from-github（GitHub 残課題抽出）と intake-promote（review、分�
 
 ## adversarial-review 候補判断と内部挿入
 
-intake-promote 経路C における review 候補判断基準と内部手続き（候補確定位置、
-呼出タイミング、結果反映先）を規定する。
+本節は intake-promote 経路C における review 候補判断基準と内部手続き（候補確定位置、呼出タイミング、結果反映先）を正典として所有する（REQ-015-006）。挿入境界、発動条件、戻り先は intake-promote command SPEC「adversarial-review 挿入境界（経路C）」節が正であり、本節は domain skill 側の候補判断と内部手続きのみを所有する。
+
+### 候補判断基準
+
+intake-promote が review 候補を確定する基準は次のとおり。
+
+| 基準 | 内容 |
+|---|---|
+| 暫定分類の意味的完成度 | Step 3「レビュー、評価」と Step 4「分類の提示」を経て各 item の採用/保留/却下、変更種別、根拠が提示済みであること |
+| review 対象の存在 | 暫定分類結果のうち、意味的争点（分類の妥当性、変更種別の適合、優先度、後続ルートの適切さ）を持ち得る item が少なくとも1件存在すること |
+| ユーザー明示指定 | ユーザーが明示的に review を指定した場合は上記基準に関わらず候補確定とする（REQ-015-002） |
+
+候補確定後、review 呼出 Step へ進む。候補非該当時は従来フローを維持する（REQ-015-003）。
+
+### 内部手続き
+
+| 項目 | 内容 |
+|---|---|
+| 候補確定位置 | Step 4「分類の提示」完了直後。暫定分類表が生成された時点 |
+| 呼出タイミング | Step 5「ユーザー確認」開始前。暫定分類をユーザへ提示する前 |
+| 結果反映先 | intake-promote 本体。accepted finding を暫定分類表へ反映し、反映後の分類を Step 5 へ渡す |
+
+### 参照契約
+
+副作用禁止、accepted finding 反映責務、再 review 条件、停止条件、呼出失敗時取扱いは adversarial-review SPEC「adversarial-review caller integration 共通契約」節（REQ-014）を正とし、本 SPEC は再定義しない。intake-promote 本体は本節に従い候補判断と内部手続きを実行する。
 

--- a/src/opencode/commands/agentdev/intake-promote.md
+++ b/src/opencode/commands/agentdev/intake-promote.md
@@ -68,6 +68,31 @@ intake-promote の内部 review フェーズにおける分類値は以下の 3 
 見出しは `## Findings / Capture候補` とする。
 詳細は `agentdev-intake-pipeline` を参照
 
+### Step 4a: 発動条件判定（経路C、任意）
+
+暫定分類生成後、ユーザ提示前に adversarial-review を発動するかを判定する（REQ-015-001、REQ-015-006）。本 Step は review 呼出（Step 4b）と分離された発動条件判定 Step であり、review 呼出そのものは行わない。
+
+判定基準:
+
+- ユーザー明示指定がある場合: 必ず「発動」とする（REQ-015-002）。明示指定は起動時引数、対話中の指示、extension（`.agentdev/extensions/commands/intake-promote.yaml`）の `rules` により表明される
+- ユーザー明示指定がない場合: 自動発動しない（任意助言手段、REQ-014-001）。「非発動」とする
+
+判定結果が「非発動」の場合は Step 4b をスキップし、Step 4 の暫定分類をそのまま Step 5 へ渡し従来フローを維持する（REQ-015-003）。既存の HITL（G06, G07, G08）、自動実行ルール（REQ-003-008）、破壊的変更制約（G18）は変更しない。
+
+詳細な候補判断基準は `agentdev-intake-pipeline` を参照。
+
+### Step 4b: adversarial-review 呼出（経路C、任意）
+
+Step 4a で「発動」と判定された場合に限り adversarial-review を呼び出す（REQ-015-001）。本 Step は発動条件判定（Step 4a）と分離された review 呼出 Step であり、発動条件の再判定は行わない。
+
+review 対象は Step 4 で生成された暫定分類（各 item の採用/保留/却下、変更種別、根拠）とする。呼出タイミングは Step 5「ユーザー確認」開始前、結果反映先は intake-promote 本体とする（詳細は `agentdev-intake-pipeline` 参照）。
+
+- accepted finding を得た場合: 呼出元（intake-promote 本体）が暫定分類へ finding を反映し、反映後の分類を Step 5 へ渡す（REQ-014-006）。adversarial-review 自身は反映を行わない
+- unresolved な本質的争点が残る場合: Step 5 のユーザー確認で既存 HITL 経由で扱い、後続の保存、inbox 削除等の不可逆処理へは進まない（REQ-014-009）
+- 呼出失敗時（スキル不在、起動異常、timeout 等）: silent skip を禁止し、利用不能を報告した上で従来フローと既存 QG/HITL を維持する（REQ-014-010）
+
+共通契約（任意性、副作用禁止、accepted finding 反映責務、再 review 条件、停止条件、呼出失敗時取扱い）の正規所有者は adversarial-review SPEC「adversarial-review caller integration 共通契約」節（REQ-014）であり、本 command 定義は再定義しない。
+
 ### Step 5: ユーザー確認
 
 評価、分類結果をユーザーに提示し、明示的な承認を得る（判断の確定、REQ）。

--- a/src/opencode/skills/agentdev-intake-pipeline/SKILL.md
+++ b/src/opencode/skills/agentdev-intake-pipeline/SKILL.md
@@ -39,7 +39,20 @@ extension（`.agentdev/extensions/skills/`）は標準 SKILL.md を前提とし�
 | ファイル | 内容 |
 |----------|------|
 | `references/intake-extraction.md` | GitHub残課題抽出ロジック: 期間解釈、データ取得、構造検出、LLM全文解析、intake item生成 |
-| `references/intake-promotion.md` | intake-promote詳細手順: Inbox確認、Review観点、分類提示、ユーザー確認、採用item整形、保存と振り分け、Git永続化 |
+| `references/intake-promotion.md` | intake-promote詳細手順: Inbox確認、Review観点、分類提示、ユーザー確認、採用item整形、保存と振り分け、Git永続化、adversarial-review候補判断と内部手続き（経路C） |
+
+## adversarial-review 候補判断と内部手続き（経路C）
+
+本スキルは intake-promote 経路C の review 候補判断と内部手続きの参照実装を `references/intake-promotion.md` に保持する。正典は `agentdev-intake-pipeline` SPEC「adversarial-review 候補判断と内部挿入」節（REQ-015-006）であり、本 SKILL.md は重複定義しない（REQ-014-011）。
+
+| 項目 | 要件 | 概要 |
+|---|---|---|
+| 挿入位置 | REQ-015-006 | Step 4（暫定分類生成）完了後、Step 5（ユーザ提示）開始前 |
+| 発動条件判定 / review 呼出 Step 分離 | REQ-015-001 | 発動条件判定 Step と review 呼出 Step を独立手順として分離 |
+| ユーザー明示指定時の発動 | REQ-015-002 | ユーザー明示指定時は必ず発動 |
+| 条件非該当時の従来フロー維持 | REQ-015-003 | 条件非該当時は従来フローを維持 |
+
+挿入境界、発動条件、戻り先は intake-promote command SPEC「adversarial-review 挿入境界（経路C）」節が正であり、共通契約（任意性、副作用禁止、accepted finding 反映責務、再 review 条件、停止条件、呼出失敗時取扱い）は adversarial-review SPEC「adversarial-review caller integration 共通契約」節（REQ-014）が正とする。
 
 ## See Also
 

--- a/src/opencode/skills/agentdev-intake-pipeline/references/intake-promotion.md
+++ b/src/opencode/skills/agentdev-intake-pipeline/references/intake-promotion.md
@@ -72,7 +72,37 @@ learning 分岐は `agentdev-workflow-orchestration` の intake/learning 境界�
 3. `git diff --name-only` で `.agentdev/intake/` 配下の変更ファイルを確認する。
 4. 変更なしの場合は commit/push せず、完了報告で「変更なし」と報告する。
 5. 変更ありの場合、`git add` は `.agentdev/intake/` 配下の変更ファイルのみを対象とする。
-6. commit message は採用・保留のみの場合 `chore(agentdev): review and promote intake items` とする。reject item を含む場合は当該 item の却下理由を commit message に含める（AG-006、監査証跠の補強）。
+6. commit message は採用・保留のみの場合 `chore(agentdev): review and promote intake items` とする。reject item を含む場合は当該 item の却下理由を commit message に含める（AG-006、監査証跡の補強）。
 7. `git push` を実行する。
 8. push が失敗した場合は構造化エラーメッセージを表示し、完了扱いにしない。
+
+## adversarial-review 候補判断と内部手続き（経路C）
+
+本節は intake-promote 経路C における adversarial-review 候補判断と内部手続きの参照実装を提供する。正典は `agentdev-intake-pipeline` SPEC「adversarial-review 候補判断と内部挿入」節（REQ-015-006）であり、本ファイルは SPEC を補完する実行手続きのみを保持する。
+
+### 候補判断基準
+
+intake-promote は Step 4「分類の提示」完了直後に候補判断を行う。判断基準は SPEC「候補判断基準」節が正である。
+
+- 暫定分類の意味的完成度: 各 item の採用/保留/却下、変更種別、根拠が Step 3 と Step 4 を経て提示済みであること
+- review 対象の存在: 暫定分類結果のうち、意味的争点（分類の妥当性、変更種別の適合、優先度、後続ルートの適切さ）を持ち得る item が少なくとも1件存在すること
+- ユーザー明示指定: ユーザー明示指定時は上記基準に関わらず候補確定とする（REQ-015-002）
+
+ユーザー明示指定がない限り自動発動しない（REQ-014-001）。
+
+### 内部手続き
+
+| 項目 | 内容 |
+|---|---|
+| 候補確定位置 | Step 4「分類の提示」完了直後。暫定分類表が生成された時点 |
+| 呼出タイミング | Step 5「ユーザー確認」開始前。暫定分類をユーザへ提示する前 |
+| 結果反映先 | intake-promote 本体。accepted finding を暫定分類表へ反映し、反映後の分類を Step 5 へ渡す |
+
+### 呼出失敗時の扱い
+
+adversarial-review の呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止する（REQ-014-010）。intake-promote は利用不能を報告した上で従来フローと既存 QG/HITL を維持する。呼出失敗を理由に暫定分類を自動承認、自動棄却、または既存 QG を飛ばしてはならない。
+
+### 参照契約
+
+挿入境界、発動条件、戻り先は intake-promote command SPEC「adversarial-review 挿入境界（経路C）」節が正であり、共通契約（任意性、副作用禁止、accepted finding 反映責務、再 review 条件、停止条件、呼出失敗時取扱い）は adversarial-review SPEC「adversarial-review caller integration 共通契約」節（REQ-014）が正とする。本ファイルはこれらを再定義しない（REQ-014-011）。
 


### PR DESCRIPTION
## 概要

<!-- 【必須】 -->

Issue #1966（Epic #1962 Wave 2 子Issue、OU-002 経路C、REQ-015 intake-promote）の実装。adversarial-review caller integration 経路C（intake-promote）の review 挿入境界、発動条件、戻り先、候補判断と内部手続きを正典配置する。spec-save で追加済みのセクション見出しに対し、各要件を明記する本文を実装する。

## 実装内容

<!-- 【必須】 -->

REQ-015 経路C（intake-promote）の caller integration を2 SPEC、command 定義、配布スキルへ実装した。

**intake-promote command SPEC**（docs/specs/commands/intake-promote.md）
- 「adversarial-review 挿入境界（経路C）」節を充実。REQ-015-001/002/003/006 を明記:
  - 挿入位置（REQ-015-006）: Step 4「分類の提示」（暫定分類生成）完了後、Step 5「ユーザー確認」（ユーザ提示）開始前
  - 発動条件判定 Step と review 呼出 Step の分離（REQ-015-001）: 2 Step 役割表で明示、command 定義で Step 4a / Step 4b として独立手順化
  - ユーザー明示指定時の発動（REQ-015-002）: 起動時引数、対話中指示、extension rules による明示指定時に必ず発動
  - 条件非該当時の従来フロー維持（REQ-015-003）: 既存 HITL（G06, G07, G08）、自動実行ルール（REQ-003-008）、破壊的変更制約（G18）は変更しない
  - accepted finding の反映と戻り先（REQ-014-006/009/010）: 呼出元が暫定分類へ反映、unresolved は既存 HITL 経由、呼出失敗時 silent skip 禁止

**agentdev-intake-pipeline SPEC**（docs/specs/skills/agentdev-intake-pipeline.md）
- 「adversarial-review 候補判断と内部挿入」節を充実。REQ-015-006 を明記:
  - 候補判断基準: 暫定分類の意味的完成度、review 対象の存在、ユーザー明示指定
  - 内部手続き: 候補確定位置（Step 4 完了直後）、呼出タイミング（Step 5 開始前）、結果反映先（intake-promote 本体）
  - 参照契約: 共通契約は adversarial-review SPEC（REQ-014）を正とし再定義しない

**intake-promote command 定義**（src/opencode/commands/agentdev/intake-promote.md）
- Step 4 と Step 5 の間へ Step 4a（発動条件判定）と Step 4b（adversarial-review 呼出）を独立手順として追加。発動条件判定 Step と review 呼出 Step の分離を達成（REQ-015-001）。Step 5-11 の番号は変更せず、下流参照への影響を最小化

**agentdev-intake-pipeline SKILL.md**（src/opencode/skills/agentdev-intake-pipeline/SKILL.md）
- 「adversarial-review 候補判断と内部手続き（経路C）」節を追加。正典は SPEC（REQ-015-006）とし、SKILL.md は重複定義しない（REQ-014-011）。4 要件（REQ-015-001/002/003/006）を一覧表で参照

**intake-promotion.md**（src/opencode/skills/agentdev-intake-pipeline/references/intake-promotion.md）
- 「adversarial-review 候補判断と内部手続き（経路C）」節を追加。SPEC を補完する実行手続き（候補判断基準、内部手続き、呼出失敗時の扱い、参照契約）を提供

REQ-014 共通契約、REQ-016 横断整合、他経路（A, B, D, E, F, G, H）は対象外（各 Epic 子Issue が所有）。

## 完了条件

<!-- 【必須】 -->

- [x] REQ-015-001（経路C分）: intake-promote command SPEC に発動条件判定 Step と review 呼出 Step が分離された review 挿入境界節が存在する
- [x] REQ-015-002（経路C分）: ユーザー明示指定時に intake-promote で review が発動することが明記される
- [x] REQ-015-003（経路C分）: 条件非該当時は従来フローが維持されることが明記される
- [x] REQ-015-006: review 挿入位置が「暫定分類生成後・ユーザ提示前」と一意に特定可能である
- [x] REQ-015-006: agentdev-intake-pipeline SPEC に候補判断基準と内部手続きが規定される

※ チェックボックスの評価は case-close QG-4 の責務（G24）。本 PR では完了条件の実装証拠を本文に示す。

## テスト結果

<!-- 【必須】 -->

- **TS-001（経路C分）検証**: PASS
  - target_item: AG-008
  - verification: intake-promote command SPEC 経路C 節に review 挿入境界が存在することを確認
  - pass_criteria: intake-promote command SPEC 経路C 節に発動条件 Step と呼出 Step が分離されている
  - 証拠: docs/specs/commands/intake-promote.md「adversarial-review 挿入境界（経路C）」節の「発動条件判定 Step と review 呼出 Step の分離（REQ-015-001）」subsection + 2 Step 役割表
- **docs 整合性検査**（check_changed_docs.ts --workflow case-run --files ...）: PASS
  - files_checked: 2 件（docs/specs/commands/intake-promote.md, docs/specs/skills/agentdev-intake-pipeline.md）
  - coupled_files_checked: docs/README.md, docs/specs/README.md
  - failures: 0, warnings: 0
- **lsp_diagnostics**: .md 用 LSP サーバー未設定のため N/A（markdown diagnostic 対象外）
- **手動 QG-3 検証**: REQ-015-001/002/003/006（5 完了条件）すべて SPEC/command 定義/SKILL で明記済み（「実装内容」節の各要件別記載を参照）

## 品質メトリクス

<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| REQ-015-001（経路C分）充足（QG-3） | 発動条件判定 Step（Step 4a）と review 呼出 Step（Step 4b）が command 定義で分離、SPEC で役割表明示 | 分離 | ✅ |
| REQ-015-002（経路C分）充足（QG-3） | ユーザー明示指定時に必ず発動と SPEC/command 定義へ明記 | 明記 | ✅ |
| REQ-015-003（経路C分）充足（QG-3） | 条件非該当時は従来フロー維持と SPEC/command 定義へ明記 | 明記 | ✅ |
| REQ-015-006 挿入位置（QG-3） | Step 4 完了後・Step 5 開始前と一意特定可能 | 一意 | ✅ |
| REQ-015-006 候補判断・内部手続き（QG-3） | intake-pipeline SPEC へ候補判断基準・内部手続き表を規定 | 規定 | ✅ |
| docs 整合性検査（case-run） | failures 0, warnings 0 | strict severity 0 件 | ✅ |
| 変更ファイル数 | 5 | scope 内 | ✅ |
| 行数変化 | +123/-5 | – | – |
| lsp_diagnostics | N/A（.md 用 LSP サーバー未設定） | – | – |

## Findings/ Capture候補

<!-- 【必須】 -->

### intake

該当なし

### learning

該当なし

## 決定事項

- Step 挿入方式: 既存 Step 5-11 の番号を維持し、Step 4 と Step 5 の間へ Step 4a / Step 4b を sub-letter で挿入。下流参照（G06-G19、REQ-003-003/008 等）への影響を最小化しつつ、発動条件判定 Step と review 呼出 Step の分離（REQ-015-001）を明確に達成
- SPEC 正典分離: intake-promote command SPEC は経路C 固有の挿入境界・発動条件・戻り先を所有し、agentdev-intake-pipeline SPEC は domain skill 側の候補判断基準・内部手続きを所有。共通契約（REQ-014）は adversarial-review SPEC へ集約し重複規範禁止（REQ-014-011）に従う

## SPEC確定候補

該当なし。本 PR は spec-save で確定済みのセクション見出しへ本文を実装するものであり、新規 SPEC schema、enum、判定表、内部アルゴリズムの追加はない。

## 関連Issue

<!-- 【必須】 -->

Parent: #1962
Closes #1966