### PR TITLE
feat(adversarial-review): REQ-015 経路F case-open review 挿入境界の実装

### DIFF
--- a/docs/specs/commands/case-open.md
+++ b/docs/specs/commands/case-open.md
@@ -263,6 +263,54 @@ case-open は Epic 構成推論の根拠を Epic Issue 本文または `case_ope
 
 ## adversarial-review 挿入境界（経路F）
 
-経路F の review 挿入境界: 発動条件（execution structure / Issue 本文候補 / 完了条件構成後・
-最初の Issue 作成前）、変更影響別の QG-2 / preflight / 両方 / 不要 再実行ルールを規定する。
+本節は case-open への adversarial-review caller integration（経路F、REQ-015-009）の挿入境界を正典として所有する。共通 caller integration 契約（任意性、QG/HITL 非代替、副作用禁止、accepted finding 反映責務、再 review 条件と停止条件、呼出失敗時取扱い）は [adversarial-review SPEC](../skills/agentdev-adversarial-review.md)「adversarial-review caller integration 共通契約」節が正であり、本節は経路F 固有の挿入位置、発動条件、変更影響別再実行ルール、最初の副作用との順序のみを規定する（REQ-014-011）。
+
+### 挿入位置（REQ-015-009）
+
+review 挿入位置は「execution structure / Issue 本文候補 / 完了条件構成後・最初の GitHub Issue 作成前」と一意に特定可能である。execution structure（Epic flow の自律構成生成、Standard flow の単一 OU 構成）、Issue 本文候補（Epic Issue 本文、Standard Issue 本文）、完了条件（QG-2 で網羅性検証済み）の3者すべてが確定した後、最初の GitHub Issue 作成呼び出しの前に挿入する。現行 Step 構造への対応付けを次に示す。
+
+| flow | execution structure 確定 | Issue 本文候補確定 | 完了条件確定 | 最初の GitHub Issue 作成 | review 挿入位置 |
+|---|---|---|---|---|---|
+| Epic flow（マルチREQ、`scale: large`） | Step 3-1（自律構成生成） | Step 6（Epic Issue 本文生成） | Step 2-1（QG-2） | Step 7（Epic Issue 作成） | Step 6 完了後、Step 7 の前 |
+| Standard flow（`scale: standard`、フィールドなし） | Step 4（規模判定）、Step 4-1（preflight）で単一 OU 構成を確定 | Step 2（Issue 本文生成） | Step 2-1（QG-2） | Step 12（Standard Issue 作成） | Step 4-1（preflight）完了後、Step 12 の前 |
+
+Epic flow では Step 5（テンプレート読込）、Step 6（Epic Issue 本文生成）の完了後に review を挿入し、Step 7（Epic Issue 作成）の前に実行する。Step 8（子 Issue 本文生成、子 Issue 作成）は Step 7 完了後に実行するため、review 挿入時点では未確定であり review 対象外である。子 Issue 構成は Step 3-1 の execution structure（Epic/Wave/Issue 構成）として Epic Issue 本文に反映済みであるため、execution structure 経由で review 対象となる。Standard flow では Step 2（Issue 本文生成）、Step 2-1（QG-2）、Step 4-1（preflight）の完了後に review を挿入し、Step 12（Standard Issue 作成）の前に実行する。
+
+### 発動条件判定 Step（REQ-015-001、REQ-015-002、REQ-015-003）
+
+発動条件判定と review 呼出を分離する（REQ-015-001）。発動条件判定 Step は次の条件を評価する。
+
+- **ユーザー明示指定時発動**: ユーザーが case-open 実行中に adversarial-review の実施を明示的に指定した場合に発動する（REQ-015-002）。adversarial-review は任意助言手段であり（REQ-014-001）、case-open の標準フローへ自動発動しない。
+- **条件非該当時の従来フロー維持**: ユーザー明示指定がない場合、従来フロー（review を挿入せず最初の GitHub Issue 作成 Step へ進む）を維持する（REQ-015-003）。Epic flow は Step 7、Standard flow は Step 12 へそのまま進む。
+
+### review 呼出 Step（REQ-015-001）
+
+発動条件判定 Step で発動と判定された場合、review 呼出 Step で adversarial-review を呼び出す（REQ-015-001）。
+
+- **委譲契約**: adversarial-review は `semantic_review`（書き込み禁止型）として適用する（[delegation-contracts SPEC](../workflows/delegation-contracts.md)「adversarial-review との委譲契約接続」節）。adversarial-review 自身は対象ファイル、Issue、PR、git 操作を行わない（REQ-014-004）。
+- **review 対象**: execution structure（Epic/Wave/Issue 構成、Step 3-1 または Step 4-1 で確定）、Issue 本文候補（Epic Issue 本文、Standard Issue 本文）、完了条件（QG-2 で網羅性検証済み）の3者。
+- **採用後戻り先**: accepted finding のうち execution structure に関わる finding は Step 3-1（自律構成生成）または Step 4（規模判定）へ戻し再評価する。Issue 本文、完了条件に関わる finding は Step 2（Issue 本文生成）、Step 2-1（QG-2）、Step 6（Epic Issue 本文生成）の該当 Step へ戻す。accepted finding の対象候補への反映は case-open（呼出元）の責務である（REQ-014-006）。
+- **unresolved 時の取扱い**: 未解決のユーザー判断事項が残る場合、最初の GitHub Issue 作成（Epic flow は Step 7、Standard flow は Step 12）へ進まない（REQ-014-009）。工程委譲起源であるため、既存 status（pass/warn/fail/partial）に unresolved 判断事項を付加し、case-auto 経由時は user-decision-required 停止理由分類として伝播する（REQ-014-012、[workflow-contracts SPEC](../workflows/workflow-contracts.md)「adversarial-review 由来の停止信号」節）。
+- **呼出失敗時**: adversarial-review の呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し、利用不能を報告した上で従来フローと既存 QG/HITL を維持する（REQ-014-010）。
+
+### 変更影響別の再実行ルール（REQ-015-009）
+
+review の結果反映で review 対象の意味内容が変更された場合（REQ-014-007）、変更影響範囲に応じて次の4パターンのいずれかを実行する（REQ-015-009）。
+
+| 変更影響 | 再実行対象 | 戻り先 Step | 根拠 |
+|---|---|---|---|
+| 完了条件のみ変更 | QG-2 | Step 2-1 | 完了条件網羅性検証を再実行し、REQ/ADR/SPEC 必達要件の網羅性を再確認する |
+| execution structure のみ変更 | preflight | Step 4-1 | 構成生成事前検証（子 Issue 数上限、Wave 同時実行上限、OU 対応、必須依存関係維持、OU 割当網羅）を再実行する |
+| 完了条件と execution structure の両方が変更 | QG-2 + preflight | Step 2-1、Step 4-1 | 両方を再実行する。実行順序は QG-2（Step 2-1）→ preflight（Step 4-1）を維持する |
+| 意味内容変更なし | 再実行不要 | （なし） | review 対象の意味内容に変更がないため、既存検証結果をそのまま使用し、最初の GitHub Issue 作成 Step へ進む |
+
+4パターンのいずれかを完了した後、意味内容変更から新たな本質的争点が生じ得る場合のみ再 review を発動できる（REQ-014-007）。同一 finding を新証拠・新前提・異なる failure condition・未評価範囲なしに再起票しない。再 review の停止条件（REQ-014-008）を満たした場合、最初の GitHub Issue 作成 Step（Epic flow は Step 7、Standard flow は Step 12）へ進む。
+
+### 最初の副作用（GitHub Issue 作成）との順序
+
+review は最初の GitHub Issue 作成呼び出し（Epic flow は Step 7、Standard flow は Step 12）より前に実行する。GitHub Issue 作成が case-open の最初の副作用（GitHub API 呼び出しによる Issue レコード生成）であるため、review は最初の副作用の前に挿入される。review の結果、execution structure、Issue 本文候補、完了条件のいずれかが変更された場合は、変更影響別の再実行ルール（REQ-015-009）に従い、最初の GitHub Issue 作成前に反映を完了する。
+
+### 正規所有者マトリックス参照
+
+本節と adversarial-review SPEC「adversarial-review caller integration 共通契約」節（REQ-014-011）、delegation-contracts SPEC「adversarial-review との委譲契約接続」節、workflow-contracts SPEC「adversarial-review 由来の停止信号」節との間で意味の重複、矛盾を生じない。case-open command 固有の挿入境界（発動条件、Step 構造、変更影響別再実行ルール、順序）のみを本節が所有し、共通 caller integration 契約、adversarial-review 自身の振る舞い契約、再 review 条件と停止条件の詳細は各正規所有者 SPEC を正とする。
 

--- a/src/opencode/commands/agentdev/case-open.md
+++ b/src/opencode/commands/agentdev/case-open.md
@@ -50,6 +50,17 @@ description: 要件定義をもとにGitHub Issueを作成する
 
 **共通ルール**（全Step適用）: VERIFY（gh CLI 書込後は毎回 `agentdev-gh-cli` VERIFY 操作で検証）、テンプレート準拠（テンプレート読込後は毎回【必須】セクションの完備を確認、【任意】は内容がある場合のみ含める、欠落時は再生成）
 
+### adversarial-review 挿入境界（経路F、REQ-015-009）
+
+execution structure、Issue 本文候補、完了条件を構成した後、最初の GitHub Issue 作成の前に挿入する。Epic flow の場合は Step 5（テンプレート読込）、Step 6（Epic Issue 本文生成）完了後、Step 7（Epic Issue 作成）の前。Standard flow の場合は Step 4-1（preflight）完了後、Step 10（関連ADR特定）の前。adversarial-review は任意助言手段であり（REQ-014-001）、標準フローへ自動発動しない。発動条件判定と review 呼出を分離する（REQ-015-001）。詳細な挿入境界、Step 構造対応付け、変更影響別再実行ルールは case-open command SPEC（extension 経由）「adversarial-review 挿入境界（経路F）」節を正とする。
+
+- **発動条件判定（REQ-015-002、REQ-015-003）**: ユーザーが adversarial-review の実施を明示的に指定した場合に発動する（REQ-015-002）。指定がない場合は従来フロー（review を挿入せず最初の GitHub Issue 作成 Step へ進む）を維持する（REQ-015-003）。Epic flow は Step 7、Standard flow は Step 12 へそのまま進む。
+- **review 呼出（REQ-015-001）**: 発動条件判定で発動と判定された場合、execution structure（Step 3-1 または Step 4-1 で確定）、Issue 本文候補（Epic flow は Step 6 Epic Issue 本文、Standard flow は Step 2 Issue 本文）、完了条件（Step 2-1 の QG-2 で検証済み）の3者を対象に adversarial-review を呼び出す。委譲契約は delegation-contracts SPEC（extension 経由）「adversarial-review との委譲契約接続」節に従う。
+  - execution structure に関わる finding は Step 3-1（自律構成生成）または Step 4（規模判定）へ戻し再評価する。Issue 本文、完了条件に関わる finding は該当 Step へ戻す。accepted finding の反映は呼出元の責務である（REQ-014-006）。
+  - **変更影響別の再実行ルール（REQ-015-009）**: review の結果反映で review 対象の意味内容が変更された場合、変更影響範囲に応じて4パターンのいずれかを実行する。完了条件のみ変更 → QG-2（Step 2-1）を再実行。execution structure のみ変更 → preflight（Step 4-1）を再実行。両方が変更 → QG-2、preflight 両方を再実行（順序は QG-2 → preflight）。意味内容変更なし → 再実行不要、最初の GitHub Issue 作成 Step へ進む。
+  - 未解決のユーザー判断事項が残る場合、最初の GitHub Issue 作成 Step へ進まない（REQ-014-009）。工程委譲起源であるため既存 status に unresolved 判断事項を付加する（REQ-014-012）。
+  - 呼出失敗時は silent skip を禁止し、従来フローを維持する（REQ-014-010）。
+
 ### Step 5: テンプレート読込（Epic flow）
 
 `agentdev-workflow-templates` の選定ルールに従いテンプレートを読み込む。詳細は `agentdev-issue-management` を参照。Epic flow は Step 3 または Step 4 のルーティングにより開始。マルチREQ/ 単一REQ の差分（分解ソース、Waveテーブル列、子Issue数上限、子Issue内容ソース、子Issue追加要素）の詳細は `agentdev-epic-tracker` を参照


### PR DESCRIPTION
## 概要
<!-- 【必須】 -->

OU-002 / REQ-015 経路F: case-open への adversarial-review caller integration を実装する。spec-save で追加済みのセクション見出しに対し本文を実装し、コマンド定義へ review 呼出 Step を追加する。

## 実装内容
<!-- 【必須】 -->

- **SPEC（`docs/specs/commands/case-open.md`）**: 「adversarial-review 挿入境界（経路F）」節へ本文を実装
  - 挿入位置（REQ-015-009）: 「execution structure / Issue 本文候補 / 完了条件構成後・最初の GitHub Issue 作成前」と一意に特定可能。flow 別対応表（Epic flow / Standard flow）で Step 番号を明示
  - 発動条件判定 Step（REQ-015-001/002/003）: ユーザー明示指定時発動、条件非該当時従来フロー維持
  - review 呼出 Step（REQ-015-001）: 委譲契約（`semantic_review`）、review 対象、採用後戻り先、unresolved 時取扱い、呼出失敗時取扱い
  - 変更影響別の再実行ルール（REQ-015-009）: 4パターン（完了条件のみ/QG-2、execution structure のみ/preflight、両方/QG-2+preflight、意味内容変更なし/再実行不要）を表で明記
  - 最初の副作用（GitHub Issue 作成）との順序
  - 正規所有者マトリックス参照（REQ-014-011）
- **コマンド定義（`src/opencode/commands/agentdev/case-open.md`）**: Step 4-1（preflight）完了後に「adversarial-review 挿入境界（経路F、REQ-015-009）」セクションを追加
  - Epic flow は Step 6（Epic Issue 本文生成）完了後・Step 7（Epic Issue 作成）の前
  - Standard flow は Step 4-1（preflight）完了後・Step 10（関連ADR特定）の前
  - 発動条件判定 Step と review 呼出 Step を分離（REQ-015-001）
  - 変更影響別4パターン再実行ルール（REQ-015-009）を要約

共通 caller integration 契約は adversarial-review SPEC、workflow-contracts SPEC、delegation-contracts SPEC が正典として所有し（子 #1963 で実装済み）、本 PR は経路F 固有の呼出統合のみを規定する（REQ-014-011）。

## 完了条件
<!-- 【必須】 -->

- [x] REQ-015-001（経路F分）: case-open command SPEC に発動条件判定 Step と review 呼出 Step が分離された review 挿入境界節が存在する
- [x] REQ-015-002（経路F分）: ユーザー明示指定時に case-open で review が発動することが明記される
- [x] REQ-015-003（経路F分）: 条件非該当時は従来フローが維持されることが明記される
- [x] REQ-015-009: review 挿入位置が「execution structure / Issue 本文候補 / 完了条件構成後・最初の Issue 作成前」と一意に特定可能である
- [x] REQ-015-009: 変更影響別の QG-2 / preflight / 両方 / 不要 再実行ルール（4パターン）が明記される

## テスト結果
<!-- 【必須】 -->

- **TS-001（経路F分）**: case-open command SPEC の経路F 節に review 挿入境界が存在することを確認。発動条件判定 Step（`### 発動条件判定 Step`）と review 呼出 Step（`### review 呼出 Step`）が分離されている。pass。
- **TS-013**: case-open SPEC の経路F 節に変更影響別の QG-2 / preflight / 両方 / 不要 再実行ルール（4パターン）が「変更影響別の再実行ルール（REQ-015-009）」節の表で明記されている。pass。
- **docs-check（`check_changed_docs.ts --workflow case-run --files docs/specs/commands/case-open.md`）**: failures=[], warnings=[]。pass。
- **extensions check（`check_extensions.ts`）**: failures は既存の `repo-agentdev-artifact-graph` 関連警告6件のみで、本 PR 由来の新規違反なし。pass。

## 品質メトリクス
<!-- 【必須】 -->

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| docs-check failures | 0件 | 0件 | ✅ |
| extensions check 新規違反 | 0件 | 0件 | ✅ |
| REQ-015-001/002/003/009 充足 | 5/5 完了条件 | 5/5 | ✅ |
| TS-001/TS-013 pass | 2/2 | 2/2 | ✅ |

## Findings/ Capture候補
<!-- 【必須】 -->

### intake

該当なし

### learning

該当なし

## 関連Issue
<!-- 【必須】 -->

Parent: #1962

Closes #1969
