### PR TITLE
feat(adversarial-review): REQ-015 経路D learning-promote review 挿入境界 (#1967)

### DIFF
--- a/docs/specs/commands/learning-promote.md
+++ b/docs/specs/commands/learning-promote.md
@@ -116,6 +116,48 @@ learning-promote は change_nature と併せて、observed_evidence（根拠と�
 
 ## adversarial-review 挿入境界（経路D）
 
-経路D の review 挿入境界: 発動条件（既存対策確認後・判定結果提示前）、
-review 反映時の evaluation-report 更新へ戻し、関連 Step 再実行ループを規定する。
+本節は learning-promote 経路D の review 挿入境界を正典として所有する（REQ-015-007）。共通 caller integration 契約（任意性、副作用禁止、accepted finding 反映、再 review 条件と停止条件、呼出失敗時取扱い）は `agentdev-adversarial-review` SPEC「adversarial-review caller integration 共通契約」節（REQ-014）が正規所有し、本節は再定義しない。本節は経路D 固有の発動条件、挿入位置、戻り先、Step 6 戻しループのみを所有する。
+
+### 発動条件判定 Step と review 呼出 Step の分離（REQ-015-001/002/003）
+
+経路D は発動条件判定 Step と review 呼出 Step を分離する。両 Step を分離することで、条件非該当時は review 呼出を迂回して従来フロー（Step 8 → Step 9）を維持する（REQ-015-003）。
+
+#### 発動条件判定 Step
+
+発動条件は Step 8（既存対策確認）の完了直後、Step 9（ユーザーへの判定結果提示）の前に判定する（REQ-015-007）。この位置は inbox → deferred 移動（Step 13）、prune（Step 14）、commit/push（Step 15）等の不可逆処理に先立つ。
+
+発動条件は次のいずれも満たすこととする。
+
+- ユーザーが review を明示的に要求していること（REQ-015-002）。明示要求がない場合は発動しない
+- 判定対象（正規化済エントリ、問題クラス分類、8軸評価、廃棄判定、既存対策照合結果）が evaluation-report.md へ反映済みであること
+
+明示要求のない限り review は発動せず、従来フローを維持する（REQ-014-001、REQ-015-003）。adversarial-review を新規必須工程、QG、承認ゲートとして扱わない。
+
+#### review 呼出 Step
+
+発動条件が成立した場合のみ、Step 8 と Step 9 の間に review 呼出 Step を実行する。呼出 Step は evaluation-report.md の判定結果（正規化、問題クラス分類、8軸評価、廃棄判定、既存対策照合）を review 対象として渡す。呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し、利用不能を報告した上で従来フローと既存 QG/HITL を維持する（REQ-014-010）。
+
+### review 反映時の evaluation-report 更新戻しと関連 Step 再実行（REQ-015-007）
+
+review で accepted finding が提示され、呼出元が判定対象へ反映した場合、意味内容が変更されたときは evaluation-report.md の更新へ戻し、関連 Step を再実行する。手続きは次のとおり。
+
+1. accepted finding を判定対象（正規化結果、問題クラス分類、8軸評価、廃棄判定、既存対策照合）へ反映する（REQ-014-006）。反映は呼出元の責務であり、adversarial-review 自身は行わない
+2. 反映結果で evaluation-report.md を更新するため Step 6 へ戻る
+3. Step 6（evaluation-report 生成、更新）→ Step 7（廃棄判定）→ Step 8（既存対策確認）→ 発動条件判定 Step → review 呼出 Step の順に再実行する
+
+再 review の発動は、反映により review 対象の意味内容が変更され、新たな本質的争点が生じ得る場合にのみ許容する（REQ-014-007）。新証拠、新前提、異なる failure condition、未評価範囲のいずれも伴わない同一 finding の再起票を禁止する。再 review の停止条件（REQ-014-008）を満たした時点でループを離脱し、Step 9 へ進む。
+
+unresolved な本質的争点またはユーザー判断事項が残る場合、Step 9（判定結果提示）、Step 10（ユーザー承認）、Step 13（deferred 移動）、Step 14（prune）、Step 15（commit/push）等の不可逆処理へ進まない（REQ-014-009）。ただし adversarial-review 自体を恒久的な統制ゲートとしない。unresolved は既存の HITL（Step 10 ユーザー承認）または blocker 扱いへ振り向ける。
+
+### 挿入位置の一意特定（REQ-015-007）
+
+経路D の review 挿入位置は Step 8（既存対策確認）完了直後、Step 9（ユーザーへの判定結果提示）前である。最初の不可逆副作用は Step 11（git pull）以降（Step 13 deferred 移動、Step 14 prune、Step 15 commit/push）であり、review 挿入位置は全不可逆処理に先立つ。handoff.md、promoted/ 等の成果物は review より後の Step で生成されるため、review 時点では存在せず、review 対象は evaluation-report.md のみとなる。
+
+### 正規所有者と参照関係
+
+| 意味 | 正規所有者 |
+|---|---|
+| 経路D の発動条件、挿入位置、戻り先、Step 6 戻しループ | 本 SPEC（learning-promote command SPEC） |
+| 候補判断基準、内部手続き（候補確定位置、呼出タイミング、evaluation-report 反映、Step 6 戻しループの実装詳細） | `agentdev-learning-pipeline` domain skill SPEC（ACT-SPEC-013） |
+| 共通 caller integration 契約（任意性、副作用禁止、accepted finding 反映、再 review 条件、停止条件、呼出失敗時取扱い） | `agentdev-adversarial-review` SPEC（REQ-014） |
 

--- a/docs/specs/skills/agentdev-learning-pipeline.md
+++ b/docs/specs/skills/agentdev-learning-pipeline.md
@@ -59,6 +59,50 @@ schema、分類基準、評価ディメンション、prune 方針を定義す�
 
 ## adversarial-review 候補判断と内部挿入
 
-learning-promote 経路D における review 候補判断基準と内部手続き（候補確定位置、
-呼出タイミング、evaluation-report 反映、Step 6 戻しループ）を規定する。
+本節は learning-promote 経路D における review 候補判断基準と内部手続きを正典として所有する（ACT-SPEC-013、REQ-015-007）。経路D の発動条件、挿入位置、戻り先、Step 6 戻しループは learning-promote command SPEC「adversarial-review 挿入境界（経路D）」節が正規所有し、本節は再定義しない。共通 caller integration 契約（任意性、副作用禁止、accepted finding 反映、再 review 条件と停止条件、呼出失敗時取扱い）は `agentdev-adversarial-review` SPEC（REQ-014）が正規所有する。本節は learning-promote が参照する本 skill 内部の候補判断、呼出タイミング、evaluation-report 反映、Step 6 戻しループの実装詳細を所有する。
+
+### 候補判断基準
+
+review 候補は learning-promote command SPEC「発動条件判定 Step」が定める条件を満たす場合に確定する。本 skill は候補確定に必要な入力（正規化結果、問題クラス分類、8軸評価スコア、廃棄判定、既存対策照合結果）を evaluation-report.md へ集約し、候補判断が evaluation-report.md のみを参照して完結するよう保証する。候補判断基準は次のとおり。
+
+- ユーザーが review を明示要求していること（REQ-015-002）。明示要求がない場合は候補を確定しない
+- evaluation-report.md が Step 6 で生成・更新済みであり、Step 7（廃棄判定）と Step 8（既存対策確認）の結果が反映されていること
+- review 対象が未確定の判定要素を含まないこと。inbox → deferred 移動、prune、promoted 成果物生成等の不可逆処理が実行されていないこと
+
+### 内部手続き
+
+#### 候補確定位置
+
+候補は Step 8（既存対策確認）完了直後、Step 9（ユーザーへの判定結果提示）前に確定する。候補確定位置は learning-promote command SPEC「発動条件判定 Step」と同一位置である。候補確定後、review 呼出 Step へ進む。
+
+#### 呼出タイミング
+
+呼出タイミングは候補確定直後であり、Step 9 へ進む前である。review 対象は evaluation-report.md のみとし、handoff.md、promoted/、deferred.md への反映前とする。この順序により、accepted finding の反映結果が evaluation-report.md へ集約され、後続の不可逆処理（Step 13 deferred 移動、Step 14 prune、Step 15 commit/push）へ混入しない。
+
+呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止する（REQ-014-010）。learning-promote は利用不能を報告し、従来フロー（Step 9 ユーザーへの判定結果提示以降）と既存 HITL（Step 10 ユーザー承認）を維持する。
+
+#### evaluation-report 反映
+
+accepted finding は learning-promote が責任を持って判定対象（正規化結果、問題クラス分類、8軸評価スコア、廃棄判定、既存対策照合結果）へ反映する（REQ-014-006）。adversarial-review 自身は反映を行わない。反映結果は evaluation-report.md へ集約し、Step 9 の提示内容、Step 13 の deferred 移動、Step 14 の prune、promoted 成果物が反映後の evaluation-report.md と整合するよう維持する。
+
+#### Step 6 戻しループ
+
+accepted finding を反映し、review 対象の意味内容が変更された場合は Step 6 へ戻し、関連 Step を再実行する（REQ-015-007）。ループの実行手続きは次のとおり。
+
+1. accepted finding を判定対象へ反映する（REQ-014-006）
+2. Step 6（evaluation-report 生成、更新）へ戻り、反映結果を evaluation-report.md へ集約する
+3. Step 7（廃棄判定、11カテゴリ + duplicate）を再実行する
+4. Step 8（既存対策確認）を再実行する
+5. 発動条件判定 Step を再実行し、review 呼出 Step を再実行する（REQ-014-007）。再 review の発動は反映により review 対象の意味内容が変更され、新たな本質的争点が生じ得る場合にのみ許容する
+6. 再 review 停止条件（REQ-014-008）を満たした時点でループを離脱し、Step 9 へ進む
+
+ループ中に unresolved な本質的争点またはユーザー判断事項が残る場合、Step 9（判定結果提示）、Step 10（ユーザー承認）、Step 13（deferred 移動）、Step 14（prune）、Step 15（commit/push）等の不可逆処理へ進まない（REQ-014-009）。unresolved は既存の HITL（Step 10 ユーザー承認）または blocker 扱いへ振り向ける。adversarial-review 自体を恒久的な統制ゲートとしない。
+
+### 正規所有者と参照関係
+
+| 意味 | 正規所有者 |
+|---|---|
+| 経路D の発動条件、挿入位置、戻り先、Step 6 戻しループ（command 視点） | learning-promote command SPEC（ACT-SPEC-009） |
+| 候補判断基準、内部手続き（候補確定位置、呼出タイミング、evaluation-report 反映、Step 6 戻しループの実装詳細） | 本 SPEC（agentdev-learning-pipeline domain skill SPEC、ACT-SPEC-013） |
+| 共通 caller integration 契約 | `agentdev-adversarial-review` SPEC（REQ-014） |
 

--- a/src/opencode/commands/agentdev/learning-promote.md
+++ b/src/opencode/commands/agentdev/learning-promote.md
@@ -73,6 +73,41 @@ description: inbox.mdから正規化、分類、8軸評価、HITL確定を経て
 
 `agentdev-learning-pipeline` を参照
 
+### Step 8-R1: adversarial-review 発動条件判定（経路D）
+
+`agentdev-learning-pipeline` の「adversarial-review 候補判断と内部挿入」節（経路D）を参照。本 Step は発動条件判定のみを行い、review 呼出（Step 8-R2）と分離する（REQ-015-001）。
+
+発動条件は次のいずれも満たすこと。
+
+- ユーザーが adversarial-review を明示的に要求していること（REQ-015-002）。明示要求がない場合は発動せず、Step 9 へ進む（REQ-015-003）
+- evaluation-report.md が Step 6 で生成・更新済みであり、Step 7（廃棄判定）と Step 8（既存対策確認）の結果が反映されていること
+
+明示要求がない限り review は発動せず、従来フローを維持する。adversarial-review は任意助言手段であり、新規必須工程、QG、承認ゲートとして導入しない（REQ-014-001）。共通 caller integration 契約の正規所有者は `agentdev-adversarial-review` SPEC（REQ-014）である。
+
+発動条件成立時は Step 8-R2 へ進む。非成立時は Step 8-R2 を迂回し Step 9 へ進む。
+
+### Step 8-R2: adversarial-review 呼出（経路D）
+
+`agentdev-learning-pipeline` の「adversarial-review 候補判断と内部挿入」節（経路D）を参照。本 Step は review 呼出のみを行い、発動条件判定（Step 8-R1）と分離する（REQ-015-001）。
+
+review 対象は evaluation-report.md のみとする（正規化結果、問題クラス分類、8軸評価スコア、廃棄判定、既存対策照合結果）。inbox → deferred 移動（Step 13）、prune（Step 14）、commit/push（Step 15）等の不可逆処理は未実行である。
+
+呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し（REQ-014-010）、利用不能を報告した上で従来フロー（Step 9 以降）と既存 HITL（Step 10 ユーザー承認）を維持する。
+
+accepted finding は learning-promote が責任を持って判定対象へ反映する（REQ-014-006）。adversarial-review 自身は反映を行わない。
+
+review 反映時（review 対象の意味内容が変更された場合）は Step 6 へ戻り、次の順で関連 Step を再実行する（REQ-015-007、Step 6 戻しループ）。
+
+1. Step 6（evaluation-report 生成、更新）: accepted finding の反映結果を evaluation-report.md へ集約
+2. Step 7（廃棄判定）: 反映後の判定結果で再判定
+3. Step 8（既存対策確認）: 反映後の対策照合結果で再確認
+4. Step 8-R1（発動条件判定）: 再発動可否を判定
+5. Step 8-R2（review 呼出）: REQ-014-007 が定める再 review 発動条件（新たな本質的争点が生じ得る場合）を満たす場合のみ再 review
+
+再 review の停止条件（REQ-014-008、4点）を満たした時点でループを離脱し、Step 9 へ進む。新証拠、新前提、異なる failure condition、未評価範囲のいずれも伴わない同一 finding の再起票を禁止する（REQ-014-007）。
+
+unresolved な本質的争点またはユーザー判断事項が残る場合、Step 9（判定結果提示）、Step 10（ユーザー承認）、Step 13（deferred 移動）、Step 14（prune）、Step 15（commit/push）等の不可逆処理へ進まない（REQ-014-009）。unresolved は既存の HITL（Step 10 ユーザー承認）または blocker 扱いへ振り向ける。adversarial-review 自体を恒久的な統制ゲートとしない。
+
 ### Step 9: ユーザーへの判定結果提示
 
 `agentdev-learning-pipeline` を参照
@@ -134,6 +169,7 @@ template: `.opencode/commands/agentdev/templates/learning-promote/standard.md`�
 - G08: `learning-refine` への依存禁止: 本コマンドは旧機能を内包し事前実行を前提としない
 - G09: 破壊的変更（inbox.md 全体強制クリア、大量エントリ一括削除等）は Step 10 承認とは別に明示承認を維持する（REQ）
 - G10: 無条件の自動REQ化禁止（REQ）: 学びを直接 REQ 化しない。恒久契約（REQ/ADR/SPEC）への昇華可能性を Step 7 で評価し、昇華可能なもののみ `promoted/` へ出力する。昇華不能な知見は living pool（`deferred.md`）で維持する
+- G11: adversarial-review は任意助言手段（経路D、REQ）: ユーザー明示要求時のみ Step 8-R1（発動条件判定）→ Step 8-R2（review 呼出）を経て発動する。明示要求時以外は Step 9 へ従来フローを維持する。review 反映時は Step 6 へ戻し関連 Step を再実行する（REQ-015-007）。共通契約（任意性、副作用禁止、再 review 条件、停止条件、呼出失敗時取扱い）は `agentdev-adversarial-review` SPEC（REQ-014）が正規所有する
 
 ## ユーザー確認ポイント、エラー処理
 

--- a/src/opencode/skills/agentdev-learning-pipeline/SKILL.md
+++ b/src/opencode/skills/agentdev-learning-pipeline/SKILL.md
@@ -67,6 +67,7 @@ pipeline 各層を構成する 4 成果物の役割、性格、command 間の振
 - raw learning item を実行時コマンド/ skill の直接参照対象にしない
 - ADR 候補分類の前に `agentdev-adr-guidelines` の除外基準（禁止条件フィルタリングゲート）を必須適用する
 - `case-run` への直接受け渡しは禁止（`backlog-review` → `req-define` を経由すること）
+- **adversarial-review は任意助言手段（経路D、REQ）**: ユーザー明示要求時のみ Step 8-R1（発動条件判定）→ Step 8-R2（review 呼出）を経て発動する。明示要求がない場合は Phase 5 へ従来フローを維持する（REQ-015-002/003）。共通 caller integration 契約（任意性、副作用禁止、再 review 条件、停止条件、呼出失敗時取扱い）は `agentdev-adversarial-review` SPEC（REQ-014）が正規所有する。本 skill は経路D 固有の候補判断、呼出タイミング、evaluation-report 反映、Step 6 戻しループの実装詳細のみを提供する
 
 ## 主要な判断順序
 
@@ -85,7 +86,7 @@ pipeline 各層を構成する 4 成果物の役割、性格、command 間の振
 |---|---|
 | inbox entry の13フィールド schema、旧5フィールドからのマッピング、正規化ルール、問題クラス分類基準、8軸評価ディメンション、禁止条件フィルタリングゲート、evaluation-report schema が必要な場合 | [references/inbox-and-evaluation-schema.md](references/inbox-and-evaluation-schema.md) |
 | 処分区分（11カテゴリ + duplicate）、反映先マッピング、既存対策照合、採用済み成果物スキーマ、カテゴリ別反映先パス例、プロジェクト固有知識の振り分け、prune 方針詳細が必要な場合 | [references/disposition-and-artifact-schema.md](references/disposition-and-artifact-schema.md) |
-| learning-promote の Phase ごとの判定ロジック（正規化、分類、8軸評価、廃棄判定、HITL承認）を実行する場合 | [references/promote-judgment-logic.md](references/promote-judgment-logic.md) |
+| learning-promote の Phase ごとの判定ロジック（正規化、分類、8軸評価、廃棄判定、HITL承認）、経路D の review 候補判断と内部挿入（Step 8-R1/8-R2、Step 6 戻しループ）を実行する場合 | [references/promote-judgment-logic.md](references/promote-judgment-logic.md) |
 | inbox → deferred の原子的移動プロシージャ（追記、検証、クリア）を実行する場合 | [references/deferred-atomic-move-procedure.md](references/deferred-atomic-move-procedure.md) |
 
 ## 反映ルート

--- a/src/opencode/skills/agentdev-learning-pipeline/references/promote-judgment-logic.md
+++ b/src/opencode/skills/agentdev-learning-pipeline/references/promote-judgment-logic.md
@@ -46,6 +46,31 @@ learning-promote コマンドの Steps における判定ロジック（旧フ�
 - 確認対象とギャップ分類は `agentdev-learning-pipeline` skill の `references/disposition-and-artifact-schema.md`（既存対策照合）を参照
 - 「新規X化」より「既存Xへ反映」を優先
 
+## Phase 4-R: adversarial-review 候補判断と内部挿入（経路D）
+
+本 Phase は learning-promote 経路D における review 候補判断と内部手続きの実装詳細を提供する。経路D の発動条件、挿入位置、戻り先、Step 6 戻しループは learning-promote command SPEC「adversarial-review 挿入境界（経路D）」節と `agentdev-learning-pipeline` SPEC「adversarial-review 候補判断と内部挿入」節が正規所有し、本 Phase は再定義しない。共通 caller integration 契約は `agentdev-adversarial-review` SPEC（REQ-014）が正規所有する。
+
+### 候補判断（Step 8-R1）
+
+Phase 4（廃棄判定 + 既存対策確認）完了後、Phase 5（HITL 承認）前に候補判断を行う。候補は次のいずれも満たす場合に確定する。
+
+- ユーザーが adversarial-review を明示要求していること（REQ-015-002）
+- evaluation-report.md が Step 6 で生成・更新済みであり、Step 7（廃棄判定）と Step 8（既存対策確認）の結果が反映されていること
+
+候補確定後、Step 8-R2（review 呼出）へ進む。非成立時は Step 8-R2 を迂回し Phase 5 へ進む（REQ-015-003）。
+
+### review 呼出（Step 8-R2）
+
+review 対象は evaluation-report.md のみとする。呼出失敗時は silent skip を禁止し（REQ-014-010）、利用不能を報告した上で Phase 5 以降の従来フローと既存 HITL を維持する。
+
+accepted finding は learning-promote が責任を持って判定対象へ反映する（REQ-014-006）。adversarial-review 自身は反映を行わない。
+
+### Step 6 戻しループ
+
+accepted finding を反映し review 対象の意味内容が変更された場合、Step 6（evaluation-report 生成、更新）へ戻り、関連 Step を再実行する（REQ-015-007）。再実行順は Step 6 → Step 7（廃棄判定）→ Step 8（既存対策確認）→ Step 8-R1（候補判断）→ Step 8-R2（review 呼出）。再 review の発動は REQ-014-007 が定める条件（新たな本質的争点が生じ得る場合）を満たす場合のみ許容し、停止条件（REQ-014-008、4点）を満たした時点でループを離脱し Phase 5 へ進む。
+
+unresolved な本質的争点またはユーザー判断事項が残る場合、Phase 5（判定結果提示）、Phase 5 のユーザー承認、Phase 6（採用済み成果物生成、deferred 移動、prune、commit/push）等の不可逆処理へ進まない（REQ-014-009）。unresolved は既存の HITL（Step 10 ユーザー承認）または blocker 扱いへ振り向ける。
+
 ## Phase 5: HITL承認
 
 ### ユーザーへの判定結果提示


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

Issue #1967（Epic #1962 Wave 2 子Issue、OU-002 / REQ-015 経路D）の実装。learning-promote への adversarial-review caller integration を実装する。spec-save で追加済みの節見出しへ本文を実装し、REQ-015-001/002/003/007 を充足する。

## 実装内容

<!-- 【必須】 -->

REQ-015 経路D の review 挿入境界を5ファイルへ実装した。

**learning-promote command SPEC**（`docs/specs/commands/learning-promote.md`）
- 「adversarial-review 挿入境界（経路D）」節へ本文実装
  - 発動条件判定 Step と review 呼出 Step の分離（REQ-015-001/002/003）
  - 挿入位置の一意特定: Step 8（既存対策確認）完了直後、Step 9（ユーザーへの判定結果提示）前（REQ-015-007）
  - review 反映時の evaluation-report 更新戻しと関連 Step 再実行ループ（REQ-015-007）
  - 正規所有者マトリックス（共通契約 REQ-014 / 経路D command SPEC / 経路D domain skill SPEC）

**agentdev-learning-pipeline domain skill SPEC**（`docs/specs/skills/agentdev-learning-pipeline.md`）
- 「adversarial-review 候補判断と内部挿入」節へ本文実装（ACT-SPEC-013）
  - 候補判断基準、内部手続き（候補確定位置、呼出タイミング、evaluation-report 反映、Step 6 戻しループ）
  - 正規所有者と参照関係

**learning-promote command 定義**（`src/opencode/commands/agentdev/learning-promote.md`）
- Step 8（既存対策確認）と Step 9（ユーザーへの判定結果提示）の間へ Step 8-R1（発動条件判定）と Step 8-R2（review 呼出）を挿入
- Step 6 戻しループ（Step 6 → Step 7 → Step 8 → Step 8-R1 → Step 8-R2）を実装
- ガードレール G11 を追加（任意助言手段、明示要求時のみ発動、共通契約は REQ-014 が正規所有）

**agentdev-learning-pipeline SKILL.md**（`src/opencode/skills/agentdev-learning-pipeline/SKILL.md`）
- reference選択表へ経路D 条件のエントリを追記
- 「常に守る不変条件」へ adversarial-review 任意性の不変条件を追記

**promote-judgment-logic.md**（`src/opencode/skills/agentdev-learning-pipeline/references/promote-judgment-logic.md`）
- Phase 4 と Phase 5 の間へ「Phase 4-R: adversarial-review 候補判断と内部挿入（経路D）」を追記
- 候補判断（Step 8-R1）、review 呼出（Step 8-R2）、Step 6 戻しループの実装詳細

詳細パラメータ、入力フィールド構成、enum 値は共通契約（REQ-014）の対象外とし、各 command SPEC（REQ-015）が個別呼出統合を所有する正規所有者マトリックス（REQ-014-011）に従い、経路D 固有の発動条件、挿入位置、戻り先、Step 6 戻しループのみを本 PR で所有する。

## 完了条件

<!-- 【必須】 -->

- [x] REQ-015-001（経路D分）: learning-promote command SPEC に発動条件判定 Step と review 呼出 Step が分離された review 挿入境界節が存在する（121-138行）
- [x] REQ-015-002（経路D分）: ユーザー明示指定時に learning-promote で review が発動することが明記される（130-132行）
- [x] REQ-015-003（経路D分）: 条件非該当時は従来フローが維持されることが明記される（123行）
- [x] REQ-015-007: review 挿入位置が「既存対策確認後・判定結果提示前」と一意に特定可能である（128行）
- [x] REQ-015-007: review 反映時の evaluation-report 更新戻しと関連 Step 再実行が明記される（140-149行）

※ 完了条件の評価は case-close QG-4 の責務。本 PR では実装確認証拠を本文に示す。

## テスト結果

<!-- 【必須】 -->

**test strategy 検証（Issue #1967 テスト戦略セクション）**:

- TS-001（経路D分、target_item: AG-008）: PASS
  - verification: learning-promote command SPEC の経路D 節に review 挿入境界が存在することを確認
  - pass_criteria: learning-promote command SPEC 経路D 節に発動条件 Step と呼出 Step が分離されている
  - 証拠: docs/specs/commands/learning-promote.md 121-138行「発動条件判定 Step と review 呼出 Step の分離（REQ-015-001/002/003）」、「#### 発動条件判定 Step」、「#### review 呼出 Step」

- TS-012（target_item: AG-013）: PASS
  - verification: learning-promote SPEC の経路D に review 反映時の evaluation-report 更新戻しと関連 Step 再実行が明記されていることを確認
  - pass_criteria: learning-promote SPEC 経路D 節に evaluation-report 反映ループが明記される
  - 証拠: docs/specs/commands/learning-promote.md 140-149行「review 反映時の evaluation-report 更新戻しと関連 Step 再実行（REQ-015-007）」

**docs 整合性検査**:
- `check_changed_docs.ts --workflow case-run --files ...`: PASS
  - files_checked: 2件（docs/specs/commands/learning-promote.md, docs/specs/skills/agentdev-learning-pipeline.md）
  - coupled_files_checked: docs/README.md, docs/specs/README.md
  - failures: [], warnings: []

**check_extensions.ts (IR-056)**: ok: true（warning 6件は ADR-007 既知事象、本変更無関係）

**lsp_diagnostics**: .md 用 LSP サーバ未設定のため N/A

**事前 QG-3 検証**: REQ-015-001/002/003/007 の4要件すべて SPEC/SKILL/command で充足確認済み。経路D 固有の節のみ追加し、他経路への影響なし。

## 品質メトリクス

<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| REQ-015-001/002/003/007 (4要件) QG-3 | 4/4 要件 | 全要件 | OK |
| docs 整合性検査 (case-run) | failures 0, warnings 0 | strict severity 0 件 | OK |
| check_extensions.ts (IR-056) | ok: true | ok: true | OK |
| 変更ファイル数 | 5 | scope 内 | OK |
| 行数変更 | +153/-5 | - | - |
| lsp_diagnostics | N/A（.md 用 LSP サーバ未設定） | - | - |

## Findings/ Intake候補

<!-- 【必須】 -->

### intake

該当なし

### learning

- **発見元**: case-run インライン実行 PR 作成 (#1976)
- **内容**: Windows PowerShell 環境で gh pr create --body-file に UTF-8 BOM なしファイルを渡すと、chcp 65001 + PYTHONIOENCODING=utf-8 のコンソールエンコーディング初期化を実施しても、PR 本文が多重エンコード化け（UTF-8 バイト列を ASCII 数字文字列として展開した状態）になる事象を確認。agentdev-gh-cli standard-procedures.md「コンソールエンコーディング初期化」のみでは未防止で、gh api -X PATCH --input <JSON> 経由（Node.js で JSON を UTF-8 書き出し）で修復可能。PR #1973 (Wave 1 #1963) も同様の文字化け状態でマージ済みの可能性
- **分類**: learning（gh CLI Windows encoding 実運用時の追加事象）

## SPEC確定候補

該当なし（共通契約のパラメータ、入力フィールド構成、enum 値は REQ-014 対象外であり、経路D 固有の新規 schema、enum、判定表は発生しなかった）

## 確認事項

- adversarial-review 経路D の発動条件、挿入位置、戻り先、Step 6 戻しループは learning-promote command SPEC が正規所有する。共通 caller integration 契約は REQ-014 が正規所有し、本 PR では経路D 固有の呼出統合のみを所有する（REQ-014-011 重複防止制約に従う）
- 他経路（A, B, C, E, F, G, H）は別 Issue（#1964, #1965, #1966, #1968, #1969, #1970, #1971）の責務であり、本 PR では触れない

## 関連Issue

<!-- 【必須】 -->

Parent: #1962
Closes: #1967
