### PR TITLE
feat(scripts): query_graph.ts 出力へ type/source/target 追加（後方互換維持）（RU-0002 OU-001）

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,10 +6,10 @@ AgentDevFlow の基本原則と管理方式は [DEC-001](decisions/DEC-001.md) �
 ## 要件
 
 <!-- AUTOGEN:BEGIN:id=readme-req-summary-count -->
-現行 REQ: 22件、廃止済み: 0件
+現行 REQ: 23件、廃止済み: 0件
 <!-- AUTOGEN:END -->
 
-現行要件は REQ-001 から REQ-022 の22件である。各 REQ の詳細は各 REQ ファイル本文を参照。
+現行要件は REQ-001 から REQ-023 の23件である。各 REQ の詳細は各 REQ ファイル本文を参照。
 
 | REQ | タイトル |
 |---|---|
@@ -35,6 +35,7 @@ AgentDevFlow の基本原則と管理方式は [DEC-001](decisions/DEC-001.md) �
 | [REQ-020](requirements/REQ-020.md) | Artifact Graph 解析品質と検証 |
 | [REQ-021](requirements/REQ-021.md) | Artifact Graph ワークフロー統合 |
 | [REQ-022](requirements/REQ-022.md) | Artifact Graph augmentation 配置先正規化 |
+| [REQ-023](requirements/REQ-023.md) | Artifact Graph 問い合わせ結果の関係情報拡張 |
 
 - [要件インデックス](requirements/README.md)
 

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -3,7 +3,7 @@
 ## 現行要件
 
 <!-- AUTOGEN:BEGIN:id=req-active-count -->
-現在の要件判断では、以下22件を第一参照先とする。
+現在の要件判断では、以下23件を第一参照先とする。
 <!-- AUTOGEN:END -->
 
 各 REQ の詳細関心は各 REQ ファイル本文を参照のこと。
@@ -34,6 +34,7 @@
 | [REQ-020](REQ-020.md) | Artifact Graph 解析品質と検証 |
 | [REQ-021](REQ-021.md) | Artifact Graph ワークフロー統合 |
 | [REQ-022](REQ-022.md) | Artifact Graph augmentation 配置先正規化 |
+| [REQ-023](REQ-023.md) | Artifact Graph 問い合わせ結果の関係情報拡張 |
 <!-- AUTOGEN:END -->
 
 ## 廃止済み要件

--- a/docs/requirements/REQ-023.md
+++ b/docs/requirements/REQ-023.md
@@ -1,0 +1,28 @@
+---
+id: REQ-023
+title: "Artifact Graph 問い合わせ結果の関係情報拡張"
+created: "2026-08-10"
+updated: "2026-08-10"
+---
+
+## 目的
+
+Artifact Graph 問い合わせ結果（query_graph.ts）の使いやすさを改善し、利用者が関係IDを追加解釈することなく関係種別・接続元・接続先を読めるようにする。
+
+## 要件
+
+| ID | 要件 |
+|---|---|
+| REQ-023-001 | query_graph.ts の問い合わせ結果に、各関係の type（関係種別）、source（接続元ノード）、target（接続先ノード）を含める。利用者は関係IDを追加解釈せずに関係の意味を行単位で読めること。 |
+| REQ-023-002 | 既存のノードID、関係ID、根拠情報（evidence）の出力との後方互換性を維持する。既存フィールドを削除せず、type/source/target を追加する。 |
+
+## 適用範囲
+
+- **対象**: src/opencode/skills/repo-agentdev-artifact-graph/scripts/query_graph.ts、当該スクリプトの出力形式（関係情報の表示拡張）
+- **対象外**: check_graph.ts の抽出規則改善（RU-0003 で扱う）、augmentation 配置先の SPEC 明示化（RU-0001 で扱う）
+
+## 関連情報
+
+**関連 REQ**: REQ-012（Artifact Graph 標準化）、REQ-020（Artifact Graph 解析品質と検証）、REQ-021（Artifact Graph ワークフロー統合）
+**関連 SPEC**: docs/specs/skills/agentdev-artifact-graph.md（問い合わせ結果の出力形式 section）
+**関連 Issue**: Epic #1941（本体リポジトリ固有 Artifact Graph）、#1944（代表質問での効果検証）、#1947（追加解釈操作確認 PR）

--- a/docs/specs/skills/agentdev-artifact-graph.md
+++ b/docs/specs/skills/agentdev-artifact-graph.md
@@ -70,6 +70,18 @@ consumer 環境では AgentDevFlow 配布物（`.opencode/commands/agentdev/`、
 
 `.agentdev/graph/` は手編集せず、正規情報として扱わない。
 
