### PR TITLE
Wave 3: Workflow effectiveness 検証インフラ (#2045)

### DIFF
--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/README.md
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/README.md
@@ -1,0 +1,115 @@
+# `effectiveness/` — Workflow Effectiveness 検証インフラ (REQ-021-006)
+
+AgentDevFlow の代表質問（workflow question）6 種について、**Artifact Graph による探索**
+と **Graph を使わない独立探索（rg / glob / frontmatter scan 相当）** を比較する診断
+harness。REQ-021-006 が定める 6 つの比較観点を計算し、diagnostic report を出力する。
+
+> **本検証は診断目的であり、性能閾値による合否判定は行わない（REQ-021-006, TS-010）。**
+> Parser/Graph regression は REQ-020 傘下の `tests/*.test.ts` が独立に判断可能であり、
+> 本 harness は重複しない（CR-003）。
+
+## 構成
+
+```
+effectiveness/
+├── types.ts              — Query suite / result / 6 指標の型定義、category 一覧
+├── queries.ts            — 代表 6 query と ground truth 定義（real artifact 参照）
+├── independent_search.ts — rg / glob / frontmatter 相当の独立探索実装
+├── harness.ts            — Graph + 独立探索を実行し 6 指標を計算する中心処理
+├── run.ts                — CLI entry point（diagnostic report / JSON 出力）
+└── README.md             — 本ファイル
+```
+
+## 必要入力
+
+- **Graph**: `bun src/build_graph.ts --root . --output .agentdev/graph` で生成済みの
+  Graph directory（`manifest.json`, `nodes.jsonl`, `edges.jsonl`, `provenance.jsonl`,
+  `diagnostics.json` が揃っていること）。
+- **repo root**: 計測対象リポジトリのルート。`docs/`, `src/opencode/`,
+  `.agentdev/extensions/` が配置された状態を想定する。
+
+## 実行方法
+
+```bash
+cd src/opencode/skills/agentdev-artifact-graph/scripts
+
+# 初回のみ Graph を生成（既存 Graph があればスキップ可）
+bun src/build_graph.ts --root ../../../../../.. --output ../../../../../../.agentdev/graph
+
+# harness 実行（diagnostic report を stdout へ人間可読形式で出力）
+bun effectiveness/run.ts --root ../../../../../.. --graph ../../../../../../.agentdev/graph
+
+# JSON 形式で受け取りたい場合（CI / 後段集計）
+bun effectiveness/run.ts --root ../../../../../.. --graph ../../../../../../.agentdev/graph --json
+```
+
+上記の `--root` / `--graph` はリポジトリルートからの相対パス。本 worktree から実行する
+場合は、この README のある `scripts/` ディレクトリから 5 つ上がリポジトリルートになる。
+
+## 6 つの query category（REQ-021-006 1:1 対応）
+
+| id 接頭辞 | category | 質問の代表例 |
+|---|---|---|
+| Q1 | `req-change-impact` | REQ-012 を変更した場合、影響を受ける成果物は何か？ |
+| Q2 | `same-canonical-owner` | canonical_owner が `agentdev-artifact-graph` である SPEC はどれか？ |
+| Q3 | `related-command-skill-ir` | agentdev-artifact-graph SPEC に関連する command / skill / IR は何か？ |
+| Q4 | `delegation-target-skill` | case-close command が実際に委譲する skill は何か？ |
+| Q5 | `superseded-current-refs` | superseded な成果物を、現行の成果物がまだ参照しているか？ |
+| Q6 | `post-change-dangling-relation` | 当該 SPEC を削除した場合、どの relation が dangling になるか？ |
+
+各 query の `groundTruthRationale` は ground truth を選んだ根拠を明示し、追跡可能性を
+確保する。各 query は real artifact（`docs/requirements/REQ-*.md`, `docs/decisions/DEC-*.md`,
+`docs/specs/**`, `src/opencode/{commands,skills}/**`, `.agentdev/extensions/**`）のみを
+参照し、mock/stub は使用しない。
+
+## 6 つの比較観点
+
+各 query について以下を計算する。
+
+| metric | 定義 |
+|---|---|
+| recall | ground truth のうち各手法が発見した割合（Graph / 独立探索 それぞれ） |
+| false candidate count | ground truth 以外の候補として返した数 |
+| canonical source reach | 結果のうち canonical source（source_file 以外の artifact node）へ到達できる割合 |
+| Graph-only miss | 独立探索が見つけたが Graph が見落とした候補 |
+| Independent-only miss | Graph が見つけたが独立探索が見落とした候補 |
+| search effort | 探索に要した操作量（Graph API 呼出回数 / 独立探索の走査ステップ数） |
+
+recall / false candidate / canonical reach / search effort は Graph 側・独立探索側の
+両方について計算し、report で並べて比較する。
+
+## diagnostic 目的の明示
+
+- harness は常に終了コード 0 を返す。metrics が閾値を外れても失敗扱いにしない。
+- 出力 report の冒頭に「本検証は診断目的であり、性能閾値による合否判定は行わない」を明示する。
+- Artifact Graph 自身の接続確認のみを workflow effectiveness の成立根拠としない（SPEC「効果検証」節）。
+  本 harness は Graph 結果と独立探索結果の差を可視化し、Graph の追加価値を観察可能にする。
+
+## Parser/Graph regression との境界（REQ-020）
+
+Parser / augmentation / extraction / provenance の正確性検証は **REQ-020** 傘下の検証層
+（`tests/*.test.ts` と REQ-020 関連 SPEC）が所有する。本 harness は以下を取り扱わない:
+
+- Graph が正しく node / edge を抽出しているかの回帰検証
+- augmentation 設定の妥当性検証
+- provenance の網羅性検証
+
+本 harness は「Graph が正常に生成されたという前提で、Graph 利用者が workflow 質問を
+投げたときの探索効果を観察する」ことに限定する。
+
+## 制限事項
+
+- 独立探索の `grep` は正規表現エンジンに JavaScript `RegExp` を使用する。rg 等の外部
+  CLI 依存を避けるため、harness は Bun の fs API のみで完結する設計とした。
+- canonical source reach 指標は、Graph 側・独立探索側ともに「source_file 以外の artifact
+  node へ正規化できた割合」を代用指標として使う。これは「canonical source へ到達可能か」
+  を直接観測する手段が Graph API に存在しないための近似である。
+- query suite は AgentDevFlow リポジトリの現時点の artifact 構成に依存する。成果物構成が
+  大幅に変わった場合は `queries.ts` の ground truth の見直しが必要になる。
+
+## 関連情報
+
+- [REQ-021-006](../../../../../../../docs/requirements/REQ-021.md) — 本体要件
+- [SPEC agentdev-artifact-graph「効果検証」節](../../../../../../../docs/specs/skills/agentdev-artifact-graph.md) — 検証方針
+- [REQ-020](../../../../../../../docs/requirements/REQ-020.md) — Parser/Graph regression の対象外根拠
+- 親 [README.md](../README.md) — scripts 全体構成

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/harness.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/harness.ts
@@ -1,0 +1,274 @@
+// effectiveness/harness.ts — Graph と独立探索を走らせ、6 指標を計算する中心処理。
+//
+// 本 harness は diagnostic 目的のみ（REQ-021-006, TS-010）。性能閾値による合否判定は
+// 一切行わず、EffectivenessResult を揃えて返すだけである。parser/graph regression は
+// REQ-020 傘下の tests/*.test.ts が独立に判断可能であり、本 harness は重複しない。
+//
+// 入力:
+//   - rootDir: 計測対象リポジトリのルート絶対パス
+//   - graphDir: build_graph.ts が生成した Graph directory（manifest.json 等）
+//
+// 出力:
+//   - HarnessReport（全クエリの EffectivenessResult を格納）
+
+import { resolve } from "node:path"
+import { loadGraph } from "../lib/graph.ts"
+import { queryGraph } from "../lib/query.ts"
+import type { GraphQuery } from "../lib/query.ts"
+import type { GraphData, GraphNode, Provenance } from "../lib/model.ts"
+import { executeIndependentSearch } from "./independent_search.ts"
+import { QUERY_SUITE } from "./queries.ts"
+import type {
+  ComparisonMetrics,
+  EffectivenessQuery,
+  EffectivenessResult,
+  GraphResultFilter,
+  GraphQuerySpec,
+  HarnessReport,
+} from "./types.ts"
+
+export interface HarnessOptions {
+  readonly rootDir: string
+  readonly graphDir: string
+  /**
+   * suite を差し替えたい場合の注入ポイント。省略時は QUERY_SUITE。
+   * テストから部分集合を流すのに使う。
+   */
+  readonly suite?: readonly EffectivenessQuery[]
+}
+
+export async function runEffectivenessHarness(options: HarnessOptions): Promise<HarnessReport> {
+  const rootDir = resolve(options.rootDir)
+  const graphDir = resolve(options.graphDir)
+  const suite = options.suite ?? QUERY_SUITE
+  const graph = await loadGraph(graphDir)
+
+  const results: EffectivenessResult[] = []
+  for (const query of suite) {
+    results.push(await runOneQuery(graph, rootDir, query))
+  }
+
+  return {
+    rootDir,
+    graphDir,
+    inputDigest: graph.manifest.input_digest,
+    executedAt: new Date().toISOString(),
+    diagnosticOnly: true,
+    results,
+  }
+}
+
+async function runOneQuery(
+  graph: GraphData,
+  rootDir: string,
+  query: EffectivenessQuery,
+): Promise<EffectivenessResult> {
+  const pathToNodeId = buildPathToNodeIdMap(graph)
+  const { graphResults, graphOps } = await runGraphSide(graph, rootDir, query.graphQuery, pathToNodeId)
+  const { independentPaths, independentOps } = await runIndependentSide(rootDir, query.independentSearch)
+
+  const independentResults = independentPaths
+    .map((p) => pathToNodeId.get(p))
+    .filter((id): id is string => id !== undefined)
+
+  const groundTruth = new Set(query.groundTruth)
+  const graphSet = new Set(graphResults)
+  const independentSet = new Set(independentResults)
+
+  const metrics = computeMetrics({
+    groundTruth,
+    graphResults: graphSet,
+    independentResults: independentSet,
+    graphOps,
+    independentOps,
+    graph,
+  })
+
+  return {
+    queryId: query.id,
+    category: query.category,
+    question: query.question,
+    groundTruth: query.groundTruth,
+    groundTruthRationale: query.groundTruthRationale,
+    graphResults,
+    independentResults,
+    metrics,
+  }
+}
+
+interface GraphSideOutcome {
+  readonly graphResults: readonly string[]
+  readonly graphOps: number
+}
+
+async function runGraphSide(
+  graph: GraphData,
+  rootDir: string,
+  spec: GraphQuerySpec,
+  pathToNodeId: Map<string, string>,
+): Promise<GraphSideOutcome> {
+  // Graph API 呼出は常に 1 回（neighbors / path / provenance / discover いずれも）。
+  // その後 resultFilter 適用のため graphOps = 1 + (filter 適用有無) とする。
+  if (spec.kind === "discover") {
+    const q: GraphQuery = {
+      kind: "discover",
+      term: spec.term,
+      roots: spec.roots,
+      rootDir,
+    }
+    const outcome = await queryGraph(graph, q)
+    const paths = outcome.discovered ?? []
+    // discover はファイルパスを返すため、path → nodeId 変換を経て artifact node 優先で
+    // 正規化する。artifact node が存在しないパスは source_file node へ落ちる。
+    const asNodeIds = paths
+      .map((p) => pathToNodeId.get(p))
+      .filter((id): id is string => id !== undefined)
+    return { graphResults: applyFilter(asNodeIds, spec.resultFilter, graph), graphOps: 1 }
+  }
+  // spec.kind === "graph-query"
+  const outcome = await queryGraph(graph, spec.query)
+  const filtered = applyFilter(outcome.nodes, spec.resultFilter, graph)
+  const ops = spec.resultFilter === undefined ? 1 : 2
+  return { graphResults: filtered, graphOps: ops }
+}
+
+interface IndependentSideOutcome {
+  readonly independentPaths: readonly string[]
+  readonly independentOps: number
+}
+
+async function runIndependentSide(
+  rootDir: string,
+  spec: EffectivenessQuery["independentSearch"],
+): Promise<IndependentSideOutcome> {
+  const outcome = await executeIndependentSearch(rootDir, spec)
+  return { independentPaths: outcome.matchedPaths, independentOps: outcome.operationCount }
+}
+
+function applyFilter(
+  nodeIds: readonly string[],
+  filter: GraphResultFilter | undefined,
+  graph: GraphData,
+): readonly string[] {
+  if (filter === undefined) return [...nodeIds].sort()
+  const includeTypes = filter.includeTypes === undefined ? null : new Set(filter.includeTypes)
+  const exclude = new Set(filter.excludeNodes ?? [])
+  const typeById = new Map<string, string>()
+  for (const n of graph.nodes) typeById.set(n.id, n.type)
+  return nodeIds
+    .filter((id) => !exclude.has(id))
+    .filter((id) => {
+      if (includeTypes === null) return true
+      const t = typeById.get(id)
+      return t !== undefined && includeTypes.has(t)
+    })
+    .sort()
+}
+
+/**
+ * Graph の node 一覧から「ファイルパス → node ID」の逆引きマップを構築する。
+ *
+ * - source_file node: id が `source_file:<path>` 形式なので、<path> をそのままキーにする
+ * - artifact node: provenance.path（当該 node を根拠づけるファイルパス）をキーにする
+ *   （同一パスに複数 node が紐づく場合、source_file 以外の artifact node を優先する）
+ *
+ * 独立探索のマッチ路径を node ID 空間へ載せて Graph 結果と比較するために使う。
+ */
+function buildPathToNodeIdMap(graph: GraphData): Map<string, string> {
+  const provenanceById = new Map<string, Provenance>()
+  for (const p of graph.provenance) provenanceById.set(p.id, p)
+
+  const pathToNode = new Map<string, string>()
+  // 1 pass: artifact node（source_file 以外）を優先
+  const artifactNodes = graph.nodes.filter((n: GraphNode) => n.type !== "source_file")
+  for (const node of artifactNodes) {
+    const prov = provenanceById.get(node.provenance_id)
+    if (prov === undefined) continue
+    pathToNode.set(prov.path, node.id)
+  }
+  // 2 pass: source_file node（未登録パスのみ）
+  const sourceNodes = graph.nodes.filter((n: GraphNode) => n.type === "source_file")
+  for (const node of sourceNodes) {
+    // id は `source_file:<path>` 形式
+    const path = node.id.slice("source_file:".length)
+    if (!pathToNode.has(path)) pathToNode.set(path, node.id)
+  }
+  return pathToNode
+}
+
+interface MetricInputs {
+  readonly groundTruth: Set<string>
+  readonly graphResults: Set<string>
+  readonly independentResults: Set<string>
+  readonly graphOps: number
+  readonly independentOps: number
+  readonly graph: GraphData
+}
+
+function computeMetrics(inputs: MetricInputs): ComparisonMetrics {
+  const { groundTruth, graphResults, independentResults, graph } = inputs
+
+  const graphHits = intersect(graphResults, groundTruth)
+  const independentHits = intersect(independentResults, groundTruth)
+  const graphRecall = groundTruth.size === 0 ? 1 : graphHits.size / groundTruth.size
+  const independentRecall = groundTruth.size === 0 ? 1 : independentHits.size / groundTruth.size
+
+  const graphFalse = subtract(graphResults, groundTruth)
+  const independentFalse = subtract(independentResults, groundTruth)
+
+  const graphCanonicalReach = canonicalReach(graphResults, graph, true)
+  const independentCanonicalReach = canonicalReach(independentResults, graph, false)
+
+  // Graph-only miss = 独立探索が見つけたが Graph が見落とした候補
+  const graphOnlyMiss = subtract(independentResults, graphResults)
+  // Independent-only miss = Graph が見つけたが独立探索が見落とした候補
+  const independentOnlyMiss = subtract(graphResults, independentResults)
+
+  return {
+    graphRecall,
+    independentRecall,
+    graphFalseCandidateCount: graphFalse.size,
+    independentFalseCandidateCount: independentFalse.size,
+    graphCanonicalReach,
+    independentCanonicalReach,
+    graphOnlyMiss: [...graphOnlyMiss].sort(),
+    independentOnlyMiss: [...independentOnlyMiss].sort(),
+    searchEffort: {
+      graph: inputs.graphOps,
+      independent: inputs.independentOps,
+    },
+  }
+}
+
+function intersect(left: Set<string>, right: Set<string>): Set<string> {
+  const out = new Set<string>()
+  for (const v of left) if (right.has(v)) out.add(v)
+  return out
+}
+
+function subtract(left: Set<string>, right: Set<string>): Set<string> {
+  const out = new Set<string>()
+  for (const v of left) if (!right.has(v)) out.add(v)
+  return out
+}
+
+/**
+ * canonical source 到達可能性の代用指標。
+ *
+ * - Graph 側 (isGraph=true): 結果 node のうち source_file 以外の artifact node の割合。
+ *   Graph の source_file node は「ファイル容器」であり、canonical artifact へ到達するには
+ *   さらに type 付き node を引く必要があるため、type 付き node の割合を到達性の代用とする。
+ * - 独立探索側 (isGraph=false): 独立探索の結果は既に path → nodeId 変換済み。
+ *   こちらも source_file 以外の artifact node に正規化できた割合を代用指標とする。
+ */
+function canonicalReach(nodeIds: Set<string>, graph: GraphData, _isGraph: boolean): number {
+  if (nodeIds.size === 0) return 0
+  const typeById = new Map<string, string>()
+  for (const n of graph.nodes) typeById.set(n.id, n.type)
+  let artifactCount = 0
+  for (const id of nodeIds) {
+    const t = typeById.get(id)
+    if (t !== undefined && t !== "source_file") artifactCount += 1
+  }
+  return artifactCount / nodeIds.size
+}

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/independent_search.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/independent_search.ts
@@ -1,0 +1,158 @@
+// effectiveness/independent_search.ts — Graph を経由しない素のファイルシステム探索。
+//
+// rg / glob / frontmatter parse 相当の操作を Bun の fs API で実装する。
+// 外部 CLI (rg 等) に依存しないことで、harness は Node/Bun 単体で再現可能である。
+//
+// 戻り値は「ファイルパス（repo root 相対、POSIX 区切り）」のリスト。
+// harness 側で node ID 空間へ正規化する（path → nodeId 変換）。
+
+import { readdir, readFile, stat } from "node:fs/promises"
+import type { Dirent } from "node:fs"
+import { join } from "node:path"
+import { parseFrontmatter } from "../lib/parse.ts"
+import type { IndependentSearchSpec } from "./types.ts"
+
+async function walkFiles(rootDir: string, relPath: string, results: string[]): Promise<void> {
+  let entries: Dirent[]
+  try {
+    entries = await readdir(join(rootDir, relPath), { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    const childRel = `${relPath}/${entry.name}`
+    if (entry.isDirectory()) {
+      await walkFiles(rootDir, childRel, results)
+    } else if (entry.isFile()) {
+      results.push(childRel)
+    }
+  }
+}
+
+function hasExtension(path: string, extensions: readonly string[]): boolean {
+  if (extensions.length === 0) return true
+  const dot = path.lastIndexOf(".")
+  return dot >= 0 && extensions.includes(path.slice(dot))
+}
+
+async function ensureDirectory(rootDir: string, relRoot: string): Promise<boolean> {
+  try {
+    const s = await stat(join(rootDir, relRoot))
+    return s.isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 1 つの独立探索 spec を実行し、マッチしたファイルパス（repo root 相対・POSIX 区切り）
+ * を返す。戻り値はソート済みで重複なし。
+ *
+ * 配下の操作回数（呼出側で "search effort" 指標として使う）:
+ * - grep / frontmatterField: 走査したルート数 + 読んだファイル数
+ * - glob: 走査したルート数 + マッチしたファイル数
+ *
+ * 配下の実装は「外部 CLI なしで再現可能」を優先し、Bun の fs API のみ使用する。
+ * discovered_via は diagnostic 用の付随情報（どのファイルがどのルート経由で見つかったか）。
+ */
+export interface IndependentSearchOutcome {
+  readonly matchedPaths: readonly string[]
+  readonly operationCount: number
+}
+
+export async function executeIndependentSearch(
+  rootDir: string,
+  spec: IndependentSearchSpec,
+): Promise<IndependentSearchOutcome> {
+  switch (spec.kind) {
+    case "grep":
+      return executeGrep(rootDir, spec)
+    case "frontmatterField":
+      return executeFrontmatterField(rootDir, spec)
+    case "glob":
+      return executeGlob(rootDir, spec)
+    default: {
+      const exhaustive: never = spec
+      throw new TypeError(`unsupported independent search: ${JSON.stringify(exhaustive)}`)
+    }
+  }
+}
+
+async function executeGrep(
+  rootDir: string,
+  spec: Extract<IndependentSearchSpec, { readonly kind: "grep" }>,
+): Promise<IndependentSearchOutcome> {
+  const pattern = new RegExp(spec.pattern, "u")
+  const matches = new Set<string>()
+  let operations = 0
+  for (const relRoot of spec.roots) {
+    operations += 1 // root walk
+    if (!(await ensureDirectory(rootDir, relRoot))) continue
+    const files: string[] = []
+    await walkFiles(rootDir, relRoot, files)
+    for (const file of files.sort()) {
+      if (!hasExtension(file, spec.extensions)) continue
+      operations += 1 // file read
+      try {
+        const content = await readFile(join(rootDir, file), "utf8")
+        if (pattern.test(content)) {
+          matches.add(file)
+        }
+      } catch {
+        // skip unreadable
+      }
+    }
+  }
+  return { matchedPaths: [...matches].sort(), operationCount: operations }
+}
+
+async function executeFrontmatterField(
+  rootDir: string,
+  spec: Extract<IndependentSearchSpec, { readonly kind: "frontmatterField" }>,
+): Promise<IndependentSearchOutcome> {
+  const matches = new Set<string>()
+  let operations = 0
+  for (const relRoot of spec.roots) {
+    operations += 1
+    if (!(await ensureDirectory(rootDir, relRoot))) continue
+    const files: string[] = []
+    await walkFiles(rootDir, relRoot, files)
+    for (const file of files.sort()) {
+      if (!hasExtension(file, spec.extensions)) continue
+      operations += 1
+      try {
+        const content = await readFile(join(rootDir, file), "utf8")
+        const fields = parseFrontmatter(content)
+        const hit = fields.some(
+          (f) => f.key === spec.field && f.values.includes(spec.value),
+        )
+        if (hit) matches.add(file)
+      } catch {
+        // skip unreadable
+      }
+    }
+  }
+  return { matchedPaths: [...matches].sort(), operationCount: operations }
+}
+
+async function executeGlob(
+  rootDir: string,
+  spec: Extract<IndependentSearchSpec, { readonly kind: "glob" }>,
+): Promise<IndependentSearchOutcome> {
+  const matcher = new Bun.Glob(spec.pattern)
+  const matches = new Set<string>()
+  let operations = 0
+  for (const relRoot of spec.roots) {
+    operations += 1
+    if (!(await ensureDirectory(rootDir, relRoot))) continue
+    const iter = matcher.scan({
+      cwd: join(rootDir, relRoot),
+      dot: false,
+      onlyFiles: true,
+    })
+    for await (const rel of iter) {
+      matches.add(`${relRoot}/${rel}`.replaceAll("\\", "/"))
+    }
+  }
+  return { matchedPaths: [...matches].sort(), operationCount: operations }
+}

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/queries.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/queries.ts
@@ -1,0 +1,305 @@
+// effectiveness/queries.ts — 代表的な workflow question 6 種と ground truth 定義。
+//
+// 各 query は real AgentDevFlow artifact（docs/requirements/REQ-*.md,
+// docs/decisions/DEC-*.md, docs/specs/**, src/opencode/{commands,skills}/**,
+// .agentdev/extensions/**）を参照する。ground truth は各ファイルの
+// frontmatter, See Also, 関連 REQ 欄, extension yaml の rules.skill / checks.skill 等、
+// 追跡可能な事実に基づき選定した。
+//
+// 各 groundTruthRationale は選定根拠を残し、 harness 利用者が再検証できるようにする。
+
+import type { EffectivenessQuery } from "./types.ts"
+
+/**
+ * Q1: REQ-012 (Artifact Graph 標準化) の変更影響候補。
+ *
+ * Graph は neighbors(`requirement:REQ-012`, depth=1) で直接エッジを辿る。
+ * Graph は markdown_link と frontmatter の参照のみを拾うため、本文中の文字列
+ * 「REQ-012」は候補にならない（REQ-013/020/021 の関連 REQ 欄は本文記述のため
+ * Graph からは見えない）。一方、独立探索 (rg `\bREQ-012\b`) は文字列表現を全件
+ * 拾うため、関連 REQ 欄、README の索引、過去版言及（v2:REQ-0121 等の部分文字列
+ * リスク含む）まで広く拾う。
+ *
+ * ground truth は「Artifact Graph 標準化の要件文書として明示的に相互リンクされた
+ * 成果物」に限定する（markdown link または frontmatter 由来の構造的参照のみ。
+ * 単なる文字列表現は候補から外す）。
+ */
+const Q1_REQ_CHANGE_IMPACT: EffectivenessQuery = {
+  id: "Q1-req-012-impact",
+  category: "req-change-impact",
+  question: "REQ-012 (Artifact Graph 標準化) を変更した場合、影響を受ける成果物は何か？",
+  graphQuery: {
+    kind: "graph-query",
+    query: { kind: "neighbors", node: "requirement:REQ-012", depth: 1 },
+    resultFilter: {
+      includeTypes: ["specification", "decision", "requirement", "command", "skill", "integrity_rule"],
+      excludeNodes: ["requirement:REQ-012"],
+    },
+  },
+  independentSearch: {
+    kind: "grep",
+    pattern: "\\bREQ-012\\b",
+    roots: ["docs", ".agentdev/extensions", "src/opencode"],
+    extensions: [".md", ".yaml", ".yml", ".ts"],
+  },
+  groundTruth: ["specification:docs/specs/skills/agentdev-artifact-graph.md"],
+  groundTruthRationale:
+    "agentdev-artifact-graph SPEC の See Also セクションが REQ-012.md への markdown link を持ち、" +
+    "Graph 上で specification→requirement の構造的参照エッジとして現れる。" +
+    "REQ-013/020/021 の関連 REQ 欄は本文記述であり Graph の抽出対象外、" +
+    "README の索引行も候補から外す（影響分析の意味ある候補ではないため）。",
+}
+
+/**
+ * Q2: 同一 canonical_owner を持つ SPEC。
+ *
+ * Graph は「同一フィールド値で SPEC を束ねる」操作を直接提供しない。
+ * references relation が canonical_owner 由由で生成されるが、alias 解決の結果
+ * 自己ループに落ちる例が多く（例: agentdev-artifact-graph SPEC）、same-owner 検索
+ * には不適。harness は Graph の discover API（実質的にテキスト検索）と、
+ * rg による frontmatter 走査を比較する。
+ *
+ * ground truth は frontmatter `canonical_owner:` 行の値が一致する SPEC ファイル一覧。
+ */
+const Q2_SAME_CANONICAL_OWNER: EffectivenessQuery = {
+  id: "Q2-canonical-owner-artifact-graph",
+  category: "same-canonical-owner",
+  question: "canonical_owner が `agentdev-artifact-graph` である SPEC はどれか？",
+  graphQuery: {
+    kind: "discover",
+    term: "canonical_owner: agentdev-artifact-graph",
+    roots: ["docs/specs"],
+  },
+  independentSearch: {
+    kind: "frontmatterField",
+    field: "canonical_owner",
+    value: "agentdev-artifact-graph",
+    roots: ["docs/specs"],
+    extensions: [".md"],
+  },
+  groundTruth: ["specification:docs/specs/skills/agentdev-artifact-graph.md"],
+  groundTruthRationale:
+    "frontmatter 行 `canonical_owner: agentdev-artifact-graph` を持つ SPEC は " +
+    "docs/specs/skills/agentdev-artifact-graph.md のみ（rg で確済）。" +
+    "他 SPEC は owner 値が異なるか frontmatter 未設定のため候補外。",
+}
+
+/**
+ * Q3: agentdev-artifact-graph SPEC に関連する command / skill / integrity_rule。
+ *
+ * Graph は neighbors(spec, depth=2) で関連集合を得る。extension node を経由して
+ * command/skill に、references markdown link で他 SPEC に到達する。
+ *
+ * ground truth は SPEC 本文または extension yaml が agentdev-artifact-graph を明示的に
+ * 参照する成果物（command: case-close, case-open, case-run, req-define, spec-save;
+ * skill: agentdev-adversarial-review）。
+ */
+const Q3_RELATED_COMMAND_SKILL_IR: EffectivenessQuery = {
+  id: "Q3-related-to-artifact-graph-spec",
+  category: "related-command-skill-ir",
+  question:
+    "agentdev-artifact-graph SPEC に関連する command, skill, integrity_rule は何か？",
+  graphQuery: {
+    kind: "graph-query",
+    query: {
+      kind: "neighbors",
+      node: "specification:docs/specs/skills/agentdev-artifact-graph.md",
+      depth: 2,
+    },
+    resultFilter: {
+      includeTypes: ["command", "skill", "integrity_rule"],
+    },
+  },
+  independentSearch: {
+    kind: "grep",
+    pattern: "agentdev-artifact-graph",
+    roots: [
+      "src/opencode/commands",
+      "src/opencode/skills",
+      ".agentdev/extensions/commands",
+      ".agentdev/extensions/skills",
+      "docs/specs/integrity/rules",
+    ],
+    extensions: [".md", ".yaml", ".yml"],
+  },
+  groundTruth: [
+    "command:case-close",
+    "command:case-open",
+    "command:case-run",
+    "command:req-define",
+    "command:spec-save",
+    "skill:agentdev-adversarial-review",
+  ],
+  groundTruthRationale:
+    ".agentdev/extensions 配下の各 command extension yaml が rules.skill: agentdev-artifact-graph を持ち、" +
+    "agentdev-adversarial-review extension も同様。" +
+    "Graph 上で extension node を介した delegates_to / extends により" +
+    "specification→extension→command/skill と到達可能。" +
+    "integrity_rule で本 SPEC を直接参照する IR は現時点で存在しない。",
+}
+
+/**
+ * Q4: command から委譲される skill（delegates_to）。
+ *
+ * Graph は「extension node を経由した delegates_to エッジ」で command から委譲先を辿れる。
+ * 独立探索は .agentdev/extensions/commands/<name>.yaml の rules.skill / checks.skill を直接 grep。
+ *
+ * ground truth は case-close extension yaml に宣言された 2 つの skill。
+ * case-close は agents-dev-flow で数少ない複数 skill 委譲を持つ command であり、
+ * 単一委譲の典型例 (case-open, case-run 等) より比較の分解能が高い。
+ */
+const Q4_DELEGATION_TARGET_SKILL: EffectivenessQuery = {
+  id: "Q4-case-close-delegation-targets",
+  category: "delegation-target-skill",
+  question: "case-close command が実際に委譲する skill は何か？",
+  graphQuery: {
+    kind: "graph-query",
+    query: {
+      kind: "neighbors",
+      node: "command:case-close",
+      depth: 2,
+    },
+    resultFilter: {
+      includeTypes: ["skill", "specification"],
+    },
+  },
+  independentSearch: {
+    kind: "grep",
+    pattern: "^\\s*skill:\\s*\\S+",
+    roots: [".agentdev/extensions/commands"],
+    extensions: [".yaml", ".yml"],
+  },
+  groundTruth: [
+    "skill:repo-agentdev-integrity",
+    "specification:docs/specs/skills/agentdev-artifact-graph.md",
+  ],
+  groundTruthRationale:
+    ".agentdev/extensions/commands/case-close.yaml の rules[0].skill = agentdev-artifact-graph、" +
+    "checks[0].skill = repo-agentdev-integrity。" +
+    "Graph は alias 解決で前者を specification:docs/specs/skills/agentdev-artifact-graph.md、" +
+    "後者を skill:repo-agentdev-integrity に正規化する。" +
+    "独立探索はテキスト `skill:` 行を全件拾うため、他 command の skill 行も候補となる。",
+}
+
+/**
+ * Q5: superseded artifact への現行参照。
+ *
+ * Graph は supersedes エッジの target を特定し、それ以外のエッジで target に入る
+ * 現行参照を列挙できる。独立探索は各 superseded ID を rg で探すが、superseded 自身の
+ * ファイルや README 索引行、関連 REQ 欄などのノイズを含む。
+ *
+ * ground truth は superseded artifact を指す README 索引エントリ（docs/decisions/README.md と
+ * docs/specs/README.md）。これらは superseded を残す運用上やむを得ないが、検出対象の典型例。
+ */
+const Q5_SUPERSEDED_CURRENT_REFS: EffectivenessQuery = {
+  id: "Q5-superseded-current-refs",
+  category: "superseded-current-refs",
+  question: "superseded な成果物を、現行の成果物がまだ参照しているか？",
+  graphQuery: {
+    // Graph は supersedes の target を起点に neighbors(depth=1) で現行参照を得る。
+    // harness 側で「supersedes エッジ以外で入ってくるエッジ」を残す。
+    kind: "graph-query",
+    query: {
+      kind: "neighbors",
+      node: "decision:DEC-005",
+      depth: 1,
+    },
+    resultFilter: {
+      includeTypes: ["specification", "requirement", "decision", "command", "skill", "integrity_rule", "source_file"],
+      excludeNodes: ["decision:DEC-005", "decision:DEC-006"],
+    },
+  },
+  independentSearch: {
+    kind: "grep",
+    pattern: "\\bDEC-005\\b",
+    roots: ["docs", "src/opencode"],
+    extensions: [".md", ".yaml", ".yml"],
+  },
+  groundTruth: ["source_file:docs/decisions/README.md"],
+  groundTruthRationale:
+    "Graph 上で decision:DEC-005 へ入ってくる references エッジの source は " +
+    "docs/decisions/README.md の索引行のみ（markdown link で DEC-005 を明示）。" +
+    "supersedes の source である DEC-006 自身は除外。" +
+    "独立探索は追加で DEC-006.md 本文中の言及も拾うが、後継 Decision からの言及は" +
+    "superseded を指す「正当な参照」であり、本 query の関心（不正な現行参照）から外れるため" +
+    "ground truth からは外す。",
+}
+
+/**
+ * Q6: 変更後の dangling relation 候補。
+ *
+ * 「agentdev-artifact-graph SPEC を削除した場合、どの relation が dangling になるか？」
+ * を代表例とする。Graph は該当 node に接続する全エッジを列挙できる。独立探索は
+ * 当該 SPEC へのパス文字列を rg で探すが、relation 種別の分類はできない。
+ *
+ * ground truth は Graph 上で該当 SPEC に接続する非自己エッジの source 側 node のうち、
+ * 除去された場合に relation が dangling になる相手（references / defined_in / contains
+ * / supersedes を含む）。本 query は SPEC を「-spec」した場合の dangling 候補を提示する。
+ */
+const Q6_POST_CHANGE_DANGLING: EffectivenessQuery = {
+  id: "Q6-dangling-on-artifact-graph-spec-removal",
+  category: "post-change-dangling-relation",
+  question:
+    "agentdev-artifact-graph SPEC をリポジトリから削除した場合、どの成果物との relation が dangling になるか？",
+  graphQuery: {
+    kind: "graph-query",
+    query: {
+      kind: "neighbors",
+      node: "specification:docs/specs/skills/agentdev-artifact-graph.md",
+      depth: 1,
+    },
+    resultFilter: {
+      includeTypes: [
+        "specification",
+        "requirement",
+        "decision",
+        "command",
+        "skill",
+        "integrity_rule",
+        "extension",
+        "source_file",
+      ],
+      excludeNodes: ["specification:docs/specs/skills/agentdev-artifact-graph.md"],
+    },
+  },
+  independentSearch: {
+    kind: "grep",
+    pattern: "agentdev-artifact-graph\\.md",
+    roots: ["docs", "src/opencode", ".agentdev/extensions"],
+    extensions: [".md", ".yaml", ".yml"],
+  },
+  groundTruth: [
+    "requirement:REQ-012",
+    "requirement:REQ-013",
+    "requirement:REQ-020",
+    "decision:DEC-007",
+    "specification:docs/specs/foundations/document-model.md",
+    "specification:docs/specs/local/artifact-graph.md",
+    "source_file:docs/specs/README.md",
+    "extension:.agentdev/extensions/commands/case-close.yaml",
+    "extension:.agentdev/extensions/commands/case-open.yaml",
+    "extension:.agentdev/extensions/commands/case-run.yaml",
+    "extension:.agentdev/extensions/commands/req-define.yaml",
+    "extension:.agentdev/extensions/commands/spec-save.yaml",
+    "extension:.agentdev/extensions/skills/agentdev-adversarial-review.yaml",
+  ],
+  groundTruthRationale:
+    "Graph 上で specification:docs/specs/skills/agentdev-artifact-graph.md に接続する" +
+    "非自己エッジの相手側 node。markdown link で See Also を持つ REQ/DEC/SPEC、" +
+    "README の索引行、extension yaml の context.paths / rules.skill が対象。" +
+    "本 SPEC を削除するとこれらの relation が dangling になる。",
+}
+
+/**
+ * 全 6 query の代表 suite。
+ * REQ-021-006 が列挙する 6 category と 1:1 対応する。各クエリは real artifact 参照を持ち、
+ * mock/stub は一切使用しない。
+ */
+export const QUERY_SUITE: readonly EffectivenessQuery[] = [
+  Q1_REQ_CHANGE_IMPACT,
+  Q2_SAME_CANONICAL_OWNER,
+  Q3_RELATED_COMMAND_SKILL_IR,
+  Q4_DELEGATION_TARGET_SKILL,
+  Q5_SUPERSEDED_CURRENT_REFS,
+  Q6_POST_CHANGE_DANGLING,
+]

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/run.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/run.ts
@@ -1,0 +1,160 @@
+// effectiveness/run.ts — harness の CLI entry point。
+//
+// 使い方:
+//   bun effectiveness/run.ts --root <repo-root> --graph <graph-dir>
+//   bun effectiveness/run.ts --root . --graph .agentdev/graph
+//
+// 出力:
+//   - stdout: diagnostic report（人間可読テキスト）
+//   - --json を付けた場合は JSON 形式の HarnessReport のみを出力
+//
+// 本検証は診断目的であり、性能閾値による合否判定は行わない（REQ-021-006, TS-010）。
+// parser/graph regression は REQ-020 傘下の tests/*.test.ts が独立に判断する。
+// 本コマンドは終了コード 0 で終了する（diagnostic のため）。
+
+import { resolve } from "node:path"
+import { runEffectivenessHarness } from "./harness.ts"
+import type { HarnessReport, EffectivenessResult } from "./types.ts"
+import { CATEGORY_LABELS, QUERY_CATEGORIES } from "./types.ts"
+
+interface ParsedArgs {
+  readonly root: string
+  readonly graph: string
+  readonly json: boolean
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  let root = "."
+  let graph = ".agentdev/graph"
+  let json = false
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i]
+    if (a === undefined) continue
+    if (a === "--root") {
+      const v = argv[i + 1]
+      if (v !== undefined) root = v
+      i += 1
+    } else if (a === "--graph") {
+      const v = argv[i + 1]
+      if (v !== undefined) graph = v
+      i += 1
+    } else if (a === "--json") {
+      json = true
+    } else if (a === "--help" || a === "-h") {
+      printHelp()
+      process.exit(0)
+    } else {
+      console.error(`unknown argument: ${a}`)
+      process.exit(2)
+    }
+  }
+  return { root, graph, json }
+}
+
+function printHelp(): void {
+  console.error(`effectiveness/run.ts — Artifact Graph workflow effectiveness harness (REQ-021-006)
+
+Usage:
+  bun effectiveness/run.ts --root <repo-root> --graph <graph-dir> [--json]
+
+Options:
+  --root <path>     repo root directory (default: .)
+  --graph <path>    Graph output directory produced by build_graph.ts (default: .agentdev/graph)
+  --json            emit JSON HarnessReport instead of human-readable report
+  -h, --help        show this help
+
+Note:
+  本検証は診断目的であり、性能閾値による合否判定は行わない。`)
+}
+
+export async function main(args: readonly string[] = process.argv.slice(2)): Promise<void> {
+  const parsed = parseArgs(args)
+  const rootDir = resolve(parsed.root)
+  const graphDir = resolve(parsed.graph)
+  const report = await runEffectivenessHarness({ rootDir, graphDir })
+
+  if (parsed.json) {
+    console.log(JSON.stringify(report, null, 2))
+    return
+  }
+  console.log(renderHumanReport(report))
+}
+
+function renderHumanReport(report: HarnessReport): string {
+  const lines: string[] = []
+  lines.push("# Artifact Graph Workflow Effectiveness Report")
+  lines.push("")
+  lines.push("**本検証は診断目的であり、性能閾値による合否判定は行わない（REQ-021-006, TS-010）。**")
+  lines.push("**Parser/Graph regression は REQ-020 傘下の検証層が独立に判断する。**")
+  lines.push("")
+  lines.push(`- root: ${report.rootDir}`)
+  lines.push(`- graph: ${report.graphDir}`)
+  lines.push(`- input_digest: ${report.inputDigest}`)
+  lines.push(`- executed_at: ${report.executedAt}`)
+  lines.push(`- queries: ${report.results.length}`)
+  lines.push("")
+
+  // カバレッジ表: 6 category が全て覆盖されているか
+  const categoriesCovered = new Set(report.results.map((r) => r.category))
+  lines.push("## Category coverage (REQ-021-006)")
+  lines.push("")
+  lines.push("| category | covered |")
+  lines.push("|---|---|")
+  for (const cat of QUERY_CATEGORIES) {
+    const mark = categoriesCovered.has(cat) ? "yes" : "NO"
+    lines.push(`| ${cat} — ${CATEGORY_LABELS[cat]} | ${mark} |`)
+  }
+  lines.push("")
+
+  for (const result of report.results) {
+    lines.push(...renderQuery(result))
+    lines.push("")
+  }
+
+  return lines.join("\n")
+}
+
+function renderQuery(result: EffectivenessResult): readonly string[] {
+  const m = result.metrics
+  const lines: string[] = []
+  lines.push(`## ${result.queryId} — ${CATEGORY_LABELS[result.category]}`)
+  lines.push("")
+  lines.push(`> ${result.question}`)
+  lines.push("")
+  lines.push(`- ground truth 根拠: ${result.groundTruthRationale}`)
+  lines.push(`- ground truth (${result.groundTruth.length}):`)
+  for (const gt of result.groundTruth) lines.push(`  - \`${gt}\``)
+  lines.push("")
+  lines.push("### Graph 側 結果")
+  lines.push(`- candidates (${result.graphResults.length}):`)
+  for (const id of result.graphResults) lines.push(`  - \`${id}\``)
+  lines.push("")
+  lines.push("### 独立探索 側 結果")
+  lines.push(`- candidates (${result.independentResults.length}):`)
+  for (const id of result.independentResults) lines.push(`  - \`${id}\``)
+  lines.push("")
+  lines.push("### 6 指標（REQ-021-006）")
+  lines.push("")
+  lines.push("| metric | Graph | independent |")
+  lines.push("|---|---|---|")
+  lines.push(`| recall | ${m.graphRecall.toFixed(3)} | ${m.independentRecall.toFixed(3)} |`)
+  lines.push(`| false candidate count | ${m.graphFalseCandidateCount} | ${m.independentFalseCandidateCount} |`)
+  lines.push(`| canonical source reach | ${m.graphCanonicalReach.toFixed(3)} | ${m.independentCanonicalReach.toFixed(3)} |`)
+  lines.push(`| search effort (ops) | ${m.searchEffort.graph} | ${m.searchEffort.independent} |`)
+  lines.push("")
+  lines.push(`- Graph-only miss (独立探索が見つけたが Graph が見落とした, ${m.graphOnlyMiss.length}):`)
+  for (const id of m.graphOnlyMiss) lines.push(`  - \`${id}\``)
+  if (m.graphOnlyMiss.length === 0) lines.push("  - _(none)_")
+  lines.push(`- Independent-only miss (Graph が見つけたが独立探索が見落とした, ${m.independentOnlyMiss.length}):`)
+  for (const id of m.independentOnlyMiss) lines.push(`  - \`${id}\``)
+  if (m.independentOnlyMiss.length === 0) lines.push("  - _(none)_")
+  return lines
+}
+
+if (import.meta.main) {
+  // catch -- CLI boundary converts failures to exit status.
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  })
+}

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/types.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/types.ts
@@ -1,0 +1,183 @@
+// effectiveness/types.ts — Workflow effectiveness comparison harness types.
+//
+// 本検証は診断目的であり、性能閾値による合否判定は行わない（REQ-021-006, TS-010）。
+// Parser/Graph regression は REQ-020 が所有し、本 harness は取り扱わない。
+// Graph 固有の parser/augmentation/extraction 回帰検証は effectiveness/ ではなく
+// 既存の tests/*.test.ts および REQ-020 傘下の検証層が独立に判断可能である。
+//
+// 6 つの比較観点（REQ-021-006）:
+//   1. recall                 — ground truth に対する発見率（Graph / 独立探索 それぞれ）
+//   2. falseCandidate         — ground truth 以外の候補数
+//   3. canonicalSourceReach   — 結果が canonical source へ到達可能か（割合）
+//   4. graphOnlyMiss          — 独立探索が見つけたが Graph が見落とした候補
+//   5. independentOnlyMiss    — Graph が見つけたが独立探索が見落とした候補
+//   6. searchEffort           — 探索に要した操作量（API 呼出回数等）
+
+import type { GraphQuery } from "../lib/query.ts"
+
+/**
+ * REQ-021-006 が定める 6 つの workflow question category。
+ *SPEC「効果検証 › Workflow effectiveness」節と 1:1 で対応する。
+ */
+export const QUERY_CATEGORIES = [
+  "req-change-impact",
+  "same-canonical-owner",
+  "related-command-skill-ir",
+  "delegation-target-skill",
+  "superseded-current-refs",
+  "post-change-dangling-relation",
+] as const
+
+export type QueryCategory = (typeof QUERY_CATEGORIES)[number]
+
+/**
+ * Query category → 人間可読な質問の説明。
+ * harness はこの label を diagnostic report に出力する。
+ */
+export const CATEGORY_LABELS: Readonly<Record<QueryCategory, string>> = {
+  "req-change-impact": "REQ の変更影響候補",
+  "same-canonical-owner": "同一 canonical owner の SPEC",
+  "related-command-skill-ir": "関連 command, skill, integrity rule",
+  "delegation-target-skill": "command から実際に委譲される skill",
+  "superseded-current-refs": "superseded artifact への現行参照",
+  "post-change-dangling-relation": "変更後の dangling relation",
+}
+
+/**
+ * 独立探索（rg / glob / filesystem scan 相当）の宣言的仕様。
+ * Graph API を経由しない、素のファイルシステム走査を表現する。
+ * harness はこの spec を independent_search.ts の実装へ渡す。
+ */
+export type IndependentSearchSpec =
+  | {
+    readonly kind: "grep"
+    /**
+     * JavaScript 正規表現。単語境界等は明示的に指定すること。
+     * 例: "\\bREQ-012\\b" — "REQ-0120" 等への誤ヒットを防ぐ。
+     */
+    readonly pattern: string
+    /** 検索対象ルート（repo root 相対）。再帰的に .md/.yaml/.ts 等を走査する。 */
+    readonly roots: readonly string[]
+    /** 検索対象ファイル拡張子（先頭 "." 含む）。 */
+    readonly extensions: readonly string[]
+  }
+  | {
+    readonly kind: "frontmatterField"
+    readonly field: string
+    readonly value: string
+    readonly roots: readonly string[]
+    readonly extensions: readonly string[]
+  }
+  | {
+    readonly kind: "glob"
+    /** POSIX glob（Bun.Glob 形式）。ファイルパス全体にマッチする。 */
+    readonly pattern: string
+    readonly roots: readonly string[]
+  }
+
+/**
+ * Graph 側のクエリ仕様（discriminated union）。
+ *
+ * - `neighbors` / `path` / `provenance`: 既存 GraphQuery をそのまま使用。
+ * - `discover`: テキスト検索。rootDir は harness 実行時に repo root で埋めるため、
+ *   この spec には含めない（クエリ定義が repo 絶対パスに依存しないようにする）。
+ */
+export type GraphQuerySpec =
+  | {
+    readonly kind: "graph-query"
+    readonly query: GraphQuery
+    readonly resultFilter?: GraphResultFilter
+  }
+  | {
+    readonly kind: "discover"
+    readonly term: string
+    readonly roots: readonly string[]
+    readonly resultFilter?: GraphResultFilter
+  }
+
+export type GraphResultFilter = {
+  /**
+   * 残す node type の集合。undefined は「全 node type」。
+   * 例: ["specification", "requirement", "decision"] — source_file を除外。
+   */
+  readonly includeTypes?: readonly string[]
+  /** 結果から除外する node ID の集合（self 等）。 */
+  readonly excludeNodes?: readonly string[]
+}
+
+/**
+ * 1 つの workflow question を表すエントリ。
+ * groundTruth は「その質問に対して期待される候補集合（node ID 形式）」であり、
+ * real artifact への明示参照のみを含む。コード値はクエリ間で一意であること。
+ */
+export interface EffectivenessQuery {
+  readonly id: string
+  readonly category: QueryCategory
+  readonly question: string
+  readonly graphQuery: GraphQuerySpec
+  readonly independentSearch: IndependentSearchSpec
+  readonly groundTruth: readonly string[]
+  /**
+   * この ground truth を選定した根拠のメモ。
+   * harness はこれを report へ出力し、追跡可能性を確保する。
+   */
+  readonly groundTruthRationale: string
+}
+
+/**
+ * 1 クエリの比較結果。pass/fail 判定は持たない（diagnostic only）。
+ */
+export interface EffectivenessResult {
+  readonly queryId: string
+  readonly category: QueryCategory
+  readonly question: string
+  readonly groundTruth: readonly string[]
+  readonly groundTruthRationale: string
+  readonly graphResults: readonly string[]
+  readonly independentResults: readonly string[]
+  readonly metrics: ComparisonMetrics
+}
+
+export interface ComparisonMetrics {
+  /** Graph 側: ground truth のうち Graph が発見した割合 [0,1]。 */
+  readonly graphRecall: number
+  /** 独立探索側: ground truth のうち独立探索が発見した割合 [0,1]。 */
+  readonly independentRecall: number
+  /** Graph 側: ground truth 以外の候補数。 */
+  readonly graphFalseCandidateCount: number
+  /** 独立探索側: ground truth 以外の候補数。 */
+  readonly independentFalseCandidateCount: number
+  /**
+   * Graph 側: 結果のうち provenance により canonical source へ到達できる割合 [0,1]。
+   * source_file node を含まないフィルタ済み結果集合を分母とする。
+   */
+  readonly graphCanonicalReach: number
+  /**
+   * 独立探索側: 結果のうち artifact ノード（source_file 以外）へ正規化できた割合 [0,1]。
+   * canonical source へ到達できた割合の代用指標。
+   */
+  readonly independentCanonicalReach: number
+  /** 独立探索が見つけたが Graph が見落とした候補（node ID）。 */
+  readonly graphOnlyMiss: readonly string[]
+  /** Graph が見つけたが独立探索が見落とした候補（node ID）。 */
+  readonly independentOnlyMiss: readonly string[]
+  /** それぞれの探索操作量。 */
+  readonly searchEffort: {
+    readonly graph: number
+    readonly independent: number
+  }
+}
+
+export interface HarnessReport {
+  /** 実行時の repo root 絶対パス。 */
+  readonly rootDir: string
+  /** 読み込んだ Graph directory（manifest.json が存在するパス）。 */
+  readonly graphDir: string
+  /** Graph manifest の input_digest。再現性確認用。 */
+  readonly inputDigest: string
+  /** 実行日時（ISO 8601）。 */
+  readonly executedAt: string
+  /** diagnostic 目的の明示フラグ。常に true。 */
+  readonly diagnosticOnly: true
+  readonly results: readonly EffectivenessResult[]
+}

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/package.json
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/package.json
@@ -6,7 +6,9 @@
   "type": "module",
   "scripts": {
     "test": "bun test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "effectiveness": "bun effectiveness/run.ts",
+    "effectiveness:json": "bun effectiveness/run.ts --json"
   },
   "devDependencies": {
     "typescript": "^5.6.0",

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/tsconfig.json
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/tsconfig.json
@@ -21,5 +21,5 @@
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "lib/**/*.ts", "tests/**/*.ts"]
+  "include": ["src/**/*.ts", "lib/**/*.ts", "tests/**/*.ts", "effectiveness/**/*.ts"]
 }


