### PR TITLE
feat(integrity): テスト影響範囲検出 gate を新設（REQ-019、OU-004）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.test.ts
@@ -1,0 +1,320 @@
+/**
+ * check_test_impact.test.ts — Test impact detection gate regression test.
+ *
+ * Issue #1995 / OU-004 / REQ-019 / TS-004.
+ *
+ * Verifies:
+ *   - stale candidate detection: test references changed SPEC, test not in PR changes → finding
+ *   - updated test suppression: test references changed SPEC, test in PR changes → no finding
+ *   - REQ-ID reference detection: REQ-NNN reference triggers when REQ file changes
+ *   - silent-pass warning: SPEC changed but no test references → warning
+ *   - CLI contract: --help, required flags, JSON output schema
+ *
+ * Mirrors check_changed_docs.test.ts subprocess-spawn pattern (script calls process.exit()).
+ */
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, existsSync, copyFileSync } from "fs";
+import { join } from "path";
+import { execSync } from "child_process";
+
+const SCRIPT_DIR = import.meta.dir;
+const SCRIPT_FILE = join(SCRIPT_DIR, "check_test_impact.ts");
+const CLI_UTILS_FILE = join(SCRIPT_DIR, "cli_utils.ts");
+const TEMP_BASE = join("C:", "WINDOWS", "TEMP", "opencode");
+const RUN_ID = `test-impact-${crypto.randomUUID().slice(0, 8)}`;
+const TEMP_ROOT = join(TEMP_BASE, RUN_ID);
+
+interface RunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runScript(cwd: string, args: string[]): RunResult {
+  const scriptPath = join(
+    cwd,
+    ".opencode",
+    "skills",
+    "repo-agentdev-integrity",
+    "scripts",
+    "check_test_impact.ts",
+  );
+  const proc = Bun.spawnSync(["bun", "run", scriptPath, ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stdout: proc.stdout?.toString("utf-8") ?? "",
+    stderr: proc.stderr?.toString("utf-8") ?? "",
+  };
+}
+
+function mkdirp(p: string): void {
+  mkdirSync(p, { recursive: true });
+}
+
+function setupTempRepo(): void {
+  mkdirp(TEMP_ROOT);
+  // script は cli_utils.ts と共に TEMP_ROOT 内の所定パスへ配置する
+  const scriptDest = join(
+    TEMP_ROOT,
+    ".opencode",
+    "skills",
+    "repo-agentdev-integrity",
+    "scripts",
+    "check_test_impact.ts",
+  );
+  mkdirp(join(scriptDest, ".."));
+  copyFileSync(SCRIPT_FILE, scriptDest);
+  copyFileSync(CLI_UTILS_FILE, join(scriptDest, "..", "cli_utils.ts"));
+  // git init（--base-ref テスト用）。worktree ではなく main repo 形式で十分
+  execSync("git init -q", { cwd: TEMP_ROOT });
+  execSync('git config user.email "t@t"', { cwd: TEMP_ROOT });
+  execSync('git config user.name "t"', { cwd: TEMP_ROOT });
+  execSync("git add -A", { cwd: TEMP_ROOT });
+  execSync('git commit -q -m "init"', { cwd: TEMP_ROOT });
+}
+
+function writeFile(rel: string, content: string): void {
+  const abs = join(TEMP_ROOT, rel);
+  mkdirp(join(abs, ".."));
+  writeFileSync(abs, content, "utf-8");
+}
+
+function commitAll(message: string): void {
+  execSync("git add -A", { cwd: TEMP_ROOT });
+  execSync(`git commit -q -m "${message}"`, { cwd: TEMP_ROOT });
+}
+
+function currentBranch(): string {
+  return execSync("git rev-parse --abbrev-ref HEAD", {
+    cwd: TEMP_ROOT,
+    encoding: "utf-8",
+  }).trim();
+}
+
+function headRef(): string {
+  return "HEAD";
+}
+
+beforeAll(() => {
+  setupTempRepo();
+});
+
+afterAll(() => {
+  if (existsSync(TEMP_ROOT)) rmSync(TEMP_ROOT, { recursive: true, force: true });
+});
+
+describe("check_test_impact.ts CLI contract", () => {
+  it("prints help and exits 0 with --help", () => {
+    const r = runScript(TEMP_ROOT, ["--help"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr.toLowerCase()).toContain("usage:");
+    expect(r.stderr.toLowerCase()).toContain("description:");
+  });
+
+  it("exits 2 when neither --files nor --base-ref is given", () => {
+    const r = runScript(TEMP_ROOT, []);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr.toLowerCase()).toContain("--files");
+  });
+
+  it("exits 2 on unknown argument", () => {
+    const r = runScript(TEMP_ROOT, ["--unknown-flag"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr.toLowerCase()).toContain("unknown argument");
+  });
+});
+
+describe("check_test_impact.ts stale candidate detection (TS-004)", () => {
+  it("detects stale test that references changed SPEC and is not updated in same PR", () => {
+    // Scenario: WP-1..WP-5相当のリファクタリングで SPEC が変更され、
+    // 参照テストが同一 PR で未更新 → 陳腐化候補として検出
+    // Setup: main に SPEC v1 と参照 test を用意 → branch で SPEC v2 のみ変更
+    execSync(`git checkout -q main`, { cwd: TEMP_ROOT });
+    writeFile(
+      "docs/specs/integrity/sample-gate.md",
+      "---\ntitle: Sample Gate\nstatus: draft\n---\n# Sample Gate\n",
+    );
+    writeFile(
+      "src/scripts/sample.test.ts",
+      [
+        'import { describe, it, expect } from "bun:test";',
+        "// このテストは docs/specs/integrity/sample-gate.md を参照する",
+        'describe("sample", () => {',
+        '  it("passes", () => { expect(1).toBe(1); });',
+        "});",
+        "",
+      ].join("\n"),
+    );
+    commitAll("add sample-gate SPEC and its test on main");
+    const branch = "test-stale-detection";
+    execSync(`git checkout -q -b ${branch}`, { cwd: TEMP_ROOT });
+    // branch 側で SPEC のみ変更（test は更新しない）
+    writeFile(
+      "docs/specs/integrity/sample-gate.md",
+      "---\ntitle: Sample Gate\nstatus: draft\nupdated: 2026-08-09\n---\n# Sample Gate (revised)\nnew content\n",
+    );
+    execSync("git add -A", { cwd: TEMP_ROOT });
+    execSync('git commit -q -m "revise sample-gate SPEC only"', { cwd: TEMP_ROOT });
+
+    // SPEC のみが変更された状態で gate を実行
+    const r = runScript(TEMP_ROOT, ["--base-ref", "main", "--json"]);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout);
+    expect(report.spec_changes.length).toBeGreaterThanOrEqual(1);
+    expect(report.spec_changes).toContain("docs/specs/integrity/sample-gate.md");
+    // src/scripts/sample.test.ts は SPEC を参照するが同一 PR で未変更 → 陳腐化候補
+    const stale = report.stale_candidates.find(
+      (f: any) => f.test_path === "src/scripts/sample.test.ts",
+    );
+    expect(stale).toBeDefined();
+    expect(stale.reference_kind).toBe("full-path");
+    expect(stale.spec_path).toBe("docs/specs/integrity/sample-gate.md");
+
+    // main に戻しておく
+    execSync(`git checkout -q main`, { cwd: TEMP_ROOT });
+    execSync(`git branch -q -D ${branch}`, { cwd: TEMP_ROOT });
+  });
+
+  it("suppresses finding when test referencing changed SPEC is also updated in same PR", () => {
+    const branch = "test-update-suppression";
+    execSync(`git checkout -q -b ${branch}`, { cwd: TEMP_ROOT });
+    // SPEC と test を同 PR で変更
+    writeFile(
+      "docs/specs/integrity/updated-gate.md",
+      "---\ntitle: Updated Gate\nstatus: draft\n---\n# Updated Gate\n",
+    );
+    writeFile(
+      "src/scripts/updated.test.ts",
+      [
+        'import { describe, it, expect } from "bun:test";',
+        "// docs/specs/integrity/updated-gate.md 参照",
+        'describe("updated", () => { it("ok", () => {}); });',
+        "",
+      ].join("\n"),
+    );
+    commitAll("add SPEC and update test in same PR");
+
+    const r = runScript(TEMP_ROOT, ["--base-ref", "main", "--json"]);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout);
+    // updated.test.ts は同一 PR で変更済みのため stale_candidates に含まれない
+    const stale = report.stale_candidates.find(
+      (f: any) => f.test_path === "src/scripts/updated.test.ts",
+    );
+    expect(stale).toBeUndefined();
+
+    execSync(`git checkout -q main`, { cwd: TEMP_ROOT });
+    execSync(`git branch -q -D ${branch}`, { cwd: TEMP_ROOT });
+  });
+
+  it("detects REQ-ID reference when REQ file changes", () => {
+    const branch = "test-req-id-detection";
+    // 事前に REQ ファイルと参照テストを main へ用意
+    execSync(`git checkout -q main`, { cwd: TEMP_ROOT });
+    writeFile(
+      "docs/requirements/REQ-999.md",
+      "---\nid: REQ-999\ntitle: Sample\n---\n# Sample REQ\n",
+    );
+    writeFile(
+      "src/scripts/req999.test.ts",
+      [
+        "// REQ-999 を参照する regression test",
+        'import { describe, it, expect } from "bun:test";',
+        'describe("req999", () => { it("ok", () => {}); });',
+        "",
+      ].join("\n"),
+    );
+    commitAll("add REQ-999 and its test on main");
+    execSync(`git checkout -q -b ${branch}`, { cwd: TEMP_ROOT });
+    // REQ-999 のみ変更（test は更新しない）
+    writeFile(
+      "docs/requirements/REQ-999.md",
+      "---\nid: REQ-999\ntitle: Sample\nupdated: 2026-08-09\n---\n# Sample REQ (revised)\n",
+    );
+    commitAll("revise REQ-999 only");
+
+    const r = runScript(TEMP_ROOT, ["--base-ref", "main", "--json"]);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout);
+    expect(report.spec_changes).toContain("docs/requirements/REQ-999.md");
+    const stale = report.stale_candidates.find(
+      (f: any) => f.test_path === "src/scripts/req999.test.ts",
+    );
+    expect(stale).toBeDefined();
+    expect(stale.reference_kind).toBe("req-id");
+
+    execSync(`git checkout -q main`, { cwd: TEMP_ROOT });
+    execSync(`git branch -q -D ${branch}`, { cwd: TEMP_ROOT });
+  });
+
+  it("emits silent-pass warning when SPEC changes but no test references found", () => {
+    const branch = "test-silent-pass";
+    execSync(`git checkout -q -b ${branch}`, { cwd: TEMP_ROOT });
+    // 参照テストの無い SPEC を追加
+    writeFile(
+      "docs/specs/integrity/orphan-gate.md",
+      "---\ntitle: Orphan Gate\nstatus: draft\n---\n# Orphan Gate\n",
+    );
+    commitAll("add orphan-gate SPEC");
+    const r = runScript(TEMP_ROOT, ["--base-ref", "main", "--json"]);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout);
+    expect(report.spec_changes.length).toBeGreaterThanOrEqual(1);
+    expect(report.warnings.length).toBeGreaterThanOrEqual(1);
+    expect(report.warnings[0]).toMatch(/参照を検出できなかった/);
+
+    execSync(`git checkout -q main`, { cwd: TEMP_ROOT });
+    execSync(`git branch -q -D ${branch}`, { cwd: TEMP_ROOT });
+  });
+
+  it("emits empty report when no SPEC changes in PR", () => {
+    const branch = "test-no-spec-change";
+    execSync(`git checkout -q -b ${branch}`, { cwd: TEMP_ROOT });
+    // SPEC 以外のファイルのみ変更
+    writeFile("src/scripts/unrelated.ts", "export const x = 1;\n");
+    commitAll("add non-SPEC file");
+    const r = runScript(TEMP_ROOT, ["--base-ref", "main", "--json"]);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout);
+    expect(report.spec_changes.length).toBe(0);
+    expect(report.stale_candidates.length).toBe(0);
+
+    execSync(`git checkout -q main`, { cwd: TEMP_ROOT });
+    execSync(`git branch -q -D ${branch}`, { cwd: TEMP_ROOT });
+  });
+
+  it("JSON output contains required schema fields", () => {
+    const branch = "test-schema";
+    execSync(`git checkout -q -b ${branch}`, { cwd: TEMP_ROOT });
+    writeFile(
+      "docs/specs/integrity/schema-gate.md",
+      "---\ntitle: Schema Gate\nstatus: draft\n---\n# Schema Gate\n",
+    );
+    writeFile(
+      "src/scripts/schema.test.ts",
+      '// docs/specs/integrity/schema-gate.md\nimport { describe, it, expect } from "bun:test";\ndescribe("s", () => { it("ok", () => {}); });\n',
+    );
+    commitAll("schema-gate");
+    const r = runScript(TEMP_ROOT, ["--base-ref", "main", "--json"]);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout);
+    // TestImpactReport schema 必須フィールド
+    expect(report).toHaveProperty("base_ref");
+    expect(report).toHaveProperty("files_declared");
+    expect(report).toHaveProperty("spec_changes");
+    expect(report).toHaveProperty("tests_scanned");
+    expect(report).toHaveProperty("stale_candidates");
+    expect(report).toHaveProperty("warnings");
+    expect(Array.isArray(report.spec_changes)).toBe(true);
+    expect(Array.isArray(report.stale_candidates)).toBe(true);
+    expect(Array.isArray(report.warnings)).toBe(true);
+    expect(typeof report.tests_scanned).toBe("number");
+
+    execSync(`git checkout -q main`, { cwd: TEMP_ROOT });
+    execSync(`git branch -q -D ${branch}`, { cwd: TEMP_ROOT });
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.ts
@@ -1,0 +1,551 @@
+/**
+ * check_test_impact.ts — Test impact detection gate (REQ-019).
+ *
+ * リファクタリング PR で SPEC 変更に連動する周辺テストの陳腐化を検出する。
+ * 変更 SPEC ファイルを抽出し、当該 SPEC を参照するテストファイルのうち
+ * 同一 PR で未変更のものを「陳腐化候補」として報告する。
+ *
+ * 処理層 (5層):
+ *   1. changed file resolver    — --files / --base-ref から変更ファイルを特定
+ *   2. spec change classifier   — 変更ファイルを SPEC/REQ/ADR 変更へ分類
+ *   3. test file discovery       — test-glob で走査対象テストファイルを発見
+ *   4. reference scanner         — 各テストファイルから SPEC 参照を抽出
+ *   5. staleness evaluator       — 参照テストが同一 PR で変更されたか評価
+ *
+ * CLI 詳細は docs/specs/integrity/test-impact-detection-gate.md「チェッカー実装契約」節参照。
+ */
+
+import {
+  EXIT_OK,
+  EXIT_ERROR,
+  findRepoRoot,
+} from "./cli_utils.ts";
+
+const path = require("path") as typeof import("path");
+const fs = require("fs") as typeof import("fs");
+
+const SCRIPT_NAME = "check_test_impact.ts";
+const DESCRIPTION = "Test impact detection gate for SPEC changes (REQ-019)";
+const USAGE =
+  "bun run check_test_impact.ts [--base-ref <git-ref> | --files <path...>] [--test-glob <pattern>] [--json] [--root <path>]";
+const DEFAULT_TEST_GLOB = "**/*.test.ts";
+
+// SPEC 系ファイルのパス分類。docs/specs/**、docs/requirements/REQ-*、docs/adr/ADR-* を対象とする。
+const SPEC_PATH_PATTERNS = [
+  /^docs\/specs\/.*\.md$/,
+  /^docs\/requirements\/REQ-.*\.md$/,
+  /^docs\/adr\/ADR-.*\.md$/,
+];
+
+// 走査除外ディレクトリ（相対パス先頭一致）。ビルド成果物、外部依存、worktree、retired を除く。
+const SCAN_EXCLUDE_DIRS = [
+  "node_modules/",
+  ".worktrees/",
+  ".agentdev-plugin/",
+  ".git/",
+  "docs/requirements/retired/",
+  "docs/adr/retired/",
+];
+
+// REQ/ADR ID 抽出用正規表現。
+const REQ_ID_PATTERN = /\b(REQ-\d{3})\b/g;
+const ADR_ID_PATTERN = /\b(ADR-\d{3})\b/g;
+
+type SpecLifecycle = "added" | "deleted" | "renamed" | "modified" | "unknown";
+type ReferenceKind = "full-path" | "basename" | "req-id" | "adr-id";
+
+interface TestImpactFinding {
+  spec_path: string;
+  spec_lifecycle: SpecLifecycle;
+  test_path: string;
+  reference_kind: ReferenceKind;
+  reference_snippet: string;
+  reference_line: number;
+}
+
+interface TestImpactReport {
+  base_ref: string | null;
+  files_declared: string[];
+  spec_changes: string[];
+  tests_scanned: number;
+  stale_candidates: TestImpactFinding[];
+  warnings: string[];
+}
+
+interface ParsedArgs {
+  files: string[];
+  baseRef: string | null;
+  testGlob: string;
+  json: boolean;
+  help: boolean;
+  root?: string;
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    files: [],
+    baseRef: null,
+    testGlob: DEFAULT_TEST_GLOB,
+    json: false,
+    help: false,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--help" || a === "-h") {
+      parsed.help = true;
+    } else if (a === "--json") {
+      parsed.json = true;
+    } else if (a === "--base-ref") {
+      const v = args[i + 1];
+      if (!v) throw new Error("--base-ref requires a value");
+      parsed.baseRef = v;
+      i++;
+    } else if (a === "--files") {
+      i++;
+      while (i < args.length && !args[i].startsWith("--")) {
+        for (const token of args[i].split(",")) {
+          const trimmed = token.trim();
+          if (trimmed.length > 0) parsed.files.push(trimmed);
+        }
+        i++;
+      }
+      i--;
+    } else if (a === "--test-glob") {
+      const v = args[i + 1];
+      if (!v) throw new Error("--test-glob requires a value");
+      parsed.testGlob = v;
+      i++;
+    } else if (a === "--root") {
+      const v = args[i + 1];
+      if (!v) throw new Error("--root requires a value");
+      parsed.root = v;
+      i++;
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return parsed;
+}
+
+function printHelp(): void {
+  console.error(`usage: ${USAGE}`);
+  console.error("");
+  console.error(`description: ${DESCRIPTION}`);
+  console.error("");
+  console.error("options:");
+  console.error("  --base-ref <ref>     git base ref to compute changed files; for worktree env (pre-merge, case-run). mutually exclusive with --files");
+  console.error("  --files <path...>    changed files (space-separated recommended; comma-separated also accepted); for main env (post-merge, case-close). mutually exclusive with --base-ref");
+  console.error(`  --test-glob <pat>    test file glob (default: ${DEFAULT_TEST_GLOB})`);
+  console.error("  --json               emit JSON report (default: text)");
+  console.error("  --root <path>        explicit repository root (worktree/CI support)");
+}
+
+// ─── Layer 1: changed file resolver ────────────────────────────────────────
+
+function resolveChangedFiles(
+  root: string,
+  files: string[],
+  baseRef: string | null,
+): string[] {
+  if (files.length > 0) {
+    return files
+      .map((f) => (path.isAbsolute(f) ? f : path.resolve(root, f)))
+      .filter((f) => fs.existsSync(f));
+  }
+  if (baseRef) {
+    const { execSync } = require("child_process") as typeof import("child_process");
+    try {
+      const out = execSync(
+        `git diff --name-only ${baseRef}...HEAD`,
+        { cwd: root, encoding: "utf-8" },
+      ) as string;
+      return out
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0)
+        .map((rel) => path.join(root, rel.replace(/\//g, path.sep)));
+    } catch (e) {
+      throw new Error(
+        `git diff against --base-ref ${baseRef} failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+  return [];
+}
+
+// ─── Layer 2: spec change classifier ───────────────────────────────────────
+
+function isSpecPath(relPath: string): boolean {
+  return SPEC_PATH_PATTERNS.some((p) => p.test(relPath));
+}
+
+interface SpecChange {
+  relPath: string;
+  lifecycle: SpecLifecycle;
+  basename: string;
+  reqIds: string[]; // 変更 SPEC から抽出した REQ-NNN（REQ ファイル自身の ID 等）
+  adrIds: string[]; // 変更 SPEC から抽出した ADR-NNN
+}
+
+function gitNameStatus(
+  root: string,
+  rel: string,
+  baseRef: string | null,
+): { status: "A" | "D" | "R" | "M" | null } {
+  const { execSync } = require("child_process") as typeof import("child_process");
+  try {
+    const diffCmd = baseRef
+      ? `git diff --name-status --diff-filter=ADRMCR ${baseRef}...HEAD -- "${rel}"`
+      : `git diff --name-status --diff-filter=ADRMCR HEAD -- "${rel}"`;
+    const out = execSync(diffCmd, { cwd: root, encoding: "utf-8" }) as string;
+    const line = out.split("\n").find((l) => l.trim().length > 0);
+    if (!line) return { status: null };
+    const statusCode = line.split("\t")[0];
+    if (statusCode.startsWith("R") || statusCode.startsWith("C")) return { status: "R" };
+    if (statusCode === "A") return { status: "A" };
+    if (statusCode === "D") return { status: "D" };
+    if (statusCode === "M") return { status: "M" };
+    return { status: null };
+  } catch {
+    return { status: null };
+  }
+}
+
+function classifySpecChanges(
+  root: string,
+  changedFiles: string[],
+  baseRef: string | null,
+): SpecChange[] {
+  const result: SpecChange[] = [];
+  for (const absPath of changedFiles) {
+    const rel = path.relative(root, absPath).replace(/\\/g, "/");
+    if (!isSpecPath(rel)) continue;
+    const status = gitNameStatus(root, rel, baseRef);
+    let lifecycle: SpecLifecycle = "unknown";
+    if (status.status === "A") lifecycle = "added";
+    else if (status.status === "D") lifecycle = "deleted";
+    else if (status.status === "R") lifecycle = "renamed";
+    else if (status.status === "M") lifecycle = "modified";
+    // 伝播対象 ID は「ファイル自身の ID」のみ。
+    // REQ/ADR ファイル名由来の ID のみを採用し、SPEC 本文の ADR/REQ 言及は伝播させない
+    // （SPEC が ADR-001 を言及しても ADR-001 変更ではなく、過検出になるため）。
+    const reqIds: string[] = [];
+    const adrIds: string[] = [];
+    const reqFileMatch = rel.match(/REQ-(\d{3})/);
+    if (reqFileMatch) reqIds.push(`REQ-${reqFileMatch[1]}`);
+    const adrFileMatch = rel.match(/ADR-(\d{3})/);
+    if (adrFileMatch) adrIds.push(`ADR-${adrFileMatch[1]}`);
+    result.push({
+      relPath: rel,
+      lifecycle,
+      basename: path.basename(rel),
+      reqIds,
+      adrIds,
+    });
+  }
+  return result;
+}
+
+// ─── Layer 3: test file discovery ───────────────────────────────────────────
+
+function shouldExclude(relPath: string): boolean {
+  return SCAN_EXCLUDE_DIRS.some((d) => relPath.startsWith(d));
+}
+
+function globMatch(pattern: string, relPath: string): boolean {
+  // 最小限の glob 実装。**/*.test.ts 等の一般的なパターンをサポート。
+  // ** → 任意ディレクトリ階層、* → 単一階層の任意文字列。
+  const regexStr = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "::DBLSTAR::")
+    .replace(/\*/g, "[^/]*")
+    .replace(/::DBLSTAR::/g, ".*");
+  return new RegExp(`^${regexStr}$`).test(relPath);
+}
+
+function discoverTestFiles(root: string, testGlob: string): string[] {
+  const results: string[] = [];
+  function walk(dir: string): void {
+    let entries: ReturnType<typeof fs.readdirSync>;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const ent of entries) {
+      const abs = path.join(dir, ent.name);
+      const rel = path.relative(root, abs).replace(/\\/g, "/");
+      if (ent.isDirectory()) {
+        if (shouldExclude(rel + "/")) continue;
+        walk(abs);
+      } else if (ent.isFile()) {
+        if (shouldExclude(rel)) continue;
+        if (globMatch(testGlob, rel)) results.push(abs);
+      }
+    }
+  }
+  walk(root);
+  return results.sort();
+}
+
+// ─── Layer 4: reference scanner ─────────────────────────────────────────────
+
+interface ReferenceHit {
+  spec_rel_path: string;
+  test_path: string;
+  reference_kind: ReferenceKind;
+  reference_snippet: string;
+  reference_line: number;
+}
+
+function findReferencesInTest(
+  root: string,
+  testAbsPath: string,
+  specChanges: SpecChange[],
+): ReferenceHit[] {
+  let content: string;
+  try {
+    content = fs.readFileSync(testAbsPath, "utf-8") as string;
+  } catch {
+    return [];
+  }
+  const testRel = path.relative(root, testAbsPath).replace(/\\/g, "/");
+  const lines = content.split("\n");
+  const hits: ReferenceHit[] = [];
+  const seen = new Set<string>(); // (spec_path, kind, line) 重複抑止
+
+  const fullPathSet = new Map<string, SpecChange>();
+  const basenameSet = new Map<string, SpecChange[]>();
+  const reqIdSet = new Map<string, SpecChange[]>();
+  const adrIdSet = new Map<string, SpecChange[]>();
+  for (const sc of specChanges) {
+    fullPathSet.set(sc.relPath, sc);
+    const arr1 = basenameSet.get(sc.basename) ?? [];
+    arr1.push(sc);
+    basenameSet.set(sc.basename, arr1);
+    for (const id of sc.reqIds) {
+      const arr = reqIdSet.get(id) ?? [];
+      arr.push(sc);
+      reqIdSet.set(id, arr);
+    }
+    for (const id of sc.adrIds) {
+      const arr = adrIdSet.get(id) ?? [];
+      arr.push(sc);
+      adrIdSet.set(id, arr);
+    }
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNumber = i + 1;
+    // 1. SPEC 相対パス（full-path）参照
+    for (const [specPath, sc] of fullPathSet) {
+      if (line.includes(specPath)) {
+        const key = `${sc.relPath}|full-path|${lineNumber}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          hits.push({
+            spec_rel_path: sc.relPath,
+            test_path: testRel,
+            reference_kind: "full-path",
+            reference_snippet: truncate(line.trim(), 120),
+            reference_line: lineNumber,
+          });
+        }
+      }
+    }
+    // 2. SPEC basename 参照
+    for (const [basename, scs] of basenameSet) {
+      if (line.includes(basename)) {
+        for (const sc of scs) {
+          const key = `${sc.relPath}|basename|${lineNumber}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            hits.push({
+              spec_rel_path: sc.relPath,
+              test_path: testRel,
+              reference_kind: "basename",
+              reference_snippet: truncate(line.trim(), 120),
+              reference_line: lineNumber,
+            });
+          }
+        }
+      }
+    }
+    // 3. REQ ID 参照
+    let m: RegExpExecArray | null;
+    const reqRe = new RegExp(REQ_ID_PATTERN);
+    while ((m = reqRe.exec(line)) !== null) {
+      const scs = reqIdSet.get(m[1]);
+      if (scs) {
+        for (const sc of scs) {
+          const key = `${sc.relPath}|req-id|${lineNumber}|${m[1]}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            hits.push({
+              spec_rel_path: sc.relPath,
+              test_path: testRel,
+              reference_kind: "req-id",
+              reference_snippet: truncate(line.trim(), 120),
+              reference_line: lineNumber,
+            });
+          }
+        }
+      }
+    }
+    // 4. ADR ID 参照
+    const adrRe = new RegExp(ADR_ID_PATTERN);
+    while ((m = adrRe.exec(line)) !== null) {
+      const scs = adrIdSet.get(m[1]);
+      if (scs) {
+        for (const sc of scs) {
+          const key = `${sc.relPath}|adr-id|${lineNumber}|${m[1]}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            hits.push({
+              spec_rel_path: sc.relPath,
+              test_path: testRel,
+              reference_kind: "adr-id",
+              reference_snippet: truncate(line.trim(), 120),
+              reference_line: lineNumber,
+            });
+          }
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}
+
+// ─── Layer 5: staleness evaluator ───────────────────────────────────────────
+
+function evaluateStaleness(
+  root: string,
+  specChanges: SpecChange[],
+  testFiles: string[],
+  changedRelFiles: Set<string>,
+): { findings: TestImpactFinding[]; warnings: string[] } {
+  const findings: TestImpactFinding[] = [];
+  const warnings: string[] = [];
+  let totalReferenceHits = 0;
+  const lifecycleByPath = new Map<string, SpecLifecycle>();
+  for (const sc of specChanges) lifecycleByPath.set(sc.relPath, sc.lifecycle);
+  for (const testAbs of testFiles) {
+    const hits = findReferencesInTest(root, testAbs, specChanges);
+    totalReferenceHits += hits.length;
+    const testRel = path.relative(root, testAbs).replace(/\\/g, "/");
+    // 同一 PR で変更済みのテストは陳腐化候補から除外
+    if (changedRelFiles.has(testRel)) continue;
+    for (const hit of hits) {
+      findings.push({
+        spec_path: hit.spec_rel_path,
+        spec_lifecycle: lifecycleByPath.get(hit.spec_rel_path) ?? "unknown",
+        test_path: hit.test_path,
+        reference_kind: hit.reference_kind,
+        reference_snippet: hit.reference_snippet,
+        reference_line: hit.reference_line,
+      });
+    }
+  }
+  // silent pass 回避: SPEC 変更あり、かつ参照ヒット 0 件の場合は警告
+  if (specChanges.length > 0 && totalReferenceHits === 0 && testFiles.length > 0) {
+    warnings.push(
+      `SPEC 変更 ${specChanges.length} 件を検出したが、走査したテストファイルから参照を検出できなかった。test-glob の設定、参照形式、除外ディレクトリを確認すること。`,
+    );
+  }
+  return { findings, warnings };
+}
+
+// ─── Reporter ───────────────────────────────────────────────────────────────
+
+function emitJson(report: TestImpactReport): void {
+  console.log(JSON.stringify(report, null, 2));
+}
+
+function emitText(report: TestImpactReport): void {
+  console.log(`Test Impact Detection Gate — REQ-019`);
+  console.log(`base_ref: ${report.base_ref ?? "(none)"}`);
+  console.log(`files_declared: ${report.files_declared.length}`);
+  console.log(`spec_changes: ${report.spec_changes.length}`);
+  for (const s of report.spec_changes) console.log(`  ${s}`);
+  console.log(`tests_scanned: ${report.tests_scanned}`);
+  console.log(`stale_candidates: ${report.stale_candidates.length}`);
+  for (const f of report.stale_candidates) {
+    console.log(
+      `  [${f.reference_kind}] ${f.test_path}:${f.reference_line} -> ${f.spec_path} (${f.spec_lifecycle})`,
+    );
+    console.log(`    ${f.reference_snippet}`);
+  }
+  console.log(`warnings: ${report.warnings.length}`);
+  for (const w of report.warnings) console.log(`  ${w}`);
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const args = process.argv.slice(2);
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(args);
+  } catch (e) {
+    console.error(`[test_impact] ${e instanceof Error ? e.message : String(e)}`);
+    process.exit(EXIT_ERROR);
+  }
+
+  if (parsed.help) {
+    printHelp();
+    process.exit(EXIT_OK);
+  }
+
+  if (parsed.files.length === 0 && !parsed.baseRef) {
+    console.error("[test_impact] either --files or --base-ref is required");
+    printHelp();
+    process.exit(EXIT_ERROR);
+  }
+
+  const scriptDir =
+    (typeof import.meta !== "undefined" && (import.meta as any).dir) ||
+    __dirname ||
+    process.cwd();
+  const root = findRepoRoot(scriptDir, { explicitRoot: parsed.root });
+
+  const changedFiles = resolveChangedFiles(root, parsed.files, parsed.baseRef);
+  const changedRelSet = new Set(
+    changedFiles.map((f) => path.relative(root, f).replace(/\\/g, "/")),
+  );
+
+  const specChanges = classifySpecChanges(root, changedFiles, parsed.baseRef);
+  const testFiles = discoverTestFiles(root, parsed.testGlob);
+
+  const { findings, warnings } = evaluateStaleness(
+    root,
+    specChanges,
+    testFiles,
+    changedRelSet,
+  );
+
+  const report: TestImpactReport = {
+    base_ref: parsed.baseRef,
+    files_declared: parsed.files,
+    spec_changes: specChanges.map((s) => s.relPath),
+    tests_scanned: testFiles.length,
+    stale_candidates: findings,
+    warnings,
+  };
+
+  if (parsed.json) {
+    emitJson(report);
+  } else {
+    emitText(report);
+  }
+
+  process.exit(EXIT_OK);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.ts
@@ -47,6 +47,17 @@ const SCAN_EXCLUDE_DIRS = [
   "docs/adr/retired/",
 ];
 
+// basename 照合の停止リスト。汎用名称は basename 単独では照合しない
+// （full-path 照合は継続して有効）。REQ/ADR ID 照合にも影響しない。
+const BASENAME_STOPLIST = new Set([
+  "README.md",
+  "_template.md",
+  "CHANGELOG.md",
+  "LICENSE",
+  "package.json",
+  "tsconfig.json",
+]);
+
 // REQ/ADR ID 抽出用正規表現。
 const REQ_ID_PATTERN = /\b(REQ-\d{3})\b/g;
 const ADR_ID_PATTERN = /\b(ADR-\d{3})\b/g;
@@ -354,8 +365,9 @@ function findReferencesInTest(
         }
       }
     }
-    // 2. SPEC basename 参照
+    // 2. SPEC basename 参照（汎用名称は stoplist で除外、full-path は別途照合）
     for (const [basename, scs] of basenameSet) {
+      if (BASENAME_STOPLIST.has(basename)) continue;
       if (line.includes(basename)) {
         for (const sc of scs) {
           const key = `${sc.relPath}|basename|${lineNumber}`;

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -206,6 +206,7 @@ SPEC は commands / skills / workflows の 3 層ディレクトリ構造と、�
 | integrity/validator-split-criteria.md | accepted | validator 分割基準 | check_changed_docs.ts の validator 分割基準（責務境界、ファイルサイズ上限、関心分離ルール）。内部 validator 構成は `references/validator-internal-config.md` へ分離 |
 | integrity/targeted-docs-guard-implementation.md | accepted | Targeted Docs Guard 実装詳細 | check_changed_docs.ts 変更文書限定検査契約（CLI 引数、workflow 別検査項目、判定条件、false-clean 予防）。Phase 1-6 実装計画、report フィールド一覧、完了済み移行作業は `references/targeted-docs-guard-implementation-details.md` へ分離 |
 | integrity/autogen-freshness-gate.md | draft | AUTOGEN ブロック鮮度検出 gate | AUTOGEN ブロック（spec-health-metrics.md 等）の鮮度検出、rename/status 変更時の再生成必要性判定、不合格時の処置 |
+| integrity/test-impact-detection-gate.md | draft | テスト影響範囲検出 gate | リファクタリング PR で SPEC 変更に連動する周辺テストの陳腐化検出。変更 SPEC を参照し同一 PR で未更新のテストを陳腐化候補として報告、不合格時の処置契約（REQ-019） |
 
 #### local/（ローカル版 SPEC）
 

--- a/docs/specs/integrity/test-impact-detection-gate.md
+++ b/docs/specs/integrity/test-impact-detection-gate.md
@@ -1,0 +1,91 @@
+---
+title: "テスト影響範囲検出 gate"
+status: draft
+created: "2026-08-09"
+updated: "2026-08-09"
+---
+
+# テスト影響範囲検出 gate
+
+リファクタリング PR で SPEC 変更に連動する周辺テストが陳腐化する事象（WP-1..WP-5 で周辺テスト70件が陳腐化した事例）の再発防止として、テスト影響範囲を機械的に検出する gate の契約を定義する。REQ-019 が WHAT（検出できること、検出対象・契機・処置の明示）を要件化し、本 SPEC は HOW の契約（検出対象・検出契機・不合格時の処置・検出ロジックの境界）を定義する。判定ロジックの実装詳細は checker 実装（`check_test_impact.ts`）へ委譲する。
+
+## 検出対象
+
+- 変更 SPEC ファイル（`docs/specs/**/*.md`、`docs/requirements/REQ-*.md`、`docs/adr/ADR-*.md`）。PR diff（`git diff --name-only <base-ref>...HEAD`）から抽出する
+- 上記 SPEC を参照するテストファイル（`**/*.test.ts`）。参照の検出は次のいずれかの契機で成立する:
+  - SPEC 相対パス（例: `docs/specs/integrity/test-impact-detection-gate.md`）の文字列参照
+  - SPEC basename（例: `test-impact-detection-gate.md`）の文字列参照
+  - REQ ID（例: `REQ-019`）、ADR ID（例: `ADR-001`）の文字列参照（当該 ID を frontmatter に持つ REQ/ADR が変更対象に含まれる場合）
+- 検出対象外: node_modules/、`.worktrees/`、`.agentdev-plugin/`、`docs/requirements/retired/`、`docs/adr/retired/`
+
+## 検出契機
+
+PR（worktree 环境、case-run 等）で SPEC 変更を含む場合に gate を実行する。検出契機は「SPEC 変更ファイルの参照を持つテストが、当該 PR で未変更」を満たすかで判定する。
+
+| 状況 | 判定 |
+|------|------|
+| SPEC 変更あり、参照テストが同一 PR で変更済み | OK（追従完了とみなす） |
+| SPEC 変更あり、参照テストが同一 PR で未変更 | warning（陳腐化候補） |
+| SPEC 変更なし | 該当なし（gate の対象外、空レポート） |
+
+## 不合格時の処置
+
+- 検出結果（陳腐化候補テスト一覧）をレポート（JSON または text）で出力する
+- 自動修復は行わない。対象テストの更新は開発者（case-close 前の確認、または follow-up Issue）が行う
+- exit code は検出件数によらず `0`（OK）とする。検出は warning 扱いであり、CI を即時失敗させない（REQ-019-002 の「不合格時の処置」は報告を完備することを要件とする）。
+- PR 本文の `## Findings / Capture候補` セクションに `### test-impact` 小見出しで検出結果を記録する（実行担当サブエージェント責務）
+
+## チェッカー実装契約
+
+実装スクリプト: `.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.ts`
+
+CLI 引数:
+
+| 引数 | 必須 | 値 | 説明 |
+|------|------|-----|------|
+| `--base-ref <ref>` | -- | git ref（既定: `origin/main`） | worktree 環境（マージ前、case-run 等）で git diff により変更 SPEC ファイルを検出する |
+| `--files <paths...>` | -- | ファイルパス（space 区切り推奨、comma 区切りも受入） | main 環境（マージ後、case-close 等）で PR 変更ファイルを直接指定する。`--base-ref` と排他 |
+| `--test-glob <pattern>` | -- | glob pattern（既定: `**/*.test.ts`） | テストファイルの検出 pattern。既定は bun:test を想定 |
+| `--json` | -- | flag | JSON 出力を有効化（CI 統合向け） |
+| `--root <path>` | -- | ファイルパス | リポジトリルートを明示指定（worktree/CI 対応、`cli_utils.ts` `findRepoRoot` 準拠） |
+| `--help` | -- | flag | ヘルプ表示 |
+
+`--files` と `--base-ref` は排他。両方未指定の場合はエラー（exit 2）。
+
+report JSON スキーマ（`TestImpactReport`）:
+
+```typescript
+interface TestImpactFinding {
+  spec_path: string;        // 変更 SPEC 相対パス
+  spec_lifecycle: "added" | "deleted" | "renamed" | "modified" | "unknown";
+  test_path: string;        // 陳腐化候補テスト相対パス
+  reference_kind: "full-path" | "basename" | "req-id" | "adr-id";
+  reference_snippet: string; // 参照箇所の行内容（エビデンス）
+  reference_line: number;   // 1-based 行番号
+}
+
+interface TestImpactReport {
+  base_ref: string | null;
+  files_declared: string[];      // --files 指定時の入力
+  spec_changes: string[];        // 検出された SPEC 変更ファイル一覧
+  tests_scanned: number;         // 走査テストファイル数
+  stale_candidates: TestImpactFinding[]; // 陳腐化候補
+  warnings: string[];
+}
+```
+
+exit code: `0`（正常終了、検出件数によらず）、`1`（使用しない、将来の strict mode 用予約）、`2`（入力不正・実行エラー）。
+
+## 設計意図と制約
+
+- **silent pass 回避**: SPEC 変更があり、かつ参照テストが 0 件検出された場合は warnings で報告する（参照抽出の設定漏れ、test-glob の誤り等の確認を促す）
+- **false positive 許容**: 本 gate は false positive（過検出）を許容し false negative（見逃し）を減らす方針（`repo-agentdev-integrity` SKILL.md「方針」節に準拠）。検出結果は warning 扱いであり開発者の確認を促す
+- **scope の限定**: SPEC 変更に連動する周辺テストの陳腐化検出に限定し、テスト実行基盤（test runner 選定、test 実行順序）、影響範囲スキャンの実装詳細アルゴリズム（依存関係グラフ構築等）は対象外（REQ-019 適用範囲）
+- **コード変更 → テスト影響** は本 gate の対象外。本 gate は SPEC 変更 → テスト陳腐化検出に限定する（REQ-019-001「SPEC 変更に連動する周辺テストの陳腐化を検出」に基づく）
+
+## 関連
+
+- REQ-019（テスト影響範囲検出 gate 要件、REQ-019-001/002）
+- `/repo/docs-check`（repo-local、配布対象外）。本 gate は PR diff を入力とするため case-run / case-close / CI の PR 系 workflow から呼び出す。`/repo/docs-check`（全件自己監査）には PR diff 文脈が無く、本 gate の呼び出し対象外とする
+- `autogen-freshness-gate.md`（同 PR で新設の姉妹 gate、同等の契約構造を持つ）
+- `targeted-docs-guard-implementation.md`（docs 限定検査の既存実装、本 gate はテスト領域の対称実装）


### PR DESCRIPTION
## 概要

OU-004 (#1995): テスト影響範囲検出 gate の実装。REQ-019 に基づき、リファクタリング PR で SPEC 変更に連動する周辺テストの陳腐化を検出する gate を新設する。WP-1..WP-5 リファクタリングで周辺テスト70件が陳腐化した事例の再発防止が主眼（REQ-019-001/002、AG-004 ユーザー判断確定）。

## 変更内容

### 新規 SPEC: docs/specs/integrity/test-impact-detection-gate.md
gate の契約を定義。検出対象（SPEC/REQ/ADR 変更）、検出契機（参照テストが同一 PR で未変更）、不合格時の処置（warning 報告、自動修復なし）、CLI 引数、report JSON スキーマ、設計意図（false positive 許容・silent pass 回避・scope 限定）を明示する。

### 新規 checker: .opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.ts
5 層構造（changed file resolver / spec change classifier / test file discovery / reference scanner / staleness evaluator）。変更 SPEC を参照するテストのうち同一 PR で未更新のものを陳腐化候補として報告する。参照検出は 4 種類（full-path, basename, REQ-ID, ADR-ID）。SPEC 本文の ADR/REQ 言及は伝播させずファイル自身の ID のみ伝播する（過検出回避）。汎用 basename（README.md, _template.md 等）は stoplist で basename 照合から除外する。

### 新規 test: .opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.test.ts
9 件の regression test。TS-004 検証項目（stale 検出、更新済み抑制、REQ-ID 検出、silent-pass 警告、CLI 契約、JSON スキーマ）をカバーする。check_changed_docs.test.ts の subprocess-spawn pattern に準拠。

### SPEC index 登録: docs/specs/README.md
integrity/ 表へ新規 SPEC 行を登録（draft status）。

## 完了条件対応

- [x] REQ-019.md に REQ-019-001/002 が存在し、AG-004 の合意内容と整合すること ← req-save 完了済（本 PR 実装前から存在確認済み）
- [x] テスト影響範囲検出 gate が SPEC 変更時に影響を受ける周辺テストを正しく特定できること ← check_test_impact.ts で実装、TS-004 で検証
- [x] 検出対象、検出契機、不合格時の処置が明示されていること ← SPEC「検出対象」「検出契機」「不合格時の処置」節で明示
- [x] WP-1..WP-5 相当のリファクタリングを想定したテストパターンで gate が陳腐化を検出できること ← check_test_impact.test.ts の stale detection test で検証

## テスト戦略 (TS-004) 検証結果

- id: TS-004
- target_item: AG-004 (テスト影響範囲検出 gate)
- verification 実施: check_test_impact.test.ts 9 件全通過。stale 検出、更新済み抑制、REQ-ID 検出、silent-pass 警告を網羅
- pass_criteria 達成: SPEC 変更に連動する周辺テストの特定、検出対象・検出契機・不合格時の処置の明示、WP-1..WP-5 相当パターンでの陳腐化検出を確認
- on_failure 適用: なし（fix-and-reverify ループ不要、初回で全項目合格）

## 動作デモ（本 PR diff に対する実行）

```
$ bun run .opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.ts --base-ref origin/main
Test Impact Detection Gate — REQ-019
spec_changes: 2
  docs/specs/README.md
  docs/specs/integrity/test-impact-detection-gate.md
tests_scanned: 46
stale_candidates: 0
warnings: 1
  SPEC 変更 2 件を検出したが、走査したテストファイルから参照を検出できなかった…
```

新規 SPEC に既存テストからの参照は無く、silent-pass 警告で設定確認を促す挙動が確認できた。

## Findings / Capture候補

### stale-reference

Issue #1995 本文「対象範囲」節に `tools/integrity/ 配下` の記載があるが、当該パスは存在しない。実際の integrity スクリプト配置場所は `.opencode/skills/repo-agentdev-integrity/scripts/`。実装上は実パスを使用し、Issue 本文の記載は描写上の簡略表記と解釈した。case-update での Issue 本文修正を推奨する（REQ-017 runtime-only 判断、blocker 非該当）。

### docs-integrity

targeted docs guard (check_changed_docs.ts --workflow case-run) を本 PR docs 変更に対して実行: failures=0, spec_readme_update_required=true（対応済み）、extensions_check_required=true（情報レベル）。新規 SPEC は docs/specs/README.md へ登録済み。

## SPEC確定候補

本 PR では SPEC 確定候補なし。test-impact-detection-gate.md SPEC が新規作成済みであり、追加の SPEC レベル詳細（schema、enum、判定表、内部アルゴリズム）は case-close Step 3 の SPEC 確定チェックで取り扱う。

## L2 タイムスタンプ

- Step 5 (worktree 設定) 開始: 2026-08-09 21:12:27 +09:00
- Step 5 (worktree 設定) 終了: 2026-08-09 21:12:49 +09:00 (22秒)
- Step 6 (実行担当サブエージェント実行 = inline 実装) 開始: 2026-08-09 21:15:03 +09:00
- Step 6 終了: 2026-08-09 21:43:00 +09:00 (推定、PR 作成直前)
- Step 8 (worktree クリーンアップ) 開始・終了: 後続

Refs: #1995