+## 問い合わせ結果の出力形式
+
+query_graph.ts の問い合わせ結果は、各関係について以下の情報を含める。
+
+- 関係ID（既存）
+- 関係 type（関係種別、例: depends_on、derived_from）
+- source（接続元ノード）
+- target（接続先ノード）
+- 根拠 evidence（既存）
+
+既存のノードID、関係ID、根拠情報との互換性を維持し、新規フィールドを追加する形式とする。
+
 ## グラフモデル（open extensibility を含む）
 
 ### 標準コア node_types（デフォルト）

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/lib/query.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/lib/query.ts
@@ -9,11 +9,27 @@ export type GraphQuery =
   | { readonly kind: "provenance"; readonly id: string }
   | { readonly kind: "discover"; readonly term: string; readonly roots: readonly string[]; readonly rootDir: string }
 
+export type QueryRelation = {
+  readonly id: string
+  readonly type: string
+  readonly source: string
+  readonly target: string
+}
+
 export type QueryResult = {
   readonly nodes: readonly string[]
   readonly edges: readonly string[]
+  readonly relations: readonly QueryRelation[]
   readonly provenance: readonly Provenance[]
   readonly discovered?: readonly string[]
+}
+
+function relationsFor(graph: GraphData, edgeIds: readonly string[]): readonly QueryRelation[] {
+  const idSet = new Set(edgeIds)
+  return graph.edges
+    .filter((edge) => idSet.has(edge.id))
+    .map((edge) => ({ id: edge.id, type: edge.type, source: edge.source, target: edge.target }))
+    .sort((left, right) => left.id.localeCompare(right.id))
 }
 
 function evidenceFor(graph: GraphData, nodeIds: readonly string[], edgeIds: readonly string[]): readonly Provenance[] {
@@ -38,9 +54,11 @@ function provenanceResult(graph: GraphData, id: string): QueryResult {
   const node = graph.nodes.find((candidate) => candidate.id === id)
   const edge = graph.edges.find((candidate) => candidate.id === id)
   const provenanceId = node?.provenance_id ?? edge?.provenance_id
+  const edgeIds = edge === undefined ? [] : [edge.id]
   return {
     nodes: node === undefined ? [] : [node.id],
-    edges: edge === undefined ? [] : [edge.id],
+    edges: edgeIds,
+    relations: relationsFor(graph, edgeIds),
     provenance: provenanceId === undefined ? [] : graph.provenance.filter((entry) => entry.id === provenanceId),
   }
 }
@@ -62,7 +80,7 @@ function neighborResult(graph: GraphData, start: string, maxDepth: number): Quer
   }
   const nodes = [...visited].sort()
   const edges = [...edgeIds].sort()
-  return { nodes, edges, provenance: evidenceFor(graph, nodes, edges) }
+  return { nodes, edges, relations: relationsFor(graph, edges), provenance: evidenceFor(graph, nodes, edges) }
 }
 
 function pathResult(graph: GraphData, source: string, target: string, maxDepth: number): QueryResult {
@@ -74,7 +92,7 @@ function pathResult(graph: GraphData, source: string, target: string, maxDepth: 
     const current = queue.shift()
     if (current === undefined) break
     if (current.node === target) {
-      return { nodes: current.nodes, edges: current.edges, provenance: evidenceFor(graph, current.nodes, current.edges) }
+      return { nodes: current.nodes, edges: current.edges, relations: relationsFor(graph, current.edges), provenance: evidenceFor(graph, current.nodes, current.edges) }
     }
     if (current.edges.length >= maxDepth) continue
     for (const neighbor of adjacent(graph.edges, current.node)) {
@@ -87,7 +105,7 @@ function pathResult(graph: GraphData, source: string, target: string, maxDepth: 
       })
     }
   }
-  return { nodes: [], edges: [], provenance: [] }
+  return { nodes: [], edges: [], relations: [], provenance: [] }
 }
 
 async function walkDir(root: string, dir: string, results: string[]): Promise<void> {
@@ -133,7 +151,7 @@ async function discoverResult(query: { readonly term: string; readonly roots: re
       }
     }
   }
