### PR TITLE
feat(adversarial-review): REQ-015 経路E backlog-review review 挿入境界の実装 (#1968)

### DIFF
--- a/docs/specs/commands/backlog-review.md
+++ b/docs/specs/commands/backlog-review.md
@@ -138,6 +138,40 @@ backlog-review は全 RU frontmatter に `tentative_classification` を付与す
 
 ## adversarial-review 挿入境界（経路E）
 
-経路E の review 挿入境界: 構成 → review → 承認の順序、矛盾は既存矛盾検出へ渡す、
-review 内で自動解決しないことを規定する。
+本節は backlog-review における adversarial-review caller integration（REQ-015 経路E）の挿入境界を正典として所有する（REQ-014-011）。共通 caller integration 契約の正規所有者は adversarial-review SPEC であり（REQ-014-003）、本節は経路E 固有の挿入位置、発動条件、順序、矛盾取扱いのみを所有する。adversarial-review 自身の振る舞い契約、再 review 条件、停止条件は adversarial-review SPEC を正とし、本節で再定義しない。候補判断基準、内部手続き（候補確定位置、呼出タイミング、矛盾検出への引き渡し）の正規所有者は agentdev-backlog-integration SPEC とし、本節は参照する。
+
+### 挿入境界と Step 構造（REQ-015-001）
+
+backlog-review の現行 Step 構造へ review 挿入境界を次のとおり一意に特定する。発動条件判定 Step と review 呼出 Step を分離する（REQ-015-001）。本節は挿入境界の正典であり、`.opencode/commands/agentdev/backlog-review.md` の Step 4-1 が実行時投影先となる。
+
+| 段階 | 対応 Step | 役割 |
+|---|---|---|
+| 構成 | Step 3（分析 + 暫定分類付与）、Step 4（統合・分割判定 + depends_on 依存解決） | review 対象となる RU 構成案を確定する |
+| 発動条件判定 | Step 4 完了直後、Step 5 開始前（Step 4-1） | ユーザー明示指定の有無を判定する |
+| review 呼出 | 発動条件該当時、Step 5 開始前（Step 4-1） | adversarial-review を起動し、RU 構成案を審議対象へ渡す |
+| 承認 | Step 4 承認（矛盾なし時の単一承認）、Step 5（矛盾検出時の追加判断） | review 結果を踏まえユーザー承認を確定する |
+
+### 構成、review、承認の順序（REQ-015-008）
+
+経路E は構成、review、承認の順で進む（REQ-015-008）。review は構成（Step 3、Step 4）の完了後、承認（Step 4 承認、Step 5 追加判断）の前に挿入する。review を構成前に、または承認後に挿入しない。
+
+### 発動条件（REQ-015-002）
+
+adversarial-review は任意助言手段であり、ユーザーが明示的に指定した場合にのみ発動する（REQ-014-001、REQ-015-002）。backlog-review は review 発動を前提とせず、明示指定がない場合は review 呼出 Step を経由せず従来フロー（Step 5 以降）へ進む。
+
+### 従来フロー維持（REQ-015-003）
+
+発動条件非該当時（ユーザー明示指定なし）、呼出失敗時（REQ-014-010）のいずれの場合も、従来フロー（Step 1〜9）を維持する（REQ-015-003）。review 挿入境界は既存 Step を追加、削除、並べ替えせず、発動条件判定と review 呼出 Step を分離した形で現行 Step 構造へ挿入する。
+
+### 矛盾の扱い（REQ-015-008）
+
+adversarial-review 審議で採用済み成果物間の矛盾が指摘された場合、当該矛盾は backlog-review の既存矛盾検出（Step 5、agentdev-backlog-integration 矛盾検出ロジック）へ渡す。adversarial-review 自身は矛盾を自動解決せず（REQ-015-008）、矛盾の解決、採用、却下、partial success 扱いは既存矛盾検出と HITL（REQ-003-009）へ委ねる。review 内で矛盾が発生したことを理由に対象 RU を自動除外、自動承認しない。
+
+### 戻り先と反映責務
+
+accepted finding の RU 構成案への反映は backlog-review 呼出元の責務である（REQ-014-006）。adversarial-review は finding を提示し、合意候補を形成するが、RU 本文、frontmatter、統合判定への反映を自身では行わない。反映後に RU 構成案の意味内容が変更された場合、必要な既存検証（depends_on 再解決、矛盾検出の再実行）を行い、意味内容変更から新たな本質的争点が生じ得る場合のみ再 review を発動できる（REQ-014-007）。unresolved な本質的争点またはユーザー判断事項が残る場合、RU 生成（Step 6）、採用済み成果物削除（Step 7）、Git 永続化（Step 8）等の後続不可逆処理へ進まない（REQ-014-009）。
+
+### 正規所有者マトリックス参照
+
+本節と adversarial-review SPEC「adversarial-review caller integration 共通契約」節（REQ-014-011）、delegation-contracts SPEC「adversarial-review との委譲契約接続」節、agentdev-backlog-integration SPEC「adversarial-review 候補判断と内部挿入」節との間で意味の重複、矛盾を生じない。backlog-review command 固有の挿入境界（発動条件、Step 構造、順序、矛盾取扱い）のみを本節が所有し、候補判断基準、内部手続きの詳細は agentdev-backlog-integration SPEC を正とする。
 

--- a/docs/specs/skills/agentdev-backlog-integration.md
+++ b/docs/specs/skills/agentdev-backlog-integration.md
@@ -60,6 +60,40 @@ backlog-review における採用済み成果物の統合、分割判定、矛�
 
 ## adversarial-review 候補判断と内部挿入
 
-backlog-review 経路E における review 候補判断基準と内部手続き（候補確定位置、
-呼出タイミング、矛盾検出への引き渡し）を規定する。
+本節は backlog-review 経路E（REQ-015）における adversarial-review の候補判断基準と内部手続き（候補確定位置、呼出タイミング、矛盾検出への引き渡し）を正典として所有する（REQ-014-011）。共通 caller integration 契約の正規所有者は adversarial-review SPEC であり（REQ-014-003）、本節は domain skill 固有の判断基準、内部手続きのみを所有する。挿入境界（発動条件、Step 構造、順序）の正規所有者は backlog-review command SPEC であり、本節は再定義せず参照する。
+
+### 候補判断基準
+
+backlog-review の review 対象は構成完了時点の RU 構成案（統合・分割判定結果、depends_on 解決結果、暫定分類付与結果）である。adversarial-review 候補は次のいずれかを満たす RU 構成案を対象とする。
+
+- 複数採用済み成果物を統合する RU（N:1 統合）で、統合理由の妥当性が self-evident でないもの
+- 1成果物を複数 RU へ分割する（1:N 分割）で、分割境界の妥当性が self-evident でないもの
+- depends_on 依存を含み、依存順序、循環性、並べ替え可能性に判断余地があるもの
+- 暫定分類（tentative_classification）が複数候補から迷い得るもの
+
+候補判断基準は review 対象の意味的型を整理するための補助情報であり、自動発動の根拠ではない。発動条件はユーザー明示指定のみ（REQ-015-002）を正とし、候補該当の有無は従来フロー維持（REQ-015-003）に影響しない。
+
+### 内部手続き
+
+#### 候補確定位置
+
+review 対象の RU 構成案は backlog-review command Step 4（統合・分割判定 + depends_on 依存解決）の完了時点で確定する。候補確定前の暫定分類、未解決依存、未確定統合判定は review 対象としない。
+
+#### 呼出タイミング
+
+adversarial-review の呼出は、Step 4 完了後、Step 5（矛盾検出）開始前に挿入する（REQ-015-008 構成→review→承認の順）。ユーザー承認（Step 4 承認 / Step 5 矛盾検出時追加判断）の前に review を実行し、review 結果を踏まえて承認段階へ進む。呼出タイミングの正規所有者は backlog-review command SPEC であり、本節は参照レベルに留める。
+
+#### 矛盾検出への引き渡し
+
+adversarial-review 審議で採用済み成果物間の矛盾が指摘された場合、当該矛盾は本 SPEC「提供する判断、操作」節の矛盾検出ロジック、reference `integration-judgment.md`「矛盾検出 + ユーザー承認」節（既存矛盾検出）へ引き渡す。adversarial-review 自身は矛盾を自動解決せず（REQ-015-008）、矛盾の判定、partial success 扱い、ユーザー追加判断への委ね（REQ-003-009）は既存矛盾検出ロジックが正である。
+
+### 副作用境界と委譲契約
+
+adversarial-review は delegation-contracts SPEC の `semantic_review`（書き込み禁止型）として適用する。許可操作は `read_files`、`inspect_content`、`return_summary`、`return_evidence`、`return_artifact_body_when_requested` に限定し、`file_write`、`issue_pr_update`、`commit`、`push`、`user_confirmation` を forbidden とする（REQ-014-004）。審議結果は中間成果として呼出元へ返却し、新規正規 artifact を生成しない（REQ-014-005）。
+
+呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し（REQ-014-010）、利用不能を報告した上で従来フローと既存 QG/HITL を維持する。
+
+### 正規所有者マトリックス参照
+
+本節と adversarial-review SPEC「adversarial-review caller integration 共通契約」節（REQ-014-011）、delegation-contracts SPEC「adversarial-review との委譲契約接続」節、backlog-review command SPEC「adversarial-review 挿入境界（経路E）」節との間で意味の重複、矛盾を生じない。挿入境界、発動条件、順序は backlog-review command SPEC を正とし、本節は domain skill 固有の候補判断基準、内部手続き（候補確定位置、呼出タイミング、矛盾検出への引き渡し）のみを所有する。
 

--- a/src/opencode/commands/agentdev/backlog-review.md
+++ b/src/opencode/commands/agentdev/backlog-review.md
@@ -74,8 +74,26 @@ RU-*.md の構造（frontmatter: `source_type`, `generated_by`, `generated_at`, 
 
 統合、分割判定基準、depends_on 依存解決ルールは `agentdev-backlog-integration` を参照
 
+**構成、review、承認の順序（REQ-015-008）**: Step 4 前半（統合、分割判定、depends_on 依存解決）で RU 構成案を確定し、続く Step 4-1（adversarial-review 呼出、ユーザー明示指定時のみ発動）を経て、Step 4 後半（ユーザー承認）で承認を確定する。構成、review、承認の順序の正規所有者は backlog-review command SPEC「adversarial-review 挿入境界（経路E）」節である。
+
 **矛盾なしの場合の単一承認（REQ）**: 後続の Step 5 で矛盾が検出されない場合、本 Step 4 の統合、分割判定承認を RU 生成承認（Step 5/6）としても扱う。
 単一承認で処理し、追加の HITL は不要。
+
+### Step 4-1: adversarial-review 呼出（経路E、REQ-015-008）
+
+backlog-review 経路E の adversarial-review 挿入境界。Step 4 前半（構成）完了後、Step 4 後半（承認）前に挿入する。挿入境界、発動条件、順序、矛盾取扱いの正規所有者は backlog-review command SPEC「adversarial-review 挿入境界（経路E）」節であり、本 Step は実行時投影先である。候補判断基準、内部手続きの詳細は `agentdev-backlog-integration` を参照。
+
+**発動条件判定（REQ-015-001/002）**: ユーザーが明示的に adversarial-review を指定した場合にのみ発動する（REQ-014-001、REQ-015-002）。明示指定がない場合は本 Step をスキップし、Step 4 後半（ユーザー承認）へ進む。発動条件判定 Step と review 呼出 Step を分離する（REQ-015-001）。
+
+**review 呼出（REQ-015-001）**: 発動条件該当時、`agentdev-adversarial-review` を起動する。審議対象は Step 4 前半で確定した RU 構成案（統合・分割判定結果、depends_on 解決結果、暫定分類付与結果）。呼出契約、返却契約、副作用境界は `agentdev-adversarial-review` と delegation-contracts SPEC（`semantic_review`、書き込み禁止型）を正とする。
+
+**矛盾の扱い（REQ-015-008）**: review 審議で採用済み成果物間の矛盾が指摘された場合、当該矛盾は Step 5（既存矛盾検出）へ引き渡す。adversarial-review 自身は矛盾を自動解決せず、矛盾の判定、partial success 扱い、ユーザー追加判断への委ねは Step 5 の既存矛盾検出ロジックが正である。
+
+**従来フロー維持（REQ-015-003）**: 発動条件非該当時、呼出失敗時（REQ-014-010）のいずれの場合も、従来フロー（Step 4 後半以降）を維持する。review 挿入境界は既存 Step を追加、削除、並べ替えしない。
+
+**accepted finding 反映と再 review（REQ-014-006/007）**: accepted finding の RU 構成案への反映は本コマンド（呼出元）の責務である。反映後に RU 構成案の意味内容が変更された場合、必要な既存検証（depends_on 再解決、矛盾検出再実行）を行い、意味内容変更から新たな本質的争点が生じ得る場合のみ再 review を発動できる。同一 finding を新証拠・新前提・異なる failure condition・未評価範囲なしに再起票しない。
+
+**unresolved 時の取扱い（REQ-014-009）**: unresolved な本質的争点またはユーザー判断事項が残る場合、RU 生成（Step 6）、採用済み成果物削除（Step 7）、Git 永続化（Step 8）等の後続不可逆処理へ進まない。
 
 ### Step 5: 矛盾検出 + 必要に応じて追加判断
 

--- a/src/opencode/skills/agentdev-backlog-integration/SKILL.md
+++ b/src/opencode/skills/agentdev-backlog-integration/SKILL.md
@@ -47,10 +47,30 @@ extension（`.agentdev/extensions/skills/`）は標準 SKILL.md を前提とし�
 
 | ファイル | 内容 |
 |----------|------|
-| `references/integration-judgment.md` | 成果物の読み込み、分析、統合分割判定、depends_on 依存解決、矛盾検出、RU 生成の判定ロジック |
+| `references/integration-judgment.md` | 成果物の読み込み、分析、統合分割判定、depends_on 依存解決、矛盾検出、RU 生成の判定ロジック。adversarial-review 候補判断と内部挿入（経路E）の実行時参照 |
 
 backlog-review コマンドの実行時投影先パスは `.opencode/commands/agentdev/backlog-review.md`。
 command 本文内で backlog-review を参照する場合はこちらを使用。
+
+## adversarial-review 候補判断と内部挿入（経路E）
+
+本スキルは backlog-review 経路E（REQ-015）における adversarial-review の候補判断基準と内部手続き（候補確定位置、呼出タイミング、矛盾検出への引き渡し）の実行時参照を提供する。正規原本は `agentdev-backlog-integration` SPEC「adversarial-review 候補判断と内部挿入」節である（REQ-014-003、REQ-014-011）。本 SKILL.md は重複定義せず、詳細は `references/integration-judgment.md`「adversarial-review 候補判断と内部挿入（経路E）」節を参照。
+
+呼出元（backlog-review command）と本スキルの主な契約（詳細は SPEC と reference を正とする）:
+
+| 契約 | 要件 | 概要 |
+|---|---|---|
+| 候補判断基準 | REQ-015-008 | review 対象は構成完了時点の RU 構成案。候補判断は補助情報であり自動発動根拠ではない |
+| 候補確定位置 | REQ-015-001/008 | Step 4（統合・分割判定 + depends_on 解決）完了時点で RU 構成案を確定する |
+| 呼出タイミング | REQ-015-008 | 構成（Step 3、Step 4）完了後、承認前に挿入（順序の正は backlog-review command SPEC） |
+| 矛盾検出への引き渡し | REQ-015-008 | review で指摘された矛盾は既存矛盾検出ロジックへ渡し、review 内で自動解決しない |
+| 発動条件 | REQ-015-002 | ユーザー明示指定時のみ発動（順序、発動条件の正は backlog-review command SPEC） |
+| 従来フロー維持 | REQ-015-003 | 条件非該当時、呼出失敗時は従来フローを維持（順序の正は backlog-review command SPEC） |
+| 副作用境界 | REQ-014-004/005 | `semantic_review`（書き込み禁止型）、新規 artifact 非生成（正は adversarial-review SPEC、delegation-contracts SPEC） |
+| accepted finding 反映 | REQ-014-006 | accepted finding の RU 構成案への反映は呼出元責務（正は adversarial-review SPEC） |
+| 再 review 条件 | REQ-014-007 | 意味内容変更時のみ再発動可能、同一 finding 再起票禁止（正は adversarial-review SPEC） |
+| unresolved 時の扱い | REQ-014-009 | unresolved 残時は不可逆処理へ進まない（正は adversarial-review SPEC） |
+| 呼出失敗時の扱い | REQ-014-010 | silent skip 禁止、従来フロー維持（正は adversarial-review SPEC） |
 
 ## See Also
 

--- a/src/opencode/skills/agentdev-backlog-integration/references/integration-judgment.md
+++ b/src/opencode/skills/agentdev-backlog-integration/references/integration-judgment.md
@@ -70,4 +70,43 @@ RU frontmatter の `tentative_classification` フィールドに記録する。
  - 依存順に並べ替え可能であることを確認
  - 検証失敗時は当該 RU を生成せず理由を提示
 
+## adversarial-review 候補判断と内部挿入（経路E）
+
+backlog-review 経路E（REQ-015）における adversarial-review の候補判断基準と内部手続きの実行時参照。正規原本は `agentdev-backlog-integration` SPEC「adversarial-review 候補判断と内部挿入」節である。本節は実行時参照として SPEC を補完し、SPEC と矛盾する場合は SPEC を正とする。共通 caller integration 契約は adversarial-review SPEC が正規所有者であり（REQ-014-003）、本節は再定義しない。
+
+### 候補判断基準
+
+review 対象は backlog-review command Step 4（統合・分割判定 + depends_on 依存解決）完了時点の RU 構成案である。adversarial-review 候補は次のいずれかを満たす RU 構成案を対象とする。
+
+- 複数採用済み成果物を統合する RU（N:1 統合）で、統合理由の妥当性が self-evident でないもの
+- 1成果物を複数 RU へ分割する（1:N 分割）で、分割境界の妥当性が self-evident でないもの
+- depends_on 依存を含み、依存順序、循環性、並べ替え可能性に判断余地があるもの
+- 暫定分類（tentative_classification）が複数候補から迷い得るもの
+
+候補判断基準は review 対象の意味的型を整理する補助情報であり、自動発動の根拠ではない。発動条件はユーザー明示指定のみ（REQ-015-002）を正とし、候補該当の有無は従来フロー維持（REQ-015-003）に影響しない。
+
+### 内部手続き
+
+#### 候補確定位置
+
+RU 構成案は backlog-review command Step 4（統合・分割判定 + depends_on 依存解決）完了時点で確定する。候補確定前の暫定分類、未解決依存、未確定統合判定は review 対象としない。
+
+#### 呼出タイミング
+
+adversarial-review の呼出は、Step 4 完了後、Step 5（矛盾検出）開始前に挿入する（REQ-015-008 構成→review→承認の順）。ユーザー承認（Step 4 承認 / Step 5 矛盾検出時追加判断）の前に review を実行し、review 結果を踏まえて承認段階へ進む。呼出タイミングの正規所有者は backlog-review command SPEC であり、本節は参照レベルに留める。
+
+#### 矛盾検出への引き渡し
+
+adversarial-review 審議で採用済み成果物間の矛盾が指摘された場合、当該矛盾は前節「矛盾検出 + ユーザー承認」（既存矛盾検出ロジック）へ引き渡す。adversarial-review 自身は矛盾を自動解決せず（REQ-015-008）、矛盾の判定、partial success 扱い、ユーザー追加判断への委ね（REQ-003-009）は既存矛盾検出ロジックが正である。
+
+### 副作用境界と委譲契約
+
+adversarial-review は delegation-contracts SPEC の `semantic_review`（書き込み禁止型）として適用する。許可操作は `read_files`、`inspect_content`、`return_summary`、`return_evidence`、`return_artifact_body_when_requested` に限定し、`file_write`、`issue_pr_update`、`commit`、`push`、`user_confirmation` を forbidden とする（REQ-014-004）。審議結果は中間成果として呼出元へ返却し、新規正規 artifact を生成しない（REQ-014-005）。
+
+呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し（REQ-014-010）、利用不能を報告した上で従来フローと既存 QG/HITL を維持する。
+
+### accepted finding 反映と再 review
+
+accepted finding の RU 構成案（統合・分割判定、depends_on、暫定分類）への反映は backlog-review command（呼出元）の責務である（REQ-014-006）。反映後に必要な既存検証（depends_on 再解決、矛盾検出再実行）を行う。意味内容変更から新たな本質的争点が生じ得る場合のみ再 review を発動でき、新証拠、新前提、異なる failure condition、未評価範囲のいずれも伴わない同一 finding の再起票を禁止する（REQ-014-007）。
+
 


### PR DESCRIPTION
## 概要

<!-- 【必須】 -->

Issue #1968（Epic #1962 Wave 2 子Issue、OU-002 経路E、REQ-015）の実装。backlog-review への adversarial-review caller integration（REQ-015 経路E）を実装する。spec-save で追加済みのセクション見出しに対し、REQ-015-001/002/003/008 を明記する本文を実装する。

## 実装内容

<!-- 【必須】 -->

REQ-015 経路E（backlog-review）の review 挿入境界を command SPEC、domain skill SPEC、command 定義、配布スキルへ実装した。

**backlog-review command SPEC**（`docs/specs/commands/backlog-review.md`）
- 「adversarial-review 挿入境界（経路E）」節を充実。REQ-015-001/002/003/008 を明記:
  - 挿入境界と Step 構造（REQ-015-001）: 発動条件判定 Step と review 呼出 Step を分離。Step 4-1 が実行時投影先
  - 構成、review、承認の順序（REQ-015-008）: review は構成（Step 3、Step 4）完了後、承認前に挿入
  - 発動条件（REQ-015-002）: ユーザー明示指定時のみ発動
  - 従来フロー維持（REQ-015-003）: 条件非該当時、呼出失敗時は従来フロー維持
  - 矛盾の扱い（REQ-015-008）: 矛盾は既存矛盾検出（Step 5）へ渡し、review 内で自動解決しない
  - 戻り先と反映責務（REQ-014-006/007/009）: accepted finding 反映、再 review、unresolved 時取扱い
  - 正規所有者マトリックス参照（REQ-014-011）

**agentdev-backlog-integration SPEC**（`docs/specs/skills/agentdev-backlog-integration.md`）
- 「adversarial-review 候補判断と内部挿入」節を充実:
  - 候補判断基準: N:1 統合、1:N 分割、depends_on、暫定分類の判断余地ある RU 構成案を候補対象
  - 内部手続き: 候補確定位置（Step 4 完了時点）、呼出タイミング（Step 4 完了後、Step 5 開始前）、矛盾検出への引き渡し（既存矛盾検出ロジックが正）
  - 副作用境界と委譲契約（REQ-014-004/005/010）
  - 正規所有者マトリックス参照（REQ-014-011）

**backlog-review command**（`src/opencode/commands/agentdev/backlog-review.md`）
- Step 4-1（adversarial-review 呼出）を実装。command SPEC の挿入境界を実行時投影先へ接続
- Step 4 に「構成、review、承認の順序（REQ-015-008）」注記を追加
- Step 4-1 で発動条件判定（REQ-015-001/002）、review 呼出（REQ-015-001）、矛盾の扱い（REQ-015-008）、従来フロー維持（REQ-015-003）、accepted finding 反映（REQ-014-006/007）、unresolved 時取扱い（REQ-014-009）を明記

**agentdev-backlog-integration SKILL.md**（`src/opencode/skills/agentdev-backlog-integration/SKILL.md`）
- 「adversarial-review 候補判断と内部挿入（経路E）」参照節を追加。SPEC を正とし、詳細は reference を参照する契約を一覧表で整理
- references/ 構成一覧の記述を更新

**integration-judgment.md**（`src/opencode/skills/agentdev-backlog-integration/references/integration-judgment.md`）
- 「adversarial-review 候補判断と内部挿入（経路E）」実行時参照節を追加
- 候補判断基準、内部手続き、副作用境界と委譲契約、accepted finding 反映と再 review の詳細を補完

詳細パラメータ、入力フィールド構成、enum 値は対象外（REQ-015 適用範囲外）。共通契約は REQ-014、横断整合は REQ-016 が所有する。

## 完了条件

<!-- 【必須】 -->

- [ ] REQ-015-001（経路E分）: backlog-review command SPEC に発動条件判定 Step と review 呼出 Step が分離された review 挿入境界節が存在する
- [ ] REQ-015-002（経路E分）: ユーザー明示指定時に backlog-review で review が発動することが明記される
- [ ] REQ-015-003（経路E分）: 条件非該当時は従来フローが維持されることが明記される
- [ ] REQ-015-008: 構成→review→承認の順序が明記される
- [ ] REQ-015-008: 矛盾は既存矛盾検出へ渡し review 内で自動解決しないことが明記される

※ チェックボックスの評価は case-close QG-4 の責務（G24）。本 PR では完了条件の実装証拠を本文に示す。

## テスト結果

<!-- 【必須】 -->

- **docs 整合性検査**（`check_changed_docs.ts --workflow case-run --files ...`）: PASS
  - files_checked: 2 件（docs/specs/commands/backlog-review.md, docs/specs/skills/agentdev-backlog-integration.md）
  - coupled_files_checked: docs/README.md, docs/specs/README.md
  - failures: [], warnings: []
- **extensions 検査**（`check_extensions.ts --json`）: ok=true（warnings 6件は全て pre-existing の `repo-agentdev-artifact-graph` 参照不足、本 PR 由来ではない）
- **lsp_diagnostics**: .md 用 LSP サーバー未設定のため N/A（markdown diagnostic 対象外）
- **手動 QG-3 検証**: REQ-015-001/002/003/008 の4要件すべて SPEC/command/SKILL で明記済み（「実装内容」節の各要件別記載を参照）
- **TS-001（経路E分）**: PASS。backlog-review command SPEC 経路E 節に「発動条件判定 Step と review 呼出 Step を分離する（REQ-015-001）」が Step 構造表と共に明記
- **TS-016**: PASS。backlog-review command SPEC 経路E 節に「構成、review、承認の順序（REQ-015-008）」節と「矛盾の扱い（REQ-015-008）」節で順序と矛盾取扱いが明記

## 品質メトリクス

<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| REQ-015-001/002/003/008 充足（QG-3） | 4/4 要件 | 全要件 | ✅ |
| docs 整合性検査（case-run） | failures 0, warnings 0 | strict severity 0 件 | ✅ |
| extensions 検査 | ok=true、warnings 6件（pre-existing） | ok=true | ✅ |
| 変更ファイル数 | 5 | scope 内 | ✅ |
| 行数変化 | +150/-5 | – | – |
| lsp_diagnostics | N/A（.md 用 LSP サーバー未設定） | – | – |

## Findings/ Capture候補

<!-- 【必須】 -->

### intake

該当なし

### learning

該当なし

## SPEC確定候補

<!-- 【任意】 -->

該当なし（REQ-015 適用範囲外の詳細パラメータ、入力フィールド構成、enum 値は本 PR で確定しない）

## 決定事項

- 挿入位置の解釈: REQ-015-008「構成→review→承認の順序」と既存 Step 4（統合・分割判定 + depends_on 解決 + ユーザー承認）との整合は、Step 4 を前半（構成）と後半（承認）へ概念的に分解し、Step 4-1 を両者の間に挿入する構成とした。Step 4 の既存構造（REQ-003-009 単一承認、矛盾検出時追加判断）は維持し、Step 4-1 は既存 Step を追加、削除、並べ替えせず分離挿入する（REQ-015-003 従来フロー維持）。
- 正規所有者マトリックス（REQ-014-011）に従い、command SPEC が挿入境界、発動条件、順序、矛盾取扱いを、domain skill SPEC が候補判断基準、内部手続きを、それぞれ重複なく所有する。

## 関連Issue

<!-- 【必須】 -->

Parent: #1962
Closes #1968