### PR TITLE
feat(decision): OU-001 Decision bootstrap (DEC-009)

### DIFF
--- a/docs/decisions/DEC-009.md
+++ b/docs/decisions/DEC-009.md
@@ -1,0 +1,90 @@
+---
+id: DEC-009
+title: "ADR から Decision への正規成果物モデル移行"
+status: accepted
+created: "2026-08-10"
+updated: "2026-08-10"
+---
+
+<!-- ブートストラップ手動作成（OU-001）。OU-002 完了後に agentdev-decision-file-manager 経路で検証・補正予定。 -->
+
+# DEC-009: ADR から Decision への正規成果物モデル移行
+
+## 背景
+
+AgentDevFlow では判断記録文書として ADR（Architecture Decision Record）を使用してきた。ADR-001 から ADR-008 までの8件が `docs/adr/` 配下に存在する。
+
+ADR という名称はソフトウェアアーキテクチャ決定に限定されたニュアンスを持つ。AgentDevFlow で記録すべき判断には、プロセス設計、文書体系、ツール連携、品質ゲート運用等のアーキテクチャ以外の領域が含まれる。これらの判断を「Architecture Decision」と呼ぶことは名称と実態のずれを生む。
+
+本 Decision は、判断記録の正規成果物種別を ADR から Decision へ移行し、ID 方式、ディレクトリ構造、関係モデル、健全性評価モデルを一貫して更新することを決定する。ADR-001 から ADR-008 は番号部を維持したまま DEC-001 から DEC-008 へ1対1移行する。本 Decision は移行に続く最初の新規 Decision である。
+
+## 決定
+
+以下の17項目を合意し、実行する。
+
+### 成果物モデル定義
+
+1. **正規文書種別名**: Decision（単数 Decision、複数集合は Decisions、AG-001）
+2. **配置と識別子**: `docs/decisions/` 配下、ID は `DEC-NNN`（3桁ゼロ埋め）、artifact type は `decision`（AG-002）
+3. **責務**: Decision は継続的判断と理由の保持を責務とする。状態要求、仕様詳細、作業手順は非所有（AG-003）
+
+### REQ と Decision の管理特性分離
+
+4. **管理特性分離**: REQ と Decision は重複排除、粒度管理の機械適用を分離する。意味的に近い複数 Decision の存在だけを理由として重複違反または自動統合対象としない（AG-004）
+5. **関係モデル**: Decision 間の意味的関係（関連、置換、再確認）を frontmatter `relations` フィールドで追跡可能とする。具体的なフィールド名、enum、serialization 形式は SPEC（`decision-lifecycle.md`）の責務（AG-005）
+6. **粒度管理**: Decision の SPLIT / MERGE は固定件数ではなく意味的健全性で評価する（AG-006）
+7. **健全性評価の分離**: Decision の健全性評価を REQ の重複・分割モデルと分離する（AG-017）
+
+### 移行方針
+
+8. **1対1移行**: 現行 ADR-001 から ADR-008 を番号部維持で DEC-001 から DEC-008 へ1対1移行する（AG-007）
+9. **ID 不変原則のスコープ例外**: 本移行は REQ-001-008（識別子不変原則）のスコープ例外とする。番号部維持、意味変更なしの正規文書種別移行に限定される。移行後の DEC-NNN は通常の ID 不変原則に従う（AG-008、CR-001）
+10. **意味的不変性**: accepted 判断記録の意味的不変性を維持する。体系移行に必要な変更と意味変更を分離する（AG-009）
+11. **歴史参照の維持**: 過去版 `v2:ADR-*` 参照は名称、ID とも変更せず維持する。`v2:DEC-*` は生成しない（AG-010）
+12. **旧契約の退役**: 旧 current ADR 契約（`docs/adr/`、current ADR-NNN、`artifact: adr`）を通常経路で生成しない（AG-011）
+
+### 実行方針
+
+13. **保存経路の確立**: req-define から case-auto まで全経路を Decision 化する（AG-012）
+14. **Skill 移行**: `agentdev-adr-file-manager` から `agentdev-decision-file-manager`、`agentdev-adr-guidelines` から `agentdev-decision-guidelines` へ移行する（AG-013）
+15. **正規索引**: `docs/decisions/README.md` を正規索引とする。分類ビューであり SSoT ではない（AG-014）
+16. **横断移行対象**: `docs/adr/**` に限定せず全領域を対象とする。実行時 HEAD の inventory を正とする（AG-015）
+17. **文字列一括置換禁止**: 無条件の全文字列置換を禁止する。8 分類後に個別変更する（AG-016）
+
+## 結果、影響
+
+### 正の影響
+
+- 判断記録の範囲がアーキテクチャに限定されず、プロセス、文書体系、ツール連携等の判断を正確に表現できる
+- Decision 固有の関係モデル（relates-to / supersedes / reaffirms）により、判断間の意味的関係が追跡可能になる
+- REQ と Decision の管理特性が分離され、意味的に近い判断の誤った自動統合を防げる
+- Decision 固有の健全性評価モデルにより、判断境界、関係、矛盾を独立して評価できる
+
+### 負の影響
+
+- 既存の ADR 参照（766件、54ファイル以上）の横断更新が必要である
+- Artifact Graph の `node_type` スキーマ変更（`adr` から `decision`）に伴う再生成が必要である
+- 移行期間中のブートストラップ課題がある。本 DEC-009 は Decision 保存経路（OU-002）が確立される前に手動作成される
+
+### ID 不変原則の例外（CR-001）
+
+REQ-001-008 は「識別子は一度確定したら不変である」ことを定める。本移行は ADR-NNN から DEC-NNN への文書種別変更をスコープ例外として認める。例外の根拠は以下の通りである。
+
+- 番号部は維持する（ADR-001 から DEC-001）。識別子の実質的な一意性は保たれる
+- accepted 判断記録の意味的不変性（AG-009）を維持する。文書種別名の変更は意味変更ではない
+- 本例外は正規文書種別の移行という一回限りのスコープに限定される。移行後の DEC-NNN は通常の ID 不変原則に従う
+
+### 移行後の整合性確認
+
+本 Decision の実行にあたり、以下の整合性を確認する。
+
+- REQ-001（行 056〜064）と SPEC 6 件の間で ID 形式（DEC-NNN 3桁ゼロ埋め）、配置（`docs/decisions/`）、artifact type（`decision`）、関係モデル enum（`relates-to` / `supersedes` / `reaffirms`）が一貫していること
+- `decision-lifecycle.md` の関係モデル定義と Decision frontmatter schema が整合していること
+- 過去版 `v2:ADR-*` 参照が維持されていること
+
+## 関連情報
+
+- 根拠要件: REQ-001（文書体系と持続可能な基準構造、要件行 056〜064）
+- 関連 SPEC: `document-model.md`、`decision-lifecycle.md`、`patterns.md`、`numbering-policy.md`、`artifact-contracts.md`、`document-type-responsibilities.md`
+- 移行対象: ADR-001 から ADR-008（DEC-001 から DEC-008 へ1対1移行、OU-003 責務）
+- 合意項目: AG-001 から AG-017（RU-0016）


