### PR TITLE
feat(req-define): adversarial-review caller integration route A (REQ-015)

### DIFF
--- a/docs/specs/commands/req-define.md
+++ b/docs/specs/commands/req-define.md
@@ -441,7 +441,38 @@ auto_gate:
 
 ## adversarial-review 挿入境界（経路A）
 
-経路A の review 挿入境界: 発動条件（Scale 判断後・ADR判断前・要件doc生成前）、
-review 対象確定位置、採用後戻り先（ADR finding は Step 6 へ）、
-最初の副作用（要件doc保存）との順序を規定する。
+本節は req-define への adversarial-review caller integration（経路A、REQ-015-004）の挿入境界を正典として所有する。共通 caller integration 契約（任意性、QG/HITL 非代替、副作用禁止、accepted finding 反映責務、再 review 条件と停止条件、呼出失敗時取扱い）は [adversarial-review SPEC](../skills/agentdev-adversarial-review.md)「adversarial-review caller integration 共通契約」節が正であり、本節は経路A 固有の発動条件、review 対象確定位置、採用後戻り先、最初の副作用との順序のみを規定する（REQ-014-011）。
+
+### 挿入位置（REQ-015-004）
+
+review 挿入位置は「Scale 判断後・ADR判断前・要件doc生成前」と一意に特定可能である。現行 Step 構造への対応付けを次に示す。
+
+| 条件 | feature の場合 | feature 以外（bugfix, maintenance, docs_chore）の場合 |
+|---|---|---|
+| Scale 判断後 | Step 9（Scale判断）完了後 | Step 8（work_type 判定）完了後。Scale判断 は feature のみ実行するため、work_type 判定完了をもって意味的完成とする |
+| ADR判断前 | Step 6（ADR判断）の判断結果が Step 10（ドラフト保存）で永続化される前 | 同左 |
+| 要件doc生成前 | Step 7（要件doc生成）の成果物が Step 10（ドラフト保存）で永続化される前 | 同左 |
+
+review は Step 9（feature 以外は Step 8）完了後、Step 10（ドラフト保存）の前に挿入する。Step 6（ADR判断）および Step 7（要件doc生成）は当該時点で実行済みであるが、その成果物は Step 10 で永続化されるまで確定扱いとならない。review の finding は Step 6、Step 7 の成果物へ反映可能であり、ADR finding は Step 6（ADR判断）へ戻す。
+
+### 発動条件判定 Step（REQ-015-001、REQ-015-002、REQ-015-003）
+
+発動条件判定と review 呼出を分離する（REQ-015-001）。発動条件判定 Step は次の条件を評価する。
+
+- **ユーザー明示指定時発動**: ユーザーが req-define 実行中に adversarial-review の実施を明示的に指定した場合に発動する（REQ-015-002）。adversarial-review は任意助言手段であり（REQ-014-001）、req-define の標準フローへ自動発動しない。
+- **条件非該当時の従来フロー維持**: ユーザー明示指定がない場合、従来フロー（review を挿入せず Step 10 へ進む）を維持する（REQ-015-003）。
+
+### review 呼出 Step（REQ-015-001）
+
+発動条件判定 Step で発動と判定された場合、review 呼出 Step で adversarial-review を呼び出す（REQ-015-001）。
+
+- **委譲契約**: adversarial-review は `semantic_review`（書き込み禁止型）として適用する（[delegation-contracts SPEC](../workflows/delegation-contracts.md)「adversarial-review との委譲契約接続」節）。adversarial-review 自身は対象ファイル、Issue、PR、git 操作を行わない（REQ-014-004）。
+- **review 対象**: 当該 req-define で生成した要件候補（draft-data、`agreed_items`、`artifact_actions`、ADR判断結果、Scale判断結果）。
+- **採用後戻り先**: accepted finding のうち ADR 関連の finding は Step 6（ADR判断）へ戻し再評価する。要件展開に関わる finding は該当 Step（Step 5 以降）へ戻す。accepted finding の対象候補への反映は req-define（呼出元）の責務である（REQ-014-006）。
+- **unresolved 時の取扱い**: 未解決のユーザー判断事項が残る場合、Step 10（ドラフト保存）へ進まない（REQ-014-009）。工程委譲起源であるため、既存 status（pass/warn/fail/partial）に unresolved 判断事項を付加し、case-auto 経由時は user-decision-required 停止理由分類として伝播する（REQ-014-012、[workflow-contracts SPEC](../workflows/workflow-contracts.md)「adversarial-review 由来の停止信号」節）。
+- **呼出失敗時**: adversarial-review の呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し、利用不能を報告した上で従来フローと既存 QG/HITL を維持する（REQ-014-010）。
+
+### 最初の副作用（要件doc保存）との順序
+
+review は Step 10（ドラフト保存）より前に実行する。ドラフト保存が req-define の最初の副作用（`.agentdev/drafts/req-draft-{topic-slug}.md` のファイル作成）であるため、review は最初の副作用の前に挿入される。review の結果、要件候補が変更された場合は、Step 10 で保存されるドラフトへ反映する。
 