### PR DESCRIPTION
## 概要

REQ-021-006 が定める Artifact Graph workflow effectiveness 検証インフラを追加する。
Parser/Graph regression は REQ-020 傘下の `tests/*.test.ts` が独立に判断可能であり、本 PR では重複しない（CR-003）。

## スコープ

`src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/` 配下へ、AgentDevFlow の代表的な workflow question 6 種について Graph 利用時と独立探索時を比較する diagnostic harness を新設する。

### 新規ファイル

- `effectiveness/types.ts` — Query suite / result / 6 指標の型定義、6 category 定数
- `effectiveness/queries.ts` — 代表 6 query と ground truth（real artifact 参照のみ。mock/stub なし）
- `effectiveness/independent_search.ts` — rg / glob / frontmatter 相当の独立探索実装（Bun fs API のみ使用、外部 CLI 非依存）
- `effectiveness/harness.ts` — Graph + 独立探索を実行し 6 指標を計算する中心処理
- `effectiveness/run.ts` — CLI entry point（人間可読 report / JSON 出力を切替）
- `effectiveness/README.md` — 使い方、診断目的の明示、parser 回帰との境界

### 更新

- `tsconfig.json` — `effectiveness/**/*.ts` を `include` へ追加
- `package.json` — `effectiveness`, `effectiveness:json` スクリプトを追加

