### PR TITLE
feat(worktree): 構造系テストの src/opencode/ fallback と制約明文化（REQ-018）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/skills_structure.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/skills_structure.test.ts
@@ -6,6 +6,7 @@ function findRepoRoot(start: string): string {
   let dir = path.resolve(start);
   for (let i = 0; i < 20; i++) {
     if (fs.existsSync(path.join(dir, ".opencode"))) return dir;
+    if (fs.existsSync(path.join(dir, "src", "opencode"))) return dir;
     const parent = path.dirname(dir);
     if (parent === dir) break;
     dir = parent;
@@ -13,7 +14,12 @@ function findRepoRoot(start: string): string {
   return path.resolve(start);
 }
 const REPO_ROOT = findRepoRoot(SCRIPT_DIR);
-const SKILLS_DIR = path.join(REPO_ROOT, ".opencode", "skills");
+const PROJECTION_SKILLS_DIR = path.join(REPO_ROOT, ".opencode", "skills");
+const SOURCE_SKILLS_DIR = path.join(REPO_ROOT, "src", "opencode", "skills");
+// worktree junction 未設定環境では projection に配布スキルが存在しないため src/opencode/ へ fallback する（REQ-018-001）。
+const SKILLS_DIR = fs.existsSync(path.join(PROJECTION_SKILLS_DIR, "agentdev-workflow-templates"))
+  ? PROJECTION_SKILLS_DIR
+  : SOURCE_SKILLS_DIR;
 function getSkillDirs(): string[] {
   if (!fs.existsSync(SKILLS_DIR)) return [];
   return fs

--- a/.opencode/skills/repo-agentdev-integrity/scripts/templates_structure.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/templates_structure.test.ts
@@ -6,6 +6,7 @@ function findRepoRoot(start: string): string {
   let dir = path.resolve(start);
   for (let i = 0; i < 20; i++) {
     if (fs.existsSync(path.join(dir, ".opencode"))) return dir;
+    if (fs.existsSync(path.join(dir, "src", "opencode"))) return dir;
     const parent = path.dirname(dir);
     if (parent === dir) break;
     dir = parent;
@@ -13,13 +14,25 @@ function findRepoRoot(start: string): string {
   return path.resolve(start);
 }
 const REPO_ROOT = findRepoRoot(SCRIPT_DIR);
-const TEMPLATES_DIR = path.join(
+const PROJECTION_TEMPLATES_DIR = path.join(
   REPO_ROOT,
   ".opencode",
   "skills",
   "agentdev-workflow-templates",
   "templates",
 );
+const SOURCE_TEMPLATES_DIR = path.join(
+  REPO_ROOT,
+  "src",
+  "opencode",
+  "skills",
+  "agentdev-workflow-templates",
+  "templates",
+);
+// worktree junction 未設定環境では projection に agentdev-workflow-templates が存在しないため src/opencode/ へ fallback する（REQ-018-001）。
+const TEMPLATES_DIR = fs.existsSync(PROJECTION_TEMPLATES_DIR)
+  ? PROJECTION_TEMPLATES_DIR
+  : SOURCE_TEMPLATES_DIR;
 const TEMPLATES_WITH_FRONTMATTER = [
   "issue_desc_feature.md",
   "issue_desc_bug.md",

--- a/src/opencode/skills/agentdev-git-worktree/references/worktree-operations.md
+++ b/src/opencode/skills/agentdev-git-worktree/references/worktree-operations.md
@@ -93,6 +93,22 @@ worktree 内で junction が再作成されない場合の偽陽性を防止す�
 `checkSourceProjectionConsistency` 以外の junction 依存検査に対する `isInsideWorktree` 適用を評価対象として明記すること。
 junction 依存の整合性検査全般に worktree 実行判定を拡張する候補を個別に評価し、偽陽性の発生する検査から順次適用する。
 
+## worktree 構造的制約（REQ-018-002、agentdev-git-worktree-test-fallback SPEC）
+
+worktree は独立した working tree を持つため、本体リポジトリ直下を前提とする検査が worktree 内では成立しない事象がある。次の構造的制約を前提として運用する。
+
+### gitignore 対象ファイル受け渡し不可
+
+worktree は独立した working tree であるため、メインリポジトリで `.gitignore` 対象となっているファイル（`.opencode/skills/agentdev-*/` ジャンクション配下、`.agentdev-plugin/` 等）は worktree 側へ受け渡しできない。worktree 内で当該ファイルを参照する検査は失敗する。
+
+worktree 内で gitignore 対象ファイルを参照・編集する必要がある場合は、`git add -f` で強制追加して worktree の working tree に存在させるか、source パス（`src/opencode/`）へ fallback して参照する。
+
+### junction 依存 checker の skip 挙動
+
+`.opencode/skills/agentdev-*` ジャンクションは worktree へ伝播しない。このため junction の存在を前提とする checker（`checkSourceProjectionConsistency` 等）は worktree 内で偽陽性を発生させる。
+
+junction 依存 checker は worktree 実行時（`isInsideWorktree` 判定で worktree 内と判定された場合）に skip する。skip せずに検査が必要な場合は構造系テスト fallback（REQ-018-001、commands_e2e / skills_structure / templates_structure の source パス切替）を適用する。
+
 ## 削除手順
 
 **追跡済みファイル削除禁止**: クリーンアップ操作中は追跡済みファイルを削除してはならない。


### PR DESCRIPTION
## Issue

- Closes #1993
- Parent Epic: #1992
- OU-002: worktree 構造的制約とテスト fallback（REQ-018、agentdev-git-worktree-test-fallback SPEC）

## 変更概要

REQ-018（worktree 構造的制約とテスト fallback）の実装。worktree junction 未設定環境（独立 working tree）で構造系テストが src/opencode/ へ fallback して実行されるよう、テストスクリプトへ fallback 処理を追加。worktree の構造的制約を agentdev-git-worktree skill references へ明文化。

### REQ-018-001: 構造系テストの src/opencode/ fallback

- `skills_structure.test.ts`: `findRepoRoot` に `src/opencode` チェックを追加し、`SKILLS_DIR` を PROJECTION→SOURCE 切替へ変更（`agentdev-workflow-templates` をプローブとする）
- `templates_structure.test.ts`: 同上、`TEMPLATES_DIR` を PROJECTION→SOURCE 切替へ変更
- `commands_e2e.test.ts`: 既存の fallback 実装（PROJECTION→SOURCE 切替）を踏襲し変更なし

### REQ-018-002: worktree 構造的制約の明文化

`src/opencode/skills/agentdev-git-worktree/references/worktree-operations.md` に新規セクション「worktree 構造的制約」を追加:

- gitignore 対象ファイル受け渡し不可（`git add -f` または source パス fallback で対処）
- junction 依存 checker の skip 挙動（`isInsideWorktree` 判定で skip、または構造系テスト fallback 適用）

## 完了条件の対応

- [x] REQ-018.md に REQ-018-001/002 が存在し、AG-002 の合意内容と整合する（req-save で既存確認）
- [x] docs/specs/skills/agentdev-git-worktree-test-fallback.md が存在し、fallback 契約と構造的制約が明示されている（spec-save で既存確認）
- [x] 構造系テスト（commands_e2e、skills_structure、templates_structure）に src/opencode/ への fallback 実装がされている
- [x] agentdev-git-worktree skill references に worktree の構造的制約が明文化されている

## テスト結果

worktree junction 未設定環境（`.worktrees/1993-feature` 内、`.opencode/skills/` は `repo-agentdev-integrity` のみ）で構造系テスト3本を実行:

```
skills_structure.test.ts:   326 pass / 0 fail
templates_structure.test.ts: 31 pass / 0 fail
commands_e2e.test.ts:       117 pass / 0 fail
合計:                       474 pass / 0 fail
```

check_extensions.ts: `ok: true`（failures 6件は全て `[warning]` で `repo-agentdev-artifact-graph` 関連の既存警告、本 PR 無関係）

## Findings / Capture候補

### stale-reference

Step 5-3 (QG-3 前置 staleness check): 差異非検出。Issue 本文「変更対象成果物」に「src/opencode/ 配下の構造系テストスクリプト」とあるが、実態は `.opencode/skills/repo-agentdev-integrity/scripts/` 配下（repo-local、配布対象外）。これは Issue 表現と実態のズレであり、実装時の調整として `.opencode/` 配下のファイルを編集した。REQ-018-001 本質（構造系テストの src/opencode/ fallback）は達成。

## SPEC確定候補

該当なし
