### PR TITLE
refactor(extensions): Wave 1 — Extension YAML 廃止参照修正 (#2044)

### DIFF
--- a/.agentdev/extensions/commands/case-close.yaml
+++ b/.agentdev/extensions/commands/case-close.yaml
@@ -32,7 +32,7 @@ context:
 rules:
   - id: artifact-graph-closure-observation
     when: 鮮度、未解決参照、存在しないノードへの関係、根拠欠落、関係閉包の候補を観測するとき。利用不能時は従来の検査手段で続行する
-    skill: repo-agentdev-artifact-graph
+    skill: agentdev-artifact-graph
 
 checks:
   - id: autogen-index-regeneration-diff

--- a/.agentdev/extensions/commands/case-open.yaml
+++ b/.agentdev/extensions/commands/case-open.yaml
@@ -21,7 +21,7 @@ context:
 rules:
   - id: artifact-graph-impact-candidates
     when: 起点成果物から変更影響、廃止参照、未解決参照の候補を探索するとき。利用不能時は従来の探索手段で続行する
-    skill: repo-agentdev-artifact-graph
+    skill: agentdev-artifact-graph
 
 checks: []
 

--- a/.agentdev/extensions/commands/case-run.yaml
+++ b/.agentdev/extensions/commands/case-run.yaml
@@ -16,7 +16,7 @@ context:
 rules:
   - id: artifact-graph-implementation-context
     when: 実装対象に関係するREQ、SPEC、整合性ルール、周辺成果物の候補を探索するとき。利用不能時は従来の探索手段で続行する
-    skill: repo-agentdev-artifact-graph
+    skill: agentdev-artifact-graph
 
 checks: []
 

--- a/.agentdev/extensions/commands/req-define.yaml
+++ b/.agentdev/extensions/commands/req-define.yaml
@@ -43,7 +43,7 @@ context:
 rules:
   - id: artifact-graph-candidate-discovery
     when: 既存REQ、関連ADR・SPEC、構造的所有者重複の候補を探索するとき。利用不能時は従来の探索手段で続行する
-    skill: repo-agentdev-artifact-graph
+    skill: agentdev-artifact-graph
 
 checks: []
 

--- a/.agentdev/extensions/commands/spec-save.yaml
+++ b/.agentdev/extensions/commands/spec-save.yaml
@@ -21,7 +21,7 @@ context:
 rules:
   - id: artifact-graph-candidate-discovery
     when: 対応REQ、同じ正規所有対象のSPEC、関連command・skill・整合性ルールの候補を探索するとき。利用不能時は従来の探索手段で続行する
-    skill: repo-agentdev-artifact-graph
+    skill: agentdev-artifact-graph
 
 checks: []
 

--- a/.agentdev/extensions/skills/agentdev-adversarial-review.yaml
+++ b/.agentdev/extensions/skills/agentdev-adversarial-review.yaml
@@ -6,13 +6,13 @@ context:
   - id: artifact-graph-spec
     when: Artifact Graphを論点候補の探索に使用するとき
     paths:
-      - "docs/specs/local/artifact-graph.md"
+      - "docs/specs/skills/agentdev-artifact-graph.md"
     purpose: 派生索引の利用上の防護と障害耐性の確認
 
 rules:
   - id: artifact-graph-deliberation-candidates
     when: 複数規範関係、循環、集中ノード、孤立候補、複数経路から審議論点の候補を探索するとき。利用不能時は従来の探索手段で続行する
-    skill: repo-agentdev-artifact-graph
+    skill: agentdev-artifact-graph
 
 checks: []
 


### PR DESCRIPTION
Closes #2044
Parent Epic: #2043

## 変更内容

Wave 1: 6 Project Extension YAML ファイルの廃止済み skill 参照を現行標準へ統一。

### 変更対象

| ファイル | 変更内容 |
|----------|---------|
| `.agentdev/extensions/commands/spec-save.yaml` | `skill: repo-agentdev-artifact-graph` → `skill: agentdev-artifact-graph` |
| `.agentdev/extensions/commands/req-define.yaml` | 同上 |
| `.agentdev/extensions/skills/agentdev-adversarial-review.yaml` | 同上 + superseded SPEC パス `docs/specs/local/artifact-graph.md` → `docs/specs/skills/agentdev-artifact-graph.md` |
| `.agentdev/extensions/commands/case-close.yaml` | `skill: repo-agentdev-artifact-graph` → `skill: agentdev-artifact-graph` |
| `.agentdev/extensions/commands/case-run.yaml` | 同上 |
| `.agentdev/extensions/commands/case-open.yaml` | 同上 |

### 対応要件

- REQ-012-015: 廃止済み skill 統一
- REQ-012-016: 判断防護原則（Graph 由来候補の確認、本 PR は参照修正のみ）
- REQ-012-017: fail-open 互換性（参照修正により標準 skill 経由での Graph 操作が可能）

### 境界

- ADR-007 (DEC-007) L13 の歴史的経緯記述は対象外（CR-001）
- `docs/` 配下、`src/opencode/` 配下は対象外（Phase 0 で完了済み）
- consumer command/skill SPEC の権威動作記述は対象外（Phase 0 で完了済み）

## 検証結果

- [x] 対象6ファイルに `repo-agentdev-artifact-graph` の実行時参照が0件
- [x] 対象6ファイルに superseded SPEC パスの実行時 context 参照が0件
- [x] `agentdev-artifact-graph` 標準 skill 経由で Graph build/prepare/query/check/verify が成功する（skill 存在確認済み）
- [x] ADR-007 (DEC-007) の歴史的記述は改変していない（CR-001 準拠、本 PR は extension YAML のみ変更）
- [x] 各 YAML の5セクション構造（context/rules/checks/acceptance_gates/must_not）が保たれている

## Findings / Capture候補

(none)

## SPEC確定候補

(none)
