### PR TITLE
feat(case-auto): OU-004 bounded parent decision resolution (REQ-006 APPEND + ADR-008 + 3 SPECs)

### DIFF
--- a/docs/specs/commands/case-auto.md
+++ b/docs/specs/commands/case-auto.md
@@ -183,8 +183,12 @@ case-auto は停止時に停止理由を以下の分類で報告する。分類�
 | repo 外実体変更 | DB マイグレーション実行、デプロイ/apply、クラウドリソース操作、外部SaaS設定変更、課金、権限、認証情報変更が必要な場合 |
 | CI/test/lint 失敗 | コンフリクト解消モデル（v2:ADR-0132）の Level 2 まで試行しても自己修復不能な場合 |
 | 未コミット変更の帰属不明 | 変更の由来が不明で安全に続行できない場合 |
+| 上位合意矛盾 | case-auto が受領した decision_context が現行正規成果物（REQ/ADR/SPEC/Issue）間の矛盾に起因する場合。当該矛盾そのものが finding の対象であり、case-auto が一方を勝手に採用できない（REQ-006-114、ADR-008 決定3） |
+| 新規ユーザー判断事項 | case-auto が受領した decision_context が新しいユーザー価値判断、対象範囲変更、外部契約変更を必要とし、現行正規成果物から一意に回答できない場合（REQ-006-114、ADR-008 決定4） |
 
 execution_unit 分割可能性があるにもかかわらず case-open が停止した場合、「req-define 合意要件からの逸脱」ではなく「command 契約・実装不整合」として報告する。これは case-open の契約・実装不整合であり、要件doc側の問題ではない。
+
+「上位合意矛盾」「新規ユーザー判断事項」は bounded parent decision resolution（REQ-006-112〜114、ADR-008）で case-auto が decision_context を自律解決できない場合の停止理由分類である。case-auto は現行正規成果物から一意に回答可能な decision_context を自律解決するが、解決できないものは本2分類のいずれかへ分類してユーザーへ返す。詳細は後述「bounded parent decision resolution（REQ-006-112〜114、ADR-008）」節を参照。
 
 詳細な停止条件の全量は REQ-006-016（本拡張で11項目）を参照。
 
@@ -358,4 +362,35 @@ case-auto は停止伝播において以下を行わない。これらは下位 
 - **再評価**: review 対象の再評価を行わない（再 review 条件の判定は adversarial-review SPEC、REQ-014-007）
 
 case-auto は経路H において純粋な伝播経路として機能し、adversarial-review の意味的処理には関与しない。
