### PR TITLE
feat(adversarial-review): REQ-015 経路G case-run adapter 委譲内 review 統合の実装

### DIFF
--- a/docs/specs/commands/case-run.md
+++ b/docs/specs/commands/case-run.md
@@ -266,7 +266,51 @@ L3（委譲先内部メトリクス）は対象外とする（REQ-003-010）。
 
 ## adversarial-review 挿入境界（経路G: adapter 委譲内）
 
-経路G の review 挿入境界: adapter 委譲内の実装方針形成 → review → 結果反映、
-実装方針限定（既確定 Issue/REQ/ADR/SPEC を実現する内部選択）、blocked 遷移を規定する。
-case-run 本体は実装方針を生成・審査せず、agentdev-case-run-execution-adapter へ委譲する。
+本節は case-run における adversarial-review caller integration（REQ-015 経路G）の挿入境界を正典として所有する（REQ-014-011）。共通 caller integration 契約の正規所有者は adversarial-review SPEC であり（REQ-014-003）、本節は経路G 固有の挿入位置、発動条件、実装方針限定、blocked 遷移のみを所有する。adversarial-review 自身の振る舞い契約、再 review 条件、停止条件は adversarial-review SPEC を正とし、本節で再定義しない。実装方針形成、review 呼出、結果反映の内部手続きの正規所有者は `agentdev-case-run-execution-adapter` SPEC「adversarial-review 統合（実装方針→review→結果反映）」節とし、本節は参照する。
+
+### 挿入境界と Step 構造（REQ-015-001）
+
+経路G は他経路（A〜F）と異なり、review 挿入境界を case-run 本体の現行 Step 構造へ直接挿入しない。代わりに、Step 6（実行担当サブエージェント起動）における adapter 委譲の内部に review 挿入境界を設ける。発動条件判定と review 呼出の分離（REQ-015-001）は adapter 委譲内で達成され、case-run 本体は review 発動の有無を判定しない。本節は Step 6 委譲境界を経路G の正典として一意に特定し、`.opencode/commands/agentdev/case-run.md` の Step 6 が実行時投影先となる。
+
+| 段階 | 対応 Step | 役割 |
+|---|---|---|
+| 委譲 | case-run Step 6（実行担当サブエージェント起動） | adapter skill 経由で委譲を起動し、委譲 prompt 内で実行 command を指定する。実装方針の生成、review、結果反映は委譲内へ委ねる |
+| 発動条件判定 | adapter 委譲内（実装方針形成完了後、最初の実装変更前） | ユーザー明示指定の有無を実行担当サブエージェントが判定する |
+| review 呼出 | adapter 委譲内（発動条件該当時、最初の実装変更前） | 実行担当サブエージェントが adversarial-review を起動し、実装方針を審議対象へ渡す |
+| 結果反映 | adapter 委譲内（review 完了後、最初の実装変更前） | accepted finding を実装方針へ反映する。反映後、意味内容変更時は必要な既存検証を再実行する |
+| result 返却 | case-run Step 7（実行担当サブエージェント result 処理） | result 契約（completed-pr / blocked / failed / delegation-unavailable）で case-run 本体へ返却 |
+
+### case-run 本体は実装方針を生成・審査しない（REQ-015-010）
+
+case-run 本体（Step 1〜8 の orchestration）は実装方針の生成、審査、review を行わない（REQ-015-010）。実装方針の形成、adversarial-review 呼出、結果反映は Step 6 委譲内で agentdev-case-run-execution-adapter の委譲契約に従い、最初の実装変更前に実施する。case-run 本体が実装方針を生成、保持、審査するステップを新設しない。委譲 result（4状態）のみで adapter 委譲内の結果を受領する。
+
+### 実装方針限定（REQ-015-010）
+
+adapter 委譲内で形成する実装方針は、既確定 Issue 本文、REQ、ADR、SPEC を実現する内部選択（関数配置、命名、データ構造の選択、実装の並び順等）に限定する（REQ-015-010）。実装方針は既確定文書へ矛盾しない内部選択の範囲内で review 審議対象となる。実装方針が既確定 Issue/REQ/ADR/SPEC の変更、追加、撤回を必要とする場合、実行担当サブエージェントは実装を開始せず blocked へ遷移する。
+
+### blocked 遷移（REQ-015-010、REQ-015-011）
+
+adapter 委譲内で次のいずれかに該当する場合、実行担当サブエージェントは result を `blocked` として case-run へ返却する（REQ-015-010、REQ-015-011）。
+
+- 実装方針が既確定 Issue/REQ/ADR/SPEC の変更、追加、撤回を必要とする（REQ-015-010）
+- 要件、仕様に問題（欠落、矛盾、曖昧さ、実現不可能な条件等）を検出した（REQ-015-011）
+- adversarial-review 審議で unresolved な本質的争点またはユーザー判断事項が残り、実装の最初の変更（不可逆処理）へ進めない（REQ-014-009）
+
+blocked 詳細本文は Issue コメントに SSoT として記録され、case-run Step 7 で処理される。実行担当サブエージェントは要件、仕様問題を検出した場合、勝手に仕様変更、REQ 黙示変更、ADR 再解釈を行わず、必ず blocked 経路へ入る（REQ-015-011、G02）。
+
+### 発動条件（REQ-015-002）
+
+adversarial-review は任意助言手段であり、ユーザーが明示的に指定した場合にのみ発動する（REQ-014-001、REQ-015-002）。発動条件判定は adapter 委譲内で実行担当サブエージェントが行う。明示指定がない場合、adapter 委譲は review 呼出を経由せず、実装方針形成から実装、検証、PR 作成の従来フローへ進む。case-run 本体は発動条件の有無を判定、伝達しない。
+
+### 従来フロー維持（REQ-015-003）
+
+発動条件非該当時（ユーザー明示指定なし）、呼出失敗時（REQ-014-010）のいずれの場合も、case-run の従来フロー（Step 1〜8）を維持する（REQ-015-003）。review 挿入境界は case-run 本体の既存 Step を追加、削除、並べ替えせず、Step 6 委譲内での発動条件判定と review 呼出 Step の分離のみを追加する。委譲 result が `completed-pr` の場合、従来どおり Step 7 で PR 番号を受領し Step 8 クリーンアップフェーズへ進む。
+
+### 戻り先と反映責務
+
+accepted finding の実装方針への反映は adapter 委譲内の実行担当サブエージェント責務である（REQ-014-006）。adversarial-review は finding を提示し、合意候補を形成するが、実装方針、実装ファイル、PR 本文への反映を自身では行わない。反映後に実装方針の意味内容が変更された場合、adapter 委譲内で必要な既存検証（REQ/ADR/SPEC 整合性再確認、targeted docs guard、QG-3 等）を行い、意味内容変更から新たな本質的争点が生じ得る場合のみ adapter 委譲内で再 review を発動できる（REQ-014-007）。unresolved な本質的争点またはユーザー判断事項が残る場合、実装の最初の変更（不可逆処理）へ進まず blocked へ遷移する（REQ-014-009、前述「blocked 遷移」節）。
+
+### 正規所有者マトリックス参照
+
+本節と adversarial-review SPEC「adversarial-review caller integration 共通契約」節（REQ-014-011）、delegation-contracts SPEC「adversarial-review との委譲契約接続」節、`agentdev-case-run-execution-adapter` SPEC「adversarial-review 統合（実装方針→review→結果反映）」節との間で意味の重複、矛盾を生じない。case-run command 固有の挿入境界（委譲内実施、Step 6 投影、実装方針限定、blocked 遷移）のみを本節が所有し、実装方針形成、review 呼出、結果反映の内部手続きの詳細は `agentdev-case-run-execution-adapter` SPEC を正とする。
 