--- a/src/opencode/commands/agentdev/req-define.md
+++ b/src/opencode/commands/agentdev/req-define.md
@@ -97,6 +97,18 @@ CREATE 前に APPEND/UPDATE 候補を必ず評価すること。
 
 `agentdev-workflow-lifecycle` で standard/large を判定。large 時はユーザーと分解計画を協議。9-1 実装スコープシグナル確認（ドラフト内に修正候補リスト、検出事項カタログ、影響ファイル一覧等の実装詳細セクション存在時に large 昇格判定、昇格理由をユーザー提示）の詳細は `agentdev-workflow-lifecycle` を参照
 
+### adversarial-review 挿入境界（経路A、REQ-015-004）
+
+Step 9（Scale判断: feature）または Step 8（work_type 判定: feature 以外）完了後、Step 10（ドラフト保存）の前に挿入する。adversarial-review は任意助言手段であり（REQ-014-001）、標準フローへ自動発動しない。発動条件判定と review 呼出を分離する（REQ-015-001）。
+
+- **発動条件判定（REQ-015-002、REQ-015-003）**: ユーザーが adversarial-review の実施を明示的に指定した場合に発動する（REQ-015-002）。指定がない場合は従来フロー（review を挿入せず Step 10 へ進む）を維持する（REQ-015-003）。
+- **review 呼出（REQ-015-001）**: 発動条件判定で発動と判定された場合、要件候補（draft-data、`agreed_items`、`artifact_actions`、ADR判断結果、Scale判断結果）を対象に adversarial-review を呼び出す。委譲契約は delegation-contracts SPEC（extension 経由）「adversarial-review との委譲契約接続」節に従う。
+  - ADR finding は Step 6（ADR判断）へ戻し再評価する。要件展開に関わる finding は該当 Step へ戻す。accepted finding の反映は呼出元の責務である（REQ-014-006）。
+  - 未解決のユーザー判断事項が残る場合、Step 10（ドラフト保存）へ進まない（REQ-014-009）。工程委譲起源であるため既存 status に unresolved 判断事項を付加する（REQ-014-012）。
+  - 呼出失敗時は silent skip を禁止し、従来フローを維持する（REQ-014-010）。
+
+詳細な挿入境界は req-define command SPEC（extension 経由）「adversarial-review 挿入境界（経路A）」節を正とする。
+
 ### Step 10: ドラフト保存
 
 全 work_type（feature/ bugfix/ maintenance/ docs_chore）で `.agentdev/drafts/req-draft-{topic-slug}.md` に保存。Step 7 の構造化 `draft-data` 形式（`# draft-data` fenced YAML block）で保存する。標準データモデル fields（`work_type`, `scale`, `summary`, `auto_gate`, `agreed_items`, `artifact_actions`, `conflict_resolutions`, `operation_units`, `test_strategy`, `review_dispositions`, `case_open_hints`）を保持する。`workflow_route` は派生値として保存しない。後続工程の分岐は `artifact_actions` の存在で決定する（`artifact: req`/`adr` → req-save、`artifact: spec` → spec-save）。`operation_units` を含め、`execution_groups` は出力しない。`summary` 等の人間可読セクションは補助的であり下流処理の正として扱われない


### PR DESCRIPTION
## 概要

OU-002 / REQ-015 経路A: req-define への adversarial-review caller integration 実装。要件候補が意味的に完成した後（Scale 判断後）、ADR判断前、要件doc生成前に review を挿入する境界を req-define command SPEC とコマンド定義へ実装する。ADR finding は ADR判断（Step 6）へ戻す。

