### PR TITLE
配布consumer導入スクリプトの信頼アンカーを更新

### DIFF
--- a/scripts/check-consumer-opencode.ps1
+++ b/scripts/check-consumer-opencode.ps1
@@ -55,7 +55,7 @@ $ProjectionDir = Join-Path $RepoRoot '.opencode'
 $CommandsDir = Join-Path $ProjectionDir 'commands'
 $SkillsDir = Join-Path $ProjectionDir 'skills'
 
-# Skill redirected to src/opencode-local/ in local mode (REQ-0103-158, ADR-0131 decision #3)
+# Skill redirected to src/opencode-local/ in local mode (REQ-{NNNN}-{NNN}, ADR-{NNNN} decision #3)
 $LocalModeRedirectSkill = 'agentdev-gh-cli'
 
 # --- Helper Functions ---
@@ -64,7 +64,7 @@ function Assert-ValidConsumerCwd {
     <#
     .SYNOPSIS
         実行ディレクトリが AgentDevFlow 導入先として適切か検査する。
-        想定外ディレクトリの場合、即座に停止する（REQ-009-041）。
+        想定外ディレクトリの場合、即座に停止する（REQ-{NNNN}-{NNN}）。
     #>
     $cwd = $PWD.Path
 
@@ -113,7 +113,7 @@ function Get-TargetSourcePath {
     .SYNOPSIS
         Resolve the absolute source path backing a projection relative path.
         When $DetectedLocalMode is true, skills\<LocalModeRedirectSkill> is redirected
-        to src/opencode-local/<LocalModeRedirectSkill>/ (REQ-0103-158, ADR-0131 decision #3).
+        to src/opencode-local/<LocalModeRedirectSkill>/ (REQ-{NNNN}-{NNN}, ADR-{NNNN} decision #3).
     #>
     param([string]$RelPath, [bool]$LocalMode)
     if ($LocalMode -and $RelPath -eq "skills\$LocalModeRedirectSkill") {
@@ -124,7 +124,7 @@ function Get-TargetSourcePath {
 
 # --- Main ---
 
-# cwd 安全化（REQ-009-041）
+# cwd 安全化（REQ-{NNNN}-{NNN}）
 Assert-ValidConsumerCwd
 
 Write-Host '=== Consumer Install Status Check ==='

--- a/scripts/install-consumer-opencode.ps1
+++ b/scripts/install-consumer-opencode.ps1
@@ -12,7 +12,7 @@
     - .opencode/commands/agentdev/  = junction -> .agentdev-plugin/src/opencode/commands/agentdev/
     - .opencode/skills/agentdev-*/  = individual junctions -> .agentdev-plugin/src/opencode/skills/agentdev-*/
     - .opencode/skills/japanese-tech-writing/ = junction -> .agentdev-plugin/src/opencode/skills/japanese-tech-writing/
-      (distribution-dependent skill referenced by agentdev-doc-writing, ADR-0134/REQ-0159-001)
+      (distribution-dependent skill referenced by agentdev-doc-writing, ADR-{NNNN}/REQ-{NNNN}-{NNN})
 
     Does NOT touch repo-local commands/skills:
     - .opencode/commands/repo/      = real directory (repo-local only)
@@ -24,12 +24,12 @@
 
 .PARAMETER Mode
     One of: dry-run, check, apply
-    省略可能。引数なし起動時（-Mode 未指定）は対話ウィザードが起動し、Mode と環境を問う（REQ-009-040）。
+    省略可能。引数なし起動時（-Mode 未指定）は対話ウィザードが起動し、Mode と環境を問う（REQ-{NNNN}-{NNN}）。
 
 .PARAMETER LocalMode
     Switch. When set, agentdev-gh-cli is junctioned to src/opencode-local/agentdev-gh-cli/
     instead of src/opencode/skills/agentdev-gh-cli/. All other agentdev-* command/skill
-    junctions target src/opencode/ as normal (REQ-0103-158, ADR-0131 decision #3).
+    junctions target src/opencode/ as normal (REQ-{NNNN}-{NNN}, ADR-{NNNN} decision #3).
 
     判断基準: GitHub Issue/PR を使わずローカルファイル（.agentdev/cases/）で運用する環境
     （ローカル版 OpenCode）では -LocalMode を指定する。
@@ -49,7 +49,7 @@
 
 .EXAMPLE
     ./scripts/install-consumer-opencode.ps1
-    引数なし起動時は対話ウィザードが Mode と環境を問う（REQ-009-040）。
+    引数なし起動時は対話ウィザードが Mode と環境を問う（REQ-{NNNN}-{NNN}）。
 
     ./scripts/install-consumer-opencode.ps1 -Mode dry-run
     ./scripts/install-consumer-opencode.ps1 -Mode check
@@ -88,7 +88,7 @@ $SkillsDir = Join-Path $ProjectionDir 'skills'
 $RepoLocalCommandNames = @('repo')
 $RepoLocalSkillPrefix = 'repo-'
 
-# In LocalMode this skill is redirected from src/opencode-local/ (REQ-0103-158, ADR-0131 decision #3)
+# In LocalMode this skill is redirected from src/opencode-local/ (REQ-{NNNN}-{NNN}, ADR-{NNNN} decision #3)
 $LocalModeRedirectSkill = 'agentdev-gh-cli'
 
 # --- Helper Functions ---
@@ -97,7 +97,7 @@ function Assert-ValidConsumerCwd {
     <#
     .SYNOPSIS
         実行ディレクトリが AgentDevFlow 導入先として適切か検査する。
-        想定外ディレクトリの場合、即座に停止する（REQ-009-041）。
+        想定外ディレクトリの場合、即座に停止する（REQ-{NNNN}-{NNN}）。
     #>
     $cwd = $PWD.Path
 
@@ -129,7 +129,7 @@ function Assert-ValidConsumerCwd {
 function Invoke-InstallWizard {
     <#
     .SYNOPSIS
-        引数なし起動時（-Mode 未指定）の対話ウィザード。Mode と環境を問う（REQ-009-040）。
+        引数なし起動時（-Mode 未指定）の対話ウィザード。Mode と環境を問う（REQ-{NNNN}-{NNN}）。
     #>
     Write-Host '=== AgentDevFlow 導入ウィザード ==='
     Write-Host ''
@@ -196,12 +196,12 @@ function Get-ConsumerJunctionTargets {
     }
 
     # skills\agentdev-* (dynamic enumeration) plus japanese-tech-writing
-    # (distribution-dependent skill referenced by agentdev-doc-writing, ADR-0134/REQ-0159-001).
+    # (distribution-dependent skill referenced by agentdev-doc-writing, ADR-{NNNN}/REQ-{NNNN}-{NNN}).
     $skillsSource = Join-Path $SourceDir 'skills'
     if (Test-Path -LiteralPath $skillsSource) {
         Get-ChildItem -LiteralPath $skillsSource -Directory -Filter 'agentdev-*' |
             ForEach-Object { $targets.Add("skills\$($_.Name)") }
-        # japanese-tech-writing is promoted to src/ but lacks agentdev-* prefix (ADR-0134).
+        # japanese-tech-writing is promoted to src/ but lacks agentdev-* prefix (ADR-{NNNN}).
         if (Test-Path -LiteralPath (Join-Path $skillsSource 'japanese-tech-writing')) {
             $targets.Add('skills\japanese-tech-writing')
         }
@@ -215,7 +215,7 @@ function Get-TargetSourcePath {
     .SYNOPSIS
         Resolve the absolute source path backing a projection relative path.
         In LocalMode, skills\<LocalModeRedirectSkill> is redirected to
-        src/opencode-local/<LocalModeRedirectSkill>/ (REQ-0103-158, ADR-0131 decision #3).
+        src/opencode-local/<LocalModeRedirectSkill>/ (REQ-{NNNN}-{NNN}, ADR-{NNNN} decision #3).
         All other targets back to src/opencode/ as normal.
     #>
     param([string]$RelPath)
@@ -259,10 +259,10 @@ function Initialize-PluginCheckout {
 
 # --- Main ---
 
-# cwd 安全化（REQ-009-041）。ウィザードの前に通過すること。
+# cwd 安全化（REQ-{NNNN}-{NNN}）。ウィザードの前に通過すること。
 Assert-ValidConsumerCwd
 
-# 引数なし起動時（-Mode 未指定）の対話ウィザード（REQ-009-040）
+# 引数なし起動時（-Mode 未指定）の対話ウィザード（REQ-{NNNN}-{NNN}）
 if (-not $Mode) {
     Invoke-InstallWizard
 }


### PR DESCRIPTION
# 概要

Stage Aで保護されたconsumer導入スクリプトから、配布物に残っていた具体的な内部IDを除去します。
実行ロジック、パス、終了コード、checker、保護ポリシー、allowlistは変更しません。

## 変更範囲

- `scripts/check-consumer-opencode.ps1` のコメントとコメントベースhelpをテンプレートIDへ一般化
- `scripts/install-consumer-opencode.ps1` のコメントとコメントベースhelpをテンプレートIDへ一般化

## 検証

- PowerShell parser: 2ファイルとも構文エラー0
- 非コメント実行トークン: baseとcandidateで完全一致
- concrete ID grep: 0件
- consumer導入関連テスト: 10 pass / 0 fail
- `git diff --check`: clean
- focused Oracle review: PASS
- review-work 5 lanes: 5/5 PASS

## 信頼アンカー更新

このPRは保護対象ファイルの一回限りの信頼アンカー更新です。
merge後のmain OIDを新しいbase OIDとして固定し、通常の保護ポリシーを再適用します。

Refs: #2092