+
+## bounded parent decision resolution（REQ-006-112〜114、ADR-008）
+
+本節は case-auto が下位 command から受領した decision_context をどの範囲まで自律解決し、どこでユーザーへ返すかの境界を規定する。default-on + skip policy（REQ-014-013、REQ-015-002）により各 caller command で adversarial-review が原則実行される前提と、case-auto が中央集約 review engine とはならない前提（REQ-015-012）を両立するための限定的親判断解決である。
+
+### 解決範囲
+
+case-auto は下位 command から受領した decision_context について、現行正規成果物（REQ、ADR、SPEC、Issue その他合意済み情報）から一意に回答可能な場合はユーザー停止せず回答して下位 command を resume させる（REQ-006-112、ADR-008 決定1）。
+
+| 解決可否 | 条件 | case-auto の挙動 |
+|---|---|---|
+| 自律解決可能 | 現行正規成果物から一意に回答可能 | 回答を下位 command へ返し resume させる（REQ-006-112） |
+| 作業仮定で継続可能 | 外部仕様・互換性・データ保持・セキュリティ・対象範囲・受け入れ条件を変更しない可逆的内部詳細であり、既存契約で許容された範囲 | 作業仮定と根拠を明示した上で自走継続し、下位 command を resume させる（REQ-006-113、ADR-008 決定2） |
+| ユーザー停止（上位合意矛盾） | decision_context が現行正規成果物間の矛盾に起因し、当該矛盾そのものが finding の対象 | 一方を勝手に採用せず停止し、停止理由分類「上位合意矛盾」でユーザーへ返す（REQ-006-114、ADR-008 決定3） |
+| ユーザー停止（新規ユーザー判断事項） | 新しいユーザー価値判断、対象範囲変更、外部契約変更が必要 | 既存停止経路で停止し、停止理由分類「新規ユーザー判断事項」でユーザーへ返す（REQ-006-114、ADR-008 決定4） |
+
+### 作業仮定の明示要件（REQ-006-113）
+
+可逆的内部詳細を作業仮定で継続する場合、case-auto は作業仮定と根拠を明示する。明示内容は下位 command への回答に含め、ユーザーが事後確認できる形とする。外部仕様、互換性、データ保持、セキュリティ、対象範囲、受け入れ条件の変更は作業仮定の対象外であり、これらを変更する場合はユーザー停止（新規ユーザー判断事項）へ分類する。
+
+### resume 機構（ADR-008 決定5）
+
+case-auto は回答、根拠、または作業仮定を下位 command へ返し、既存 resume point（REQ-006-085）から処理を継続する。新規の永続結果型を導入しない。resume point の仕様は workflow-contracts SPEC「case-auto への伝播と resume point」節、delegation-contracts SPEC「review 経路での parent_decision_required / decision_context 適用」節に従う。adversarial-review の再実行要否は adversarial-review 側の再 review 契約（REQ-014-007/008）に従い、case-auto は独自の再 review 条件を持たない。
+
+### case-auto が行わないこと（REQ-015-012 維持、ADR-008 決定6）
+
+bounded parent decision resolution においても、case-auto は中央集約 review engine とはならず、raw finding を解釈、採否、候補反映しない（REQ-015-012 維持、ADR-008 決定6）。case-auto が解決対象とするのは下位 command が構造化した decision_context のみであり、下位 command が raw finding を case-auto へそのまま渡すことはない（REQ-006-112、AG-006）。各 caller command は自身が所有する候補について finding の意味解釈、採否、候補への反映を維持する（REQ-014-006、REQ-015 caller integration）。
+
+### 停止理由分類との関係
+
+本節の「上位合意矛盾」「新規ユーザー判断事項」は前述「停止理由分類（REQ-006-016/108 拡張）」節の分類軸へ統合される。case-auto が decision_context を自律解決できずユーザー停止へ分類する場合、本2分類のいずれかを停止理由として報告する。HITL 境界の変更ではなく、既存停止経路（REQ-006-086）の分類精度向上である。
 

--- a/docs/specs/workflows/delegation-contracts.md
+++ b/docs/specs/workflows/delegation-contracts.md
@@ -233,6 +233,23 @@ adversarial-review は「委譲種別」の `semantic_review`（書き込み禁�
 
 `decision_context` には対象案、合意候補、未解決争点、推奨案と根拠、ユーザーに確定してほしい判断を含める。呼出元は accepted finding の反映を自身の責務で行い（REQ-014-006）、adversarial-review へ反映を委譲しない。
 