### PR DESCRIPTION
## 概要

OU-001: Decision 文書モデル・契約確立のブートストラップ作業。`docs/decisions/DEC-009.md` を新規作成し、ADR から Decision への正規成果物モデル移行を判断記録として確定する。

REQ-001（行 056〜064）の UPDATE/APPEND と SPEC 6 件の UPDATE/CREATE は req-save（commit 6e1e294）および spec-save（commit 0e4d8f7）で適用済み。本 PR は OU-001 の残作業（DEC-009 bootstrap 作成 + 一貫性検証）を完遂する。

## 変更内容

- `docs/decisions/DEC-009.md` 新規作成
  - frontmatter: id=DEC-009, status=accepted, created/updated=2026-08-10
  - 17 AG items（AG-001〜AG-017）を判断根拠として記録
  - CR-001（REQ-001-008 識別子不変原則 vs AG-008 移行例外）の解決根拠を明示
  - ADR-001〜008 → DEC-001〜008 の 1:1 移行に続く最初の新規 Decision として位置付け

## 検証結果

- REQ-001 と SPEC 6 件の間で ID 形式（DEC-NNN）、配置、artifact type、関係モデル enum が一貫していることを確認
- DEC-009 frontmatter が decision-lifecycle.md の schema と整合していることを確認

Closes #2033
Parent: #2032