## 実装内容

spec-save で追加済みのセクション見出しに対し、本文を実装した。

### docs/specs/commands/req-define.md（command SPEC）

「## adversarial-review 挿入境界（経路A）」節へ以下を実装:

- **挿入位置（REQ-015-004）**: 「Scale 判断後・ADR判断前・要件doc生成前」の3条件を現行 Step 構造（Step 5〜10）へ対応付け。feature と feature 以外（bugfix/maintenance/docs_chore）で分けて規定
- **発動条件判定 Step（REQ-015-001/002/003）**: ユーザー明示指定時発動、条件非該当時従来フロー維持を明記。review 呼出 Step と分離
- **review 呼出 Step（REQ-015-001）**: semantic_review 委譲契約、review 対象、ADR finding 戻り先（Step 6）、unresolved 時取扱い、呼出失敗時取扱いを規定
- **最初の副作用（要件doc保存）との順序**: review は Step 10（ドラフト保存）より前に実行

### src/opencode/commands/agentdev/req-define.md（コマンド定義）

Step 9（Scale判断）と Step 10（ドラフト保存）の間に「adversarial-review 挿入境界（経路A、REQ-015-004）」セクションを追加。発動条件判定と review 呼出を分離（REQ-015-001）。詳細は SPEC を正とし、コマンド定義は操作 Step の参照のみを記載。

共通 caller integration 契約は adversarial-review SPEC、workflow-contracts SPEC、delegation-contracts SPEC が正典として所有し（子 Issue #1963 で実装済み）、本 PR は経路A 固有の呼出統合のみを規定する（REQ-014-011）。

## 完了条件

- [x] REQ-015-001（経路A分）: req-define command SPEC に発動条件判定 Step と review 呼出 Step が分離された review 挿入境界節が存在する
- [x] REQ-015-002（経路A分）: ユーザー明示指定時に req-define で review が発動することが明記される
- [x] REQ-015-003（経路A分）: 条件非該当時は従来フローが維持されることが明記される
- [x] REQ-015-004: review 挿入位置が「Scale 判断後・ADR判断前・要件doc生成前」と一意に特定可能である
- [x] REQ-015-004: ADR finding の採用後戻り先が ADR判断（Step 6）と明記される

## テスト結果

### TS-001（経路A分）

- verification: req-define command SPEC の経路A 節に発動条件判定 Step と review 呼出 Step が分離された review 挿入境界が存在することを確認
- pass_criteria: req-define command SPEC 経路A 節に発動条件 Step と呼出 Step が分離されている
- **結果**: PASS。SPEC に「### 発動条件判定 Step」と「### review 呼出 Step」が独立した節として存在

### TS-002（経路A分）

- verification: req-define の review 発動条件に「ユーザー明示指定時は発動」と「条件非該当時は従来フロー」が含まれることを確認
- pass_criteria: req-define command SPEC でユーザー明示指定時発動と条件非該当時従来フロー維持が明記される
- **結果**: PASS。発動条件判定 Step 節に両条件を明記

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| REQ-015-001 充足（Step 分離） | 発動条件判定 Step / review 呼出 Step 分離済み | 分離されている | PASS |
| REQ-015-002 充足（明示指定時発動） | 明記済み | 明記される | PASS |
| REQ-015-003 充足（条件非該当時従来フロー） | 明記済み | 明記される | PASS |
| REQ-015-004 充足（挿入位置一意特定） | feature/ feature 以外の Step 対応付け表で規定 | 一意に特定可能 | PASS |
| REQ-015-004 充足（ADR finding 戻り先 Step 6） | SPEC/コマンド定義両方に明記 | Step 6 と明記される | PASS |
| エンコーディング（UTF-8 BOM なし） | 先頭3バイト 2D 2D 2D（BOM なし確認済み） | UTF-8 BOM なし | PASS |
| 変更範囲（docs/specs 本文追記のみ） | docs/specs/ は本文追記、docs/requirements/ は未触 | 要件行/適用範囲変更なし | PASS |

## Findings/ Capture候補

### intake

該当なし

### learning

該当なし

## 関連Issue

Parent: #1962
Closes #1964