### PR TITLE
feat(req-017): implement Wave 3 execution contract in commands/skills/templates

### DIFF
--- a/src/opencode/commands/agentdev/case-open.md
+++ b/src/opencode/commands/agentdev/case-open.md
@@ -38,6 +38,17 @@ description: 要件定義をもとにGitHub Issueを作成する
 
 **Step 2-3/2-4/2-5**: 識別子中心の記載粒度ガイドライン（2-3、case-run の QG-3 前置 staleness check の入力前提、詳細・記載例は `agentdev-issue-management` 参照）、完了条件展開前の最新状態再確認（2-4、同日内複数 PR マージ後・順次 Wave 実行時の後続 Wave Issue 起票で必須、識別子存在確認を主軸）、review_dispositions の読取・evidence 再確認・証跡転記（2-5、AG-008、consumer 契約は case-open command SPEC extension 経由、evidence 失効時は停止し `stale_target` へ更新）の各詳細は `agentdev-issue-management`、case-open command SPEC（extension 経由）を参照
 
+**Step 2-6: execution contract 確定ステップ（EC-1〜EC-8、REQ-017）**: Issue 本文生成前に次の確定ステップを実行し、結果を Issue 本文の対応セクション（対象範囲、test strategy、完了条件、Execution Contract セクション）へ反映する。詳細な判定規則、対応表は case-open command SPEC（extension 経由）「execution contract 確定ステップ」節、artifact-quality-control-routing SPEC（extension 経由）を正とする。
+
+- **EC-1: 変更対象成果物の確定** — 合意済み要件doc の `artifact_actions` から変更予定成果物を抽出し、Issue 本文の「対象範囲」セクションへ確定する
+- **EC-2: 必須品質統制の導出と test strategy 投影** — artifact-quality-control-routing SPEC の合成規則に従い変更予定成果物の種別から必須品質能力を導出する。各能力について test strategy 項目を生成し、Issue 本文の test strategy セクションへ投影する
+- **EC-3: 完了条件の確定** — 合意内容から成果状態を抽出し、Issue 本文の完了条件セクションへ確定する。実行手段、検証手段は test strategy へ分離する。必須品質能力の呼出自体が利用者要求でない限り、Skill 呼出を完了条件化しない（AG-002、REQ-017-003）
+- **EC-4: 関連 ADR 拘束条件の特定と反映** — Issue の実装を拘束する関連 ADR を特定し、必要な制約を完了条件または test strategy へ反映する
+- **EC-5: 予定変更内容から事前判定可能な追加検証条件の展開** — 「関数削除時は全利用箇所を検査する」等、予定変更内容から事前判定可能な検証条件を test strategy へ展開する。case-open が追加できる test strategy は合意済み変更対象と共通ルールから決定的に導ける必須検証に限定し、新しい利用者要求を生成しない
+- **EC-6: scope-affecting impact candidate の探索と反映** — Issue 作成前に変更影響候補を探索し、scope、完了条件、test strategy に影響する候補を execution contract へ反映する
+- **EC-7: adversarial-review 発動契約の永続化** — ユーザー明示指定による adversarial-review 発動契約が Issue 作成前に判明している場合、Issue 本文の契約セクションへ永続化する（経路F 拡張）
+- **EC-8: execution contract 必須セクションの付与** — 新規 Issue 作成時、新契約識別用の必須セクション（Execution Contract セクション、必須品質統制セクション）を Issue 本文へ付与する。presence-based 判定により新旧 Issue を識別する（AG-012、REQ-017-014）。テンプレート（`issue_desc_feature.md`、`issue_desc_child.md`）の Execution Contract セクション構造は `agentdev-workflow-templates` を参照
+
 ### Step 3: マルチREQ入力判定
 
 入力要件doc数を確認。単一REQ → Step 4。複数REQ または draft-meta `scale: large` → **マルチREQ Epic flow**（Step 5〜）。OU モード時: Step 1-1 で選択した OU が複数または `scale: large` を含む場合 → Epic flow に分岐（Step 3-1 へ）