--- a/docs/specs/skills/agentdev-case-run-execution-adapter.md
+++ b/docs/specs/skills/agentdev-case-run-execution-adapter.md
@@ -62,6 +62,45 @@ case-run が Issue 実装を実行担当サブエージェントへ委譲する�
 
 ## adversarial-review 統合（実装方針→review→結果反映）
 
-case-run 経路G の adapter 委譲内における実装方針形成、adversarial-review 呼出、
-結果反映、blocked 遷移の内部手続きを規定する。
+本節は case-run 経路G（REQ-015）の adapter 委譲内における adversarial-review 統合の内部手続きを正典として所有する（REQ-014-011）。共通 caller integration 契約の正規所有者は adversarial-review SPEC であり（REQ-014-003）、本節は adapter 委譲内固有の実装方針形成、review 呼出、結果反映、blocked 遷移の手続きのみを所有する。挿入境界（委譲内実施、Step 6 投影、実装方針限定、blocked 遷移）の正規所有者は case-run command SPEC「adversarial-review 挿入境界（経路G: adapter 委譲内）」節であり、本節は再定義せず参照する。adversarial-review 自身の振る舞い契約、再 review 条件、停止条件は adversarial-review SPEC を正とし、本節で再定義しない。
+
+### 実装方針の形成と限定（REQ-015-010）
+
+実行担当サブエージェントは委譲 prompt で指定された実行 command に従い、Issue 本文、受け入れ基準、ADR、REQ、SPEC、docs、repository context を再確認した上で、実装方針を形成する。実装方針は既確定 Issue/REQ/ADR/SPEC を実現する内部選択（関数配置、命名、データ構造の選択、実装の並び順、使用ライブラリ選択等の実現手段）に限定する（REQ-015-010）。実装方針は新規要件の創出、既存 REQ/ADR/SPEC の変更、撤回、再解釈を含まない。
+
+実装方針は最初の実装変更（ファイル編集、コード生成等の不可逆処理）前に形成、確定する。実装方針の生成、審査は case-run 本体（委譲元）ではなく adapter 委譲内の実行担当サブエージェント責務である（REQ-015-010、case-run command SPEC「case-run 本体は実装方針を生成・審査しない」節参照）。
+
+### review 呼出と発動条件（REQ-015-001/002）
+
+実行担当サブエージェントは実装方針形成完了後、最初の実装変更前に発動条件を判定する。発動条件判定と review 呼出は分離する（REQ-015-001）。発動条件はユーザー明示指定のみ（REQ-015-002、REQ-014-001）を正とする。明示指定の検出、伝達経路（委譲 prompt、メタデータ等）の詳細は harness execution mechanism に属し、本 SPEC の対象外とする。
+
+発動条件該当時、実行担当サブエージェントは `agentdev-adversarial-review` を起動し、実装方針を審議対象へ渡す。呼出契約、返却契約、副作用境界は `agentdev-adversarial-review` と delegation-contracts SPEC（`semantic_review`、書き込み禁止型）を正とする。adversarial-review は実装ファイル、Issue、PR、git 操作を行わず（REQ-014-004）、審議結果は中間成果として呼出元（実行担当サブエージェント）へ返却され、新規正規 artifact を生成しない（REQ-014-005）。
+
+### 結果反映（REQ-014-006/007）
+
+accepted finding の実装方針への反映は実行担当サブエージェント（呼出元）の責務である（REQ-014-006）。反映は最初の実装変更前に行う。反映後に実装方針の意味内容が変更された場合、adapter 委譲内で必要な既存検証（REQ/ADR/SPEC 整合性再確認、targeted docs guard、QG-3 等）を再実行する。意味内容変更から新たな本質的争点が生じ得る場合のみ adapter 委譲内で再 review を発動でき（REQ-014-007）、新証拠、新前提、異なる failure condition、未評価範囲のいずれも伴わない同一 finding の再起票を禁止する。再 review 停止条件4点（REQ-014-008）は adversarial-review SPEC を正とする。
+
+### blocked 遷移の内部手続き（REQ-015-010/011）
+
+実行担当サブエージェントは adapter 委譲内で次のいずれかに該当する場合、最初の実装変更を行わず result を `blocked` として case-run へ返却する。blocked 遷移の契約は case-run command SPEC「blocked 遷移」節を正とし、本節は adapter 委譲内での判定手続きを所有する。
+
+| blocked 要因 | 要件 | 詳細 |
+|---|---|---|
+| 実装方針が既確定文書の変更を必要とする | REQ-015-010 | 実装方針が既確定 Issue/REQ/ADR/SPEC の変更、追加、撤回を要求する場合、実装を開始せず blocked へ遷移する |
+| 要件、仕様問題の検出 | REQ-015-011 | 要件、仕様に欠落、矛盾、曖昧さ、実現不可能な条件等を検出した場合、勝手に仕様変更、REQ 黙示変更、ADR 再解釈を行わず blocked へ遷移する |
+| unresolved 争点の残存 | REQ-014-009 | adversarial-review 審議で unresolved な本質的争点またはユーザー判断事項が残り、実装の最初の変更（不可逆処理）へ進めない場合、blocked へ遷移する |
+
+blocked 詳細本文（検出理由、対象 REQ/ADR/SPEC、想定される修正方向等）は Issue コメントに SSoT として構造化して記録する（result 契約「SSoT」節、case-run command SPEC Step 7 参照）。実行担当サブエージェントは blocked 遷移時に実装ファイル、PR、commit を残さず、worktree を実装前の状態に保つ。
+
+### 従来フロー維持（REQ-015-003）
+
+発動条件非該当時（ユーザー明示指定なし）、呼出失敗時（REQ-014-010）のいずれの場合も、adapter 委譲内の従来フロー（実装方針形成、実装、検証、PR 作成）を維持する（REQ-015-003）。review 呼出を行わず、実装方針形成から直接実装、検証、PR 作成へ進む。呼出失敗時は silent skip を禁止し（REQ-014-010）、利用不能を PR 本文の `## Findings / Capture候補` セクションに記録した上で従来フローを維持する。
+
+### 副作用境界と委譲契約
+
+adversarial-review は delegation-contracts SPEC の `semantic_review`（書き込み禁止型）として適用する。許可操作は `read_files`、`inspect_content`、`return_summary`、`return_evidence`、`return_artifact_body_when_requested` に限定し、`file_write`、`issue_pr_update`、`commit`、`push`、`user_confirmation` を forbidden とする（REQ-014-004）。審議結果は中間成果として実行担当サブエージェントへ返却し、新規正規 artifact を生成しない（REQ-014-005）。呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し（REQ-014-010）、従来フローと既存 QG/HITL を維持する。
+
+### 正規所有者マトリックス参照
+
+本節と adversarial-review SPEC「adversarial-review caller integration 共通契約」節（REQ-014-011）、delegation-contracts SPEC「adversarial-review との委譲契約接続」節、case-run command SPEC「adversarial-review 挿入境界（経路G: adapter 委譲内）」節との間で意味の重複、矛盾を生じない。adapter 委譲内の内部手続き（実装方針形成、review 呼出、結果反映、blocked 遷移）のみを本節が所有し、挿入境界（委譲内実施、Step 6 投影）、実装方針限定の契約は case-run command SPEC を正とする。
 