-  return { nodes: [], edges: [], provenance: [], discovered: matches.sort() }
+  return { nodes: [], edges: [], relations: [], provenance: [], discovered: matches.sort() }
 }
 
 export async function queryGraph(graph: GraphData, query: GraphQuery): Promise<QueryResult> {

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/tests/query.test.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/tests/query.test.ts
@@ -58,6 +58,55 @@ describe("graph queries", () => {
       maxDepth: 2,
     })
     expect(result.nodes).toEqual([])
+    expect(result.edges).toEqual([])
+    expect(result.relations).toEqual([])
+  })
+})
+
+describe("query result relations (REQ-023-001/002)", () => {
+  it("neighbors exposes relations with id/type/source/target for every edge", async () => {
+    const { graph } = await graphFixture()
+    const result = await queryGraph(graph, { kind: "neighbors", node: "requirement:REQ-001", depth: 2 })
+    expect(result.edges.length).toBeGreaterThan(0)
+    for (const edge of result.edges) {
+      expect(typeof edge).toBe("string")
+    }
+    expect(result.relations).toHaveLength(result.edges.length)
+    const edgeIdSet = new Set(result.edges)
+    for (const relation of result.relations) {
+      expect(edgeIdSet.has(relation.id)).toBe(true)
+      expect(relation.type.length).toBeGreaterThan(0)
+      expect(relation.source.length).toBeGreaterThan(0)
+      expect(relation.target.length).toBeGreaterThan(0)
+      const match = graph.edges.find((edge) => edge.id === relation.id)
+      expect(match).toBeDefined()
+      expect(match?.type).toBe(relation.type)
+      expect(match?.source).toBe(relation.source)
+      expect(match?.target).toBe(relation.target)
+    }
+  })
+
+  it("path exposes relations matching its edges", async () => {
+    const { graph } = await graphFixture()
+    const result = await queryGraph(graph, {
+      kind: "path",
+      source: "requirement:REQ-001",
+      target: "specification:docs/specs/feature.md",
+      maxDepth: 4,
+    })
+    expect(result.edges.length).toBeGreaterThan(0)
+    expect(result.relations).toHaveLength(result.edges.length)
+    const relationSources = new Set(result.relations.map((r) => r.source))
+    const relationTargets = new Set(result.relations.map((r) => r.target))
+    expect(relationSources.has("requirement:REQ-001")).toBe(true)
+    expect(relationTargets.has("specification:docs/specs/feature.md")).toBe(true)
+  })
+
+  it("provenance for a node has empty relations (no edges in scope)", async () => {
+    const { graph } = await graphFixture()
+    const result = await queryGraph(graph, { kind: "provenance", id: "requirement:REQ-001" })
+    expect(result.edges).toEqual([])
+    expect(result.relations).toEqual([])
   })
 })
 


### PR DESCRIPTION
## 概要

Issue #2050 の実装。Artifact Graph 問い合わせ結果（query_graph.ts）へ関係種別・接続元・接続先情報を追加し、利用者が関係 ID を追加解釈せずに関係の意味を行単位で読めるようにする。

## 変更内容

### 実装

- `src/opencode/skills/agentdev-artifact-graph/scripts/lib/query.ts`
  - `QueryRelation` 型（`id`/`type`/`source`/`target`）を新設
  - `QueryResult` へ `relations: readonly QueryRelation[]` フィールドを追加
  - `relationsFor(graph, edgeIds)` ヘルパーで edge ID 配列から関係詳細を組み立て
  - `neighbors`/`path`/`provenance`/`discover` 各 result builder で `relations` を populate
  - 既存の `nodes`/`edges`(ID 配列)/`provenance`/`discovered` は全て維持（後方互換）

### テスト

- `src/opencode/skills/agentdev-artifact-graph/scripts/tests/query.test.ts`
  - `relations` フィールドの振る舞いを検証するテスト 3 件を追加（neighbors/path/provenance）
  - 各 relation が `id`/`type`/`source`/`target` を持ち、graph の edge と一致することを検証
  - 後方互換性: `edges` が引き続き ID 文字列の配列であることを検証

### ドキュメント（前工程で確定済み、本 PR で配置）

- `docs/requirements/REQ-023.md`（新規）
- `docs/requirements/README.md`（REQ-023 追加）
- `docs/README.md`（REQ 一覧へ REQ-023 追加）
- `docs/specs/skills/agentdev-artifact-graph.md`（「問い合わせ結果の出力形式」section 追加）

## 後方互換性

REQ-023-002 に準拠し、既存フィールドは削除せず `relations` のみ追加:

| フィールド | 後方互換 | 内容 |
|---|---|---|
| `nodes` | 既存（維持） | ノード ID 配列 |
| `edges` | 既存（維持） | 関係 ID 配列 |
| `relations` | **新規追加** | `{id,type,source,target}` オブジェクト配列 |
| `provenance` | 既存（維持） | 根拠情報配列 |
| `discovered` | 既存（維持） | discover 結果（任意） |

## 検証結果

- `bun test`: 65 pass / 0 fail
- `bun run tsc --noEmit`: clean (exit 0)
- targeted docs guard (`check_changed_docs.ts --workflow case-run`): 0 failures, 0 warnings
- extensions check (`check_extensions.ts`): ok, 0 failures
- 実表面検証: CLI から `relations` に `{id,type,source,target}` が出力されることを確認

Refs: #2050