### PR TITLE
feat(inspect-promote): REQ-015 経路B adversarial-review caller integration (#1965)

### DIFF
--- a/docs/specs/commands/inspect-promote.md
+++ b/docs/specs/commands/inspect-promote.md
@@ -82,6 +82,65 @@ updated: 2026-07-18
 
 ## adversarial-review 挿入境界（経路B）
 
-経路B の review 挿入境界: 発動条件（暫定分類後・HITL 前）、--auto 経路の review 挿入迂回
-（fast path）を規定する。
+本節は inspect-promote からの adversarial-review 呼出統合（REQ-015 経路B）を正典として所有する。共通契約（任意性、副作用禁止、QG/HITL 非代替、呼出失敗時取扱い、再 review 条件、停止条件4点、accepted finding 反映責務、正規所有者マトリックス）は adversarial-review SPEC「adversarial-review caller integration 共通契約」節を正とし、本節は再定義しない（REQ-014-011）。本節は経路B 固有の挿入位置、発動条件判定 Step、review 呼出 Step、--auto fast path を所有する。
+
+### review 挿入位置（REQ-015-005）
+
+review 挿入位置は現行 Step 構造へ一意に特定する。「暫定分類後・HITL 前」とは、Step 4（自動 promote、`--auto` opt-in 時のみ）の完了時点から Step 5（HITL 確定、手動分類対象）の開始前までを指す。
+
+| 境界 | 直前 Step | 直後 Step |
+|---|---|---|
+| 暫定分類後・HITL 前 | Step 4（自動 promote、`--auto` opt-in 時のみ） | Step 5（HITL 確定） |
+
+- 「暫定分類後」: Step 3（検出事項分類）の暫定分類結果を前提とし、Step 4（`--auto` による自動 promote 対象の抽出、投入）が完了した時点
+- 「HITL 前」: Step 5（HITL 確定）によるユーザー承認を得る前の時点
+- review 対象: 自動 promote 対象外で Step 5（HITL 確定）へ進む手動分類対象の検出事項。当該検出事項の暫定分類結果（promote/ defer/ reject 判定と根拠）を入力コンテキストとする
+
+### --auto 経路の review 挿入迂回（fast path）（REQ-015-005）
+
+`--auto` opt-in により Step 4 で自動 promote された検出事項は HITL を経由しない fast path となり、review 挿入境界を迂回する。当該検出事項は `.agentdev/intake/promoted/inspect-auto-*.md` へ直接投入され、adversarial-review の対象外となる。
+
+- fast path 対象: Step 4 で自動 promote された検出事項（高確信度、自動 promote 対象カテゴリ合致）
+- review 対象（fast path 外）: 自動 promote 対象外で手動分類へ回された検出事項
+
+`--auto` opt-in の有無と review 挿入境界の発動関係は次のとおり。
+
+| `--auto` opt-in | 自動 promote 対象 | 手動分類対象 | review 挿入境界 |
+|---|---|---|---|
+| あり | あり | あり | 手動分類対象について発動条件を満たせば発動（fast path 対象は迂回） |
+| あり | あり | なし | 発動しない（全件 fast path 完了、HITL 対象なし） |
+| あり | なし | あり | 手動分類対象について発動条件を満たせば発動 |
+| なし | — | あり | 手動分類対象について発動条件を満たせば発動 |
+| なし | — | なし | 発動しない（inbox 空、Step 2 で終了） |
+
+### 発動条件判定 Step（REQ-015-001）
+
+発動条件判定 Step と review 呼出 Step は分離する（REQ-015-001）。発動条件判定 Step は review 挿入位置（暫定分類後・HITL 前）で次の3条件を全て満たす場合にのみ review 呼出 Step へ進む。
+
+1. Step 4（自動 promote、`--auto` opt-in 時のみ）が完了していること
+2. 手動分類対象の検出事項（review 対象）が1件以上存在すること
+3. ユーザー明示指定（本コマンド起動時の adversarial-review への明示要求）があること（REQ-015-002）
+
+### review 呼出 Step（REQ-015-001）
+
+review 呼出 Step は review 対象（手動分類対象の検出事項、暫定分類結果）を入力コンテキストとして adversarial-review を呼び出す。入力コンテキスト、返却契約、呼出失敗時取扱い、再 review 停止条件は adversarial-review SPEC を正とする。
+
+呼出結果の取扱い:
+
+- accepted finding は本コマンドの責務で暫定分類結果へ反映する（REQ-014-006）。adversarial-review 自身は反映を行わない（REQ-014-004）
+- finding 反映で暫定分類の意味内容が変更された場合、Step 3（検出事項分類）へ戻し再分類する。再 review 条件と停止条件4点は adversarial-review SPEC に従う（REQ-014-007/008）
+- unresolved な本質的争点が残る場合、Step 5（HITL 確定）へ進まず、ユーザー判断事項として停止する（REQ-014-009）。ただし adversarial-review 自体を恒久的な統制ゲートとしない
+- 呼出失敗時は silent skip を禁止し、利用不能を報告した上で Step 5（HITL 確定）の従来フローを維持する（REQ-014-010）
+
+### ユーザー明示指定時の発動（REQ-015-002）
+
+adversarial-review は任意助言手段であり（REQ-014-001）、本コマンド起動時にユーザーが adversarial-review を明示的に要求した場合にのみ発動する。自動発動、全件強制発動を行わない。明示要求のない場合は後述「条件非該当時の従来フロー維持」に従う。
+
+### 条件非該当時の従来フロー維持（REQ-015-003）
+
+発動条件判定 Step の3条件のいずれかを満たさない場合、review 呼出 Step を実行せず Step 5（HITL 確定）へ従来フローを維持する（REQ-015-003）。従来フロー（Step 5 HITL 確定以降の Step 6〜10）は変更せず、adversarial-review 由来の新規統制ゲートを作らない（REQ-014-009）。
+
+### 正規所有者宣言
+
+review 挿入境界（経路B の発動条件、挿入位置、戻り先、--auto fast path）は本 SPEC が正規所有する（REQ-014-011、REQ-015-005）。共通 caller integration 契約は adversarial-review SPEC を正とし、本節は再定義しない。user-decision-required の停止理由分類は workflow-contracts SPEC、review 経路での parent_decision_required / decision_context 適用は delegation-contracts SPEC をそれぞれ正とする。
 

--- a/src/opencode/commands/agentdev/inspect-promote.md
+++ b/src/opencode/commands/agentdev/inspect-promote.md
@@ -55,6 +55,27 @@ description: 検出事項を分類、採用し、採用済み成果物として 
 `--auto` が指定された場合、分類結果のうち workflow-contracts SPEC（extension 経由）の自動 promote 対象カテゴリに合致し、かつ安定契約例外および否定文脈を満たさない高確信度検出事項を HITL 承認なしで `.agentdev/intake/promoted/inspect-auto-{timestamp}-{slug}.md` へ投入する。
 各投入を `.agentdev/inspect/promoted/auto-promote-log.md` に追記する（対象検出事項、カテゴリ、投入先ファイル、根拠）。
 `--auto` 未指定時は本 step をスキップし、自動投入を行わない
+
+### Step 4-1: adversarial-review 発動条件判定（経路B）
+
+review 挿入境界（暫定分類後・HITL 前）で発動条件を判定する（REQ-015-001、REQ-015-005、詳細は inspect-promote SPEC「adversarial-review 挿入境界（経路B）」節参照）。次の3条件を全て満たす場合のみ Step 4-2（review 呼出）へ進む。
+
+1. Step 4（自動 promote、`--auto` opt-in 時のみ）が完了していること
+2. 手動分類対象の検出事項（Step 5 HITL 確定へ進む対象）が1件以上存在すること
+3. ユーザー明示指定（本コマンド起動時の adversarial-review への明示要求）があること（REQ-015-002）
+
+`--auto` により Step 4 で自動 promote された検出事項は HITL を経由しない fast path であり、本判定、Step 4-2 の対象外とする（REQ-015-005、review 挿入迂回）。3条件のいずれかを満たさない場合、Step 4-2 を実行せず Step 5（HITL 確定）へ従来フローを維持する（REQ-015-003）
+
+### Step 4-2: adversarial-review 呼出（経路B）
+
+Step 4-1 の発動条件を満たした場合、手動分類対象の検出事項とその暫定分類結果（promote/ defer/ reject 判定と根拠）を入力コンテキストとして adversarial-review を呼び出す（REQ-015-001、REQ-015-002）。adversarial-review は任意助言手段であり、必須工程、QG、承認ゲート、統制ゲートとして導入しない（REQ-014-001）。共通契約（入力コンテキスト、返却契約、呼出失敗時取扱い、再 review 条件、停止条件4点）は adversarial-review SPEC を正とし、本 step は再定義しない
+
+呼出結果の取扱い:
+
+- accepted finding を暫定分類結果へ反映する（REQ-014-006、本コマンドの責務）。反映で暫定分類の意味内容が変更された場合、Step 3（検出事項分類）へ戻し再分類する
+- unresolved な本質的争点が残る場合、Step 5（HITL 確定）へ進まず、ユーザー判断事項として停止する（REQ-014-009）。adversarial-review 自体を恒久的な統制ゲートとしない
+- 呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し、利用不能を報告した上で Step 5（HITL 確定）の従来フローを維持する（REQ-014-010、REQ-015-003）
+
 ### Step 5: HITL 確定（手動分類対象）
 
 自動 promote 対象外の検出事項はユーザーの明示的な承認なしに採用済み成果物を生成しない。分類結果を提示し、承認を得る


### PR DESCRIPTION
## 概要

<!-- 【必須】 -->

Issue #1965（Epic #1962 Wave 2 子Issue、OU-002 経路B、REQ-015 inspect-promote）の実装。adversarial-review caller integration の経路B（inspect-promote）挿入境界を inspect-promote command SPEC と inspect-promote command 定義へ実装する。spec-save で追加済みの節見出し（`## adversarial-review 挿入境界（経路B）`）に対し、各要件を明記する本文を実装する。

## 実装内容

<!-- 【必須】 -->

REQ-015 経路B（REQ-015-001/002/003/005）を inspect-promote command SPEC と command 定義へ実装した。

**SPEC**（`docs/specs/commands/inspect-promote.md`）の `## adversarial-review 挿入境界（経路B）` 節へ本文を実装:

- **review 挿入位置（REQ-015-005）**: 暫定分類後（Step 4 完了）・HITL 前（Step 5 開始前）を現行 Step 構造へ一意特定する境界表
- **--auto 経路の review 挿入迂回 fast path（REQ-015-005）**: `--auto` opt-in により Step 4 で自動 promote された検出事項は HITL 経由せず review 挿入境界を迂回する fast path となる。`--auto` opt-in × 自動 promote 対象 × 手動分類対象 × review 挿入境界の発動関係を整理した判定表
- **発動条件判定 step（REQ-015-001）**: 発動条件判定 Step と review 呼出 Step を分離。3条件（Step 4 完了、手動分類対象 1件以上、ユーザー明示指定）を全て満たす場合のみ review 呼出 Step へ進む
- **review 呼出 step（REQ-015-001）**: 入力コンテキスト、呼出結果の取扱い（accepted finding 反映責務 REQ-014-006、unresolved 時停止 REQ-014-009、呼出失敗時 silent skip 禁止 REQ-014-010）
- **ユーザー明示指定時の発動（REQ-015-002）**: 任意助言手段（REQ-014-001）、自動発動しない
- **条件非該当時の従来フロー維持（REQ-015-003）**: 発動条件3条件のいずれかを満たさない場合、Step 5（HITL 確定）へ従来フローを維持
- **正規所有者宣言（REQ-014-011）**: 共通 caller integration 契約は adversarial-review SPEC を正とし再定義しない。user-decision-required は workflow-contracts SPEC、parent_decision_required / decision_context は delegation-contracts SPEC をそれぞれ正とする

**command 定義**（`src/opencode/commands/agentdev/inspect-promote.md`）へ review 挿入 Step を追加:

- **Step 4-1: adversarial-review 発動条件判定（経路B）**: Step 4（自動 promote）と Step 5（HITL 確定）の間に配置。3条件判定、`--auto` fast path 対象外、条件非該当時は Step 5（HITL 確定）へ従来フロー維持
- **Step 4-2: adversarial-review 呼出（経路B）**: 手動分類対象と暫定分類結果を入力コンテキストとして adversarial-review を呼出。呼出結果の取扱い（accepted finding 反映で Step 3 へ戻す、unresolved 時は Step 5 へ進まず停止、呼出失敗時は silent skip 禁止で Step 5 従来フロー維持）

共通契約（REQ-014-001〜012）は adversarial-review SPEC、workflow-contracts SPEC、delegation-contracts SPEC（子 Issue #1963 で実装済み）を正とし、本 PR では経路B 固有の挿入境界、発動条件、戻り先、fast path のみを所有する。

## 完了条件

<!-- 【必須】 -->

- [x] REQ-015-001（経路B分）: inspect-promote command SPEC に発動条件判定 Step と review 呼出 Step が分離された review 挿入境界節が存在する
- [x] REQ-015-002（経路B分）: ユーザー明示指定時に inspect-promote で review が発動することが明記される
- [x] REQ-015-003（経路B分）: 条件非該当時は従来フローが維持されることが明記される
- [x] REQ-015-005: review 挿入位置が「暫定分類後・HITL 前」と一意に特定可能である
- [x] REQ-015-005: --auto 経路が review 挿入を迂回することが明記される

※ チェックボックスの評価は case-close QG-4 の責務（G24）。本 PR では完了条件の実装証拠を本文に示す。

## テスト結果

<!-- 【必須】 -->

- **TS-001（経路B分、target: AG-008）**: PASS
  - verification: `docs/specs/commands/inspect-promote.md` の `## adversarial-review 挿入境界（経路B）` 節に review 挿入境界が存在することを確認
  - pass_criteria: 経路B 節に `### 発動条件判定 Step（REQ-015-001）` と `### review 呼出 Step（REQ-015-001）` が分離されて存在。command 定義にも Step 4-1（発動条件判定）と Step 4-2（review 呼出）が分離されて存在
- **TS-011（target: AG-011）**: PASS
  - verification: inspect-promote SPEC の経路B 節に `--auto` 経路が review 挿入を迂回することが明記されていることを確認
  - pass_criteria: 経路B 節に `### --auto 経路の review 挿入迂回（fast path）（REQ-015-005）` 節が存在し、fast path 対象、review 対象、`--auto` opt-in × 対象有無 × 境界発動の判定表を明記
- **docs 整合性検査**（`check_changed_docs.ts --workflow case-run --files ...`）: PASS
  - files_checked: 1 件（docs/specs/commands/inspect-promote.md）
  - coupled_files_checked: docs/README.md, docs/specs/README.md
  - failures: [], warnings: []
- **check_extensions.ts**: PASS（`ok: true`）。6件の warning は全て既存 extension（`repo-agentdev-artifact-graph` 参照）由来で本 PR 由来ではない
- **lsp_diagnostics**: .md 用 LSP サーバー未設定のため N/A（markdown diagnostic 対象外）
- **encoding**: 変更ファイル両方とも先頭3バイト `2D 2D 2D`（`---` frontmatter）で UTF-8 BOM なしを維持

## 品質メトリクス

<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| REQ-015-001/002/003/005 充足（QG-3） | 5/5 完了条件 | 全完了条件 | ✅ |
| docs 整合性検査（case-run） | failures 0, warnings 0 | strict severity 0 件 | ✅ |
| check_extensions | ok: true（6 warning は既存由来） | ok: true | ✅ |
| 変更ファイル数 | 2 | scope 内 | ✅ |
| 行数変化 | +82/-2 | – | – |
| lsp_diagnostics | N/A（.md 用 LSP サーバー未設定） | – | – |

## Findings/ Capture候補

<!-- 【必須】 -->

### intake

該当なし

### learning

該当なし

## 決定事項

- **review 挿入境界の Step 番号付け**: 既存 Step 番号（Step 1〜10）への影響を最小化するため、`### Step 4-1`、`### Step 4-2` の sub-step 表記を採用（case-run.md の Step 5-1〜5-4 パターンに準拠）。これにより「Step 4 完了後・Step 5 開始前」という REQ-015-005 の一意特定要件を満たしつつ、後続 Step（Step 5〜10）の番号変更を回避した
- **fast path 定義の明確化**: `--auto` opt-in 時に Step 4 で自動 promote された検出事項のみを fast path とし、`--auto` opt-in あり・自動 promote 対象外で手動分類へ回された検出事項は review 挿入境界の対象（ユーザー明示指定時発動）とした。これは REQ-015-005「`--auto` 経路は review 挿入を迂回する」の「経路」を「自動 promote 対象の fast path」と解釈した結果
- **共通契約の再定義回避**: REQ-014-011（重複規範禁止）に従い、SPEC 本文の冒頭と「正規所有者宣言」節で共通契約は adversarial-review SPEC を正とすることを明記し、REQ-014-001/004/006/007/008/009/010 は参照のみとした

## 関連Issue

<!-- 【必須】 -->

Parent: #1962
Closes #1965