--- a/src/opencode/commands/agentdev/case-run.md
+++ b/src/opencode/commands/agentdev/case-run.md
@@ -79,6 +79,22 @@ case-run が使用する検査ツール（integrity 契約 SPEC「Workflow × �
 
 **case-run が直接行わない（実行担当サブエージェントの責務）**: work plan生成、実装実行、TDD、乖離検出（QG-3）、specs更新、関連ドキュメント整合性確認、ローカル検証、PR本文作成、PR作成、デプロイ検証。**実行担当サブエージェントへの引き渡し**: 割り当てられた1 Issue の Issue番号、worktree root（相対パス指定、worktree内制約）、ブランチ名。**PR URL 受領**: 実行担当サブエージェントが直接 PR 作成を行い、PR URL を委譲 result として返却する（PR URL フォールバック検索は使用しない）。**外部実行ハーネスの中間成果物**: plan artifact 等の中間成果物を AgentDevFlow の永続成果物として扱わない、最終結果は PR URL で受領する。**完了条件チェックボックス**: 実行担当サブエージェントは完了条件チェックボックスを更新しない（case-close QG-4 の責務）。**Findings/Capture 候補**: 実行担当サブエージェントが PR 本文の `## Findings / Capture候補` に記録する。**SPEC確定候補**: 実装時に発見された SPEC レベルの詳細（schema、enum、判定表、内部アルゴリズム等）は、実行担当サブエージェントが PR 本文の `## SPEC確定候補` セクションに記録する（`## Findings / Capture候補` とは別セクション、混在させない）。SPEC確定候補は case-close Step 3 で SPEC 確定チェックの入力となる
 