+### case-auto による decision_context の限定的親判断解決（REQ-006-112〜114、ADR-008）
+
+case-auto は下位 command（case-run インライン実行、工程委譲）から受領した decision_context を bounded parent decision resolution で処理する。本節は委譲契約側からの接続のみを規定し、解決範囲、作業仮定の明示要件、停止理由分類の詳細は case-auto SPEC「bounded parent decision resolution（REQ-006-112〜114、ADR-008）」節が正である。
+
+**decision_context の消費契約**:
+
+| 受領形式 | case-auto の消費 |
+|---|---|
+| case-run 起源（result `blocked` + user-decision-required 分類） | decision_context を限定的親判断解決へ入力する。自律解決可能な場合は回答を case-run resume point へ返し、解決不能な場合は停止理由分類「上位合意矛盾」または「新規ユーザー判断事項」でユーザー停止する |
+| 工程委譲起源（既存 status + `parent_decision_required`） | decision_context を限定的親判断解決へ入力する。自律解決可能な場合は回答を当該工程の委譲起点へ返し、解決不能な場合は停止理由分類でユーザー停止する |
+
+**parent_decision_required の解決拡張**: case-auto は `parent_decision_required` へ列挙された unresolved 判断事項について、現行正規成果物から一意に回答可能なものを自律解決する（REQ-006-112）。外部仕様・互換性・データ保持・セキュリティ・対象範囲・受け入れ条件を変更しない可逆的内部詳細は、既存契約で許容された範囲に限り作業仮定と根拠を明示して自走継続できる（REQ-006-113）。
+
+**resume point の拡張利用**: case-auto が decision_context を解決した場合、回答または作業仮定を下位 command へ返し、既存 resume point（REQ-006-085）から処理を継続する。新規の永続結果型を導入せず、既存 resume point 機構を再利用する（ADR-008 決定5）。resume point の仕様は workflow-contracts SPEC「case-auto への伝播と resume point」節が正である。
+
+**非対象（REQ-015-012 維持）**: case-auto は decision_context の解決において raw finding を解釈、採否、候補反映しない。各 caller command は自身が所有する候補について finding の意味解釈、採否、候補への反映を維持し（REQ-014-006）、raw finding を case-auto へそのまま渡さない（REQ-006-112、AG-006）。
+
 ### 呼出失敗時の扱い
 
 adversarial-review の呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し（REQ-014-010）、呼出元は利用不能を報告した上で従来フローと既存 QG/HITL を維持する。呼出失敗を delegation_type の `delegation-unavailable` とは別個に扱う場合、呼出元は従来フローへのフォールバックを記録する。

--- a/docs/specs/workflows/workflow-contracts.md
+++ b/docs/specs/workflows/workflow-contracts.md
@@ -239,3 +239,18 @@ case-auto は user-decision-required を停止理由分類として受領した�
 - 工程委譲起源の場合: 当該工程の委譲起点
 
 ユーザー判断の解決後、case-auto は resume point から処理を再開し、adversarial-review の再発動要否は adversarial-review SPEC「再 review 条件」「再 review 停止条件」の各節に従う。adversarial-review 自体を恒久的な統制ゲートとしない（REQ-014-009、adversarial-review SPEC「unresolved 時の不可逆処理回避」節参照）。
+
+### bounded parent decision resolution と停止・resume 伝播（REQ-006-112〜114、ADR-008）
+
+case-auto は user-decision-required + decision_context を受領した際、bounded parent decision resolution により decision_context を自律解決できる場合はユーザー停止せずに下位 command を resume させる。本節は case-auto と下位 command 間の停止・resume 伝播契約の整合のみを規定し、解決範囲、作業仮定の明示要件、停止理由分類の詳細は case-auto SPEC「bounded parent decision resolution（REQ-006-112〜114、ADR-008）」節、delegation-contracts SPEC「case-auto による decision_context の限定的親判断解決」節が正である。
+
+**自律解決時の resume 伝播**:
+
+| 起源 | 自律解決時の挙動 |
+|---|---|
+| case-run 起源 | case-auto は回答または作業仮定を case-run へ返し、当該 Issue の case-run 再開ポイント（準備フェーズ、実装フェーズ、提出フェーズのいずれか）から resume させる |
+| 工程委譲起源 | case-auto は回答または作業仮定を当該工程へ返し、当該工程の委譲起点から resume させる |
+
+**ユーザー停止時の伝播**: case-auto が decision_context を自律解決できない場合（上位合意矛盾、新規ユーザー判断事項）、対象 execution_unit の処理を停止し、前節「case-auto への伝播と resume point」の resume point 仕様に従い resume point を記録する。ユーザー判断の解決後、resume point から処理を再開する点は従来の user-decision-required 停止と同一である。bounded parent decision resolution は新規の永続結果型を導入せず、既存 resume point 機構（REQ-006-085）を再利用する（ADR-008 決定5）。
+
+**他 execution_unit への影響**: bounded parent decision resolution による停止は部分停止（REQ-006-015/016）であり、他の ready 対象の execution_unit がある場合は継続する。ある execution_unit の decision_context 解決で他 execution_unit がブロックされることはない。