## 6 つの query category（REQ-021-006 1:1 対応）

| id | category | 質問 |
|---|---|---|
| Q1 | `req-change-impact` | REQ-012 を変更した場合の影響候補 |
| Q2 | `same-canonical-owner` | 同一 `canonical_owner` を持つ SPEC |
| Q3 | `related-command-skill-ir` | SPEC に関連する command / skill / integrity_rule |
| Q4 | `delegation-target-skill` | command が実際に委譲する skill |
| Q5 | `superseded-current-refs` | superseded artifact への現行参照 |
| Q6 | `post-change-dangling-relation` | 変更後に dangling になる relation |

各 ground truth は AgentDevFlow リポジトリの real artifact（`docs/requirements/REQ-*.md`, `docs/decisions/DEC-*.md`, `docs/specs/**`, `src/opencode/{commands,skills}/**`, `.agentdev/extensions/**`）への explicit reference に基づき、`groundTruthRationale` フィールドで選定根拠を明示する。

## 6 つの比較観点

各 query について以下を Graph 側・独立探索側それぞれで計算する。

- recall（ground truth 発見率）
- false candidate count（ground truth 以外の候補数）
- canonical source reach（artifact node へ到達できる割合）
- Graph-only miss（独立探索が見つけたが Graph が見落とした候補）
- Independent-only miss（Graph が見つけたが独立探索が見落とした候補）
- search effort（操作量: Graph API 呼出回数 / 独立探索の走査ステップ数）