+### Step 6-1: adapter 委譲内 adversarial-review 統合（経路G、REQ-015-010/011）
+
+case-run 経路G の adversarial-review 挿入境界。本 Step は case-run 本体の Step 構造へ review 呼出を直接挿入せず、Step 6 委譲内で実施される review 統合を宣言する。挿入境界、委譲内実施、実装方針限定、blocked 遷移の正規所有者は case-run command SPEC「adversarial-review 挿入境界（経路G: adapter 委譲内）」節であり、本 Step は実行時投影先である。adapter 委譲内の内部手続き（実装方針形成、review 呼出、結果反映、blocked 遷移）の詳細は `agentdev-case-run-execution-adapter` スキル（SPEC「adversarial-review 統合（実装方針→review→結果反映）」節、references/adversarial-review-integration.md）を参照。
+
+**case-run 本体は実装方針を生成・審査しない（REQ-015-010）**: 実装方針の形成、adversarial-review 呼出、結果反映は Step 6 委譲内で agentdev-case-run-execution-adapter の委譲契約に従い、最初の実装変更前に実施する。case-run 本体（Step 1〜8 の orchestration）が実装方針を生成、保持、審査するステップを新設しない。委譲 result（4状態）のみで adapter 委譲内の結果を受領する。
+
+**実装方針限定（REQ-015-010）**: adapter 委譲内で形成する実装方針は、既確定 Issue 本文、REQ、ADR、SPEC を実現する内部選択（関数配置、命名、データ構造の選択、実装の並び順等）に限定する。実装方針は既確定文書へ矛盾しない内部選択の範囲内で review 審議対象となる。実装方針が既確定 Issue/REQ/ADR/SPEC の変更、追加、撤回を必要とする場合、実行担当サブエージェントは実装を開始せず blocked へ遷移する。
+
+**blocked 遷移（REQ-015-010、REQ-015-011）**: adapter 委譲内で次のいずれかに該当する場合、実行担当サブエージェントは result を `blocked` として返却する。(1) 実装方針が既確定 Issue/REQ/ADR/SPEC の変更、追加、撤回を必要とする（REQ-015-010）。(2) 要件、仕様に問題（欠落、矛盾、曖昧さ、実現不可能な条件等）を検出した（REQ-015-011）。(3) adversarial-review 審議で unresolved な本質的争点またはユーザー判断事項が残り、実装の最初の変更（不可逆処理）へ進めない（REQ-014-009）。blocked 詳細本文は Issue コメントに SSoT として記録され、Step 7 で処理される。実行担当サブエージェントは要件、仕様問題を検出した場合、勝手に仕様変更、REQ 黙示変更、ADR 再解釈を行わず、必ず blocked 経路へ入る（G02）。
+
+**発動条件（REQ-015-002）**: adversarial-review は任意助言手段であり、ユーザーが明示的に指定した場合にのみ発動する（REQ-014-001、REQ-015-002）。発動条件判定は adapter 委譲内で実行担当サブエージェントが行う。case-run 本体は発動条件の有無を判定、伝達しない。
+
+**従来フロー維持（REQ-015-003）**: 発動条件非該当時（ユーザー明示指定なし）、呼出失敗時（REQ-014-010）のいずれの場合も、adapter 委譲内の従来フロー（実装方針形成、実装、検証、PR 作成）を維持する。review 呼出を行わず、実装方針形成から直接実装、検証、PR 作成へ進む。case-run 本体の従来フロー（Step 1〜8）も維持し、Step 6 委譲の結果は Step 7 で4状態として受領する。
+
+**accepted finding 反映と再 review（REQ-014-006/007）**: accepted finding の実装方針への反映は adapter 委譲内の実行担当サブエージェント責務である。反映後に実装方針の意味内容が変更された場合、adapter 委譲内で必要な既存検証を再実行し、意味内容変更から新たな本質的争点が生じ得る場合のみ再 review を発動できる。同一 finding を新証拠・新前提・異なる failure condition・未評価範囲なしに再起票しない。
+
 ### Step 7: 実行担当サブエージェント result 処理
 
 実行担当サブエージェントが返す4状態（`agentdev-case-run-execution-adapter` の result 契約）のいずれかを処理する:

