### PR TITLE
docs(req-save): G12 に deviation capture の Skill 委譲を明示 (OU-007)

### DIFF
--- a/src/opencode/commands/agentdev/req-save.md
+++ b/src/opencode/commands/agentdev/req-save.md
@@ -133,7 +133,7 @@ ADR保存の直前に、以下の妥当性を再検証すること: ADRが技術
 - G10: 成果物本文（Issue本文、PR本文、commit message、保存対象ファイル本文、テンプレート成果物）はverbatimで返す。判定結果、調査過程、中間ログ、読解メモは要約、成果物パス、根拠、親判断事項、capture候補へ圧縮して返す
 
 ### Capture 非関与制約
-- G12: req-save の capture 責務は原則非関与。intake/ learning capture を行わない。例外: REQ 再構成 intake（`.agentdev/intake/inbox/req-restructure/**`）のみ生成可能。capture 境界（capture-boundaries）の詳細は `agentdev-workflow-orchestration` 参照
+- G12: req-save の capture 責務は原則非関与。req-save は intake/ learning capture を直接行わない。例外: REQ 再構成 intake（`.agentdev/intake/inbox/req-restructure/**`）のみ生成可能。deviation capture（req-save 実行中に実観測した deviation）は Skill（`agentdev-learning-capture` または `agentdev-intake-pipeline`）への委譲で実施し、req-save が直接 capture しない（REQ-006-106、REQ-006-111）。capture 境界（capture-boundaries）の詳細は `agentdev-workflow-orchestration` 参照
 
 ### Issue作成制約
 - G11: req-saveはIssueを作成してはならない。Issue作成はcase-openの責任範囲である


### PR DESCRIPTION
## 概要

Issue #1998（OU-007）の実装。REQ-006-111 に基づき、req-save command のガードレール G12 へ deviation capture（Skill 委譲）の明示を追加する。

## 変更内容

- `src/opencode/commands/agentdev/req-save.md`: G12 へ deviation capture（Skill 委譲）の明示を追加。責務境界は変更せず、REQ-006-106、REQ-006-111 への言及でトレーサビリティを確保。

変更後 G12:

> G12: req-save の capture 責務は原則非関与。req-save は intake/ learning capture を直接行わない。例外: REQ 再構成 intake（`.agentdev/intake/inbox/req-restructure/**`）のみ生成可能。deviation capture（req-save 実行中に実観測した deviation）は Skill（`agentdev-learning-capture` または `agentdev-intake-pipeline`）への委譲で実施し、req-save が直接 capture しない（REQ-006-106、REQ-006-111）。capture 境界（capture-boundaries）の詳細は `agentdev-workflow-orchestration` 参照

## 完了条件（Issue #1998）

- [x] REQ-006.md に REQ-006-111 が append されていること（既に append 済み、`docs/requirements/REQ-006.md` で確認）
- [x] req-save command の G12 に deviation capture（Skill 委譲）の明示があること
- [x] G12 と SPEC 副作用セクション、REQ-006-106 が整合していること

## テスト戦略 TS-007 結果（PASS）

- **verification**: req-save command の G12 記述が明確化され、deviation capture は Skill 委譲である旨が明示されていることを確認。G12 と SPEC（副作用セクション）、REQ-006-106 の整合性を再照合。
- **pass_criteria**: G12 に deviation capture（Skill 委譲）の明示があり、SPEC 副作用セクション、REQ-006-106 と整合している。→ 満たす

整合性確認:
- SPEC 副作用セクション（`docs/specs/commands/req-save.md`）: "deviation capture: req-save 実行中に実観測した deviation を agentdev-learning-capture skill または agentdev-intake-pipeline へ委譲して保存" → G12 と整合
- REQ-006-106（`docs/requirements/REQ-006.md`）: "req-save は REQ 再構成 intake に加え自工程で実観測した deviation を Split Rule で分類して intake/learning のいずれかへ保存すること" → G12 が Skill 委譲で実施する旨を明示し整合
- capture-boundaries.md（`docs/specs/workflows/capture-boundaries.md`）: "Split Rule で分類、Skill 委譲で保存（REQ-006-106）" → G12 と整合

## 品質ゲート

- check_extensions.ts（IR-056）: ok=true（strict 0、warnings は既存の ADR-007 関連で本変更と無関係）
- QG-3 前置 staleness check: 全参照パス現行存在、差異非検出
- targeted docs guard（Step 5-4）: docs/** 変更なしのためスキップ

## Findings / Capture候補

該当なし。

## SPEC確定候補

該当なし。

Refs: #1998