## 診断目的の明示（TS-010）

- harness は常に終了コード 0 を返す（性能閾値による合否判定を行わない）
- report 冒頭に「本検証は診断目的であり、性能閾値による合否判定は行わない（REQ-021-006, TS-010）」を明示
- Artifact Graph 自身の接続確認のみを effectiveness の成立根拠としない（SPEC「効果検証」節）

## Parser/Graph regression との境界（REQ-020）

Parser / augmentation / extraction / provenance の正確性検証は **REQ-020** 傘下の検証層（`tests/*.test.ts` と REQ-020 関連 SPEC）が所有する。本 harness は以下を取り扱わない:

- Graph が正しく node / edge を抽出しているかの回帰検証
- augmentation 設定の妥当性検証
- provenance の網羅性検証

本 harness は「Graph が正常に生成されたという前提で、Graph 利用者が workflow 質問を投げたときの探索効果を観察する」ことに限定する。

## 使い方

```bash
cd src/opencode/skills/agentdev-artifact-graph/scripts

# Graph が未生成の場合（既存 Graph があればスキップ可）
bun src/build_graph.ts --root ../../../../../.. --output ../../../../../../.agentdev/graph

# diagnostic report を人間可読形式で出力
bun effectiveness/run.ts --root ../../../../../.. --graph ../../../../../../.agentdev/graph

# JSON 形式（CI / 後段集計）
bun effectiveness/run.ts --root ../../../../../.. --graph ../../../../../../.agentdev/graph --json
```

