### PR TITLE
feat(integrity): AUTOGEN ブロック鮮度検出 gate を追加 (OU-003, Issue #1994)

### DIFF
--- a/.opencode/commands/repo/docs-check.md
+++ b/.opencode/commands/repo/docs-check.md
@@ -26,7 +26,7 @@ agent-dev-flow リポジトリの自己監査コマンド。AgentDevFlow 管理�
 
 ### Step 1: スクリプト実行
 
-**実行ランナー（REQ-0108-054）**: 本 command が呼び出す検査スクリプト群（`check_integrity.ts`、`check_command_format.ts`、`check_extensions.ts`、`check_distribution_boundary.ts`、`check_changed_docs.ts`、`check_templates.ts`、`lint_skills.ts`）は TypeScript 直接実行と `require()` / `import` 混在構文、併設テストの `bun:test` 依存を前提とするため、実行ランナーは **Bun** とする。`node` 等の Bun 以外のランナーで直接起動すると `ReferenceError: require is not defined` 等 ESM 解釈エラーが発生する。スクリプトは `bun run <script-path>` 形式で起動すること。
+**実行ランナー（REQ-0108-054）**: 本 command が呼び出す検査スクリプト群（`check_integrity.ts`、`check_command_format.ts`、`check_extensions.ts`、`check_distribution_boundary.ts`、`check_changed_docs.ts`、`check_templates.ts`、`lint_skills.ts`、`check_autogen_freshness.ts`）は TypeScript 直接実行と `require()` / `import` 混在構文、併設テストの `bun:test` 依存を前提とするため、実行ランナーは **Bun** とする。`node` 等の Bun 以外のランナーで直接起動すると `ReferenceError: require is not defined` 等 ESM 解釈エラーが発生する。スクリプトは `bun run <script-path>` 形式で起動すること。
 
 `repo-agentdev-integrity` の検査スクリプト（`.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts`）を `bun run` で実行。検査カテゴリ・対象パス・検出結果の分類は SKILL.md（.opencode/skills/repo-agentdev-integrity/SKILL.md）の検査カテゴリ定義を authoritative source とする
 - **コマンド形式検査（IR-049）**: `check_command_format.ts` を `bun run` で併せて実行する。`--root` にリポジトリルートを指定し、終了コード1は docs-check 全体の失敗として扱う
@@ -34,6 +34,7 @@ agent-dev-flow リポジトリの自己監査コマンド。AgentDevFlow 管理�
 - **実行 profile（Issue #1928 / WP-3）**: `check_integrity.ts` は `--profile source|installed|release` を取り、既定は `source`。docs-check は明示しない限り `source`（既定）で実行する。`installed` は配置後検査、`release` は配布アーカイブ検査（`--archive <zip>` 必須）で、いずれも `docs/specs/integrity/integrity-contracts.md`「実行プロファイル分離」と `scripts/package-release-archive.ps1` / `scripts/install-from-archive.ps1` を参照
 - **IR-056（project extensions 整合性）**: `check_extensions.ts`（`.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts`）を `bun run` で併せて実行し、IR-056 として strict に取り扱う（project extensions SPEC、project extensions 読み込み標準 skill）。check_extensions.ts の strict failure は docs-check 全体を fail とする
 - **配布物参照境界（配布 command/skill 本文の具体参照禁止）**: `check_distribution_boundary.ts`（`.opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts`）を `bun run` で併せて実行する。配布 command/skill 本文（`src/opencode/commands/agentdev/**/*.md`、`src/opencode/skills/agentdev-*/**/*.md`）に含まれる具体ID（`ADR-NNNN`、`REQ-NNNN`）、具体パス（`docs/(adr|requirements|specs)/<file>.md`、但し README.md とテンプレート表記は除外）、固定URL（blob/raw）を検出し、厳格に取り扱う。check_distribution_boundary.ts の failure は docs-check 全体を fail とする
+- **AUTOGEN ブロック鮮度検出 gate（REQ-010-059、autogen-freshness-gate SPEC）**: `check_autogen_freshness.ts`（`.opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.ts`）を `bun run` で併せて実行する。AUTOGEN ブロック（`<!-- AUTOGEN:BEGIN:id=xxx -->`〜`<!-- AUTOGEN:END -->`）を含む索引ファイル群について、ソース（frontmatter / ファイル名 / status）の rename や status 変更後に AUTOGEN ブロックが陳腐化しているかを検出し、鮮度種別（rename / status_change / content_change）を分類して報告する。check_autogen_freshness.ts の strict failure（stale blocks 検出）は docs-check 全体を fail とする。不合格時は `bun run .opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts` で AUTOGEN ブロックを再生成すること（自動修復は行わない、SPEC「不合格時の処置」）。IR-061（check_integrity.ts）と同一不整合を検出し得るが、両検査は独立して実施し、いずれか単独の実施要否にも他方の結果は影響しない
 
 ### Step 2: レポート確認・Finding整理
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.test.ts
@@ -1,0 +1,238 @@
+/**
+ * check_autogen_freshness.test.ts — bun:test 単体テスト。
+ *
+ * 合成コンテンツを用いて鮮度種別判定 (rename / status_change / content_change) と
+ * report 生成ロジックを検証する。リポジトリ実状態に依存しない。
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  CATALOG_PRE_BLOCK_ID,
+  SPEC_METRICS_BLOCK_ID,
+  ADR_BASELINE_TABLE_BLOCK_ID,
+  ADR_RETIRED_TABLE_BLOCK_ID,
+  findAutogenBlocks,
+} from "./generate_indexes.ts";
+import {
+  classifyStaleness,
+  findFirstMismatch,
+  parseTableRow,
+  truncateForLog,
+} from "./check_autogen_freshness.ts";
+
+// ─── findFirstMismatch ───────────────────────────────────────────────────
+
+describe("findFirstMismatch", () => {
+  test("同一配列は -1", () => {
+    expect(findFirstMismatch(["a", "b"], ["a", "b"])).toBe(-1);
+  });
+
+  test("不一致インデックスを返す", () => {
+    expect(findFirstMismatch(["a", "b"], ["a", "c"])).toBe(1);
+  });
+
+  test("長さが異なる場合は超過最初インデックス", () => {
+    expect(findFirstMismatch(["a"], ["a", "b"])).toBe(1);
+    expect(findFirstMismatch(["a", "b"], ["a"])).toBe(1);
+  });
+
+  test("両方空配列は -1", () => {
+    expect(findFirstMismatch([], [])).toBe(-1);
+  });
+});
+
+// ─── truncateForLog ──────────────────────────────────────────────────────
+
+describe("truncateForLog", () => {
+  test("undefined は <missing>", () => {
+    expect(truncateForLog(undefined)).toBe("<missing>");
+  });
+
+  test("max 以下は trim して返す", () => {
+    expect(truncateForLog("  hello  ")).toBe("hello");
+  });
+
+  test("max 超は切り詰めて …", () => {
+    const long = "x".repeat(100);
+    const out = truncateForLog(long, 10);
+    expect(out.length).toBe(10);
+    expect(out.endsWith("…")).toBe(true);
+  });
+});
+
+// ─── parseTableRow ───────────────────────────────────────────────────────
+
+describe("parseTableRow", () => {
+  test("通常行はセル配列", () => {
+    expect(parseTableRow("| a | b | c |")).toEqual(["a", "b", "c"]);
+  });
+
+  test("前後空白を trim", () => {
+    expect(parseTableRow("  | a | b |  ")).toEqual(["a", "b"]);
+  });
+
+  test("セパレータ行は null", () => {
+    expect(parseTableRow("|---|---|")).toBeNull();
+    expect(parseTableRow("| --- | --- |")).toBeNull();
+    expect(parseTableRow("|:---:|---:|")).toBeNull();
+  });
+
+  test("表行でないは null", () => {
+    expect(parseTableRow("not a table row")).toBeNull();
+    expect(parseTableRow("- bullet")).toBeNull();
+  });
+});
+
+// ─── classifyStaleness ───────────────────────────────────────────────────
+
+describe("classifyStaleness", () => {
+  test("行数増減は rename", () => {
+    const result = classifyStaleness(
+      SPEC_METRICS_BLOCK_ID,
+      ["| a | 1 | accepted | q |"],
+      ["| a | 1 | accepted | q |", "| b | 2 | draft | w |"],
+      1,
+    );
+    expect(result.kind).toBe("rename");
+    expect(result.detail).toContain("size differs");
+    expect(result.detail).toContain("delta=+1");
+  });
+
+  test("行数減少も rename、delta 負", () => {
+    const result = classifyStaleness(
+      SPEC_METRICS_BLOCK_ID,
+      ["| a | 1 | accepted | q |", "| b | 2 | draft | w |"],
+      ["| a | 1 | accepted | q |"],
+      1,
+    );
+    expect(result.kind).toBe("rename");
+    expect(result.detail).toContain("delta=-1");
+  });
+
+  test("SPEC metrics 同行 status 列変化は status_change", () => {
+    const result = classifyStaleness(
+      SPEC_METRICS_BLOCK_ID,
+      ["| quality/foo.md | 100 | draft | quality |"],
+      ["| quality/foo.md | 100 | accepted | quality |"],
+      0,
+    );
+    expect(result.kind).toBe("status_change");
+    expect(result.detail).toContain("SPEC status changed");
+    expect(result.detail).toContain("quality/foo.md");
+    expect(result.detail).toContain('current="draft"');
+    expect(result.detail).toContain('expected="accepted"');
+  });
+
+  test("SPEC metrics 同行でも path 異なる場合は content_change", () => {
+    const result = classifyStaleness(
+      SPEC_METRICS_BLOCK_ID,
+      ["| quality/old.md | 100 | accepted | quality |"],
+      ["| quality/new.md | 100 | accepted | quality |"],
+      0,
+    );
+    expect(result.kind).toBe("content_change");
+  });
+
+  test("ADR baseline 同行 status 列変化は status_change", () => {
+    const result = classifyStaleness(
+      ADR_BASELINE_TABLE_BLOCK_ID,
+      ["| ADR-001 | タイトル | proposed | 2026-01-01 |"],
+      ["| ADR-001 | タイトル | accepted | 2026-01-01 |"],
+      0,
+    );
+    expect(result.kind).toBe("status_change");
+    expect(result.detail).toContain("ADR status changed");
+  });
+
+  test("ADR retired 同行 status 列変化は status_change", () => {
+    const result = classifyStaleness(
+      ADR_RETIRED_TABLE_BLOCK_ID,
+      ["| ADR-001 | x | accepted |"],
+      ["| ADR-001 | x | superseded |"],
+      0,
+    );
+    expect(result.kind).toBe("status_change");
+    expect(result.detail).toContain("Retired ADR status changed");
+  });
+
+  test("行長さ同じ・表以外の変化は content_change", () => {
+    const result = classifyStaleness(
+      CATALOG_PRE_BLOCK_ID,
+      ["- [IR-001: old title](rules/IR-001-x.md)"],
+      ["- [IR-001: new title](rules/IR-001-x.md)"],
+      0,
+    );
+    expect(result.kind).toBe("content_change");
+    expect(result.detail).toContain("content differs");
+  });
+
+  test("SPEC metrics 行数値変化は content_change", () => {
+    const result = classifyStaleness(
+      SPEC_METRICS_BLOCK_ID,
+      ["| quality/foo.md | 100 | accepted | quality |"],
+      ["| quality/foo.md | 105 | accepted | quality |"],
+      0,
+    );
+    expect(result.kind).toBe("content_change");
+  });
+
+  test("不一致インデックスが本文範囲外でも安全に判定", () => {
+    // currentBody が空で expectedBody のみ存在する場合の mismatchIndex=0
+    const result = classifyStaleness(
+      SPEC_METRICS_BLOCK_ID,
+      [],
+      ["| quality/foo.md | 100 | accepted | quality |"],
+      0,
+    );
+    expect(result.kind).toBe("rename");
+  });
+});
+
+// ─── findAutogenBlocks 統合テスト（生成スクリプト側からの再エクスポート） ─
+
+describe("findAutogenBlocks integration", () => {
+  test("AUTOGEN block を正しく抽出", () => {
+    const content = [
+      "intro line",
+      "<!-- AUTOGEN:BEGIN:id=test-block -->",
+      "| col1 | col2 |",
+      "|------|------|",
+      "| a | b |",
+      "<!-- AUTOGEN:END -->",
+      "outro line",
+    ].join("\n");
+    const blocks = findAutogenBlocks(content);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0].id).toBe("test-block");
+    expect(blocks[0].currentBody).toEqual([
+      "| col1 | col2 |",
+      "|------|------|",
+      "| a | b |",
+    ]);
+  });
+
+  test("backtick 囲み説明文を marker と誤認しない", () => {
+    const content = [
+      "本文中に `<!-- AUTOGEN:BEGIN:id=foo -->` と書いても marker 扱いしない",
+      "<!-- AUTOGEN:BEGIN:id=real -->",
+      "body",
+      "<!-- AUTOGEN:END -->",
+    ].join("\n");
+    const blocks = findAutogenBlocks(content);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0].id).toBe("real");
+  });
+
+  test("複数 block を順序保持で抽出", () => {
+    const content = [
+      "<!-- AUTOGEN:BEGIN:id=b1 -->",
+      "body1",
+      "<!-- AUTOGEN:END -->",
+      "middle",
+      "<!-- AUTOGEN:BEGIN:id=b2 -->",
+      "body2",
+      "<!-- AUTOGEN:END -->",
+    ].join("\n");
+    const blocks = findAutogenBlocks(content);
+    expect(blocks.map((b) => b.id)).toEqual(["b1", "b2"]);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.ts
@@ -1,0 +1,715 @@
+/**
+ * check_autogen_freshness.ts — AUTOGEN ブロック鮮度検出 gate (REQ-010-059).
+ *
+ * AUTOGEN ブロック（`<!-- AUTOGEN:BEGIN:id=xxx -->`〜`<!-- AUTOGEN:END -->`）を含む
+ * 索引ファイル群について、ソース（frontmatter / ファイル名 / status）の rename や
+ * status 変更後に AUTOGEN ブロックが陳腐化しているかを検出する。
+ * 不合格時は再生成対象を報告し、自動修復は行わない（autogen-freshness-gate SPEC）。
+ *
+ * IR-061（check_integrity.ts checkIndexGenerationConsistency）が同一の不整合を
+ * 「内容不一致」として検出するのに対し、本 gate は鮮度の「種別」
+ * （rename / status_change / content_change）を分類して報告する。両検査は独立し、
+ * いずれか単独の実施要否にも他方の結果は影響しない。
+ *
+ * 参考 SPEC:  `docs/specs/integrity/autogen-freshness-gate.md`（REQ-010-059）
+ * 参考 IR:    `docs/specs/integrity/rules/IR-061-index-generation-consistency.md`
+ * 参考 SC-002: `docs/specs/integrity/index-auto-generation.md`（定期再生成）
+ *
+ * 使用資産: `cli_utils.ts`, `generate_indexes.ts`（生成ロジック再利用）
+ * require/import 混在許容（AG-001、既存資産踏襲）。
+ */
+import {
+  EXIT_OK,
+  EXIT_NG,
+  EXIT_ERROR,
+  printHelp,
+  findRepoRoot,
+} from "./cli_utils.ts";
+import {
+  findAutogenBlocks,
+  collectIrFiles,
+  collectAdrFiles,
+  collectRetiredAdrFiles,
+  collectReqFiles,
+  collectRetiredReqFiles,
+  collectReqMetrics,
+  collectSpecMetrics,
+  countSpecFiles,
+  generateCatalogBlocks,
+  generateRuleOwnershipAppendix,
+  generateAdrBaselineCaption,
+  generateAdrBaselineTable,
+  generateAdrStatusList,
+  generateAdrRetiredTable,
+  generateReqActiveCaption,
+  generateReqActiveTable,
+  generateReqRetiredTable,
+  generateDocMapInventory,
+  generateReqMetricsTable,
+  generateSpecMetricsTable,
+  generateReadmeReqSummaryCount,
+  formatMeasureDate,
+  CATALOG_PRE_BLOCK_ID,
+  CATALOG_POST_BLOCK_ID,
+  RULE_OWNERSHIP_BLOCK_ID,
+  ADR_BASELINE_COUNT_BLOCK_ID,
+  ADR_BASELINE_TABLE_BLOCK_ID,
+  ADR_STATUS_ACCEPTED_BLOCK_ID,
+  ADR_STATUS_PROPOSED_BLOCK_ID,
+  ADR_STATUS_SUPERSEDED_BLOCK_ID,
+  ADR_STATUS_DEPRECATED_BLOCK_ID,
+  ADR_RETIRED_TABLE_BLOCK_ID,
+  REQ_ACTIVE_COUNT_BLOCK_ID,
+  REQ_ACTIVE_TABLE_BLOCK_ID,
+  REQ_RETIRED_TABLE_BLOCK_ID,
+  DOCMAP_INVENTORY_BLOCK_ID,
+  REQ_METRICS_BLOCK_ID,
+  SPEC_METRICS_BLOCK_ID,
+  README_REQ_SUMMARY_COUNT_BLOCK_ID,
+} from "./generate_indexes.ts";
+
+const path = require("path") as typeof import("path");
+const fs = require("fs") as typeof import("fs");
+
+const SCRIPT_NAME = "check_autogen_freshness.ts";
+const DESCRIPTION =
+  "AUTOGEN block freshness gate — detects stale AUTOGEN blocks after source rename or status change (REQ-010-059)";
+const USAGE =
+  "bun run check_autogen_freshness.ts [--help] [--json] [--dry-run] [--root <path>]";
+
+// ─── 出力契約 ─────────────────────────────────────────────────────────────
+
+/** 鮮度違反の種別。autogen-freshness-gate SPEC「鮮度判定基準」に対応。 */
+type StaleKind = "rename" | "status_change" | "content_change";
+
+interface FreshnessFinding {
+  /** AUTOGEN block を持つ索引ファイルの repo root 相対パス。 */
+  file: string;
+  /** AUTOGEN block ID。 */
+  block_id: string;
+  /** ブロック開始行からの不一致行（1-based、開始マーカー行を含まない本文行）。 */
+  first_mismatch_line: number;
+  /** 鮮度違反の種別。 */
+  kind: StaleKind;
+  /** 種別判定根拠（人間が読める形式）。 */
+  detail: string;
+  /** 現在の行（切り詰め済み）。 */
+  current_line: string;
+  /** 期待される行（切り詰め済み）。 */
+  expected_line: string;
+}
+
+interface FreshnessReport {
+  /** スクリプト実行の ISO timestamp。 */
+  timestamp: string;
+  /** スクリプト名。 */
+  script: string;
+  /** 検査した索引ファイル数。 */
+  files_scanned: number;
+  /** 検出した鮮度違反の件数。 */
+  findings_count: number;
+  /** 鮮度違反の内訳。 */
+  findings: FreshnessFinding[];
+  /** スキップした索引ファイル（AUTOGEN marker 不在等）。 */
+  skipped: { file: string; block_id: string; reason: string }[];
+}
+
+// ─── helper: 行配列比較 ──────────────────────────────────────────────────
+
+/** 2つの行配列の最初の不一致インデックスを返す（一致時は -1）。 */
+export function findFirstMismatch(
+  current: string[],
+  expected: string[],
+): number {
+  const len = Math.max(current.length, expected.length);
+  for (let i = 0; i < len; i++) {
+    if (current[i] !== expected[i]) return i;
+  }
+  return -1;
+}
+
+/** ログ出力用に行を切り詰める（undefined は "<missing>" 表記）。 */
+export function truncateForLog(line: string | undefined, max = 80): string {
+  if (line === undefined) return "<missing>";
+  const trimmed = line.trim();
+  if (trimmed.length <= max) return trimmed;
+  return trimmed.slice(0, max - 1) + "…";
+}
+
+function readText(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, "utf-8") as string;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveRelative(fullPath: string, root: string): string {
+  const rel = path.relative(root, fullPath);
+  return rel.replace(/\\/g, "/");
+}
+
+// ─── 鮮度種別判定 ────────────────────────────────────────────────────────
+
+/**
+ * Markdown 表の本文行（`| ... | ... |`）をセル配列へ分解する。
+ * ヘッダー / セパレータ行（`|---|---|`）は null を返す。
+ */
+export function parseTableRow(line: string): string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) return null;
+  // セパレータ行（`|---|---|` 等）は除外。
+  if (/^\|[-:\s|]+\|$/.test(trimmed)) return null;
+  const inner = trimmed.slice(1, -1);
+  return inner.split("|").map((c) => c.trim());
+}
+
+/**
+ * 現在の AUTOGEN block 本文と期待値を比較し、鮮度種別を判定する。
+ *
+ * 判定規則（リスト順、最初に該当したものを優先）:
+ *   1. 行数の増減 → rename（行の追加・削除 = ファイル追加・削除・rename とみなす）
+ *   2. SPEC metrics 表の同行異 status 列 → status_change
+ *   3. ADR README 表の同行異 status 列 → status_change
+ *   4. REQ metrics 表の同行異シグナル/備考列 → content_change（status 列を持たないため）
+ *   5. 上記以外の不一致 → content_change
+ *
+ * 注意: 本判定は「鮮度種別の優先的付与」であり、絶対的分類ではない。
+ * 例えば SPEC rename に伴いSPEC行数も変化した場合、行追加・削除を伴えば rename、
+ * 同行の値変化だけなら status_change / content_change となる。
+ * IR-061 は同一不整合を「内容不一致」として扱い、本 gate と判定基準が異なっても
+ * 両検査の実施要否は互いに影響しない（独立実施原則、SPEC「鮮度判定基準」）。
+ */
+export function classifyStaleness(
+  blockId: string,
+  currentBody: string[],
+  expectedBody: string[],
+  mismatchIndex: number,
+): { kind: StaleKind; detail: string } {
+  // 1. 行数の増減は rename（ファイル追加・削除・rename）とみなす。
+  if (currentBody.length !== expectedBody.length) {
+    const delta = expectedBody.length - currentBody.length;
+    return {
+      kind: "rename",
+      detail:
+        `AUTOGEN block size differs (current=${currentBody.length} lines, expected=${expectedBody.length} lines, ` +
+        `delta=${delta > 0 ? "+" : ""}${delta}). Source file add / remove / rename detected without regeneration.`,
+    };
+  }
+
+  // 2. 同行の値が異なる場合。種別は表の意味構造から判定。
+  const cur = currentBody[mismatchIndex];
+  const exp = expectedBody[mismatchIndex];
+  const curCells = parseTableRow(cur);
+  const expCells = parseTableRow(exp);
+
+  if (curCells && expCells && curCells.length > 0 && expCells.length > 0) {
+    // SPEC metrics 表（SPEC_METRICS_BLOCK_ID）: 列構成 = SPEC | SPEC 行数 | status | ドメイン分類
+    // status 列（index 2）のみ変化 → status_change
+    if (blockId === SPEC_METRICS_BLOCK_ID && curCells.length >= 4 && expCells.length >= 4) {
+      if (curCells[0] === expCells[0] && curCells[2] !== expCells[2]) {
+        return {
+          kind: "status_change",
+          detail:
+            `SPEC status changed without regeneration. path=${curCells[0]}, ` +
+            `status current="${curCells[2]}" expected="${expCells[2]}".`,
+        };
+      }
+    }
+    // ADR baseline 表: 列構成 = ADR番号 | タイトル | ステータス | 作成日
+    // status 列（index 2）のみ変化 → status_change
+    if (
+      blockId === ADR_BASELINE_TABLE_BLOCK_ID &&
+      curCells.length >= 4 &&
+      expCells.length >= 4
+    ) {
+      if (curCells[0] === expCells[0] && curCells[2] !== expCells[2]) {
+        return {
+          kind: "status_change",
+          detail:
+            `ADR status changed without regeneration. id=${curCells[0]}, ` +
+            `status current="${curCells[2]}" expected="${expCells[2]}".`,
+        };
+      }
+    }
+    // ADR retired 表: 列構成 = ADR番号 | タイトル | retired時ステータス
+    // retired時ステータス列（index 2）のみ変化 → status_change
+    if (
+      blockId === ADR_RETIRED_TABLE_BLOCK_ID &&
+      curCells.length >= 3 &&
+      expCells.length >= 3
+    ) {
+      if (curCells[0] === expCells[0] && curCells[2] !== expCells[2]) {
+        return {
+          kind: "status_change",
+          detail:
+            `Retired ADR status changed without regeneration. id=${curCells[0]}, ` +
+            `status current="${curCells[2]}" expected="${expCells[2]}".`,
+        };
+      }
+    }
+  }
+
+  // 3. 上記以外の不一致は content_change（行数値、備考、リンク、キャプション等の変化）。
+  return {
+    kind: "content_change",
+    detail:
+      `AUTOGEN block content differs at line ${mismatchIndex + 1}. ` +
+      `Likely caused by source content change (line count, title, caption, etc.) without regeneration.`,
+  };
+}
+
+// ─── 対象ブロック定義 ────────────────────────────────────────────────────
+
+interface BlockTarget {
+  /** ファイル絶対パス。 */
+  file: string;
+  /** AUTOGEN block ID。 */
+  blockId: string;
+  /** 期待される本文行配列。 */
+  expected: string[];
+}
+
+/**
+ * 対象索引ファイルとその AUTOGEN block 期待値を構築する。
+ * generate_indexes.ts と同一の生成関数を呼び出すことで「検査と生成の論理的同一性」を保証する。
+ */
+function buildBlockTargets(root: string): BlockTarget[] {
+  const targets: BlockTarget[] = [];
+
+  const rulesDir = path.join(root, "docs", "specs", "integrity", "rules");
+  const catalogPath = path.join(
+    root,
+    "docs",
+    "specs",
+    "integrity",
+    "integrity-rule-catalog.md",
+  );
+  const ruleOwnershipPath = path.join(
+    root,
+    "docs",
+    "specs",
+    "integrity",
+    "rule-ownership.md",
+  );
+  const adrDir = path.join(root, "docs", "adr");
+  const adrRetiredDir = path.join(adrDir, "retired");
+  const reqDir = path.join(root, "docs", "requirements");
+  const reqRetiredDir = path.join(reqDir, "retired");
+  const specsDir = path.join(root, "docs", "specs");
+  const adrReadmePath = path.join(adrDir, "README.md");
+  const reqReadmePath = path.join(reqDir, "README.md");
+  const docMapPath = path.join(root, "docs", "DOC-MAP.md");
+  const qualityDir = path.join(specsDir, "quality");
+  const reqHealthMetricsPath = path.join(qualityDir, "req-health-metrics.md");
+  const specHealthMetricsPath = path.join(qualityDir, "spec-health-metrics.md");
+  const docsReadmePath = path.join(root, "docs", "README.md");
+
+  // catalog（pre/post IR-045 gap 2ブロック）。IR ファイルが存在しない場合は対象外。
+  if (fs.existsSync(rulesDir)) {
+    const infos = collectIrFiles(rulesDir);
+    if (infos.length > 0) {
+      const { pre, post } = generateCatalogBlocks(infos);
+      targets.push({ file: catalogPath, blockId: CATALOG_PRE_BLOCK_ID, expected: pre });
+      targets.push({
+        file: catalogPath,
+        blockId: CATALOG_POST_BLOCK_ID,
+        expected: post,
+      });
+      const ruleOwnershipLines = generateRuleOwnershipAppendix(infos);
+      targets.push({
+        file: ruleOwnershipPath,
+        blockId: RULE_OWNERSHIP_BLOCK_ID,
+        expected: ruleOwnershipLines,
+      });
+    }
+  }
+
+  // ADR README（7ブロック）。ADR ファイルが存在しない場合は対象外。
+  if (fs.existsSync(adrDir)) {
+    const adrInfos = collectAdrFiles(adrDir);
+    const adrRetiredInfos = fs.existsSync(adrRetiredDir)
+      ? collectRetiredAdrFiles(adrRetiredDir)
+      : [];
+    const acceptedAdrs = adrInfos.filter((a) => a.status === "accepted");
+    targets.push({
+      file: adrReadmePath,
+      blockId: ADR_BASELINE_COUNT_BLOCK_ID,
+      expected: generateAdrBaselineCaption(acceptedAdrs),
+    });
+    targets.push({
+      file: adrReadmePath,
+      blockId: ADR_BASELINE_TABLE_BLOCK_ID,
+      expected: generateAdrBaselineTable(acceptedAdrs),
+    });
+    targets.push({
+      file: adrReadmePath,
+      blockId: ADR_STATUS_ACCEPTED_BLOCK_ID,
+      expected: generateAdrStatusList(adrInfos, "accepted"),
+    });
+    targets.push({
+      file: adrReadmePath,
+      blockId: ADR_STATUS_PROPOSED_BLOCK_ID,
+      expected: generateAdrStatusList(adrInfos, "proposed"),
+    });
+    targets.push({
+      file: adrReadmePath,
+      blockId: ADR_STATUS_SUPERSEDED_BLOCK_ID,
+      expected: generateAdrStatusList(adrInfos, "superseded"),
+    });
+    targets.push({
+      file: adrReadmePath,
+      blockId: ADR_STATUS_DEPRECATED_BLOCK_ID,
+      expected: generateAdrStatusList(adrInfos, "deprecated"),
+    });
+    targets.push({
+      file: adrReadmePath,
+      blockId: ADR_RETIRED_TABLE_BLOCK_ID,
+      expected: generateAdrRetiredTable(adrRetiredInfos),
+    });
+  }
+
+  // REQ README（3ブロック）。REQ ファイルが存在しない場合は対象外。
+  if (fs.existsSync(reqDir)) {
+    const reqInfos = collectReqFiles(reqDir);
+    const reqRetiredInfos = fs.existsSync(reqRetiredDir)
+      ? collectRetiredReqFiles(reqRetiredDir)
+      : [];
+    targets.push({
+      file: reqReadmePath,
+      blockId: REQ_ACTIVE_COUNT_BLOCK_ID,
+      expected: generateReqActiveCaption(reqInfos),
+    });
+    targets.push({
+      file: reqReadmePath,
+      blockId: REQ_ACTIVE_TABLE_BLOCK_ID,
+      expected: generateReqActiveTable(reqInfos),
+    });
+    targets.push({
+      file: reqReadmePath,
+      blockId: REQ_RETIRED_TABLE_BLOCK_ID,
+      expected: generateReqRetiredTable(reqRetiredInfos),
+    });
+  }
+
+  // DOC-MAP（1ブロック）。
+  targets.push({
+    file: docMapPath,
+    blockId: DOCMAP_INVENTORY_BLOCK_ID,
+    expected: generateDocMapInventory({
+      activeReqCount: fs.existsSync(reqDir) ? collectReqFiles(reqDir).length : 0,
+      retiredReqCount: fs.existsSync(reqRetiredDir)
+        ? collectRetiredReqFiles(reqRetiredDir).length
+        : 0,
+      activeAdrCount: fs.existsSync(adrDir) ? collectAdrFiles(adrDir).length : 0,
+      retiredAdrCount: fs.existsSync(adrRetiredDir)
+        ? collectRetiredAdrFiles(adrRetiredDir).length
+        : 0,
+      specCount: countSpecFiles(specsDir),
+    }),
+  });
+
+  // REQ / SPEC health-metrics（各1ブロック）。計測日は実行日のローカル日付（generate_indexes.ts と同一）。
+  const measureDate = formatMeasureDate(new Date());
+  if (fs.existsSync(reqDir)) {
+    const reqMetrics = collectReqMetrics(reqDir);
+    targets.push({
+      file: reqHealthMetricsPath,
+      blockId: REQ_METRICS_BLOCK_ID,
+      expected: generateReqMetricsTable(reqMetrics, measureDate),
+    });
+  }
+  const specMetrics = collectSpecMetrics(specsDir);
+  targets.push({
+    file: specHealthMetricsPath,
+    blockId: SPEC_METRICS_BLOCK_ID,
+    expected: generateSpecMetricsTable(specMetrics, measureDate),
+  });
+
+  // docs/README.md（1ブロック）。REQ ファイル群が存在しない場合は計測不能のため対象外。
+  if (fs.existsSync(reqDir) && fs.existsSync(reqRetiredDir)) {
+    targets.push({
+      file: docsReadmePath,
+      blockId: README_REQ_SUMMARY_COUNT_BLOCK_ID,
+      expected: generateReadmeReqSummaryCount({
+        activeReqCount: collectReqFiles(reqDir).length,
+        retiredReqCount: collectRetiredReqFiles(reqRetiredDir).length,
+      }),
+    });
+  }
+
+  return targets;
+}
+
+// ─── 検査本体 ────────────────────────────────────────────────────────────
+
+interface FileScanContext {
+  /** 同一ファイル内の block 検査をまとめるためのキャッシュ。 */
+  content: string;
+  blocks: ReturnType<typeof findAutogenBlocks>;
+}
+
+function scanBlocks(
+  targets: BlockTarget[],
+  root: string,
+): { findings: FreshnessFinding[]; skipped: FreshnessReport["skipped"]; filesScanned: Set<string> } {
+  const findings: FreshnessFinding[] = [];
+  const skipped: FreshnessReport["skipped"] = [];
+  const filesScanned = new Set<string>();
+
+  // 同一ファイルの読込をキャッシュ。
+  const fileCache = new Map<string, FileScanContext | null>();
+
+  const getCached = (file: string): FileScanContext | null => {
+    if (fileCache.has(file)) return fileCache.get(file) ?? null;
+    const content = readText(file);
+    if (content === null) {
+      fileCache.set(file, null);
+      return null;
+    }
+    const ctx: FileScanContext = { content, blocks: findAutogenBlocks(content) };
+    fileCache.set(file, ctx);
+    return ctx;
+  };
+
+  for (const target of targets) {
+    const ctx = getCached(target.file);
+    if (ctx === null) {
+      skipped.push({
+        file: resolveRelative(target.file, root),
+        block_id: target.blockId,
+        reason: "file not found",
+      });
+      continue;
+    }
+    filesScanned.add(target.file);
+    const block = ctx.blocks.find((b) => b.id === target.blockId);
+    if (!block) {
+      skipped.push({
+        file: resolveRelative(target.file, root),
+        block_id: target.blockId,
+        reason: "AUTOGEN marker not found in file",
+      });
+      continue;
+    }
+    const mismatchIndex = findFirstMismatch(block.currentBody, target.expected);
+    if (mismatchIndex === -1) continue; // fresh
+
+    const classification = classifyStaleness(
+      target.blockId,
+      block.currentBody,
+      target.expected,
+      mismatchIndex,
+    );
+    findings.push({
+      file: resolveRelative(target.file, root),
+      block_id: target.blockId,
+      first_mismatch_line: mismatchIndex + 1,
+      kind: classification.kind,
+      detail: classification.detail,
+      current_line: truncateForLog(block.currentBody[mismatchIndex]),
+      expected_line: truncateForLog(target.expected[mismatchIndex]),
+    });
+  }
+
+  return { findings, skipped, filesScanned };
+}
+
+// ─── 出力 formatter ──────────────────────────────────────────────────────
+
+function formatJson(report: FreshnessReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+function formatText(report: FreshnessReport): string {
+  const lines: string[] = [];
+  lines.push(`# ${SCRIPT_NAME} Report`);
+  lines.push("");
+  lines.push(`- 実行日時: ${report.timestamp}`);
+  lines.push(`- スクリプト: ${report.script}`);
+  lines.push(`- 検査索引ファイル数: ${report.files_scanned}`);
+  lines.push(`- 検出鮮度違反: ${report.findings_count} 件`);
+  lines.push("");
+
+  const kindCount = new Map<StaleKind, number>();
+  for (const f of report.findings) {
+    kindCount.set(f.kind, (kindCount.get(f.kind) ?? 0) + 1);
+  }
+  if (kindCount.size > 0) {
+    lines.push("## 鮮度種別内訳");
+    lines.push("");
+    lines.push("| 種別 | 件数 |");
+    lines.push("|------|------|");
+    for (const kind of ["rename", "status_change", "content_change"] as StaleKind[]) {
+      const c = kindCount.get(kind) ?? 0;
+      if (c > 0) lines.push(`| ${kind} | ${c} |`);
+    }
+    lines.push("");
+  }
+
+  if (report.findings.length > 0) {
+    lines.push("## 詳細");
+    lines.push("");
+    for (const f of report.findings) {
+      lines.push(
+        `### [${f.kind.toUpperCase()}] ${f.file} (block_id=${f.block_id})`,
+      );
+      lines.push(`- 不一致行: ${f.first_mismatch_line}`);
+      lines.push(`- 詳細: ${f.detail}`);
+      lines.push(`- 現在: \`${f.current_line}\``);
+      lines.push(`- 期待: \`${f.expected_line}\``);
+      lines.push("");
+    }
+    lines.push("## 再生成手順");
+    lines.push("");
+    lines.push(
+      "AUTOGEN ブロックが陳腐化しています。次のコマンドで再生成してください（autogen-freshness-gate SPEC、不合格時の処置）。",
+    );
+    lines.push("");
+    lines.push(
+      "```",
+    );
+    lines.push(
+      "bun run .opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts",
+    );
+    lines.push("```");
+    lines.push("");
+  } else {
+    lines.push("すべての AUTOGEN ブロックは鮮度が保たれています（再生成不要）。");
+    lines.push("");
+  }
+
+  if (report.skipped.length > 0) {
+    lines.push("## スキップ");
+    lines.push("");
+    for (const s of report.skipped) {
+      lines.push(`- ${s.file} (block_id=${s.block_id}): ${s.reason}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+// ─── main ────────────────────────────────────────────────────────────────
+
+interface Options {
+  help: boolean;
+  json: boolean;
+  dryRun: boolean;
+  root?: string;
+}
+
+function parseCliArgs(args: string[]): Options {
+  const options: Options = { help: false, json: false, dryRun: false };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--root") {
+      const v = args[i + 1];
+      if (!v) throw new Error("--root requires a value");
+      options.root = v;
+      i++;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function main(): void {
+  let options: Options;
+  try {
+    options = parseCliArgs(process.argv.slice(2));
+  } catch (e) {
+    console.error(
+      `[check_autogen_freshness] ${e instanceof Error ? e.message : String(e)}`,
+    );
+    process.exit(EXIT_ERROR);
+  }
+
+  if (options.help) {
+    const helpText = `${SCRIPT_NAME} ― ${DESCRIPTION}
+
+USAGE:
+  ${USAGE}
+
+OPTIONS:
+  --help            Show this help message
+  --json            Output results in JSON format
+  --dry-run         List scan targets without running freshness checks
+  --root <path>     Explicit repository root (worktree/CI support)
+
+EXIT CODES:
+  0  All AUTOGEN blocks are fresh (no staleness detected)
+  1  Stale AUTOGEN blocks detected (regeneration required)
+  2  Input error or execution failure
+
+STALENESS CLASSIFICATION:
+  rename           Source file add / remove / rename detected (block size differs)
+  status_change    Same source id but status column changed (SPEC / ADR status)
+  content_change   Other content drift (line count, title, caption, link, etc.)
+
+RELATED:
+  - SPEC: docs/specs/integrity/autogen-freshness-gate.md (REQ-010-059)
+  - IR:   docs/specs/integrity/rules/IR-061-index-generation-consistency.md
+  - SC-002: docs/specs/integrity/index-auto-generation.md
+  - Regeneration: bun run .opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts
+  - docs-check: /repo/docs-check (Step 1)
+`;
+    console.log(helpText);
+    process.exit(EXIT_OK);
+  }
+
+  const scriptDir =
+    (typeof import.meta !== "undefined" && (import.meta as any).dir) ||
+    __dirname ||
+    process.cwd();
+  const root = findRepoRoot(scriptDir, { explicitRoot: options.root });
+
+  const targets = buildBlockTargets(root);
+
+  if (options.dryRun) {
+    console.log(
+      `[check_autogen_freshness] dry-run: ${targets.length} AUTOGEN block targets across ${new Set(targets.map((t) => t.file)).size} files`,
+    );
+    const byFile = new Map<string, string[]>();
+    for (const t of targets) {
+      const list = byFile.get(t.file) ?? [];
+      list.push(t.blockId);
+      byFile.set(t.file, list);
+    }
+    for (const [file, blockIds] of [...byFile.entries()].sort()) {
+      console.log(`  ${resolveRelative(file, root)}: ${blockIds.join(", ")}`);
+    }
+    process.exit(EXIT_OK);
+  }
+
+  const { findings, skipped, filesScanned } = scanBlocks(targets, root);
+
+  const report: FreshnessReport = {
+    timestamp: new Date().toISOString(),
+    script: SCRIPT_NAME,
+    files_scanned: filesScanned.size,
+    findings_count: findings.length,
+    findings,
+    skipped,
+  };
+
+  if (options.json) {
+    console.log(formatJson(report));
+  } else {
+    console.log(formatText(report));
+  }
+
+  process.exit(findings.length > 0 ? EXIT_NG : EXIT_OK);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/docs/specs/integrity/autogen-freshness-gate.md
+++ b/docs/specs/integrity/autogen-freshness-gate.md
@@ -7,26 +7,63 @@ updated: "2026-08-09"
 
 # AUTOGEN ブロック鮮度検出 gate
 
-`/repo/docs-check` は repo-local コマンドであり配布対象外 SPEC を持たないため、AUTOGEN ブロック鮮度検出 gate を本新規 SPEC として配置する。AUTOGEN ブロックを含む SPEC ファイル（spec-health-metrics.md 等）の陳腐化を検出し、再生成を促す契約を定義する。
+`/repo/docs-check` は repo-local コマンドであり配布対象外 SPEC を持たないため、AUTOGEN ブロック鮮度検出 gate を本新規 SPEC として配置する。AUTOGEN ブロックを含む索引ファイル（spec-health-metrics.md 等）の陳腐化を検出し、再生成を促す契約を定義する。本 SPEC は gate の契約を定義し、検出ロジックの実装詳細はスクリプト側が担う（機械化境界、charter 原則）。
 
 ## 検出対象
 
-- AUTOGEN ブロック（`<!-- AUTOGEN:BEGIN -->` 〜 `<!-- AUTOGEN:END -->`）を含む SPEC ファイル
-- 代表例: `docs/specs/quality/spec-health-metrics.md`
+- AUTOGEN ブロック（`<!-- AUTOGEN:BEGIN:id=xxx -->` 〜 `<!-- AUTOGEN:END -->`）を含む索引ファイル群
+- 代表例: `docs/specs/quality/spec-health-metrics.md`（SPEC 計測例 AUTOGEN ブロック）
+- 対象一覧は SC-002（`docs/specs/integrity/index-auto-generation.md`）が定める自動生成対象ファイルと同一
 
 ## 鮮度判定基準
 
-- 対象 SPEC の rename 発生時に AUTOGEN ブロックの再生成必要性を判定する
-- 対象 SPEC の status 変更（draft → accepted 等）時に AUTOGEN ブロックの再生成必要性を判定する
+- 対象ファイルのソース（SPEC / REQ / ADR / IR の frontmatter、ファイル名、status）の rename 発生時に AUTOGEN ブロックの再生成必要性を判定する
+- 対象ファイルのソース status 変更（draft → accepted 等）時に AUTOGEN ブロックの再生成必要性を判定する
 - SC-002（定期再生成）と整合する運用を維持する
+
+鮮度種別は検出結果に応じて次の3種に分類する。分類は「鮮度違反の優先的付与」であり絶対的分類ではない（例: rename と status 変更が同時に起きた場合、行数増減を伴えば rename、同行値変化のみなら status_change と分類）。
+
+| 種別 | 判定規則 |
+|------|----------|
+| `rename` | AUTOGEN block の行数が期待値と異なる（ソースファイル追加・削除・rename を起因とする行増減） |
+| `status_change` | 同一 id の行で status 列のみ変化（SPEC / ADR の status frontmatter 変更に起因） |
+| `content_change` | 上記以外の不一致（行数値、タイトル、キャプション、リンク等の変化） |
 
 ## 不合格時の処置
 
 - 鮮度判定不合格時は再生成を要求し、合格まで検出を継続する
 - 自動修復は行わず、再生成対象を報告に留める
+- 再生成コマンド: `bun run .opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts`
+
+## 実装契約
+
+本 SPEC が定める gate を実装する検査スクリプトとその呼出し契約。
+
+- **検査スクリプト**: `.opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.ts`
+- **実行ランナー**: Bun（`bun run`）。TypeScript 直接実行と `require()` / `import` 混在構文を前提とするため、Bun 以外のランナーでは ESM 解釈エラーが発生する
+- **docs-check からの呼出し**: `/repo/docs-check` Step 1 が `bun run` で実行する。check_autogen_freshness.ts の strict failure（stale blocks 検出）は docs-check 全体を fail とする
+- **生成スクリプトとの論理同一性**: 検査スクリプトは生成スクリプト（`generate_indexes.ts`）の exported 関数を再利用し、検査と生成で同一の再生成ロジックを共有する。これにより検査と生成の間の論理的同一性を保証する（AG-002 docs-check G01 分離原則維持）
+- **IR-061 との関係**: IR-061（`check_integrity.ts` `checkIndexGenerationConsistency`）は同一の不整合を「内容不一致」として検出する。本 gate は鮮度種別（rename / status_change / content_change）を分類して報告する点が異なる。両検査は独立して実施し、いずれか単独の実施要否にも他方の結果は影響しない（独立実施原則）
+
+### CLI 契約
+
+```
+bun run .opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.ts [--help] [--json] [--dry-run] [--root <path>]
+```
+
+| オプション | 動作 |
+|------------|------|
+| `--help` | ヘルプを表示して exit 0 |
+| `--json` | 結果を JSON 形式で出力 |
+| `--dry-run` | 検査対象のみ列挙して検査を実施せず exit 0 |
+| `--root <path>` | 明示的リポジトリルート（worktree / CI サポート） |
+
+終了コード: 0（鮮度維持）、1（陳腐化検出、再生成要求）、2（入力エラー）。
 
 ## 関連
 
 - REQ-010-059（AUTOGEN ブロック鮮度検出 gate 要件行）
-- SC-002（定期再生成、REQ-010 関連）
+- SC-002（定期再生成、`docs/specs/integrity/index-auto-generation.md`、REQ-010 関連）
+- IR-061（索引類自動生成整合性、`docs/specs/integrity/rules/IR-061-index-generation-consistency.md`）
 - `/repo/docs-check`（repo-local、配布対象外）
+


### PR DESCRIPTION
## 対応 Issue

- Closes #1994
- Parent: #1992
- OU: OU-003 (Epic A Wave 2)

## 概要

REQ-010-059、autogen-freshness-gate SPEC（`docs/specs/integrity/autogen-freshness-gate.md`）に基づき、AUTOGEN ブロック鮮度検出 gate を実装した。AUTOGEN ブロック（`<!-- AUTOGEN:BEGIN:id=xxx -->`〜`<!-- AUTOGEN:END -->`）を含む索引ファイル群について、ソース（frontmatter / ファイル名 / status）の rename や status 変更後に AUTOGEN ブロックが陳腐化しているかを検出し、鮮度種別（rename / status_change / content_change）を分類して報告する。

## 変更対象成果物

- `check_autogen_freshness.ts`（新規）: 鮮度検出スクリプト本体。Bun runtime で動作。`generate_indexes.ts` の exported 関数を再利用し、検査と生成で同一の再生成ロジックを共有する（論理的同一性、AG-002 docs-check G01 分離原則維持）
- `check_autogen_freshness.test.ts`（新規）: 単体テスト 23 件（全 pass）。合成コンテンツを用いて鮮度種別判定（rename / status_change / content_change）と report 生成ロジックを検証する
- `docs-check.md`（更新）: Step 1 に gate 呼出しを追加、実行ランナー一覧へ `check_autogen_freshness.ts` を追記
- `autogen-freshness-gate.md`（更新）: 実装契約、CLI 契約、鮮度種別判定表、不合格時の処置（再生成コマンド明示）を追記

## 完了条件

- [x] REQ-010.md に REQ-010-059 が append されていること → 既存（前工程 spec-save 完了済み）
- [x] docs/specs/integrity/autogen-freshness-gate.md が存在し、検出対象、鮮度判定基準、不合格時の処置が明示されていること → 本 PR で実装契約・CLI 契約・鮮度種別判定表を追記し、不合格時の再生成コマンドを明示
- [x] AUTOGEN ブロックのソース変更（rename、status 変更）後に gate が fail すること → `check_autogen_freshness.ts` が陳腐化検出時に exit 1 を返すことで gate fail を実現。検出確認済み（後述「動作確認」）
- [x] SC-002（定期再生成）との整合が取れていること → `generate_indexes.ts`（SC-002 Phase C 実装）の関数を再利用し、検査と生成で同一ロジックを共有することで整合性を担保。SPEC「関連」節で SC-002 へ言及

## テスト戦略 (TS-003)

- **verification**: AUTOGEN ブロック（spec-health-metrics.md 等）のソース（rename、status 変更）を変更後、`bun run check_autogen_freshness.ts` を実行した
- **pass_criteria**: AUTOGEN ブロックの陳腐化が検出され、gate が fail する。鮮度判定基準が明示されている → **PASS**。現在の origin/main 状態で既存の陳腐化 3 件（adr-baseline-table、req-metrics、spec-metrics）を検出し exit 1 を返すことを確認。鮮度種別判定表（rename / status_change / content_change）を SPEC に明示
- **on_failure**: fix-and-reverify → テスト不合格なし

## 動作確認

```
$ bun run .opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.ts
# check_autogen_freshness.ts Report
- 検査索引ファイル数: 6
- 検出鮮度違反: 3 件

## 鮮度種別内訳
| 種別 | 件数 |
| rename | 3 |

## 詳細
### [RENAME] docs/adr/README.md (block_id=adr-baseline-table)
### [RENAME] docs/specs/quality/req-health-metrics.md (block_id=req-metrics-measurement-example)
### [RENAME] docs/specs/quality/spec-health-metrics.md (block_id=spec-metrics-measurement-example)

$ bun test ./.opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.test.ts
23 pass / 0 fail / 41 expect() calls

$ bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --files docs/specs/integrity/autogen-freshness-gate.md --json
# failures: [] (docs 整合性検査 pass)
```

## Findings / Capture候補

### docs-integrity

targeted docs guard（`check_changed_docs.ts --workflow case-run --files docs/specs/integrity/autogen-freshness-gate.md`）の結果: failures なし。

### stale-reference

QG-3 前置 staleness check（Step 5-3）の結果: 差異非検出。Issue が参照する REQ-010.md、autogen-freshness-gate.md、docs-check.md は全て現行存在する。

### 既存 AUTOGEN ブロック陳腐化（本 PR 起因ではない、要観察）

現在の origin/main HEAD (15ce297b) で `check_autogen_freshness.ts` を実行すると 3 件の陳腐化を検出する。これらは本 PR 以前に蓄積した既存状態（最近の docs 変更時に AUTOGEN ブロックが再生成されなかった）であり、本 PR の変更によって発生したものではない。本 PR のスコープ（gate 実装）には AUTOGEN ブロック再生成は含まない。別途 `bun run generate_indexes.ts` で再生成する必要がある（別メンテナンス作業）。

- docs/adr/README.md (adr-baseline-table): ADR-007 (proposed) の取り扱い差分
- docs/specs/quality/req-health-metrics.md (req-metrics): REQ 追加に伴う行数増
- docs/specs/quality/spec-health-metrics.md (spec-metrics): SPEC 変更に伴う行数増

## 必須品質統制

- integrity 品質検証能力（AUTOGEN ブロック鮮度検出）: check_autogen_freshness.ts で実装
- テスト品質検証能力（gate 挙動検証）: check_autogen_freshness.test.ts (23 件) で検証

## レビュー判断

本 Issue のレビュー判断は親 Epic Issue #1992 の「レビュー判断」セクションを参照。