--- a/src/opencode/commands/agentdev/case-run.md
+++ b/src/opencode/commands/agentdev/case-run.md
@@ -41,6 +41,16 @@ Case に対して実装実行を実行担当サブエージェント経由で委
 - **Step 3**: 関連ADR特定（`docs/adr/README.md` を読み込み、関連ADRがあれば個別に読み込み、実装がADRの決定事項に矛盾しないことを確認）
 - **Step 4**: work_type 判定（`agentdev-workflow-lifecycle` に従い bugfix/feature/maintenance/docs_chore を判定、scale は feature のみ standard/large、workflow_route は都度導出し保存しない）
 
+### Step 4-1: execution contract 消費境界（REQ-017）
+
+case-run は Issue に確定済みの execution contract を消費境界として扱う。消費原則、runtime-only 判断の維持、blocked 遷移と case-update 連携、新旧 Issue 互換運用、work_type/scale 確認の縮約は case-run command SPEC（extension 経由）「execution contract 消費境界」節を正とする。本 Step は消費原則を Step 2〜4 の読取・確認結果へ適用することを宣言する。
+
+- **契約消費原則**: 完了条件、test strategy、必須品質統制を実行契約として扱う。完了条件の不足、曖昧さ、矛盾、実現不能を検出した場合は自律補完せず blocked とする。test strategy を新規設計せず記録済み項目を実行する。必須品質統制の適用要否を再判断せず記録済み test strategy を実行する。work_type/scale/Issue structure を再分類して実行契約を変更しない
+- **runtime-only 判断の維持**: worktree 状態確認（REQ-006-023）、QG-3 前置 staleness check（Step 5-3、REQ-006-030）、実 diff 検査、実装結果・test 実行結果は case-run の安全検査として維持し、execution contract 確定へ移管しない
+- **blocked 遷移と case-update 連携**: 完了条件の不足・曖昧さ・矛盾・実現不能の検出、scope-affecting impact candidate の発見（既存 scope 内を超える変更が必要）、関連 ADR への適合確認で新たな拘束 ADR の必要性が判明した場合、必須品質統制の追加変更が必要な場合、Issue metadata・構造・実態の矛盾検出時は blocked とし、Issue 更新は case-update へ委譲する（case-run 単独では Issue 本文を書き換えない）
+- **新旧 Issue 互換運用**: Issue 本文の execution contract 必須セクション（Execution Contract セクション、必須品質統制セクション）存在有無により新旧 Issue を識別する（presence-based 判定）。必須セクション存在: 新契約 Issue として扱い上記契約消費原則を適用。必須セクション不存在: legacy Issue として扱い、新契約項目欠落のみを理由に一律 blocked にしない（AG-010、REQ-017-013）
+- **work_type/scale 確認の縮約**: Step 4 の work_type 確認は再分類ではなく metadata 整合確認へ縮約して維持する（AG-008、REQ-017-011）
+
 ### Step 5: Worktree作成、ブランチ準備
 
 `agentdev-git-worktree` に従って実行。`origin/main` をベースとして明示的に指定。べき等チェック: worktree既存時は作成スキップ。**Wave 実行時、PR merge 後再開時は worktree 作成前に `git fetch origin` を実行し origin/main の鮮度を確認すること**。詳細手順は `agentdev-git-worktree` 参照

--- a/src/opencode/skills/agentdev-quality-gates/references/qg-2-acceptance-criteria-coverage.md
+++ b/src/opencode/skills/agentdev-quality-gates/references/qg-2-acceptance-criteria-coverage.md
@@ -87,11 +87,33 @@ Epic Issue の場合、テスト戦略が Epic の「対象外」記述と矛盾
 - **warn**: テスト戦略と対象外の関係が曖昧。QG-4 での再検出リスクとして警告。
 - **pass**: Epic 対象外とテスト戦略が整合している、または Epic でない（対象外セクション不存在）。
 