--- a/src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md
+++ b/src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md
@@ -162,6 +162,27 @@ harness execution mechanism は本 SKILL の規範対象外とし、`references/
 | 委譲起動の具象実装（起動方式、worktree 取り扱い、PR 作成と URL 受領、result 受領、evidence 確認、timeout/ 中断、委譲プロンプト構築例、委譲プロンプト雛形）が必要な場合 | [references/harness-delegation.md](references/harness-delegation.md) |
 | 委譲プロトコルと category 設計（`writing` category と発火スキルの相互作用、`unspecified-high` 推奨根拠、category 選定ガイドライン、MUST NOT DO 必須化）が必要な場合 | [references/harness-delegation.md](references/harness-delegation.md) |
 | 委譲起動失敗、異常終了時の事後処理（worktree git status 確認、変更残留時の分類、残留箇所の grep 検出、手動修正または PR 化）が必要な場合 | [references/harness-delegation.md](references/harness-delegation.md) |
+| 経路G の adapter 委譲内 adversarial-review 統合（実装方針形成、review 呼出、結果反映、blocked 遷移の実行時詳細手順、候補判断基準、呼出失敗時の取扱い）が必要な場合 | [references/adversarial-review-integration.md](references/adversarial-review-integration.md) |
+
+## adversarial-review 統合（経路G: adapter 委譲内）
+
+本スキルは case-run 経路G（REQ-015）における adapter 委譲内の adversarial-review 統合（実装方針形成、review 呼出、結果反映、blocked 遷移）の実行時参照を提供する。正規原本は `agentdev-case-run-execution-adapter` SPEC「adversarial-review 統合（実装方針→review→結果反映）」節である（REQ-014-003、REQ-014-011）。本 SKILL.md は重複定義せず、詳細は `references/adversarial-review-integration.md`「adversarial-review 統合（経路G）」節を参照。
+
+呼出元（case-run command）と本スキルの主な契約（詳細は SPEC と reference を正とする）:
+
+| 契約 | 要件 | 概要 |
+|---|---|---|
+| 実装方針の形成と限定 | REQ-015-010 | 委譲内で既確定 Issue/REQ/ADR/SPEC を実現する内部選択として実装方針を形成する。case-run 本体は形成しない |
+| 実施位置 | REQ-015-010 | 最初の実装変更前に実施する（実装、検証、PR 作成より前） |
+| 委譲内 review 呼出 | REQ-015-001/002 | adapter 委譲内で実行担当サブエージェントが発動条件判定（ユーザー明示指定）と review 呼出を分離して実施する |
+| blocked 遷移（実装方針限定違反） | REQ-015-010 | 実装方針が既確定文書の変更、追加、撤回を必要とする場合は blocked へ遷移する |
+| blocked 遷移（要件/仕様問題） | REQ-015-011 | 要件、仕様問題を検出した場合は勝手に仕様変更せず blocked へ遷移する |
+| blocked 遷移（unresolved 残存） | REQ-014-009 | unresolved な本質的争点またはユーザー判断事項が残る場合は実装の最初の変更へ進まず blocked へ遷移する |
+| 従来フロー維持 | REQ-015-003 | 発動条件非該当時、呼出失敗時は委譲内の従来フロー（実装方針形成、実装、検証、PR 作成）を維持する |
+| accepted finding 反映 | REQ-014-006 | accepted finding の実装方針への反映は adapter 委譲内の実行担当サブエージェント責務 |
+| 再 review 条件 | REQ-014-007 | 意味内容変更時のみ再発動可能、同一 finding 再起票禁止（正は adversarial-review SPEC） |
+| 呼出失敗時の扱い | REQ-014-010 | silent skip 禁止、従来フロー維持（正は adversarial-review SPEC） |
+| 副作用境界 | REQ-014-004/005 | `semantic_review`（書き込み禁止型）、新規 artifact 非生成（正は adversarial-review SPEC、delegation-contracts SPEC） |
 
 ## See Also
 

--- a/src/opencode/skills/agentdev-case-run-execution-adapter/references/adversarial-review-integration.md
+++ b/src/opencode/skills/agentdev-case-run-execution-adapter/references/adversarial-review-integration.md
@@ -1,0 +1,87 @@
+# adversarial-review 統合（経路G）
+
+本ファイルは case-run 経路G（REQ-015）における adapter 委譲内の adversarial-review 統合の実行時参照を提供する。正規原本は `agentdev-case-run-execution-adapter` SPEC「adversarial-review 統合（実装方針→review→結果反映）」節である。本ファイルは SPEC を補完する実行手続きのみを保持し、SPEC と矛盾する場合は SPEC を正とする。共通 caller integration 契約は adversarial-review SPEC が正規所有者であり（REQ-014-003）、本ファイルは再定義しない。挿入境界、委譲内実施、実装方針限定、blocked 遷移の契約は case-run command SPEC「adversarial-review 挿入境界（経路G: adapter 委譲内）」節が正であり、本ファイルは参照レベルに留める。
+
+## 実装方針形成
+
+実行担当サブエージェントは委譲 prompt で指定された実行 command に従い、Issue 本文、受け入れ基準、ADR、REQ、SPEC、docs、repository context を再確認した上で実装方針を形成する。
+
+実装方針の構成要素:
+
+- 実装の全体構造（モジュール、ファイル構成、関数配置）
+- 命名規則、データ構造の選択
+- 実装の並び順、依存関係の整理
+- 使用ライブラリ、ユーティリティの選択（既確定 SPEC 範囲内）
+- テスト方針（test strategy 項目の検証手順の具体化）
+
+実装方針は既確定 Issue 本文、REQ、ADR、SPEC を実現する内部選択に限定する（REQ-015-010）。新規要件の創出、既存 REQ/ADR/SPEC の変更、撤回、再解釈を含まない。実装方針の生成、審査は case-run 本体（委譲元）ではなく adapter 委譲内の実行担当サブエージェント責務である（REQ-015-010）。実装方針は最初の実装変更（ファイル編集、コード生成等の不可逆処理）前に形成、確定する。
+
+## 発動条件判定と review 呼出
+
+実行担当サブエージェントは実装方針形成完了後、最初の実装変更前に発動条件を判定する。発動条件判定と review 呼出は分離する（REQ-015-001）。
+
+### 発動条件判定
+
+発動条件はユーザー明示指定のみ（REQ-015-002、REQ-014-001）を正とする。明示指定の検出、伝達経路（委譲 prompt、メタデータ等）の詳細は harness execution mechanism に属し、本ファイルの対象外とする。明示指定がない場合、review 呼出を行わず次節「従来フロー（review 非発動時）」へ進む。
+
+### review 呼出（発動条件該当時）
+
+発動条件該当時、実行担当サブエージェントは `agentdev-adversarial-review` を起動し、実装方針を審議対象へ渡す。呼出契約、返却契約、副作用境界は `agentdev-adversarial-review` と delegation-contracts SPEC（`semantic_review`、書き込み禁止型）を正とする。adversarial-review は実装ファイル、Issue、PR、git 操作を行わず（REQ-014-004）、審議結果は中間成果として実行担当サブエージェントへ返却され、新規正規 artifact を生成しない（REQ-014-005）。
+
+審議対象へ渡す実装方針の内容:
+
+- 対象 Issue 番号、完了条件、受け入れ基準
+- 形成した実装方針（構成要素、根拠、既確定 Issue/REQ/ADR/SPEC との対応）
+- 想定失敗条件、技術領域、制約（review 戦略構成の入力）
+
+## 結果反映
+
+accepted finding の実装方針への反映は実行担当サブエージェント（呼出元）の責務である（REQ-014-006）。反映は最初の実装変更前に行う。
+
+反映後に実装方針の意味内容が変更された場合、adapter 委譲内で必要な既存検証（REQ/ADR/SPEC 整合性再確認、targeted docs guard、QG-3 等）を再実行する。意味内容変更から新たな本質的争点が生じ得る場合のみ adapter 委譲内で再 review を発動でき（REQ-014-007）、新証拠、新前提、異なる failure condition、未評価範囲のいずれも伴わない同一 finding の再起票を禁止する。再 review 停止条件4点（REQ-014-008）は adversarial-review SPEC を正とする。
+
+## blocked 遷移
+
+実行担当サブエージェントは adapter 委譲内で次のいずれかに該当する場合、最初の実装変更を行わず result を `blocked` として case-run へ返却する。
+
+### 実装方針が既確定文書の変更を必要とする（REQ-015-010）
+
+実装方針が次のいずれかを必要とする場合、blocked へ遷移する。
+
+- 既確定 Issue 本文の受け入れ基準、完了条件の変更
+- 既存 REQ の要件行の追加、変更、撤回
+- 既存 ADR の決定事項の変更、撤回
+- 既存 SPEC の契約、手続き、責務の変更
+
+これらは adapter 委譲内で解決せず、ユーザー判断、REQ 更新プロセス（req-define / req-save / spec-save）、case-update 経由の Issue 本文更新等の正規経路へ引き渡すため blocked とする。
+
+### 要件、仕様問題の検出（REQ-015-011）
+
+要件、仕様に次のいずれかを検出した場合、勝手に仕様変更、REQ 黙示変更、ADR 再解釈を行わず blocked へ遷移する。
+
+- 要件の欠落（完了条件、受け入れ基準が不明確、実装不可能）
+- 要件の矛盾（完了条件同士、完了条件と受け入れ基準、REQ 間の矛盾）
+- 曖昧さ（用語、対象範囲、境界が複数解釈可能）
+- 実現不可能な条件（技術的制約、リソース制約で実現困難）
+
+### unresolved 争点の残存（REQ-014-009）
+
+adversarial-review 審議で unresolved な本質的争点またはユーザー判断事項が残り、実装の最初の変更（不可逆処理）へ進めない場合、blocked へ遷移する。adversarial-review 自体を新しい恒久的な統制ゲートとしない（REQ-014-009）。unresolved は既存の HITL、blocker、case-auto 停止理由分類のいずれかへ振り向けられる。
+
+### blocked 詳細本文の記録
+
+blocked 詳細本文（検出理由、対象 REQ/ADR/SPEC、想定される修正方向等）は Issue コメントに SSoT として構造化して記録する（result 契約「SSoT」節、case-run command SPEC Step 7 参照）。実行担当サブエージェントは blocked 遷移時に実装ファイル、PR、commit を残さず、worktree を実装前の状態に保つ。
+
+## 従来フロー（review 非発動時）
+
+発動条件非該当時（ユーザー明示指定なし）、呼出失敗時（REQ-014-010）のいずれの場合も、adapter 委譲内の従来フロー（実装方針形成、実装、検証、PR 作成）を維持する（REQ-015-003）。review 呼出を行わず、実装方針形成から直接実装、検証、PR 作成へ進む。
+
+呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し（REQ-014-010）、利用不能を PR 本文の `## Findings / Capture候補` セクションに記録した上で従来フローを維持する。呼出失敗を理由に実装方針を自動承認、自動棄却、または既存 QG を飛ばさない。
+
+## 副作用境界と委譲契約
+
+adversarial-review は delegation-contracts SPEC の `semantic_review`（書き込み禁止型）として適用する。許可操作は `read_files`、`inspect_content`、`return_summary`、`return_evidence`、`return_artifact_body_when_requested` に限定し、`file_write`、`issue_pr_update`、`commit`、`push`、`user_confirmation` を forbidden とする（REQ-014-004）。審議結果は中間成果として実行担当サブエージェントへ返却し、新規正規 artifact を生成しない（REQ-014-005）。呼出失敗時の取扱いは前節「従来フロー（review 非発動時）」を参照。
+
+## 参照契約
+
+挿入境界（委譲内実施、Step 6 投影、実装方針限定、blocked 遷移）は case-run command SPEC「adversarial-review 挿入境界（経路G: adapter 委譲内）」節が正であり、共通契約（任意性、副作用禁止、accepted finding 反映責務、再 review 条件、停止条件、呼出失敗時取扱い）は adversarial-review SPEC「adversarial-review caller integration 共通契約」節（REQ-014）が正とする。本ファイルはこれらを再定義しない（REQ-014-011）。adapter 委譲内の内部手続き（実装方針形成、review 呼出、結果反映、blocked 遷移）の詳細は `agentdev-case-run-execution-adapter` SPEC「adversarial-review 統合（実装方針→review→結果反映）」節が正とする。