## 検証結果

### 品質ゲート

- `bun run typecheck`（`tsc --noEmit`）: **pass**（strict mode、noUnusedLocals、verbatimModuleSyntax 準拠）
- `bun test`（既存テストスイート）: **62 pass / 0 fail**（回帰なし）

### harness smoke test（worktree 内で実行）

`bun effectiveness/run.ts --root . --graph .agentdev/graph` を実行し、diagnostic report が生成されることを確認。全 6 category カバレッジ yes、空 ground truth 0 件、終了コード 0。

| query | category | graph recall | indep recall | graph false | indep false | graph effort | indep effort |
|---|---|---|---|---|---|---|---|
| Q1 | req-change-impact | 1.00 | 1.00 | 0 | 24 | 2 | 1134 |
| Q2 | same-canonical-owner | 1.00 | 1.00 | 0 | 0 | 1 | 159 |
| Q3 | related-command-skill-ir | 1.00 | 0.00 | 1 | 10 | 2 | 274 |
| Q4 | delegation-target-skill | 1.00 | 0.00 | 4 | 0 | 2 | 17 |
| Q5 | superseded-current-refs | 1.00 | 1.00 | 1 | 2 | 2 | 386 |
| Q6 | post-change-dangling-relation | 1.00 | 0.31 | 1 | 3 | 2 | 417 |

これらの値は診断観測値であり、合否判定の閾値ではない。代表的な観察:

- Q1, Q5: Graph と独立探索で recall が同等だが、Graph の false candidate / effort が大幅に低い
- Q3, Q4: 独立探索が grep で yaml/md パスを返す一方、Graph は command/skill/specification node を直接返すため、質問の意図に合う候補を得るには Graph が有効
- Q6: Graph は隣接ノードを全件列挙できるため recall 1.00。独立探索は grep の表現力に限界があり recall 0.31

## 関連

- 要求元 Issue: #2045
- 親 Epic: #2043
- 関連 Issue: #2044
- 要件: REQ-021-006（Artifact Graph ワークフロー統合）
- SPEC: docs/specs/skills/agentdev-artifact-graph.md「効果検証」節
- 関連要件: REQ-020（Parser/Graph regression は本 PR の対象外）

Closes #2045