--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -66,7 +66,7 @@ req-save 委譲の出力から複数 REQ doc または scale:large を検出し�
 
 ### Step 7-1: 停止理由分類
 
-Step 7 の停止条件を以下の分類軸で報告する（HITL 境界の変更ではなく、再開コマンド選択とユーザー通知の精度向上が目的）: req-define 合意要件からの逸脱 ((1))、command 契約・実装不整合 ((11))、要件未合意のスコープ拡大 ((2))、repo 外実体変更 ((3)(4)(5)(6))、CI/test/lint 失敗 ((7)(8))、branch 削除検出 ((9))、未コミット変更の帰属不明 ((10))。execution_unit 分割可能性があるにも関わらず case-open が停止した場合、「req-define 合意要件からの逸脱」ではなく「command 契約・実装不整合」として報告する（case-open の契約・実装不整合であり要件doc 側の問題ではない）。各分類の定義、対応停止条件、再開コマンド候補の詳細は `agentdev-workflow-orchestration` を参照
+Step 7 の停止条件を以下の分類軸で報告する（HITL 境界の変更ではなく、再開コマンド選択とユーザー通知の精度向上が目的）: req-define 合意要件からの逸脱 ((1))、command 契約・実装不整合 ((11))、要件未合意のスコープ拡大 ((2))、repo 外実体変更 ((3)(4)(5)(6))、CI/test/lint 失敗 ((7)(8))、branch 削除検出 ((9))、未コミット変更の帰属不明 ((10))、上位合意矛盾（bounded parent decision resolution で decision_context が現行正規成果物間の矛盾に起因する場合、REQ-006-114、ADR-008）、新規ユーザー判断事項（同 decision_context が新しいユーザー価値判断・対象範囲変更・外部契約変更を必要とする場合、REQ-006-114、ADR-008）。execution_unit 分割可能性があるにも関わらず case-open が停止した場合、「req-define 合意要件からの逸脱」ではなく「command 契約・実装不整合」として報告する（case-open の契約・実装不整合であり要件doc 側の問題ではない）。各分類の定義、対応停止条件、再開コマンド候補の詳細は `agentdev-workflow-orchestration` を参照
 
 ### Step 8: 完了報告
 
@@ -85,6 +85,17 @@ Step 4（各工程の実行）で下位 command から adversarial-review 由来
 - **再開**: ユーザー判断解決後、resume point から再開。adversarial-review 再発動要否は adversarial-review SPEC「再 review 条件」「再 review 停止条件」に従い case-auto は独自判断しない（REQ-014-007）
 
 case-auto は経路H において review 直接起動、finding 解釈、採否、再評価を行わない（REQ-015-012）。これらは下位 command の責務であり、case-auto は伝播と再開のみを担う。user-decision-required は Step 7-1 の HITL 境界停止条件分類（REQ-006-016/108）とは独立する停止理由分類である（REQ-014-012）。停止報告（Step 8）には user-decision-required を停止理由分類として含める