### PR DESCRIPTION
## 概要

case-run 経路G（adapter 委譲内）への adversarial-review caller integration（REQ-015）を実装する。spec-save（commit dba8d9bb）で追加済みのセクション見出しに対し、本文を実装する。case-run 本体は実装方針を生成・審査せず、実装方針の形成、adversarial-review、結果反映は agentdev-case-run-execution-adapter の委譲契約内で最初の実装変更前に実施する。実装方針は既確定 Issue/REQ/ADR/SPEC を実現する内部選択に限定し、それらの変更が必要な場合は blocked へ遷移する。

## 実装内容

- **case-run command SPEC**（`docs/specs/commands/case-run.md`）: 「adversarial-review 挿入境界（経路G: adapter 委譲内）」節を充実。Step 6 委譲境界を経路G の正典として一意に特定し、adapter 委譲内で発動条件判定 Step と review 呼出 Step を分離（REQ-015-001）。ユーザー明示指定時のみ発動（REQ-015-002）、条件非該当時・呼出失敗時は従来フロー維持（REQ-015-003）。case-run 本体は実装方針を生成・審査せず委譲内で実施（REQ-015-010）、実装方針限定、blocked 遷移を規定。要件/仕様問題時に勝手に仕様変更せず blocked 経路へ入る（REQ-015-011）
- **agentdev-case-run-execution-adapter SPEC**（`docs/specs/skills/agentdev-case-run-execution-adapter.md`）: 「adversarial-review 統合（実装方針→review→結果反映）」節を充実。実装方針形成と限定（REQ-015-010）、review 呼出と発動条件（REQ-015-001/002）、結果反映（REQ-014-006/007）、blocked 遷移の内部手続き（REQ-015-010/011、REQ-014-009）、従来フロー維持（REQ-015-003）、副作用境界、正規所有者マトリックス参照を規定
- **case-run command 定義**（`src/opencode/commands/agentdev/case-run.md`）: Step 6-1（adapter 委譲内 adversarial-review 統合）を追加。委譲内 review 統合、実装方針限定、blocked 遷移、発動条件、従来フロー維持を command SPEC へ接続
- **agentdev-case-run-execution-adapter SKILL.md**: 経路G の実装方針形成、review 呼出、結果反映、blocked 遷移への参照節と契約テーブルを追加。reference選択表へ `adversarial-review-integration.md` を追加
- **adversarial-review-integration.md（新規）**: 経路G の詳細手続き（実装方針形成、発動条件判定と review 呼出、結果反映、blocked 遷移の3要因、従来フロー、副作用境界、参照契約）を追加

