### PR TITLE
feat(scripts): OU-006 運用スクリプトで #Requires と comment-based help を両立 (#1997)

### DIFF
--- a/docs/specs/local/install-script-usability.md
+++ b/docs/specs/local/install-script-usability.md
@@ -2,7 +2,7 @@
 title: 導入スクリプトの使いやすさ詳細
 status: draft
 created: 2026-08-02
-updated: 2026-08-02
+updated: 2026-08-09
 spec_logical_division: behavior
 canonical_owner: install-script
 ---
@@ -113,16 +113,60 @@ GitHub Issue/PR を使わずローカルファイル（.agentdev/cases/）で運
 
 ## #Requires と comment-based help の両立
 
-install.ps1、check.ps1、sync-self.ps1 の `#Requires` ディレクティブ配置と comment-based help 解析位置の両立仕様を明示する。
+install-consumer-opencode.ps1、check-consumer-opencode.ps1、sync-self-opencode.ps1 の
+`#Requires` ディレクティブ配置と comment-based help 解析位置の両立仕様を明示する。
+REQ-009-044 で要求される「#Requires ディレクティブと comment-based help 解析を両立すること」を実現する。
 
 ### 課題
 
-運用スクリプト3本（install.ps1、check.ps1、sync-self.ps1）の `#Requires` ディレクティブが comment-based help 解析を阻害する問題がある。
+運用スクリプト3本の `#Requires` ディレクティブが comment-based help 解析を阻害する問題がある。
+PowerShell の comment-based help はスクリプトファイル先頭に配置する必要があり、先頭行に
+`#Requires` ディレクティブを置くとヘルプ解析位置が「ファイル先頭」の条件を満たさず、
+`Get-Help` が comment-based help を検出しない（Synopsis がパラメータ署名のフォールバック表示になり、
+Description、Parameters、Examples が全て空になる）。
 
 ### 両立仕様
 
-- `#Requires` ディレクティブの配置を comment-based help 解析位置と両立させる
-- 配置位置、解析順序、検証方法は実装固有の詳細として skill references 側で保持する
+スクリプトファイルの先頭要素の配置順序を以下の通り定める。
+
+1. comment-based help ブロック（`<# .SYNOPSIS ... #>`）をファイル先頭に配置する
+2. comment-based help ブロックの直後に `#Requires` ディレクティブを配置する
+3. `#Requires` の直後に `param(...)` ブロックを配置する
+
+```
+<#
+.SYNOPSIS
+    ...
+.DESCRIPTION
+    ...
+#>
+
+#Requires -Version 7.0
+
+param(
+    ...
+)
+```
+
+### 根拠
+
+PowerShell の comment-based help 仕様は、スクリプトヘルプが「スクリプトファイルの先頭」に
+配置され、前方に許容されるのはコメントと空行のみと定めている。`#Requires` は directive であり
+コメントではないため、comment-based help より前に置くとヘルプ解析位置の条件を満たさなくなる。
+一方 `#Requires` は行頭にあればスクリプト内の任意の位置に配置可能であり、comment-based help の
+後に置いても runtime の version 要求、module 要求等の効力は変わらない。両立のための最小の
+配置変更は「comment-based help を先頭に移動し、`#Requires` をその直後に置く」である。
+
+### 検証方法
+
+各スクリプトで `Get-Help <script-path> -Detailed` を実行し、以下を確認する。
+
+- Synopsis に `.SYNOPSIS` の内容が表示される（パラメータ署名のフォールバック表示ではない）
+- Description、Parameters、Examples の各セクションが空でない
+
+あわせて `#Requires` の runtime 効力が維持されていることを確認する。具体的には `#Requires -Version`
+のバージョン番号を現行 PowerShell より高い値に一時置換したコピーを実行し、PowerShell の
+「requires PowerShell version ...」エラーが発生することを確認する（本番ファイルは `7.0` を維持）。
 
 ## 適用範囲
 

--- a/scripts/check-consumer-opencode.ps1
+++ b/scripts/check-consumer-opencode.ps1
@@ -1,4 +1,3 @@
-#Requires -Version 7.0
 <#
 .SYNOPSIS
     Check consumer repository AgentDevFlow installation status.
@@ -39,6 +38,8 @@
     ./scripts/check-consumer-opencode.ps1
     ./scripts/check-consumer-opencode.ps1 -PluginDir .agentdev-plugin
 #>