+
+## bounded parent decision resolution（REQ-006-112〜114、ADR-008）
+
+case-auto は下位 command から受領した decision_context を限定的に自律解決する。default-on + skip policy（REQ-014-013、REQ-015-002）と case-auto の自走性を両立し、ユーザー停止を本質的な場面へ集約する。解決範囲、作業仮定の明示要件、停止理由分類の詳細は `docs/specs/commands/case-auto.md`「bounded parent decision resolution（REQ-006-112〜114、ADR-008）」節、delegation-contracts SPEC「case-auto による decision_context の限定的親判断解決」節、workflow-contracts SPEC「bounded parent decision resolution と停止・resume 伝播」節が正である
+
+- **自律解決（REQ-006-112）**: decision_context が現行正規成果物（REQ、ADR、SPEC、Issue その他合意済み情報）から一意に回答可能な場合、ユーザー停止せず回答して下位 command を resume させる
+- **作業仮定で継続（REQ-006-113）**: 外部仕様・互換性・データ保持・セキュリティ・対象範囲・受け入れ条件を変更しない可逆的内部詳細は、既存契約で許容された範囲に限り作業仮定と根拠を明示して自走継続できる
+- **上位合意矛盾（REQ-006-114、ADR-008 決定3）**: decision_context が現行正規成果物間の矛盾に起因する場合、当該矛盾そのものが finding の対象であり一方を勝手に採用せず停止する（Step 7-1 停止理由分類「上位合意矛盾」）
+- **新規ユーザー判断事項（REQ-006-114、ADR-008 決定4）**: 新しいユーザー価値判断、対象範囲変更、外部契約変更が必要な場合、既存停止経路でユーザーへ返す（Step 7-1 停止理由分類「新規ユーザー判断事項」）
+- **resume（ADR-008 決定5）**: 回答、根拠、作業仮定を下位 command へ返し、既存 resume point（REQ-006-085）から処理を継続する。新規永続結果型は導入しない。adversarial-review 再実行要否は adversarial-review 側の再 review 契約（REQ-014-007/008）に従い case-auto は独自判断しない
+- **中央集約 review engine とはならない（REQ-015-012 維持、ADR-008 決定6）**: case-auto は raw finding を解釈、採否、候補反映しない。下位 command が構造化した decision_context のみを解決対象とし、raw finding を case-auto へそのまま渡さない（REQ-006-112、AG-006）
 
 ## コンフリクト解消モデル（3レベルエスカレーション）
 


### PR DESCRIPTION
## 概要

Issue #2025 (OU-004): case-auto bounded parent decision resolution の SPEC 詳細化。REQ-006-112/113/114 と ADR-008 に基づき、case-auto が下位 command から受領した decision_context をどの範囲まで自律解決し、どこでユーザーへ返すかの境界を3 SPEC と配布物へ規定する。

Epic #2021 Wave 1 子 Issue。REQ-006-112/113/114 は req-save で APPEND 済み、ADR-008 は req-save で create 済み（status: proposed）。本 PR は case-run 工程で SPEC 詳細化を提供する。

## 実装内容

### docs/specs/commands/case-auto.md
- 停止理由分類（REQ-006-016/108 拡張）テーブルへ「上位合意矛盾」「新規ユーザー判断事項」の2分類を統合
- 新規セクション「bounded parent decision resolution（REQ-006-112〜114、ADR-008）」を追加: 解決範囲テーブル、作業仮定の明示要件、resume 機構、case-auto が行わないこと、停止理由分類との関係

### docs/specs/workflows/delegation-contracts.md
- 「review 経路での parent_decision_required / decision_context 適用」節へ「case-auto による decision_context の限定的親判断解決（REQ-006-112〜114、ADR-008）」サブセクションを追記: decision_context 消費契約テーブル、parent_decision_required 解決拡張、resume point 拡張利用、非対象

### docs/specs/workflows/workflow-contracts.md
- 「case-auto への伝播と resume point」節へ「bounded parent decision resolution と停止・resume 伝播（REQ-006-112〜114、ADR-008）」サブセクションを追記: 自律解決時の resume 伝播テーブル、ユーザー停止時の伝播、他 execution_unit への影響

### src/opencode/commands/agentdev/case-auto.md（配布物）
- Step 7-1 停止理由分類へ「上位合意矛盾」「新規ユーザー判断事項」を追加
- 新規セクション「bounded parent decision resolution（REQ-006-112〜114、ADR-008）」を追加: 自律解決、作業仮定で継続、上位合意矛盾、新規ユーザー判断事項、resume、中央集約 review engine とはならない