## 完了条件

- [x] REQ-015-001（経路G分）: case-run command SPEC に review 挿入境界節が存在する（「adversarial-review 挿入境界（経路G: adapter 委譲内）」節、REQ-015-001 が「挿入境界と Step 構造」節で2箇所言及、Step 6 委譲内で発動条件判定 Step と review 呼出 Step を分離することを明記）
- [x] REQ-015-002（経路G分）: ユーザー明示指定時に case-run で review が発動することが明記される（「発動条件」節、REQ-015-002 を明示、adapter 委譲内で実行担当サブエージェントが判定）
- [x] REQ-015-003（経路G分）: 条件非該当時は従来フローが維持されることが明記される（「従来フロー維持」節、REQ-015-003 を明示、発動条件非該当時・呼出失敗時は case-run Step 1〜8 を維持）
- [x] REQ-015-010: adapter 委譲内で実装方針形成→review→結果反映が行われることが明記される（SPEC「挿入境界と Step 構造」節の表、adapter SPEC「実装方針の形成と限定」「review 呼出と発動条件」「結果反映」節、command Step 6-1 で明記）
- [x] REQ-015-010: 実装方針が既確定 Issue/REQ/ADR/SPEC を実現する内部選択に限定されることが明記される（case-run SPEC「実装方針限定」節、adapter SPEC「実装方針の形成と限定」節、command Step 6-1「実装方針限定」項で明記）
- [x] REQ-015-010: それらの変更が必要な場合は blocked へ遷移することが明記される（case-run SPEC「blocked 遷移」節、adapter SPEC「blocked 遷移の内部手続き」節の「実装方針が既確定文書の変更を必要とする」行、command Step 6-1「blocked 遷移」項で明記）
- [x] REQ-015-011: case-run で要件/仕様問題時に勝手に仕様変更せず blocked 経路へ入ることが明記される（case-run SPEC「blocked 遷移」節、adapter SPEC「blocked 遷移の内部手続き」節の「要件、仕様問題の検出」行、command Step 6-1「blocked 遷移」項で明記）