+### 8. artifact-specific quality control 投影検証（REQ-017 拡張）
+
+REQ-017 execution contract 確定を支援するため、artifact-specific quality control の test strategy への投影を検証する（AG-002、REQ-017-003）。対応表は artifact-quality-control-routing SPEC を正とする。
+
+検証項目:
+
+- (a) 変更予定成果物から導出される全ての必須品質能力が test strategy へ反映されていること
+- (b) 各 test strategy 項目が3要素（verification、pass_criteria、on_failure）を持つこと（REQ-008-048 の維持）
+- (c) 完了条件が成果状態であり、必須品質能力の呼出自体が完了状態とされていないこと（AG-002、REQ-017-003）
+
+適用範囲:
+
+- 新規 Issue 作成時（case-open Step 1、Step 5、Step 15 で実行）
+- case-update による新契約更新時
+- legacy Issue（Execution Contract 必須セクション不存在）には適用しない（presence-based 判定、AG-010、REQ-017-013）
+
+判定:
+
+- **fail**: 変更予定成果物から導出される必須品質能力が test strategy に反映されていない、または完了条件が必須能力の呼出自体を完了状態としている。
+- **warn**: 必須品質能力の反映はあるが、一部の test strategy 項目で3要素構造が崩れている。
+- **pass**: 全ての必須品質能力が test strategy へ反映され、各項目が3要素を持ち、完了条件が成果状態として記述されている。legacy Issue は本観点の対象外（pass と同等扱い）。
+
 ## pass/ warn/ fail 基準
 
-- **pass**: 上記 1〜7 の全てを満たす。全必達要件が完了条件に traceable に対応づけられ、数値閾値と対象外整合性も確認済み。
+- **pass**: 上記 1〜8 の全てを満たす。全必達要件が完了条件に traceable に対応づけられ、数値閾値と対象外整合性も確認済み、artifact-specific quality control の投影も検証済み。legacy Issue（Execution Contract 必須セクション不存在）は観点8を適用せず観点1〜7で判定する。
 - **warn**: 対応づけはあるが表現が曖昧、または一部網羅性に疑義がある、閾値根拠が曖昧。Issue 作成可能（警告併記）。
-- **fail**: 必達要件の完了条件への対応が欠落している、完了条件セクション自体が欠けている、到達不能な数値閾値が設定されている、対象外と矛盾するテスト戦略が含まれる。Issue 作成前に req-define 差し戻しを推奨。
+- **fail**: 必達要件の完了条件への対応が欠落している、完了条件セクション自体が欠けている、到達不能な数値閾値が設定されている、対象外と矛盾するテスト戦略が含まれる、必須品質能力が test strategy に反映されていない、完了条件が必須能力の呼出自体を完了状態としている。Issue 作成前に req-define 差し戻しを推奨。
 
 ## Epic flow での適用
 

--- a/src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_child.md
+++ b/src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_child.md
@@ -53,6 +53,25 @@ REQ-{req_number}
   on_failure: |
  [不合格時の処置]
 
+## Execution Contract
+<!-- 【必須】 -->
+
+<!-- Execution Contract: REQ-017 Issue Execution Contract。case-open が新規 Issue 作成時に付与する必須セクション。本セクションの存在有無が presence-based 判定の識別子となる（AG-012、REQ-017-014）。case-run は本セクション存在有無で新旧 Issue を識別する -->
+### 変更対象成果物
+- （artifact type と対象パスのリスト）
+
+### 必須品質統制
+- （artifact-quality-control-routing SPEC に基づく能力キーと検証項目）
+
+### 関連 ADR 拘束条件
+- （該当 ADR と完了条件/test strategy への反映）
+
+### scope-affecting impact candidate
+- （case-open が事前探索した候補）
+
+### adversarial-review 発動契約（任意）
+- （ユーザー明示指定時のみ記録）
+
 ## レビュー判断
 <!-- 【必須】 -->
 

--- a/src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_feature.md
+++ b/src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_feature.md
@@ -53,6 +53,25 @@ labels: enhancement
   on_failure: |
  [不合格時の処置]
 