+
+#Requires -Version 7.0
 
 param(
     [string]$PluginDir = '.agentdev-plugin'

--- a/scripts/install-consumer-opencode.ps1
+++ b/scripts/install-consumer-opencode.ps1
@@ -1,4 +1,3 @@
-#Requires -Version 7.0
 <#
 .SYNOPSIS
     Install AgentDevFlow runtime artifacts into a consumer repository.
@@ -58,6 +57,8 @@
     ./scripts/install-consumer-opencode.ps1 -Mode apply -PluginDir .agentdev-plugin
     ./scripts/install-consumer-opencode.ps1 -Mode apply -LocalMode
 #>
+
+#Requires -Version 7.0
 
 param(
     [Parameter()]

--- a/scripts/sync-self-opencode.ps1
+++ b/scripts/sync-self-opencode.ps1
@@ -1,4 +1,3 @@
-#Requires -Version 7.0
 <#
 .SYNOPSIS
     Sync .opencode/ projection with selective junctions from src/opencode/ (self-hosting repo).
@@ -39,6 +38,8 @@
     ./scripts/sync-self-opencode.ps1 -Mode check
     ./scripts/sync-self-opencode.ps1 -Mode apply
 #>
+
+#Requires -Version 7.0
 
 param(
     [Parameter()]


### PR DESCRIPTION
## 対象 Issue

- Closes #1997
- Parent Epic: #1992（Epic A Wave 1）
- OU-006: 運用スクリプト #Requires と comment-based help 両立（REQ-009-044、install-script-usability SPEC）

## 変更概要

運用スクリプト3本（install-consumer-opencode.ps1、check-consumer-opencode.ps1、sync-self-opencode.ps1）の `#Requires -Version 7.0` ディレクティブを comment-based help ブロックの直後に移動し、`Get-Help` が comment-based help を正しく解析できるようにした。

### 背景

PowerShell の comment-based help 仕様上、スクリプトヘルプはファイル先頭に配置する必要があり、前方に許容されるのはコメントと空行のみ。`#Requires` は directive でありコメントではないため、先頭行に置くと comment-based help 解析位置の条件を満たさず、`Get-Help` がヘルプを検出しない（Synopsis がパラメータ署名のフォールバック表示になり、Description、Parameters、Examples が空になる）。

`#Requires` は行頭にあればスクリプト内の任意の位置に配置可能であり、comment-based help の後に置いても runtime の version 要求、module 要求等の効力は変わらない。両立のための最小の配置変更は「comment-based help を先頭に移動し、`#Requires` をその直後に置く」である。

## 変更ファイル

- `scripts/install-consumer-opencode.ps1`: `#Requires` を comment-based help ブロック（元 line 2-60）の直後（新 line 61）へ移動
- `scripts/check-consumer-opencode.ps1`: `#Requires` を comment-based help ブロック（元 line 2-41）の直後（新 line 42）へ移動
- `scripts/sync-self-opencode.ps1`: `#Requires` を comment-based help ブロック（元 line 2-41）の直後（新 line 42）へ移動
- `docs/specs/local/install-script-usability.md`: 「#Requires と comment-based help の両立」セクションを更新し、配置順（comment-based help → #Requires → param）、根拠（PowerShell 仕様）、検証方法（Get-Help と #Requires version チェック）を明示化。あわせて `updated` 日付を 2026-08-09 へ更新

## 完了条件の状態

- [x] REQ-009.md に REQ-009-044 が append されていること → 既存（req-save 済み、本 PR 対象外）
- [x] install-script-usability SPEC に #Requires と comment-based help の両立仕様が明示されていること → 本 PR で明示化（配置順、根拠、検証方法）
- [x] install-consumer-opencode.ps1、check-consumer-opencode.ps1、sync-self-opencode.ps1 で Get-Help を実行し comment-based help が正しく表示されること → TS-006 で検証済み
- [x] #Requires と comment-based help が両立していること → TS-006 で検証済み

※ 完了条件チェックボックスの評価と更新は case-close QG-4 の責務。本 PR は実装と検証結果を示す。

## テスト戦略（TS-006）結果

**target_item**: AG-006（運用スクリプト #Requires と comment-based help 両立）

### verification

3スクリプト全てで `Get-Help <script-path> -Detailed` を実行し、comment-based help の表示を確認した。

| スクリプト | Synopsis | Description | Parameters | Examples | 判定 |
|---|---|---|---|---|---|
| install-consumer-opencode.ps1 | "Install AgentDevFlow runtime artifacts into a consumer repository." | 3モード差、junction 対象、LocalMode 案内 | Mode, LocalMode, PluginDir, RepoUrl, Branch (5件) | 1件 | PASS |
| check-consumer-opencode.ps1 | "Check consumer repository AgentDevFlow installation status." | 導入先状態確認、3モード差、リンクモード自動検出 | PluginDir (1件) | 1件 | PASS |
| sync-self-opencode.ps1 | "Sync .opencode/ projection with selective junctions from src/opencode/ (self-hosting repo)." | 本体専用、3モード差、selective junctions | Mode (1件) | 1件 | PASS |

修正前は3スクリプト全て Description、Parameters、Examples が空で、Synopsis がパラメータ署名のフォールバック表示だった。修正後は全セクションが正しく表示される。

### pass_criteria

> 3スクリプト全てで comment-based help が正しく表示される。#Requires と comment-based help が両立している。

**PASS** - 3スクリプト全てで Synopsis、Description、Parameters、Examples が表示される。

### 追加検証: #Requires runtime 効力

`#Requires` の runtime version チェックが維持されていることを確認するため、各スクリプトの `#Requires -Version 7.0` を一時的に `#Requires -Version 99.0` に置換したコピーを実行し、PowerShell の「requires PowerShell version 99.0」エラーが発生することを3スクリプト全てで確認した（検証後、一時ファイルは削除。本番ファイルは 7.0 を維持）。

### on_failure

> fix-and-reverify。両立仕様の実装が主眼であり、失敗時は #Requires 配置を修正して再検証する。

該当なし（初回で PASS）。

## Findings / Capture候補

（なし）

## SPEC確定候補

（なし）

## L2 タイムスタンプ（JST）

| Step | 開始 | 終了 |
|---|---|---|
| Step 5（worktree 作成・ブランチ準備） | 2026-08-09 20:53:30 | 2026-08-09 20:54:23 |
| Step 6（実装・検証、inline実行） | 2026-08-09 20:54:23 | 2026-08-09 20:59:16 |
| Step 8（worktree クリーンアップ） | 記録予定 | 記録予定 |

case_auto_started_at: 2026-08-09 18:47:17 +09:00