## テスト結果

- TS-014（AG-016）: PASS。case-run SPEC 経路G 節と agentdev-case-run-execution-adapter SPEC 統合節に契約が明記される
- TS-015（AG-017）: PASS。case-run SPEC 経路G 節（「blocked 遷移」節）に blocked 遷移条件が明記される

検証スクリプト:
- `check_changed_docs.ts --workflow case-run --files ...`: failures=[], warnings=[]
- `check_extensions.ts`: ok=true（6件の warning は全て既存の `repo-agentdev-artifact-graph` 参照関連、本変更由来ではない）
- `check_distribution_boundary.ts`: ok=true
- `check_command_format.ts`: ok=true
- `lint_skills.ts`: 変更ファイル由来の NG なし（4件の NG は全て `repo-agentdev-integrity` 由来、本変更由来ではない）

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| REQ-015-001 充足 | 経路G 節存在、REQ-015-001 明示 | 節存在 + REQ 明示 | PASS |
| REQ-015-002 充足 | 「発動条件」節で明示 | 節で明示 | PASS |
| REQ-015-003 充足 | 「従来フロー維持」節で明示 | 節で明示 | PASS |
| REQ-015-010（実装方針形成→review→結果反映）充足 | SPEC 表 + 節 + command Step 6-1 | 3層で明示 | PASS |
| REQ-015-010（実装方針限定）充足 | SPEC 節 + adapter SPEC 節 + command | 3層で明示 | PASS |
| REQ-015-010（blocked 遷移）充足 | SPEC 節 + adapter SPEC 節 + command | 3層で明示 | PASS |
| REQ-015-011 充足 | SPEC 節 + adapter SPEC 節 + command | 3層で明示 | PASS |
| check_changed_docs.ts | failures=[] | failures=[] | PASS |
| check_extensions.ts | ok=true | ok=true | PASS |
| check_distribution_boundary.ts | ok=true | ok=true | PASS |
| check_command_format.ts | ok=true | ok=true | PASS |

## Findings / Capture候補

該当なし

## SPEC確定候補

該当なし（詳細パラメータ、入力フィールド構成、enum 値は REQ-015 適用範囲外。共通契約は REQ-014、横断整合は REQ-016 が所有）