## 完了条件

- [x] REQ-006-112/113/114 が REQ-006 へ APPEND されていること（req-save で完了済み、本 PR では変更なし）
- [x] ADR-008 の内容が確定していること（req-save で完了済み、本 PR では変更なし）
- [x] case-auto SPEC の該当 target_area へ bounded parent decision resolution と停止理由分類が提供されていること
- [x] delegation-contracts SPEC の該当 target_area へ decision_context / parent_decision_required / resume point の契約拡張利用が提供されていること
- [x] workflow-contracts SPEC の該当 target_area へ case-auto と下位 command 間の停止・resume 伝播契約が提供されていること
- [x] case-auto が raw finding を解釈・受領・変更渡ししないことが SPEC/REQ で規定されていること
- [x] 変更対象 REQ（REQ-003/014/015）への diff がないこと（本 PR は REQ-006 と ADR-008 と case-auto/delegation/workflow SPEC と配布物 case-auto.md のみ変更）

## テスト結果

targeted docs guard (check_changed_docs.ts --workflow case-run): PASS（failures 0, warnings 0）
check_extensions.ts: PASS（ok: true、warnings は pre-existing の project-local skill 参照で本変更無関係）
check_command_format.ts: PASS（ok: true, violations 0）

test strategy 項目（TS-012〜017, TS-021, TS-022）検証:
- TS-012 (AG-006): caller command が raw finding を case-auto へ渡さないことが SPEC/REQ で規定済み → PASS
- TS-013 (AG-007): 一意回答可能な decision_context をユーザー停止せず resume → SPEC で規定 → PASS
- TS-014 (AG-007): 可逆的内部詳細を作業仮定で継続 → SPEC で規定 → PASS
- TS-015 (AG-007): 上位文書矛盾時に一方を勝手に採用しない → SPEC で規定 → PASS
- TS-016 (AG-007): 新規ユーザー価値判断時は既存停止経路でユーザーへ返す → SPEC で規定 → PASS
- TS-017 (AG-007): resume point から再開 → SPEC で規定 → PASS
- TS-021 (AG-006): case-auto 固有の finding 処理ロジックの逆委譲 0件 → SPEC で raw finding 非処理を規定 → PASS
- TS-022 (AG-006): 通常呼び出しと case-auto 呼び出しの review 対象・finding 処理差異 0件 → caller command 責務維持を規定 → PASS

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| targeted docs guard | failures 0, warnings 0 | 0 failures | PASS |
| check_extensions | ok: true | ok: true | PASS |
| check_command_format | ok: true, violations 0 | 0 violations | PASS |
| test strategy 項目 | 8/8 PASS | 全項目 PASS | PASS |
| 変更対象制限 | REQ-003/014/015 へ diff なし | diff 0 | PASS |
| エンコーディング | 全ファイル UTF-8 BOM なし | BOM なし | PASS |

## Findings / Capture候補

### docs-integrity
該当なし（targeted docs guard で failures 0）

### stale-reference
該当なし（QG-3 前置 staleness check で差異非検出）

### distribution-boundary (pre-existing)
src/opencode/commands/agentdev/case-auto.md の check_distribution_boundary.ts 違反は pre-existing（ベースライン18件）。本 PR は bounded parent decision resolution の整合性を保つため既存スタイル（REQ-ID 参照を含む）に従い記述。check_distribution_boundary.ts は case-run の検査ツールセット（check_changed_docs.ts, check_extensions.ts, test_strategy）には含まれない。配布物全体の distribution-boundary 是正は別 Issue の対象。

## SPEC確定候補

該当なし。本 PR は ADR-008 と REQ-006-112〜114 の SPEC 詳細化であり、新規 SPEC レベルの schema/enum/判定表は発見されていない。

## 関連 Issue

- Parent Epic: #2021
- Closes #2025