+## Execution Contract
+<!-- 【必須】 -->
+
+<!-- Execution Contract: REQ-017 Issue Execution Contract。case-open が新規 Issue 作成時に付与する必須セクション。本セクションの存在有無が presence-based 判定の識別子となる（AG-012、REQ-017-014）。case-run は本セクション存在有無で新旧 Issue を識別する -->
+### 変更対象成果物
+- （artifact type と対象パスのリスト）
+
+### 必須品質統制
+- （artifact-quality-control-routing SPEC に基づく能力キーと検証項目）
+
+### 関連 ADR 拘束条件
+- （該当 ADR と完了条件/test strategy への反映）
+
+### scope-affecting impact candidate
+- （case-open が事前探索した候補）
+
+### adversarial-review 発動契約（任意）
+- （ユーザー明示指定時のみ記録）
+
 ## レビュー判断
 <!-- 【必須】 -->
 


### PR DESCRIPTION
## 概要

Epic #1983 Wave 3 の実装。spec-save で追加された REQ-017 Issue Execution Contract 関連の SPEC 新規セクションに対応し、配布物（command 定義、skill reference、template）を更新する。

## 変更対象

各 SPEC の新規セクション → 対応する source file の更新（APPEND のみ、既存内容の置換・削除なし）。

### #1987: case-open EC-1〜EC-8 execution contract 確定ステップ実装

- SPEC: `docs/specs/commands/case-open.md` 新規セクション「## execution contract 確定ステップ（新規セクション）」（EC-1〜EC-8）
- 更新: `src/opencode/commands/agentdev/case-open.md`
- Step 2-6 として EC-1〜EC-8 を追加。Issue 本文生成前に実行する確定ステップ群（変更対象成果物確定、必須品質統制の導出と test strategy 投影、完了条件確定、関連 ADR 拘束条件、追加検証条件展開、scope-affecting impact candidate 探索、adversarial-review 発動契約永続化、execution contract 必須セクション付与）

### #1988: case-run execution contract 消費境界 実装

- SPEC: `docs/specs/commands/case-run.md` 新規セクション「## execution contract 消費境界（新規セクション）」
- 更新: `src/opencode/commands/agentdev/case-run.md`
- Step 4-1 として execution contract 消費境界を追加。契約消費原則、runtime-only 判断の維持、blocked 遷移と case-update 連携、新旧 Issue 互換運用（presence-based 判定）、work_type/scale 確認の縮約

### #1989: agentdev-quality-gates QG-2 artifact-specific QC 拡張 実装

- SPEC: `docs/specs/skills/agentdev-quality-gates.md` 新規セクション「## QG-2 拡張: artifact-specific quality control 投影検証（新規セクション）」
- 更新: `src/opencode/skills/agentdev-quality-gates/references/qg-2-acceptance-criteria-coverage.md`
- 観点8「artifact-specific quality control 投影検証（REQ-017 拡張）」を追加し、pass/warn/fail 基準を観点 1〜7 → 1〜8 へ更新。検証項目 (a)(b)(c)、適用範囲（新規 Issue 作成時、case-update 新契約更新時、legacy Issue は対象外）、判定基準を記載

### #1990: workflow-templates Execution Contract section 追加 実装

- SPEC: `docs/specs/skills/agentdev-workflow-templates.md` 新規セクション「## execution contract セクション（Issue template 拡張）」
- 更新: `src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_feature.md`、`src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_child.md`
- 両テンプレートに `## Execution Contract` セクション（【必須】マーカー付き、5 つのサブセクション: 変更対象成果物、必須品質統制、関連 ADR 拘束条件、scope-affecting impact candidate、adversarial-review 発動契約（任意））を追加。presence-based 判定の識別子として機能

## 実装メモ

- 各 command 定義は SPEC の WHAT を HOW（LLM agent 向け手順）へ翻訳し、詳細は各 SPEC（extension 経由）を正とするよう pointer を保持
- template への Execution Contract セクション追加は SPEC が示す markdown 構造をそのまま配置
- QG-2 reference の pass/warn/fail 基準更新は観点8 追加に伴う必須反映（観点範囲 1〜7 → 1〜8、fail 条件の拡張）
- docs/、.agentdev/ は変更していない（REQ/ADR/SPEC は 46be8a23 で commit 済み）

## 関連 Issue

- Closes #1987
- Closes #1988
- Closes #1989
- Closes #1990

Part of Epic #1983