### PR TITLE
fix(integrity): trusted distribution-boundary detector hardening (Issue #2092)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-model.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-model.test.ts
@@ -1,0 +1,68 @@
+// Direct tests for boundary-candidate-model.ts: the typed Candidate union,
+// resolution switch, URL/path helpers. These import from the leaf module
+// directly (not via the pipeline barrel) to pin the module contract.
+
+import { describe, expect, test } from "bun:test";
+import {
+  extractOwnerRepo,
+  isConcreteDocsPath,
+  isProducerOwnedUrl,
+  matchedForCandidate,
+  normalizePathToken,
+  resolveCandidate,
+  type DetectorConfig,
+  type RepositoryIdentity,
+} from "./boundary-candidate-model.ts";
+
+const ident: RepositoryIdentity = { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" };
+const cfg: DetectorConfig = {
+  repository_identity: ident,
+  producer_internal_id_prefixes: ["ADR", "REQ"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+const S = { start: 0, end: 1 };
+
+describe("candidate-model / resolveCandidate exhaustive", () => {
+  test("direct producer-id -> producer-internal/concrete-id", () => {
+    expect(resolveCandidate({ type: "direct-id", value: "ADR-1", span: S }, cfg)).toEqual({
+      classification: "producer-internal", category: "concrete-id",
+    });
+  });
+  test("reconstructed producer-id -> producer-internal/evasion-attempt", () => {
+    expect(resolveCandidate({ type: "reconstructed-id", value: "ADR-1", original: "x", span: S }, cfg)).toEqual({
+      classification: "producer-internal", category: "evasion-attempt",
+    });
+  });
+  test("overflow -> unclassified/evasion-attempt (fail-closed)", () => {
+    expect(resolveCandidate({ type: "overflow", reason: "token-ids-exceeded" }, cfg)).toEqual({
+      classification: "unclassified", category: "evasion-attempt",
+    });
+  });
+});
+
+describe("candidate-model / matchedForCandidate", () => {
+  test("overflow matched carries the typed reason string", () => {
+    expect(matchedForCandidate({ type: "overflow", reason: "line-scan-exceeded" })).toContain("[overflow");
+  });
+});
+
+describe("candidate-model / URL helpers", () => {
+  test("extractOwnerRepo parses owner/repo", () => {
+    expect(extractOwnerRepo("https://github.com/vercel/next.js/blob/main/x.ts")).toBe("vercel/next.js");
+  });
+  test("isProducerOwnedUrl matches own repo case-insensitively", () => {
+    expect(isProducerOwnedUrl("https://github.com/Yogata/Agent-Dev-Flow/blob/main/x.md", ident)).toBe(true);
+    expect(isProducerOwnedUrl("https://github.com/vercel/next.js/blob/main/x.md", ident)).toBe(false);
+  });
+});
+
+describe("candidate-model / path helpers", () => {
+  test("normalizePathToken converts backslash and percent-slash", () => {
+    expect(normalizePathToken("docs\\x%2fy.md")).toBe("docs/x/y.md");
+  });
+  test("isConcreteDocsPath accepts concrete .md, rejects README/template/glob", () => {
+    expect(isConcreteDocsPath("docs/adr/ADR-1.md")).toBe(true);
+    expect(isConcreteDocsPath("docs/adr/README.md")).toBe(false);
+    expect(isConcreteDocsPath("docs/specs/<d>/x.md")).toBe(false);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-model.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-model.ts
@@ -135,7 +135,7 @@ export function isProducerOwnedUrl(url: string, identity: RepositoryIdentity): b
 
 /** Normalize backslashes and percent-encoded slashes to forward slashes. */
 export function normalizePathToken(token: string): string {
-  return token.replace(/\\/g, "/").replace(/%2[fF]/g, "/");
+  return token.replace(/\\/g, "/").replace(/%2[fF]/g, "/").replace(/%5[cC]/g, "/");
 }
 
 /** True when a docs path token is a CONCRETE .md file (not index/template/glob). */

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-model.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-model.ts
@@ -73,7 +73,7 @@ export type Candidate =
     readonly span: Span;
   }
   | { readonly type: "path"; readonly value: string; readonly span: Span }
-  | { readonly type: "url"; readonly value: string; readonly span: Span }
+  | { readonly type: "url"; readonly value: string; readonly span: Span; readonly malformed: boolean }
   | { readonly type: "overflow"; readonly reason: OverflowReason };
 
 export type CandidateType = Candidate["type"];
@@ -190,6 +190,9 @@ export function resolveCandidate(c: Candidate, cfg: DetectorConfig): {
       return { classification: "generic-or-template", category: "concrete-path" };
     }
     case "url": {
+      if (c.malformed) {
+        return { classification: "unclassified", category: "evasion-attempt" };
+      }
       // Classify by repository identity, NOT by path content. A URL into
       // the producer repo is producer-internal at any path; a URL into a
       // different repo is consumer-resolvable. An empty identity fails closed.

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-model.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-model.ts
@@ -1,0 +1,234 @@
+// Candidate model and resolution: the typed Candidate union, the URL/path
+// classification helpers, and the resolveCandidate switch. Extracted from
+// boundary-pipeline.ts to keep that module under the 250 pure LOC ceiling
+// (parent defect #12). One responsibility: turning a candidate into a
+// classification + category.
+//
+// DAG position: types -> reconstruction -> ownership -> candidate-model ->
+// pipeline -> gate -> runner. This module imports from ownership (Span) and
+// reconstruction (ReconstructionOverflowReason); nothing downstream of
+// pipeline imports it directly except via pipeline's re-exports.
+//
+// Side-effect-free: no I/O, pure over inputs and config.
+
+import type {
+  DependencyClass,
+  Detection,
+  DetectionCategory,
+  Projection,
+} from "./types.ts";
+import type {
+  ReconstructionOverflowReason,
+} from "./boundary-reconstruction.ts";
+import type {
+  CandidatePrecedence,
+  Span,
+} from "./boundary-candidate-ownership.ts";
+
+// ---------------------------------------------------------------------------
+// Configuration types
+// ---------------------------------------------------------------------------
+
+export interface RepositoryIdentity {
+  readonly owner_slash_name: string;
+  readonly default_branch: string;
+}
+
+export interface DetectorConfig {
+  readonly repository_identity: RepositoryIdentity;
+  readonly producer_internal_id_prefixes: readonly string[];
+  readonly distributed_workflow_control_prefixes: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Candidate model
+// ---------------------------------------------------------------------------
+
+/** Exhaustive reasons detectCandidates/decideProjection turns a typed overflow. */
+export type OverflowReason =
+  | "candidate-cap-exceeded"
+  | "projection-detections-exceeded"
+  | ReconstructionOverflowReason;
+
+export const OVERFLOW_MATCHED: Record<OverflowReason, string> = {
+  "candidate-cap-exceeded": "[overflow: candidate bound exceeded]",
+  "projection-detections-exceeded": "[overflow: projection detections bound exceeded]",
+  "token-ids-exceeded": "[overflow: token id bound exceeded]",
+  "line-scan-exceeded": "[overflow: line scan bound exceeded]",
+};
+
+// Candidate is a discriminated object union so the resolver can switch
+// exhaustively at compile time. Every spanned candidate carries a UTF-16
+// half-open [start, end) source span used by the ownership stage.
+export type Candidate =
+  | { readonly type: "direct-id"; readonly value: string; readonly span: Span }
+  | {
+    readonly type: "reconstructed-id";
+    readonly value: string;
+    readonly original: string;
+    readonly span: Span;
+  }
+  | { readonly type: "path"; readonly value: string; readonly span: Span }
+  | { readonly type: "url"; readonly value: string; readonly span: Span }
+  | { readonly type: "overflow"; readonly reason: OverflowReason };
+
+export type CandidateType = Candidate["type"];
+
+function assertNeverCandidate(c: never): never {
+  throw new Error(`unhandled candidate: ${JSON.stringify(c)}`);
+}
+
+export function precedenceFor(type: CandidateType): CandidatePrecedence {
+  switch (type) {
+    case "url": return "url";
+    case "path": return "path";
+    case "reconstructed-id": return "reconstructed";
+    case "direct-id": return "direct";
+    case "overflow": return "direct";
+    default: return assertNeverCandidate(type);
+  }
+}
+
+export function matchedForCandidate(c: Candidate): string {
+  switch (c.type) {
+    case "direct-id":
+      return c.value;
+    case "reconstructed-id":
+      return c.original;
+    case "path":
+      return c.value;
+    case "url":
+      return c.value;
+    case "overflow":
+      return OVERFLOW_MATCHED[c.reason];
+    default:
+      return assertNeverCandidate(c);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// URL classification helpers
+// ---------------------------------------------------------------------------
+
+export const URL_CANDIDATE_PATTERN =
+  /(?:github\.com\/[A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+\/(?:blob|raw)\/|raw\.githubusercontent\.com\/[A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+\/)[^\s)\]\\"'`<>{}]+/g;
+
+/** Extract the `owner/repo` segment from a GitHub blob/raw URL, or null. */
+export function extractOwnerRepo(url: string): string | null {
+  const m = /(?:github\.com\/|raw\.githubusercontent\.com\/)([A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+)\//.exec(url);
+  if (!m) return null;
+  return m[1] ?? null;
+}
+
+/** True when the URL points into the producer's own repo (case-insensitive). */
+export function isProducerOwnedUrl(url: string, identity: RepositoryIdentity): boolean {
+  if (identity.owner_slash_name.length === 0) return false;
+  const ownerRepo = extractOwnerRepo(url);
+  if (ownerRepo === null) return false;
+  return ownerRepo.toLowerCase() === identity.owner_slash_name.toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Path classification helpers
+// ---------------------------------------------------------------------------
+
+export const DOCS_PATH_PATTERN = /docs[\\/](?:adr|requirements|specs|decisions)[\\/][^\s)\]\|\\"'`<>{}]+/g;
+export const DOCS_PATH_PERCENT_PATTERN = /docs%2[Ff](?:adr|requirements|specs|decisions)%2[Ff][^\s)\]\|\\"'`<>{}]+/g;
+
+/** Normalize backslashes and percent-encoded slashes to forward slashes. */
+export function normalizePathToken(token: string): string {
+  return token.replace(/\\/g, "/").replace(/%2[fF]/g, "/");
+}
+
+/** True when a docs path token is a CONCRETE .md file (not index/template/glob). */
+export function isConcreteDocsPath(token: string): boolean {
+  const normalized = normalizePathToken(token);
+  if (normalized.endsWith("/README.md")) return false;
+  if (/[<>{}]/.test(normalized)) return false;
+  if (normalized.includes("*")) return false;
+  if (!normalized.endsWith(".md")) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Resolution: candidate -> classification + category
+// ---------------------------------------------------------------------------
+
+export function resolveCandidate(c: Candidate, cfg: DetectorConfig): {
+  classification: DependencyClass;
+  category: DetectionCategory;
+} {
+  switch (c.type) {
+    case "direct-id": {
+      const m = /^([A-Z]{2,})-\d{1,}$/.exec(c.value);
+      if (!m) {
+        return { classification: "unclassified", category: "unclassified-entry" };
+      }
+      const prefix = m[1] ?? "";
+      if (cfg.producer_internal_id_prefixes.includes(prefix)) {
+        return { classification: "producer-internal", category: "concrete-id" };
+      }
+      if (cfg.distributed_workflow_control_prefixes.includes(prefix)) {
+        return { classification: "generic-or-template", category: "distributed-control" };
+      }
+      return { classification: "unclassified", category: "unclassified-entry" };
+    }
+    case "reconstructed-id": {
+      const m = /^([A-Z]{2,})-\d{1,}$/.exec(c.value);
+      if (!m) {
+        return { classification: "unclassified", category: "evasion-attempt" };
+      }
+      const prefix = m[1] ?? "";
+      // Producer wins over distributed on overlap.
+      if (cfg.producer_internal_id_prefixes.includes(prefix)) {
+        return { classification: "producer-internal", category: "evasion-attempt" };
+      }
+      return { classification: "unclassified", category: "evasion-attempt" };
+    }
+    case "path": {
+      if (isConcreteDocsPath(c.value)) {
+        return { classification: "producer-internal", category: "concrete-path" };
+      }
+      return { classification: "generic-or-template", category: "concrete-path" };
+    }
+    case "url": {
+      // Classify by repository identity, NOT by path content. A URL into
+      // the producer repo is producer-internal at any path; a URL into a
+      // different repo is consumer-resolvable. An empty identity fails closed.
+      if (cfg.repository_identity.owner_slash_name.length === 0) {
+        return { classification: "unclassified", category: "unclassified-entry" };
+      }
+      if (isProducerOwnedUrl(c.value, cfg.repository_identity)) {
+        return { classification: "producer-internal", category: "fixed-url" };
+      }
+      return { classification: "consumer-resolvable", category: "fixed-url" };
+    }
+    case "overflow": {
+      return { classification: "unclassified", category: "evasion-attempt" };
+    }
+    default:
+      return assertNeverCandidate(c);
+  }
+}
+
+/**
+ * Build a typed projection-overflow Detection. Used by the gate when the
+ * per-projection detection cap (combined failures + errors) is reached: one
+ * is appended and classification stops. Evidence fields are empty/bounded
+ * because the overflow is structural, not line-specific.
+ */
+export function projectionOverflowDetection(
+  filePath: string,
+  projection: Projection,
+): Detection {
+  return {
+    text: "",
+    line: 0,
+    file: filePath,
+    projection,
+    classification: "unclassified",
+    matched: OVERFLOW_MATCHED["projection-detections-exceeded"],
+    snippet: "",
+    category: "evasion-attempt",
+  };
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-model.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-model.ts
@@ -73,7 +73,7 @@ export type Candidate =
     readonly span: Span;
   }
   | { readonly type: "path"; readonly value: string; readonly span: Span }
-  | { readonly type: "url"; readonly value: string; readonly span: Span; readonly malformed: boolean }
+  | { readonly type: "url"; readonly value: string; readonly span: Span; readonly ownershipSpan: Span | null; readonly malformed: boolean }
   | { readonly type: "overflow"; readonly reason: OverflowReason };
 
 export type CandidateType = Candidate["type"];

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-model.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-model.ts
@@ -24,6 +24,10 @@ import type {
   CandidatePrecedence,
   Span,
 } from "./boundary-candidate-ownership.ts";
+import {
+  extractOwnerRepo as authorityExtractOwnerRepo,
+  isProducerOwnedUrl as authorityIsProducerOwnedUrl,
+} from "./boundary-url-parser.ts";
 
 // ---------------------------------------------------------------------------
 // Configuration types
@@ -110,30 +114,24 @@ export function matchedForCandidate(c: Candidate): string {
 // URL classification helpers
 // ---------------------------------------------------------------------------
 
-export const URL_CANDIDATE_PATTERN =
-  /(?:github\.com\/[A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+\/(?:blob|raw)\/|raw\.githubusercontent\.com\/[A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+\/)[^\s)\]\\"'`<>{}]+/g;
-
-/** Extract the `owner/repo` segment from a GitHub blob/raw URL, or null. */
+/**
+ * Extract `owner/repo` from a URL whose host is exactly `github.com` or
+ * `raw.githubusercontent.com` (case-insensitive). Authority-aware: strips
+ * userinfo via last `@`, rejects port form, and rejects host suffix /
+ * subdomain / path / userinfo-deception lookalikes by returning null.
+ */
 export function extractOwnerRepo(url: string): string | null {
-  const m = /(?:github\.com\/|raw\.githubusercontent\.com\/)([A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+)\//.exec(url);
-  if (!m) return null;
-  return m[1] ?? null;
+  return authorityExtractOwnerRepo(url);
 }
 
 /** True when the URL points into the producer's own repo (case-insensitive). */
 export function isProducerOwnedUrl(url: string, identity: RepositoryIdentity): boolean {
-  if (identity.owner_slash_name.length === 0) return false;
-  const ownerRepo = extractOwnerRepo(url);
-  if (ownerRepo === null) return false;
-  return ownerRepo.toLowerCase() === identity.owner_slash_name.toLowerCase();
+  return authorityIsProducerOwnedUrl(url, identity);
 }
 
 // ---------------------------------------------------------------------------
 // Path classification helpers
 // ---------------------------------------------------------------------------
-
-export const DOCS_PATH_PATTERN = /docs[\\/](?:adr|requirements|specs|decisions)[\\/][^\s)\]\|\\"'`<>{}]+/g;
-export const DOCS_PATH_PERCENT_PATTERN = /docs%2[Ff](?:adr|requirements|specs|decisions)%2[Ff][^\s)\]\|\\"'`<>{}]+/g;
 
 /** Normalize backslashes and percent-encoded slashes to forward slashes. */
 export function normalizePathToken(token: string): string {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-ownership.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-ownership.ts
@@ -31,9 +31,17 @@ export type CandidatePrecedence = "url" | "path" | "reconstructed" | "direct";
  * spanned candidate to this shape so this module has no dependency on the
  * Candidate union (keeps the import graph acyclic: types -> reconstruction ->
  * ownership -> pipeline -> gate -> runner).
+ *
+ * `span` is the classification-evidence span (used for the
+ * reconstructed-over-direct overlap rule and for the precedence sort).
+ * `ownershipSpan` is the suppression range used by keepers to contain
+ * lower-precedence entries: `null` means the keeper suppresses nothing
+ * (e.g. malformed URLs); when omitted, defaults to `span` for non-URL
+ * keepers (path/reconstructed).
  */
 export interface OwnershipEntry {
   readonly span: Span;
+  readonly ownershipSpan: Span | null;
   readonly precedence: CandidatePrecedence;
 }
 
@@ -59,9 +67,11 @@ function overlaps(a: Span, b: Span): boolean {
  * `mask[i]` is true. Entries are evaluated in precedence order (url first);
  * among equal precedence, input order is preserved (stable).
  *
- * A direct entry is suppressed when ANY surviving keeper contains it (for
- * url/path keepers) or overlaps it (for reconstructed keepers). All other
- * precedences are suppressed only by containment in a surviving higher keeper.
+ * Keeper containment uses `ownershipSpan`: a URL keeper with `ownershipSpan
+ * === null` (malformed) suppresses nothing; a URL keeper with a path-only
+ * `ownershipSpan` suppresses only entries whose `span` lies fully inside
+ * that path region. The reconstructed-over-direct rule still uses the
+ * reconstructed keeper's `span` (its evidence span).
  */
 export function ownershipMask(entries: readonly OwnershipEntry[]): boolean[] {
   const order = entries
@@ -72,22 +82,22 @@ export function ownershipMask(entries: readonly OwnershipEntry[]): boolean[] {
       return ra !== rb ? ra - rb : a.idx - b.idx;
     });
 
-  const keepers: Array<{ span: Span; precedence: CandidatePrecedence }> = [];
+  const keepers: Array<{ suppressSpan: Span | null; overlapSpan: Span; precedence: CandidatePrecedence }> = [];
   const mask = new Array<boolean>(entries.length).fill(false);
 
   for (const { entry, idx } of order) {
     let suppressed = false;
     for (const k of keepers) {
       if (entry.precedence === "direct" && k.precedence === "reconstructed") {
-        if (overlaps(k.span, entry.span)) { suppressed = true; break; }
-      } else if (contains(k.span, entry.span)) {
+        if (overlaps(k.overlapSpan, entry.span)) { suppressed = true; break; }
+      } else if (k.suppressSpan !== null && contains(k.suppressSpan, entry.span)) {
         suppressed = true;
         break;
       }
     }
     if (!suppressed) {
       mask[idx] = true;
-      keepers.push({ span: entry.span, precedence: entry.precedence });
+      keepers.push({ suppressSpan: entry.ownershipSpan, overlapSpan: entry.span, precedence: entry.precedence });
     }
   }
   return mask;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-ownership.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-candidate-ownership.ts
@@ -1,0 +1,94 @@
+// Candidate ownership: span-based suppression that resolves which candidate
+// "owns" a given source region. Extracted from boundary-pipeline.ts to keep
+// that module under the 250 pure LOC ceiling (parent defect #12) and to make
+// the ownership contract independently testable.
+//
+// Ownership order (highest precedence wins):
+//   URL > path > reconstructed > direct
+//
+// Rules (UTF-16 half-open [start, end) spans):
+//   - A URL suppresses every path/reconstructed/direct candidate whose span
+//     is FULLY CONTAINED in the URL span. The URL is classified by its owner
+//     alone; embedded IDs/paths are represented by the URL, not double-counted.
+//   - A path suppresses every reconstructed/direct candidate whose span is
+//     fully contained in the path span.
+//   - A reconstructed candidate suppresses every direct candidate whose span
+//     OVERLAPS it (conflicting overlap: reconstructed wins; same value is a
+//     dedup with the same outcome — the direct is dropped).
+//
+// Side-effect-free: pure over the input entries.
+
+/** UTF-16 half-open source span [start, end). */
+export interface Span {
+  readonly start: number;
+  readonly end: number;
+}
+
+export type CandidatePrecedence = "url" | "path" | "reconstructed" | "direct";
+
+/**
+ * Minimal ownership projection of a candidate. The pipeline maps each
+ * spanned candidate to this shape so this module has no dependency on the
+ * Candidate union (keeps the import graph acyclic: types -> reconstruction ->
+ * ownership -> pipeline -> gate -> runner).
+ */
+export interface OwnershipEntry {
+  readonly span: Span;
+  readonly precedence: CandidatePrecedence;
+}
+
+const PRECEDENCE_RANK: Record<CandidatePrecedence, number> = {
+  url: 0,
+  path: 1,
+  reconstructed: 2,
+  direct: 3,
+};
+
+/** True when `outer` fully contains `inner` (inclusive bounds). */
+function contains(outer: Span, inner: Span): boolean {
+  return outer.start <= inner.start && inner.end <= outer.end;
+}
+
+/** True when the two half-open spans share at least one position. */
+function overlaps(a: Span, b: Span): boolean {
+  return a.start < b.end && b.start < a.end;
+}
+
+/**
+ * Compute a keep-mask aligned with the input order. Entry `i` survives when
+ * `mask[i]` is true. Entries are evaluated in precedence order (url first);
+ * among equal precedence, input order is preserved (stable).
+ *
+ * A direct entry is suppressed when ANY surviving keeper contains it (for
+ * url/path keepers) or overlaps it (for reconstructed keepers). All other
+ * precedences are suppressed only by containment in a surviving higher keeper.
+ */
+export function ownershipMask(entries: readonly OwnershipEntry[]): boolean[] {
+  const order = entries
+    .map((entry, idx) => ({ entry, idx }))
+    .sort((a, b) => {
+      const ra = PRECEDENCE_RANK[a.entry.precedence];
+      const rb = PRECEDENCE_RANK[b.entry.precedence];
+      return ra !== rb ? ra - rb : a.idx - b.idx;
+    });
+
+  const keepers: Array<{ span: Span; precedence: CandidatePrecedence }> = [];
+  const mask = new Array<boolean>(entries.length).fill(false);
+
+  for (const { entry, idx } of order) {
+    let suppressed = false;
+    for (const k of keepers) {
+      if (entry.precedence === "direct" && k.precedence === "reconstructed") {
+        if (overlaps(k.span, entry.span)) { suppressed = true; break; }
+      } else if (contains(k.span, entry.span)) {
+        suppressed = true;
+        break;
+      }
+    }
+    if (!suppressed) {
+      mask[idx] = true;
+      keepers.push({ span: entry.span, precedence: entry.precedence });
+    }
+  }
+  return mask;
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
@@ -112,18 +112,26 @@ function isValidRelativePrefix(line: string, pos: number): boolean {
 }
 
 /**
- * Parse the strict relative path prefix grammar: (("."|"..") separator)+
- * scanning backwards from `pos`. Returns true when the grammar matches.
+ * Parse the strict relative path prefix grammar:
+ * (("."|"..") separator+)+ scanning backwards from `pos`.
+ * Consecutive separators (e.g. /\) are allowed between dot-segments.
+ * Returns true when the grammar matches.
  */
 function parseRelativePrefix(line: string, pos: number): boolean {
   let p = pos - 1;
   let hasValidPair = false;
 
   while (p >= 0) {
-    const separatorLen = matchSeparatorBackward(line, p);
+    // Consume one or more consecutive separators.
+    let separatorLen = matchSeparatorBackward(line, p);
     if (separatorLen === 0) break;
 
-    p -= separatorLen;
+    while (separatorLen > 0) {
+      p -= separatorLen;
+      separatorLen = p >= 0 ? matchSeparatorBackward(line, p) : 0;
+    }
+
+    if (p < 0) break;
 
     const dotSegment = matchDotSegmentBackward(line, p);
     if (dotSegment === 0) break;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
@@ -31,7 +31,11 @@
 import type { Span } from "./boundary-candidate-ownership.ts";
 
 const DOCS_FAMILIES: readonly string[] = ["adr", "requirements", "specs", "decisions"];
-const PATH_STOP_CHAR = /[\s)\]\|"'`<>{},;:#?!。 、！]/;
+// Same CJK punctuation set as LEFT_BOUNDARY (U+FF1A, U+FF1B, U+FF0C,
+// U+FF1F, U+2014): when these terminate a docs path's content, the scan
+// must stop so the `.md` endpoint is recognized instead of leaking the
+// path as `foo.md<fullwidth>end` (review-v8 blocker #1).
+const PATH_STOP_CHAR = /[\s)\]\|"'`<>{},;:#?!。 、！\uFF1A\uFF1B\uFF0C\uFF1F\u2014]/;
 
 export interface ExtractedPath {
   readonly value: string;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
@@ -1,0 +1,137 @@
+// Bounded docs-path extractor for the distribution boundary detector.
+//
+// Extracted from boundary-candidate-model.ts so the path lexer is
+// independently testable and the candidate-model stays under the 250
+// pure LOC ceiling. One responsibility: turn a line into docs-path
+// candidate spans whose concrete evidence terminates at an actual `.md`
+// endpoint.
+//
+// Lexing contract (fresh-review blocker D4 + D5):
+//   - Standalone left boundary: `docs` must NOT be preceded by an
+//     identifier char (`[A-Za-z0-9_-]`) or a path separator (`/`, `\`).
+//     Identifier predecessors reject `mydocs`; separator predecessors
+//     reject `docs` inside a URL/host path (the URL owns the region).
+//   - One-or-more mixed separators after `docs` and after the family
+//     name: `/`, `\`, `%2F` (case-insensitive on the hex digit).
+//   - Directory family names are case-sensitive: `adr | requirements |
+//     specs | decisions`. `Requirements` and `SPECS` are NOT matched.
+//   - Concrete evidence terminates at the actual `.md` endpoint. Query
+//     (`?`), fragment (`#`), and terminal punctuation (`,`, `;`, `:`,
+//     Japanese `。`, `、`, etc.) terminate the path scan BEFORE `.md`,
+//     so the matched path ends at `.md`. A trailing `.` (sentence-final)
+//     is recognized when it is the only thing after `.md` and is not
+//     followed by an alphanumeric path-valid char (so `foo.md.` and
+//     `foo.md.,` truncate to `foo.md`, but `foo.md.bak` does not match
+//     because `.bak` is a continuation).
+//   - `.md.bak` is therefore NOT emitted: there is no `.md` endpoint
+//     whose suffix is empty or all terminal-period (`.`) chars.
+//
+// Side-effect-free: pure over inputs.
+
+import type { Span } from "./boundary-candidate-ownership.ts";
+
+const DOCS_FAMILIES: readonly string[] = ["adr", "requirements", "specs", "decisions"];
+const IDENT_OR_SEPARATOR_CHAR = /[A-Za-z0-9_\-\\/]/;
+const PATH_STOP_CHAR = /[\s)\]\|"'`<>{},;:#?!。 、！]/;
+
+export interface ExtractedPath {
+  readonly value: string;
+  readonly span: Span;
+}
+
+/**
+ * Scan one or more mixed separators starting at `pos`. Returns the new
+ * position; identical to `pos` when no separator is present.
+ */
+function scanSeparators(line: string, pos: number): number {
+  let p = pos;
+  while (p < line.length) {
+    const c = line.charAt(p);
+    if (c === "/" || c === "\\") { p += 1; continue; }
+    if (c === "%" && p + 2 < line.length) {
+      const c1 = line.charAt(p + 1);
+      const c2 = line.charAt(p + 2);
+      if (c1 === "2" && (c2 === "F" || c2 === "f")) { p += 3; continue; }
+    }
+    break;
+  }
+  return p;
+}
+
+/** Case-sensitive family match at `pos`, or null. */
+function matchFamily(line: string, pos: number): string | null {
+  for (const family of DOCS_FAMILIES) {
+    if (line.length - pos >= family.length && line.startsWith(family, pos)) {
+      return family;
+    }
+  }
+  return null;
+}
+
+/**
+ * Find the `.md` endpoint in the path-content string, returning its
+ * starting index, or -1 when none. The endpoint is the LATEST `.md`
+ * whose suffix is empty OR consists solely of `.` chars (sentence-final
+ * periods). `.md.bak` does not qualify (suffix `.bak` is not all `.`).
+ */
+function findMdEndpoint(content: string): number {
+  const positions: number[] = [];
+  let idx = content.indexOf(".md");
+  while (idx >= 0) {
+    positions.push(idx);
+    idx = content.indexOf(".md", idx + 1);
+  }
+  for (let i = positions.length - 1; i >= 0; i--) {
+    const pos = positions[i];
+    if (pos === undefined) continue;
+    const after = content.substring(pos + 3);
+    if (after.length === 0 || /^[.]*$/.test(after)) return pos;
+  }
+  return -1;
+}
+
+/**
+ * Scan a line for docs-path candidates. Returns at most `cap` entries;
+ * the boolean `overflow` flag is set when the cap is reached mid-scan
+ * (caller MUST surface a typed overflow; ownership never suppresses it).
+ *
+ * Each emitted path's value terminates exactly at `.md` (no trailing
+ * query/fragment/punctuation).
+ */
+export function extractDocsPaths(line: string, cap: number): {
+  readonly paths: readonly ExtractedPath[];
+  readonly overflow: boolean;
+} {
+  const out: ExtractedPath[] = [];
+  let searchFrom = 0;
+  while (true) {
+    const docsIdx = line.indexOf("docs", searchFrom);
+    if (docsIdx < 0) break;
+    searchFrom = docsIdx + 1;
+    // Left boundary: preceding char must NOT be an identifier or path separator.
+    if (docsIdx > 0 && IDENT_OR_SEPARATOR_CHAR.test(line.charAt(docsIdx - 1))) continue;
+    // After `docs`, expect one or more separators.
+    let pos = scanSeparators(line, docsIdx + 4);
+    if (pos === docsIdx + 4) continue;
+    // Then family (case-sensitive).
+    const family = matchFamily(line, pos);
+    if (family === null) continue;
+    pos += family.length;
+    // Then one or more separators.
+    const afterFamily = pos;
+    pos = scanSeparators(line, pos);
+    if (pos === afterFamily) continue;
+    // Then path content until a lexical endpoint. Backslashes, percent
+    // encoding, and non-ASCII filename characters remain part of the path.
+    const contentStart = pos;
+    while (pos < line.length && !PATH_STOP_CHAR.test(line.charAt(pos))) pos += 1;
+    const content = line.substring(contentStart, pos);
+    // Concrete .md endpoint must exist in content.
+    const mdIdx = findMdEndpoint(content);
+    if (mdIdx < 0) continue;
+    const pathEnd = contentStart + mdIdx + 3; // 3 = ".md".length
+    if (out.length >= cap) return { paths: out, overflow: true };
+    out.push({ value: line.substring(docsIdx, pathEnd), span: { start: docsIdx, end: pathEnd } });
+  }
+  return { paths: out, overflow: false };
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
@@ -91,63 +91,115 @@ function findMdEndpoint(content: string): number {
 }
 
 /**
- * Scan backwards from `pos` to validate that the prefix consists only of
- * valid relative path dot-segments (., ..) mixed with separators (/ or \).
- * Returns true when the prefix is a valid relative path (or empty).
- * Rejects absolute paths (starts with / or \ at index 0) and identifier prefixes.
+ * Strict grammar check for relative path prefix: (("."|"..") separator)+
+ * where separator is /, \, %2F, %2f, %5C, or %5c.
+ * Accepts empty prefix (docs at line start or after a plain boundary char).
+ * Rejects: .../docs, ..../docs, %2Fdocs (no dot), a/../docs (identifier prefix),
+ * /docs, \docs (absolute paths).
  */
 function isValidRelativePrefix(line: string, pos: number): boolean {
-  if (pos === 0) return true; // docs at line start is valid
+  if (pos === 0) return true;
+
   const beforeDocs = line.charAt(pos - 1);
-  if (beforeDocs === '/' || beforeDocs === '\\') {
-    // Reject absolute paths: separator at index 0 means /docs or \docs
-    if (pos - 1 === 0) return false;
-    // Check for dot-segments before the separator; reject if none found
-    let p = pos - 2;
-    let foundDot = false;
-    while (p >= 0) {
-      const c = line.charAt(p);
-      if (c === '/') {
-        if (p === 0) return false;
-        p -= 1;
-      } else if (c === '\\') {
-        if (p === 0) return false;
-        p -= 1;
-      } else if (c === '.') {
-        foundDot = true;
-        p -= 1;
-      } else if (/[A-Za-z0-9_-]/.test(c)) {
-        return false;
-      } else {
-        break;
-      }
-    }
-    // Valid relative path must have at least one dot-segment (e.g., ./ or ../)
-    return foundDot;
-  }
-  if (beforeDocs === '.' && pos < line.length) {
-    const afterDot = line.charAt(pos);
-    if (afterDot === '/' || afterDot === '\\') {
-      // Check that everything before the dot is valid dot-segments
-      let p = pos - 2;
-      while (p >= 0) {
-        const c = line.charAt(p);
-        if (c === '.' || c === '/' || c === '\\') {
-          p -= 1;
-        } else if (/[A-Za-z0-9_-]/.test(c)) {
-          return false;
-        } else {
-          break;
-        }
-      }
-      return true;
-    }
-  }
-  // Accept boundary characters (space, etc.) before docs
-  if (/\s/.test(beforeDocs) || /[)\]\|'"`<>{},;:#?!。、！]/.test(beforeDocs)) {
+  if (/[\s)\]\|'"`<>{},;:#?!。 、！]/.test(beforeDocs)) {
     return true;
   }
+  if (/\(/.test(beforeDocs) || /\[/.test(beforeDocs) || /=/.test(beforeDocs) || /&/.test(beforeDocs)) {
+    return true;
+  }
+
+  return parseRelativePrefix(line, pos);
+}
+
+/**
+ * Parse the strict relative path prefix grammar: (("."|"..") separator)+
+ * scanning backwards from `pos`. Returns true when the grammar matches.
+ */
+function parseRelativePrefix(line: string, pos: number): boolean {
+  let p = pos - 1;
+  let hasValidPair = false;
+
+  while (p >= 0) {
+    const separatorLen = matchSeparatorBackward(line, p);
+    if (separatorLen === 0) break;
+
+    p -= separatorLen;
+
+    const dotSegment = matchDotSegmentBackward(line, p);
+    if (dotSegment === 0) break;
+
+    p -= dotSegment;
+    hasValidPair = true;
+
+    if (p < 0) break;
+
+    const beforePattern = line.charAt(p);
+    if (/[\s(\[]/.test(beforePattern) || /=/.test(beforePattern) || /&/.test(beforePattern)) {
+      break;
+    }
+
+    if (matchSeparatorBackward(line, p) > 0) {
+      continue;
+    }
+
+    break;
+  }
+
+  if (!hasValidPair) return false;
+
+  if (p < 0) return true;
+
+  const beforePattern = line.charAt(p);
+  if (/[\s(\[]/.test(beforePattern) || /=/.test(beforePattern) || /&/.test(beforePattern)) {
+    return true;
+  }
+
   return false;
+}
+
+/**
+ * Match a separator at position `p` scanning backward.
+ * Returns the length of the separator matched (1-3 chars), or 0 if no match.
+ * Recognizes: /, \, %2F, %2f, %5C, %5c
+ */
+function matchSeparatorBackward(line: string, p: number): number {
+  if (p < 0) return 0;
+
+  const c = line.charAt(p);
+  if (c === '/' || c === '\\') {
+    return 1;
+  }
+
+  if (p >= 2) {
+    const c1 = line.charAt(p - 1);
+    const c2 = line.charAt(p - 2);
+    if (c2 === '%' && ((c1 === '2' && (c === 'F' || c === 'f')) || (c1 === '5' && (c === 'C' || c === 'c')))) {
+      return 3;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Match a dot-segment (.) or (..) scanning backward.
+ * Returns the length of the dot-segment matched (1 or 2), or 0 if no match.
+ * Rejects ... and longer dot runs by only matching 1 or 2 dots.
+ */
+function matchDotSegmentBackward(line: string, p: number): number {
+  if (p < 0) return 0;
+
+  const c = line.charAt(p);
+  if (c !== '.') return 0;
+
+  if (p >= 1 && line.charAt(p - 1) === '.') {
+    if (p >= 2 && line.charAt(p - 2) === '.') {
+      return 0;
+    }
+    return 2;
+  }
+
+  return 1;
 }
 
 /**

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
@@ -32,6 +32,7 @@ import type { Span } from "./boundary-candidate-ownership.ts";
 
 const DOCS_FAMILIES: readonly string[] = ["adr", "requirements", "specs", "decisions"];
 const IDENT_OR_SEPARATOR_CHAR = /[A-Za-z0-9_\-\\/]/;
+const SEPARATOR_OR_DOT = /[\/\\\.]/;
 const PATH_STOP_CHAR = /[\s)\]\|"'`<>{},;:#?!。 、！]/;
 
 export interface ExtractedPath {
@@ -108,8 +109,32 @@ export function extractDocsPaths(line: string, cap: number): {
     const docsIdx = line.indexOf("docs", searchFrom);
     if (docsIdx < 0) break;
     searchFrom = docsIdx + 1;
-    // Left boundary: preceding char must NOT be an identifier or path separator.
-    if (docsIdx > 0 && IDENT_OR_SEPARATOR_CHAR.test(line.charAt(docsIdx - 1))) continue;
+    // Left boundary: accept only clean ./ or ../ prefixes (with / or \ separator) before docs.
+    if (docsIdx > 0) {
+      const beforeDocs = line.charAt(docsIdx - 1);
+      if (beforeDocs === '/' || beforeDocs === '\\') {
+        // Check for ./ or ../ prefix (relative path)
+        if (docsIdx >= 2) {
+          const beforeSlash = line.charAt(docsIdx - 2);
+          if (beforeSlash === '.' && (docsIdx < 3 || !SEPARATOR_OR_DOT.test(line.charAt(docsIdx - 3)))) {
+            // Valid: ./docs or .\docs
+          } else if (beforeSlash === '.' && docsIdx >= 3 && line.charAt(docsIdx - 3) === '.' && (docsIdx < 4 || !SEPARATOR_OR_DOT.test(line.charAt(docsIdx - 4)))) {
+            // Valid: ../docs or ..\docs
+          } else {
+            // Invalid: a/docs, //docs, .//docs, a\docs, \\docs, /docs
+            continue;
+          }
+        } else {
+          // Invalid: /docs at index 1
+          continue;
+        }
+      } else if (IDENT_OR_SEPARATOR_CHAR.test(beforeDocs) || beforeDocs === '.') {
+        // Invalid: adocs, .docs
+        continue;
+      }
+    } else {
+      // docs at line start is valid
+    }
     // After `docs`, expect one or more separators.
     let pos = scanSeparators(line, docsIdx + 4);
     if (pos === docsIdx + 4) continue;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
@@ -53,6 +53,7 @@ function scanSeparators(line: string, pos: number): number {
       const c1 = line.charAt(p + 1);
       const c2 = line.charAt(p + 2);
       if (c1 === "2" && (c2 === "F" || c2 === "f")) { p += 3; continue; }
+      if (c1 === "5" && (c2 === "C" || c2 === "c")) { p += 3; continue; }
     }
     break;
   }
@@ -92,6 +93,66 @@ function findMdEndpoint(content: string): number {
 }
 
 /**
+ * Scan backwards from `pos` to validate that the prefix consists only of
+ * valid relative path dot-segments (., ..) mixed with separators (/ or \).
+ * Returns true when the prefix is a valid relative path (or empty).
+ * Rejects absolute paths (starts with / or \ at index 0) and identifier prefixes.
+ */
+function isValidRelativePrefix(line: string, pos: number): boolean {
+  if (pos === 0) return true; // docs at line start is valid
+  const beforeDocs = line.charAt(pos - 1);
+  if (beforeDocs === '/' || beforeDocs === '\\') {
+    // Reject absolute paths: separator at index 0 means /docs or \docs
+    if (pos - 1 === 0) return false;
+    // Check for dot-segments before the separator; reject if none found
+    let p = pos - 2;
+    let foundDot = false;
+    while (p >= 0) {
+      const c = line.charAt(p);
+      if (c === '/') {
+        if (p === 0) return false;
+        p -= 1;
+      } else if (c === '\\') {
+        if (p === 0) return false;
+        p -= 1;
+      } else if (c === '.') {
+        foundDot = true;
+        p -= 1;
+      } else if (/[A-Za-z0-9_-]/.test(c)) {
+        return false;
+      } else {
+        break;
+      }
+    }
+    // Valid relative path must have at least one dot-segment (e.g., ./ or ../)
+    return foundDot;
+  }
+  if (beforeDocs === '.' && pos < line.length) {
+    const afterDot = line.charAt(pos);
+    if (afterDot === '/' || afterDot === '\\') {
+      // Check that everything before the dot is valid dot-segments
+      let p = pos - 2;
+      while (p >= 0) {
+        const c = line.charAt(p);
+        if (c === '.' || c === '/' || c === '\\') {
+          p -= 1;
+        } else if (/[A-Za-z0-9_-]/.test(c)) {
+          return false;
+        } else {
+          break;
+        }
+      }
+      return true;
+    }
+  }
+  // Accept boundary characters (space, etc.) before docs
+  if (/\s/.test(beforeDocs) || /[)\]\|'"`<>{},;:#?!。、！]/.test(beforeDocs)) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Scan a line for docs-path candidates. Returns at most `cap` entries;
  * the boolean `overflow` flag is set when the cap is reached mid-scan
  * (caller MUST surface a typed overflow; ownership never suppresses it).
@@ -109,32 +170,9 @@ export function extractDocsPaths(line: string, cap: number): {
     const docsIdx = line.indexOf("docs", searchFrom);
     if (docsIdx < 0) break;
     searchFrom = docsIdx + 1;
-    // Left boundary: accept only clean ./ or ../ prefixes (with / or \ separator) before docs.
-    if (docsIdx > 0) {
-      const beforeDocs = line.charAt(docsIdx - 1);
-      if (beforeDocs === '/' || beforeDocs === '\\') {
-        // Check for ./ or ../ prefix (relative path)
-        if (docsIdx >= 2) {
-          const beforeSlash = line.charAt(docsIdx - 2);
-          if (beforeSlash === '.' && (docsIdx < 3 || !SEPARATOR_OR_DOT.test(line.charAt(docsIdx - 3)))) {
-            // Valid: ./docs or .\docs
-          } else if (beforeSlash === '.' && docsIdx >= 3 && line.charAt(docsIdx - 3) === '.' && (docsIdx < 4 || !SEPARATOR_OR_DOT.test(line.charAt(docsIdx - 4)))) {
-            // Valid: ../docs or ..\docs
-          } else {
-            // Invalid: a/docs, //docs, .//docs, a\docs, \\docs, /docs
-            continue;
-          }
-        } else {
-          // Invalid: /docs at index 1
-          continue;
-        }
-      } else if (IDENT_OR_SEPARATOR_CHAR.test(beforeDocs) || beforeDocs === '.') {
-        // Invalid: adocs, .docs
-        continue;
-      }
-    } else {
-      // docs at line start is valid
-    }
+    // Left boundary: accept only valid relative dot-segment prefixes or docs at start.
+    // Reject: a/../docs, .docs, /docs, identifiers before separators.
+    if (!isValidRelativePrefix(line, docsIdx)) continue;
     // After `docs`, expect one or more separators.
     let pos = scanSeparators(line, docsIdx + 4);
     if (pos === docsIdx + 4) continue;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
@@ -104,68 +104,6 @@ function findMdEndpoint(content: string): number {
 const LEFT_BOUNDARY = /[\s(),;:#?!"'`<>{}|[\]=&\u3001\u3002\uFF01\uFF1A\uFF1B\uFF0C\uFF1F\u2014]/;
 
 /**
- * Validate that the text preceding `docs` forms a relative path prefix
- * that resolves to `docs` after dot-segment normalization. Accepts docs
- * at position 0, after a plain boundary char, or after a prefix whose
- * dot-segments collapse to empty (e.g. ./ ../ x/../). Rejects absolute
- * paths (/docs, \docs, %2Fdocs), hostname form (.docs, mydocs), and
- * prefixes that do not resolve to docs (a/docs).
- */
-function isValidRelativePrefix(line: string, pos: number): boolean {
-  if (pos === 0) return true;
-  const beforeDocs = line.charAt(pos - 1);
-  if (LEFT_BOUNDARY.test(beforeDocs)) return true;
-  return prefixResolvesToDocs(line, pos);
-}
-
-/**
- * Path separators for splitting the prefix into segments.
- * Matches /, \, %2F, %2f, %5C, %5c.
- */
-const SEPARATOR_RE = /\/|\\|%2[fF]|%5[cC]/;
-
-/**
- * Backward path-normalization scanner. Collects the prefix between the
- * leftmost boundary char (or line start) and `docs`, splits on path
- * separators, and reduces dot-segments:
- *   "."  -> skip (no-op)
- *   ".." -> cancel the previous normal segment, or accumulate as leading
- *   else -> push as a normal identifier segment
- * Accepts when no normal identifier remains (prefix resolves to docs).
- * Rejects absolute paths (prefix begins with a separator), hostname
- * concatenation (char before `docs` is not a separator), and prefixes
- * where a normal identifier survives normalization.
- */
-function prefixResolvesToDocs(line: string, pos: number): boolean {
-  if (matchSeparatorBackward(line, pos - 1) === 0) return false;
-
-  let p = pos - 1;
-  while (p >= 0) {
-    const sepLen = matchSeparatorBackward(line, p);
-    if (sepLen > 0) { p -= sepLen; continue; }
-    if (LEFT_BOUNDARY.test(line.charAt(p))) break;
-    p -= 1;
-  }
-  const prefixStart = p + 1;
-
-  if (prefixStart < pos && scanSeparators(line, prefixStart) > prefixStart) return false;
-
-  const prefix = line.substring(prefixStart, pos);
-  const stack: string[] = [];
-  for (const seg of prefix.split(SEPARATOR_RE)) {
-    if (seg === "" || seg === ".") continue;
-    if (seg === "..") {
-      const top = stack.length > 0 ? stack[stack.length - 1] : null;
-      if (top !== null && top !== "..") stack.pop();
-      else stack.push("..");
-      continue;
-    }
-    stack.push(seg);
-  }
-  return stack.every((s) => s === "..");
-}
-
-/**
  * Match a separator at position `p` scanning backward.
  * Returns the length of the separator matched (1-3 chars), or 0 if no match.
  * Recognizes: /, \, %2F, %2f, %5C, %5c
@@ -190,6 +128,88 @@ function matchSeparatorBackward(line: string, p: number): number {
 }
 
 /**
+ * Forward linear precompute of prefix validity for every docs candidate
+ * position. prefixValid[i] is true iff a `docs` token at position i has
+ * a valid relative prefix under the same grammar as the original
+ * backward scanner: i === 0, OR the previous char is a LEFT_BOUNDARY,
+ * OR the previous char is a path separator AND the current prefix
+ * region (since the last LEFT_BOUNDARY) does not start with a separator
+ * AND the dot-segment normalization of that prefix leaves zero
+ * surviving normal segments.
+ *
+ * One forward pass maintains `normalCount` (surviving normal segments
+ * after dot-segment reduction), `prefixStart` (start of the current
+ * prefix region), and `prefixAbsolute` (whether the region begins with
+ * a separator). Each docs candidate is answered in O(1) from this
+ * state, giving O(line.length) total. Replaces the per-doc backward
+ * scan that made extractDocsPaths O(n^2) on adversarial input such as
+ * ("a/docs").repeat(n) (review-v8 blocker #4).
+ */
+function precomputePrefixValid(line: string): boolean[] {
+  const prefixValid: boolean[] = new Array(line.length + 1).fill(false);
+  prefixValid[0] = true;
+
+  let normalCount = 0;
+  let segBuf = "";
+  let inSeg = false;
+  let prefixStart = 0;
+  let prefixAbsolute = false;
+
+  let pos = 0;
+  while (pos < line.length) {
+    if (pos > 0) {
+      const prevChar = line.charAt(pos - 1);
+      if (LEFT_BOUNDARY.test(prevChar)) {
+        prefixValid[pos] = true;
+      } else {
+        const sepLenBefore = matchSeparatorBackward(line, pos - 1);
+        prefixValid[pos] = sepLenBefore > 0 && !prefixAbsolute && normalCount === 0;
+      }
+    }
+
+    const c = line.charAt(pos);
+
+    let sepLen = 0;
+    if (c === "/" || c === "\\") {
+      sepLen = 1;
+    } else if (c === "%" && pos + 2 < line.length) {
+      const c1 = line.charAt(pos + 1);
+      const c2 = line.charAt(pos + 2);
+      if ((c1 === "2" && (c2 === "F" || c2 === "f")) || (c1 === "5" && (c2 === "C" || c2 === "c"))) {
+        sepLen = 3;
+      }
+    }
+
+    if (sepLen > 0) {
+      if (inSeg) {
+        if (segBuf === "..") {
+          if (normalCount > 0) normalCount -= 1;
+        } else if (segBuf !== "." && segBuf !== "") {
+          normalCount += 1;
+        }
+      }
+      segBuf = "";
+      inSeg = false;
+      if (pos === prefixStart) prefixAbsolute = true;
+      pos += sepLen;
+    } else if (LEFT_BOUNDARY.test(c)) {
+      normalCount = 0;
+      segBuf = "";
+      inSeg = false;
+      prefixStart = pos + 1;
+      prefixAbsolute = false;
+      pos += 1;
+    } else {
+      segBuf += c;
+      inSeg = true;
+      pos += 1;
+    }
+  }
+
+  return prefixValid;
+}
+
+/**
  * Scan a line for docs-path candidates. Returns at most `cap` entries;
  * the boolean `overflow` flag is set when the cap is reached mid-scan
  * (caller MUST surface a typed overflow; ownership never suppresses it).
@@ -210,6 +230,7 @@ export function extractDocsPaths(
   readonly overflow: boolean;
 } {
   const out: ExtractedPath[] = [];
+  const prefixValid = precomputePrefixValid(line);
   let searchFrom = 0;
   while (true) {
     const docsIdx = line.indexOf("docs", searchFrom);
@@ -217,7 +238,7 @@ export function extractDocsPaths(
     searchFrom = docsIdx + 1;
     // Left boundary: accept only valid relative dot-segment prefixes or docs at start.
     // Reject: a/../docs, .docs, /docs, identifiers before separators.
-    if (!isValidRelativePrefix(line, docsIdx)) continue;
+    if (!prefixValid[docsIdx]) continue;
     // After `docs`, expect one or more separators.
     let pos = scanSeparators(line, docsIdx + 4);
     if (pos === docsIdx + 4) continue;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
@@ -31,8 +31,6 @@
 import type { Span } from "./boundary-candidate-ownership.ts";
 
 const DOCS_FAMILIES: readonly string[] = ["adr", "requirements", "specs", "decisions"];
-const IDENT_OR_SEPARATOR_CHAR = /[A-Za-z0-9_\-\\/]/;
-const SEPARATOR_OR_DOT = /[\/\\\.]/;
 const PATH_STOP_CHAR = /[\s)\]\|"'`<>{},;:#?!。 、！]/;
 
 export interface ExtractedPath {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
@@ -157,8 +157,16 @@ function isValidRelativePrefix(line: string, pos: number): boolean {
  *
  * Each emitted path's value terminates exactly at `.md` (no trailing
  * query/fragment/punctuation).
+ *
+ * @param ownerSpans - Optional readonly array of owner spans. A docs-path
+ * candidate fully contained by ANY owner span is skipped BEFORE the cap
+ * check. Default is an empty array for backward compatibility.
  */
-export function extractDocsPaths(line: string, cap: number): {
+export function extractDocsPaths(
+  line: string,
+  cap: number,
+  ownerSpans: readonly Span[] = [],
+): {
   readonly paths: readonly ExtractedPath[];
   readonly overflow: boolean;
 } {
@@ -191,8 +199,25 @@ export function extractDocsPaths(line: string, cap: number): {
     const mdIdx = findMdEndpoint(content);
     if (mdIdx < 0) continue;
     const pathEnd = contentStart + mdIdx + 3; // 3 = ".md".length
+    const candidateSpan: Span = { start: docsIdx, end: pathEnd };
+
+    // Skip candidates fully contained by any owner span BEFORE cap check.
+    if (isFullyContained(candidateSpan, ownerSpans)) continue;
+
     if (out.length >= cap) return { paths: out, overflow: true };
-    out.push({ value: line.substring(docsIdx, pathEnd), span: { start: docsIdx, end: pathEnd } });
+    out.push({ value: line.substring(docsIdx, pathEnd), span: candidateSpan });
   }
   return { paths: out, overflow: false };
+}
+
+/**
+ * True when `inner` is fully contained by ANY span in `keepers`.
+ * Uses half-open [start, end) bounds: containment requires
+ * keeper.start <= inner.start AND inner.end <= keeper.end.
+ */
+function isFullyContained(inner: Span, keepers: readonly Span[]): boolean {
+  for (const keeper of keepers) {
+    if (keeper.start <= inner.start && inner.end <= keeper.end) return true;
+  }
+  return false;
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-docs-path-parser.ts
@@ -91,78 +91,74 @@ function findMdEndpoint(content: string): number {
 }
 
 /**
- * Strict grammar check for relative path prefix: (("."|"..") separator)+
- * where separator is /, \, %2F, %2f, %5C, or %5c.
- * Accepts empty prefix (docs at line start or after a plain boundary char).
- * Rejects: .../docs, ..../docs, %2Fdocs (no dot), a/../docs (identifier prefix),
- * /docs, \docs (absolute paths).
+ * Left-boundary character set for the `docs` token. Includes ASCII
+ * whitespace/punctuation, CJK punctuation that also terminates URL
+ * scans (URL_STOP_CHAR parity), and Markdown/URL delimiters (( [ = &).
+ * Excludes path separators (/, \) and ASCII dot so they fall through to
+ * the dot-segment normalization scanner.
+ */
+const LEFT_BOUNDARY = /[\s(),;:#?!"'`<>{}|[\]=&\u3001\u3002\uFF01\uFF1A\uFF1B\uFF0C\uFF1F\u2014]/;
+
+/**
+ * Validate that the text preceding `docs` forms a relative path prefix
+ * that resolves to `docs` after dot-segment normalization. Accepts docs
+ * at position 0, after a plain boundary char, or after a prefix whose
+ * dot-segments collapse to empty (e.g. ./ ../ x/../). Rejects absolute
+ * paths (/docs, \docs, %2Fdocs), hostname form (.docs, mydocs), and
+ * prefixes that do not resolve to docs (a/docs).
  */
 function isValidRelativePrefix(line: string, pos: number): boolean {
   if (pos === 0) return true;
-
   const beforeDocs = line.charAt(pos - 1);
-  if (/[\s)\]\|'"`<>{},;:#?!。 、！]/.test(beforeDocs)) {
-    return true;
-  }
-  if (/\(/.test(beforeDocs) || /\[/.test(beforeDocs) || /=/.test(beforeDocs) || /&/.test(beforeDocs)) {
-    return true;
-  }
-
-  return parseRelativePrefix(line, pos);
+  if (LEFT_BOUNDARY.test(beforeDocs)) return true;
+  return prefixResolvesToDocs(line, pos);
 }
 
 /**
- * Parse the strict relative path prefix grammar:
- * (("."|"..") separator+)+ scanning backwards from `pos`.
- * Consecutive separators (e.g. /\) are allowed between dot-segments.
- * Returns true when the grammar matches.
+ * Path separators for splitting the prefix into segments.
+ * Matches /, \, %2F, %2f, %5C, %5c.
  */
-function parseRelativePrefix(line: string, pos: number): boolean {
+const SEPARATOR_RE = /\/|\\|%2[fF]|%5[cC]/;
+
+/**
+ * Backward path-normalization scanner. Collects the prefix between the
+ * leftmost boundary char (or line start) and `docs`, splits on path
+ * separators, and reduces dot-segments:
+ *   "."  -> skip (no-op)
+ *   ".." -> cancel the previous normal segment, or accumulate as leading
+ *   else -> push as a normal identifier segment
+ * Accepts when no normal identifier remains (prefix resolves to docs).
+ * Rejects absolute paths (prefix begins with a separator), hostname
+ * concatenation (char before `docs` is not a separator), and prefixes
+ * where a normal identifier survives normalization.
+ */
+function prefixResolvesToDocs(line: string, pos: number): boolean {
+  if (matchSeparatorBackward(line, pos - 1) === 0) return false;
+
   let p = pos - 1;
-  let hasValidPair = false;
-
   while (p >= 0) {
-    // Consume one or more consecutive separators.
-    let separatorLen = matchSeparatorBackward(line, p);
-    if (separatorLen === 0) break;
+    const sepLen = matchSeparatorBackward(line, p);
+    if (sepLen > 0) { p -= sepLen; continue; }
+    if (LEFT_BOUNDARY.test(line.charAt(p))) break;
+    p -= 1;
+  }
+  const prefixStart = p + 1;
 
-    while (separatorLen > 0) {
-      p -= separatorLen;
-      separatorLen = p >= 0 ? matchSeparatorBackward(line, p) : 0;
-    }
+  if (prefixStart < pos && scanSeparators(line, prefixStart) > prefixStart) return false;
 
-    if (p < 0) break;
-
-    const dotSegment = matchDotSegmentBackward(line, p);
-    if (dotSegment === 0) break;
-
-    p -= dotSegment;
-    hasValidPair = true;
-
-    if (p < 0) break;
-
-    const beforePattern = line.charAt(p);
-    if (/[\s(\[]/.test(beforePattern) || /=/.test(beforePattern) || /&/.test(beforePattern)) {
-      break;
-    }
-
-    if (matchSeparatorBackward(line, p) > 0) {
+  const prefix = line.substring(prefixStart, pos);
+  const stack: string[] = [];
+  for (const seg of prefix.split(SEPARATOR_RE)) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") {
+      const top = stack.length > 0 ? stack[stack.length - 1] : null;
+      if (top !== null && top !== "..") stack.pop();
+      else stack.push("..");
       continue;
     }
-
-    break;
+    stack.push(seg);
   }
-
-  if (!hasValidPair) return false;
-
-  if (p < 0) return true;
-
-  const beforePattern = line.charAt(p);
-  if (/[\s(\[]/.test(beforePattern) || /=/.test(beforePattern) || /&/.test(beforePattern)) {
-    return true;
-  }
-
-  return false;
+  return stack.every((s) => s === "..");
 }
 
 /**
@@ -187,27 +183,6 @@ function matchSeparatorBackward(line: string, p: number): number {
   }
 
   return 0;
-}
-
-/**
- * Match a dot-segment (.) or (..) scanning backward.
- * Returns the length of the dot-segment matched (1 or 2), or 0 if no match.
- * Rejects ... and longer dot runs by only matching 1 or 2 dots.
- */
-function matchDotSegmentBackward(line: string, p: number): number {
-  if (p < 0) return 0;
-
-  const c = line.charAt(p);
-  if (c !== '.') return 0;
-
-  if (p >= 1 && line.charAt(p - 1) === '.') {
-    if (p >= 2 && line.charAt(p - 2) === '.') {
-      return 0;
-    }
-    return 2;
-  }
-
-  return 1;
 }
 
 /**

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, test } from "bun:test";
 import {
   detectCandidates,
   type DetectorConfig,
+  type Candidate,
 } from "./boundary-pipeline.ts";
 import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
 import type { Detection } from "./types.ts";
@@ -28,7 +29,7 @@ function gateFor(text: string) {
   return decideProjection(files, "source", baseConfig).gate;
 }
 
-function urls(cs: readonly any[]) {
+function urls(cs: readonly Candidate[]) {
   return cs.filter((c) => c.type === "url");
 }
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
@@ -134,3 +134,80 @@ describe("T1.5 unsupported-scheme / evil:// and ftp:// are not scheme-less GitHu
     expect(urls(cs).length).toBe(1);
   });
 });
+
+// T2: Left-boundary handling - only clean ./ or ../ prefixes before docs
+// Relative docs paths with explicit ./ or ../ should be detected as producer-internal
+// but .docs, absolute paths, and hostname .docs should NOT be candidates
+describe("T2 relative docs-path left-boundary handling", () => {
+  test("./docs/specs/foo.md becomes concrete producer path and gate fails", () => {
+    const text = "See ./docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+  });
+
+  test("../docs/specs/foo.md becomes concrete producer path and gate fails", () => {
+    const text = "See ../docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+  });
+
+  test(".\\docs/specs/foo.md (backslash) becomes concrete producer path and gate fails", () => {
+    const text = "See .\\docs\\specs\\foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+  });
+
+  test("..\\docs/specs/foo.md (backslash) becomes concrete producer path and gate fails", () => {
+    const text = "See ..\\docs\\specs\\foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+  });
+
+  test(".docs/specs/foo.md does NOT become a candidate (no prefix separator)", () => {
+    const text = "See .docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    expect(pathFail).toBeUndefined();
+  });
+
+  test("/docs/specs/foo.md does NOT become a candidate (absolute path)", () => {
+    const text = "See /docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    expect(pathFail).toBeUndefined();
+  });
+
+  test("a/../docs/specs/foo.md does NOT become a candidate (identifier before /)", () => {
+    const text = "See a/../docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    expect(pathFail).toBeUndefined();
+  });
+
+  test("https://evil.docs/specs/x.md remains suppressed by URL ownership", () => {
+    const text = "See https://evil.docs/specs/x.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    expect(pathFail).toBeUndefined();
+  });
+
+  test("plain docs/specs/foo.md remains concrete producer path", () => {
+    const text = "See docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
@@ -201,12 +201,13 @@ describe("T2 relative docs-path left-boundary handling", () => {
     expect(pathFail).toBeUndefined();
   });
 
-  test("a/../docs/specs/foo.md does NOT become a candidate (identifier before /)", () => {
+  // dot-segment collapse後に通常segmentが残らず、docsへ解決されるためfail-closedで検出する
+  test("a/../docs/specs/foo.md becomes a candidate (dot-segment collapse)", () => {
     const text = "See a/../docs/specs/foo.md here.";
     const g = gateFor(text);
-    expect(g.pass).toBe(true);
+    expect(g.pass).toBe(false);
     const pathFail = findFailureByCategory(g, "concrete-path");
-    expect(pathFail).toBeUndefined();
+    expect(pathFail?.classification).toBe("producer-internal");
   });
 
   test("https://evil.docs/specs/x.md remains suppressed by URL ownership", () => {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
@@ -108,22 +108,28 @@ describe("T1.4 query and fragment / remain inside URL ownership", () => {
   });
 });
 
-// T1.5: unsupported-scheme fallback - evil:// and ftp:// are NOT accepted as scheme-less
-describe("T1.5 unsupported-scheme / evil:// and ftp:// are not scheme-less GitHub owners", () => {
-  test("evil://github.com/... is NOT a GitHub authority (clean, gate passes)", () => {
+// T1.5: unsupported-scheme fallback - evil:// and ftp:// emit malformed
+// candidates (fail-closed per distribution-boundary.md). Historical intent
+// was "clean, gate passes" but evasion forms must never pass clean.
+describe("T1.5 unsupported-scheme / evil:// and ftp:// emit malformed (fail-closed)", () => {
+  test("evil://github.com/... → 1 malformed URL, gate fails (evasion-attempt)", () => {
     const text = "See evil://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
     const g = gateFor(text);
-    expect(g.pass).toBe(true);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
     const cs = detectCandidates(text, baseConfig);
-    expect(urls(cs).length).toBe(0);
+    expect(urls(cs).length).toBe(1);
+    expect(urls(cs)[0]?.malformed).toBe(true);
   });
 
-  test("ftp://github.com/... is NOT a GitHub authority (clean, gate passes)", () => {
+  test("ftp://github.com/... → 1 malformed URL, gate fails (evasion-attempt)", () => {
     const text = "See ftp://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
     const g = gateFor(text);
-    expect(g.pass).toBe(true);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
     const cs = detectCandidates(text, baseConfig);
-    expect(urls(cs).length).toBe(0);
+    expect(urls(cs).length).toBe(1);
+    expect(urls(cs)[0]?.malformed).toBe(true);
   });
 
   test("normal https:// remains accepted", () => {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
@@ -211,3 +211,75 @@ describe("T2 relative docs-path left-boundary handling", () => {
     expect(pathFail?.classification).toBe("producer-internal");
   });
 });
+
+// T3: Owned-span reconstruction suppression - prevent reconstructed-ID token
+// processing inside already-owned URL/path spans. External GitHub URLs
+// containing many escaped IDs must NOT trigger token-ids-exceeded overflow.
+describe("T3 owned-span reconstruction suppression", () => {
+  test("single token with 17 reconstructable IDs overflows when standalone", () => {
+    // Use same pattern as existing overflow tests: "STEP-1\\u0032-".repeat(17)
+    const token = "STEP-1\\u0032-".repeat(17);
+    const cs = detectCandidates(token, baseConfig);
+    const overflow = cs.find((c) => c.type === "overflow");
+    expect(overflow).toBeDefined();
+    if (overflow && overflow.type === "overflow") {
+      expect(overflow.reason).toBe("token-ids-exceeded");
+    }
+  });
+
+  test("17 reconstructable IDs inside external GitHub URL do NOT overflow, gate passes", () => {
+    // Use 17 literal IDs in URL path (these are detected as direct-id, not reconstructed)
+    // but the issue pattern is the same: IDs inside owned span should not cause overflow
+    const ids = "STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1";
+    const text = `See https://github.com/vercel/next.js/blob/main/${ids} here.`;
+    const cs = detectCandidates(text, baseConfig);
+    // No overflow should be present
+    const overflow = cs.find((c) => c.type === "overflow");
+    expect(overflow).toBeUndefined();
+  });
+
+  test("17 reconstructable IDs inside producer URL do NOT overflow, gate fails with URL classification", () => {
+    // Use 17 literal IDs in producer URL
+    const ids = "STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1";
+    const text = `See https://github.com/yogata/agent-dev-flow/blob/main/${ids} here.`;
+    const cs = detectCandidates(text, baseConfig);
+    // No overflow should be present
+    const overflow = cs.find((c) => c.type === "overflow");
+    expect(overflow).toBeUndefined();
+  });
+
+  test("17 reconstructable IDs inside docs path do NOT overflow, gate fails with path classification", () => {
+    // Use 17 literal IDs in docs path
+    const ids = "STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1";
+    const text = `See docs/${ids} here.`;
+    const cs = detectCandidates(text, baseConfig);
+    // No overflow should be present
+    const overflow = cs.find((c) => c.type === "overflow");
+    expect(overflow).toBeUndefined();
+  });
+
+  test("token partially overlapping URL owner is NOT silently skipped, overflow fires", () => {
+    // Token starts before URL but extends past it - NOT fully contained
+    const ids = "STEP-1\\u0032-".repeat(17);
+    const text = `See <https://github.com/vercel/next.js/blob/main/x.md>${ids} here.`;
+    const cs = detectCandidates(text, baseConfig);
+    // Overflow should still fire because token is not fully inside URL
+    const overflow = cs.find((c) => c.type === "overflow");
+    expect(overflow).toBeDefined();
+    if (overflow && overflow.type === "overflow") {
+      expect(overflow.reason).toBe("token-ids-exceeded");
+    }
+  });
+
+  test("line-scan overflow remains unchanged when line exceeds MAX_LINE_SCAN", () => {
+    // Create a line longer than MAX_LINE_SCAN (65536)
+    const longSegment = "A".repeat(70000);
+    const text = `See ${longSegment} ADR-0001 here.`;
+    const cs = detectCandidates(text, baseConfig);
+    const overflow = cs.find((c) => c.type === "overflow");
+    expect(overflow).toBeDefined();
+    if (overflow && overflow.type === "overflow") {
+      expect(overflow.reason).toBe("line-scan-exceeded");
+    }
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   detectCandidates,
+  detectReconstructedIds,
   type DetectorConfig,
   type Candidate,
 } from "./boundary-pipeline.ts";
@@ -217,8 +218,7 @@ describe("T2 relative docs-path left-boundary handling", () => {
 // containing many escaped IDs must NOT trigger token-ids-exceeded overflow.
 describe("T3 owned-span reconstruction suppression", () => {
   test("single token with 17 reconstructable IDs overflows when standalone", () => {
-    // Use same pattern as existing overflow tests: "STEP-1\\u0032-".repeat(17)
-    const token = "STEP-1\\u0032-".repeat(17);
+    const token = "ADR-0x31-".repeat(17);
     const cs = detectCandidates(token, baseConfig);
     const overflow = cs.find((c) => c.type === "overflow");
     expect(overflow).toBeDefined();
@@ -228,51 +228,92 @@ describe("T3 owned-span reconstruction suppression", () => {
   });
 
   test("17 reconstructable IDs inside external GitHub URL do NOT overflow, gate passes", () => {
-    // Use 17 literal IDs in URL path (these are detected as direct-id, not reconstructed)
-    // but the issue pattern is the same: IDs inside owned span should not cause overflow
-    const ids = "STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1";
-    const text = `See https://github.com/vercel/next.js/blob/main/${ids} here.`;
+    const exploit = "ADR-0x31-".repeat(17);
+    const text = `See https://github.com/vercel/next.js/blob/main/${exploit}.md here.`;
     const cs = detectCandidates(text, baseConfig);
-    // No overflow should be present
+    const g = gateFor(text);
+
+    // Gate passes because URL is external
+    expect(g.pass).toBe(true);
+
+    // Exactly one URL owner, no reconstructed IDs, no overflow
+    const urlCandidates = cs.filter((c) => c.type === "url");
+    expect(urlCandidates.length).toBe(1);
+    const reconstructed = cs.filter((c) => c.type === "reconstructed-id");
+    expect(reconstructed.length).toBe(0);
     const overflow = cs.find((c) => c.type === "overflow");
     expect(overflow).toBeUndefined();
   });
 
   test("17 reconstructable IDs inside producer URL do NOT overflow, gate fails with URL classification", () => {
-    // Use 17 literal IDs in producer URL
-    const ids = "STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1";
-    const text = `See https://github.com/yogata/agent-dev-flow/blob/main/${ids} here.`;
+    const exploit = "ADR-0x31-".repeat(17);
+    const text = `See https://github.com/yogata/agent-dev-flow/blob/main/${exploit}.md here.`;
     const cs = detectCandidates(text, baseConfig);
-    // No overflow should be present
+    const g = gateFor(text);
+
+    // Gate fails because URL is producer-internal
+    expect(g.pass).toBe(false);
+
+    // Exactly one URL, no reconstructed IDs, no overflow
+    const urlCandidates = cs.filter((c) => c.type === "url");
+    expect(urlCandidates.length).toBe(1);
+    const reconstructed = cs.filter((c) => c.type === "reconstructed-id");
+    expect(reconstructed.length).toBe(0);
     const overflow = cs.find((c) => c.type === "overflow");
     expect(overflow).toBeUndefined();
+
+    // Gate failure should be fixed-url (producer-internal)
+    const urlFail = g.failures.find((d: Detection) => d.category === "fixed-url");
+    expect(urlFail?.classification).toBe("producer-internal");
   });
 
   test("17 reconstructable IDs inside docs path do NOT overflow, gate fails with path classification", () => {
-    // Use 17 literal IDs in docs path
-    const ids = "STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1-STEP-1";
-    const text = `See docs/${ids} here.`;
+    const exploit = "ADR-0x31-".repeat(17);
+    const text = `See docs/specs/${exploit}.md here.`;
     const cs = detectCandidates(text, baseConfig);
-    // No overflow should be present
+    const g = gateFor(text);
+
+    // Gate fails because path is producer-internal
+    expect(g.pass).toBe(false);
+
+    // Exactly one valid docs path, no reconstructed IDs, no overflow
+    const pathCandidates = cs.filter((c) => c.type === "path");
+    expect(pathCandidates.length).toBe(1);
+    expect(pathCandidates[0]?.value).toBe(`docs/specs/${exploit}.md`);
+    const reconstructed = cs.filter((c) => c.type === "reconstructed-id");
+    expect(reconstructed.length).toBe(0);
     const overflow = cs.find((c) => c.type === "overflow");
     expect(overflow).toBeUndefined();
+
+    // Gate failure should be concrete-path (producer-internal)
+    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
   });
 
-  test("token partially overlapping URL owner is NOT silently skipped, overflow fires", () => {
-    // Token starts before URL but extends past it - NOT fully contained
-    const ids = "STEP-1\\u0032-".repeat(17);
-    const text = `See <https://github.com/vercel/next.js/blob/main/x.md>${ids} here.`;
-    const cs = detectCandidates(text, baseConfig);
-    // Overflow should still fire because token is not fully inside URL
-    const overflow = cs.find((c) => c.type === "overflow");
-    expect(overflow).toBeDefined();
-    if (overflow && overflow.type === "overflow") {
-      expect(overflow.reason).toBe("token-ids-exceeded");
-    }
+  test("token partially overlapping owner is NOT silently skipped, overflow fires", () => {
+    const exploit = "ADR-0x31-".repeat(17);
+    // Test partial overlap directly via detectReconstructedIds with a span that ends one char early
+    const ownedSpan = { start: 0, end: exploit.length - 1 };
+    const result = detectReconstructedIds(exploit, [ownedSpan]);
+
+    // Overflow should fire because token is NOT fully inside the owned span
+    expect(result.overflow).toBe(true);
+    expect(result.overflowReason).toBe("token-ids-exceeded");
+  });
+
+  test("token fully inside owned span emits no IDs and no overflow", () => {
+    const exploit = "ADR-0x31-".repeat(17);
+    // Test full containment
+    const ownedSpan = { start: 0, end: exploit.length };
+    const result = detectReconstructedIds(exploit, [ownedSpan]);
+
+    // No IDs, no overflow when fully owned
+    expect(result.ids.length).toBe(0);
+    expect(result.overflow).toBe(false);
+    expect(result.overflowReason).toBe(null);
   });
 
   test("line-scan overflow remains unchanged when line exceeds MAX_LINE_SCAN", () => {
-    // Create a line longer than MAX_LINE_SCAN (65536)
     const longSegment = "A".repeat(70000);
     const text = `See ${longSegment} ADR-0001 here.`;
     const cs = detectCandidates(text, baseConfig);

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
@@ -1,0 +1,135 @@
+// Fresh-review-v2 lexical ownership fixes: T1 targeted coverage.
+//
+// Each test describes a specific fail-open path that was identified
+// during fresh review at 23a076c4. These tests fail against the current
+// code, then pass after the T1 fix lands.
+//
+// T1 scope:
+//   - userinfo extraction (https://user@github.com/... extracts correctly)
+//   - punctuation termination (comma, semicolon, CJK punctuation)
+//   - unsupported-scheme fallback (evil://, ftp:// are not scheme-less)
+
+import { describe, expect, test } from "bun:test";
+import {
+  classifyLine,
+  detectCandidates,
+  type DetectorConfig,
+} from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+function urls(cs: readonly any[]) {
+  return cs.filter((c) => c.type === "url");
+}
+
+// T1.1: userinfo extraction - producer URL with userinfo is still producer-internal
+describe("T1.1 userinfo / producer URL with userinfo is producer-internal", () => {
+  test("https://user@github.com/yogata/agent-dev-flow/blob/main/src/index.ts extracts one producer URL and gate fails", () => {
+    const text = "See https://user@github.com/yogata/agent-dev-flow/blob/main/src/index.ts here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const fail = g.failures.find((d: any) => d.category === "fixed-url");
+    expect(fail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs).length).toBe(1);
+  });
+});
+
+// T1.2: userinfo deception - https://github.com@evil.com/... is NOT GitHub authority
+describe("T1.2 userinfo deception / github.com@evil.com is not GitHub authority", () => {
+  test("https://github.com@evil.com/yogata/agent-dev-flow/blob/main/x.md is clean (no URL, gate passes)", () => {
+    const text = "See https://github.com@evil.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs).length).toBe(0);
+  });
+});
+
+// T1.3: punctuation termination - URL ownership ends at comma, semicolon, CJK punctuation
+describe("T1.3 punctuation termination / URL ends at comma/semicolon/CJK", () => {
+  test("external GitHub URL followed by ASCII comma + docs/specs/foo.md exposes producer reference", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md, docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    // docs/specs/foo.md is producer-internal and should trigger failure
+    const pathFail = g.failures.find((d: any) => d.category === "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+  });
+
+  test("external GitHub URL followed by ideographic period + ADR-0001 exposes producer reference", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md\u3002 ADR-0001 here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const idFail = g.failures.find((d: any) => d.category === "concrete-id");
+    expect(idFail?.classification).toBe("producer-internal");
+  });
+
+  test("external GitHub URL followed by full-width semicolon + ADR-0001 exposes producer reference", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md\uFF1B ADR-0001 here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const idFail = g.failures.find((d: any) => d.category === "concrete-id");
+    expect(idFail?.classification).toBe("producer-internal");
+  });
+});
+
+// T1.4: query and fragment remain inside valid URL ownership
+describe("T1.4 query and fragment / remain inside URL ownership", () => {
+  test("?query and #fragment remain inside valid producer URL ownership", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md?query=1#fragment here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const fail = g.failures.find((d: any) => d.category === "fixed-url");
+    expect(fail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs).length).toBe(1);
+    // URL should include query and fragment
+    expect(urls(cs)[0]?.value).toContain("?query=1#fragment");
+  });
+});
+
+// T1.5: unsupported-scheme fallback - evil:// and ftp:// are NOT accepted as scheme-less
+describe("T1.5 unsupported-scheme / evil:// and ftp:// are not scheme-less GitHub owners", () => {
+  test("evil://github.com/... is NOT a GitHub authority (clean, gate passes)", () => {
+    const text = "See evil://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs).length).toBe(0);
+  });
+
+  test("ftp://github.com/... is NOT a GitHub authority (clean, gate passes)", () => {
+    const text = "See ftp://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs).length).toBe(0);
+  });
+
+  test("normal https:// remains accepted", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const fail = g.failures.find((d: any) => d.category === "fixed-url");
+    expect(fail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs).length).toBe(1);
+  });
+
+  test("valid bare scheme-less github.com/... remains accepted", () => {
+    const text = "See github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs).length).toBe(1);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
@@ -11,11 +11,11 @@
 
 import { describe, expect, test } from "bun:test";
 import {
-  classifyLine,
   detectCandidates,
   type DetectorConfig,
 } from "./boundary-pipeline.ts";
 import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+import type { Detection } from "./types.ts";
 
 const baseConfig: DetectorConfig = {
   repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
@@ -38,7 +38,7 @@ describe("T1.1 userinfo / producer URL with userinfo is producer-internal", () =
     const text = "See https://user@github.com/yogata/agent-dev-flow/blob/main/src/index.ts here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const fail = g.failures.find((d: any) => d.category === "fixed-url");
+    const fail = g.failures.find((d: Detection) => d.category === "fixed-url");
     expect(fail?.classification).toBe("producer-internal");
     const cs = detectCandidates(text, baseConfig);
     expect(urls(cs).length).toBe(1);
@@ -63,7 +63,7 @@ describe("T1.3 punctuation termination / URL ends at comma/semicolon/CJK", () =>
     const g = gateFor(text);
     expect(g.pass).toBe(false);
     // docs/specs/foo.md is producer-internal and should trigger failure
-    const pathFail = g.failures.find((d: any) => d.category === "concrete-path");
+    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
     expect(pathFail?.classification).toBe("producer-internal");
   });
 
@@ -71,7 +71,7 @@ describe("T1.3 punctuation termination / URL ends at comma/semicolon/CJK", () =>
     const text = "See https://github.com/vercel/next.js/blob/main/x.md\u3002 ADR-0001 here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const idFail = g.failures.find((d: any) => d.category === "concrete-id");
+    const idFail = g.failures.find((d: Detection) => d.category === "concrete-id");
     expect(idFail?.classification).toBe("producer-internal");
   });
 
@@ -79,7 +79,7 @@ describe("T1.3 punctuation termination / URL ends at comma/semicolon/CJK", () =>
     const text = "See https://github.com/vercel/next.js/blob/main/x.md\uFF1B ADR-0001 here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const idFail = g.failures.find((d: any) => d.category === "concrete-id");
+    const idFail = g.failures.find((d: Detection) => d.category === "concrete-id");
     expect(idFail?.classification).toBe("producer-internal");
   });
 });
@@ -90,7 +90,7 @@ describe("T1.4 query and fragment / remain inside URL ownership", () => {
     const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md?query=1#fragment here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const fail = g.failures.find((d: any) => d.category === "fixed-url");
+    const fail = g.failures.find((d: Detection) => d.category === "fixed-url");
     expect(fail?.classification).toBe("producer-internal");
     const cs = detectCandidates(text, baseConfig);
     expect(urls(cs).length).toBe(1);
@@ -121,7 +121,7 @@ describe("T1.5 unsupported-scheme / evil:// and ftp:// are not scheme-less GitHu
     const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const fail = g.failures.find((d: any) => d.category === "fixed-url");
+    const fail = g.failures.find((d: Detection) => d.category === "fixed-url");
     expect(fail?.classification).toBe("producer-internal");
     const cs = detectCandidates(text, baseConfig);
     expect(urls(cs).length).toBe(1);

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review-v2.test.ts
@@ -10,14 +10,9 @@
 //   - unsupported-scheme fallback (evil://, ftp:// are not scheme-less)
 
 import { describe, expect, test } from "bun:test";
-import {
-  detectCandidates,
-  detectReconstructedIds,
-  type DetectorConfig,
-  type Candidate,
-} from "./boundary-pipeline.ts";
+import { detectCandidates, detectReconstructedIds, type DetectorConfig, type Candidate, type OverflowReason } from "./boundary-pipeline.ts";
 import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
-import type { Detection } from "./types.ts";
+import type { Detection, GateResult } from "./types.ts";
 
 const baseConfig: DetectorConfig = {
   repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
@@ -34,13 +29,25 @@ function urls(cs: readonly Candidate[]) {
   return cs.filter((c) => c.type === "url");
 }
 
+function assertOverflowReason(candidates: readonly Candidate[], expectedReason: OverflowReason) {
+  const overflow = candidates.find((c) => c.type === "overflow");
+  expect(overflow).toBeDefined();
+  if (overflow && overflow.type === "overflow") {
+    expect(overflow.reason).toBe(expectedReason);
+  }
+}
+
+function findFailureByCategory(gate: GateResult, category: Detection["category"]): Detection | undefined {
+  return gate.failures.find((d: Detection) => d.category === category);
+}
+
 // T1.1: userinfo extraction - producer URL with userinfo is still producer-internal
 describe("T1.1 userinfo / producer URL with userinfo is producer-internal", () => {
   test("https://user@github.com/yogata/agent-dev-flow/blob/main/src/index.ts extracts one producer URL and gate fails", () => {
     const text = "See https://user@github.com/yogata/agent-dev-flow/blob/main/src/index.ts here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const fail = g.failures.find((d: Detection) => d.category === "fixed-url");
+    const fail = findFailureByCategory(g, "fixed-url");
     expect(fail?.classification).toBe("producer-internal");
     const cs = detectCandidates(text, baseConfig);
     expect(urls(cs).length).toBe(1);
@@ -65,7 +72,7 @@ describe("T1.3 punctuation termination / URL ends at comma/semicolon/CJK", () =>
     const g = gateFor(text);
     expect(g.pass).toBe(false);
     // docs/specs/foo.md is producer-internal and should trigger failure
-    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    const pathFail = findFailureByCategory(g, "concrete-path");
     expect(pathFail?.classification).toBe("producer-internal");
   });
 
@@ -73,7 +80,7 @@ describe("T1.3 punctuation termination / URL ends at comma/semicolon/CJK", () =>
     const text = "See https://github.com/vercel/next.js/blob/main/x.md\u3002 ADR-0001 here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const idFail = g.failures.find((d: Detection) => d.category === "concrete-id");
+    const idFail = findFailureByCategory(g, "concrete-id");
     expect(idFail?.classification).toBe("producer-internal");
   });
 
@@ -81,7 +88,7 @@ describe("T1.3 punctuation termination / URL ends at comma/semicolon/CJK", () =>
     const text = "See https://github.com/vercel/next.js/blob/main/x.md\uFF1B ADR-0001 here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const idFail = g.failures.find((d: Detection) => d.category === "concrete-id");
+    const idFail = findFailureByCategory(g, "concrete-id");
     expect(idFail?.classification).toBe("producer-internal");
   });
 });
@@ -92,7 +99,7 @@ describe("T1.4 query and fragment / remain inside URL ownership", () => {
     const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md?query=1#fragment here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const fail = g.failures.find((d: Detection) => d.category === "fixed-url");
+    const fail = findFailureByCategory(g, "fixed-url");
     expect(fail?.classification).toBe("producer-internal");
     const cs = detectCandidates(text, baseConfig);
     expect(urls(cs).length).toBe(1);
@@ -123,7 +130,7 @@ describe("T1.5 unsupported-scheme / evil:// and ftp:// are not scheme-less GitHu
     const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const fail = g.failures.find((d: Detection) => d.category === "fixed-url");
+    const fail = findFailureByCategory(g, "fixed-url");
     expect(fail?.classification).toBe("producer-internal");
     const cs = detectCandidates(text, baseConfig);
     expect(urls(cs).length).toBe(1);
@@ -144,7 +151,7 @@ describe("T2 relative docs-path left-boundary handling", () => {
     const text = "See ./docs/specs/foo.md here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    const pathFail = findFailureByCategory(g, "concrete-path");
     expect(pathFail?.classification).toBe("producer-internal");
   });
 
@@ -152,7 +159,7 @@ describe("T2 relative docs-path left-boundary handling", () => {
     const text = "See ../docs/specs/foo.md here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    const pathFail = findFailureByCategory(g, "concrete-path");
     expect(pathFail?.classification).toBe("producer-internal");
   });
 
@@ -160,7 +167,7 @@ describe("T2 relative docs-path left-boundary handling", () => {
     const text = "See .\\docs\\specs\\foo.md here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    const pathFail = findFailureByCategory(g, "concrete-path");
     expect(pathFail?.classification).toBe("producer-internal");
   });
 
@@ -168,7 +175,7 @@ describe("T2 relative docs-path left-boundary handling", () => {
     const text = "See ..\\docs\\specs\\foo.md here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    const pathFail = findFailureByCategory(g, "concrete-path");
     expect(pathFail?.classification).toBe("producer-internal");
   });
 
@@ -176,7 +183,7 @@ describe("T2 relative docs-path left-boundary handling", () => {
     const text = "See .docs/specs/foo.md here.";
     const g = gateFor(text);
     expect(g.pass).toBe(true);
-    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    const pathFail = findFailureByCategory(g, "concrete-path");
     expect(pathFail).toBeUndefined();
   });
 
@@ -184,7 +191,7 @@ describe("T2 relative docs-path left-boundary handling", () => {
     const text = "See /docs/specs/foo.md here.";
     const g = gateFor(text);
     expect(g.pass).toBe(true);
-    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    const pathFail = findFailureByCategory(g, "concrete-path");
     expect(pathFail).toBeUndefined();
   });
 
@@ -192,7 +199,7 @@ describe("T2 relative docs-path left-boundary handling", () => {
     const text = "See a/../docs/specs/foo.md here.";
     const g = gateFor(text);
     expect(g.pass).toBe(true);
-    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    const pathFail = findFailureByCategory(g, "concrete-path");
     expect(pathFail).toBeUndefined();
   });
 
@@ -200,7 +207,7 @@ describe("T2 relative docs-path left-boundary handling", () => {
     const text = "See https://evil.docs/specs/x.md here.";
     const g = gateFor(text);
     expect(g.pass).toBe(true);
-    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    const pathFail = findFailureByCategory(g, "concrete-path");
     expect(pathFail).toBeUndefined();
   });
 
@@ -208,7 +215,7 @@ describe("T2 relative docs-path left-boundary handling", () => {
     const text = "See docs/specs/foo.md here.";
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    const pathFail = findFailureByCategory(g, "concrete-path");
     expect(pathFail?.classification).toBe("producer-internal");
   });
 });
@@ -220,11 +227,7 @@ describe("T3 owned-span reconstruction suppression", () => {
   test("single token with 17 reconstructable IDs overflows when standalone", () => {
     const token = "ADR-0x31-".repeat(17);
     const cs = detectCandidates(token, baseConfig);
-    const overflow = cs.find((c) => c.type === "overflow");
-    expect(overflow).toBeDefined();
-    if (overflow && overflow.type === "overflow") {
-      expect(overflow.reason).toBe("token-ids-exceeded");
-    }
+    assertOverflowReason(cs, "token-ids-exceeded");
   });
 
   test("17 reconstructable IDs inside external GitHub URL do NOT overflow, gate passes", () => {
@@ -263,7 +266,7 @@ describe("T3 owned-span reconstruction suppression", () => {
     expect(overflow).toBeUndefined();
 
     // Gate failure should be fixed-url (producer-internal)
-    const urlFail = g.failures.find((d: Detection) => d.category === "fixed-url");
+    const urlFail = findFailureByCategory(g, "fixed-url");
     expect(urlFail?.classification).toBe("producer-internal");
   });
 
@@ -286,7 +289,7 @@ describe("T3 owned-span reconstruction suppression", () => {
     expect(overflow).toBeUndefined();
 
     // Gate failure should be concrete-path (producer-internal)
-    const pathFail = g.failures.find((d: Detection) => d.category === "concrete-path");
+    const pathFail = findFailureByCategory(g, "concrete-path");
     expect(pathFail?.classification).toBe("producer-internal");
   });
 
@@ -317,10 +320,6 @@ describe("T3 owned-span reconstruction suppression", () => {
     const longSegment = "A".repeat(70000);
     const text = `See ${longSegment} ADR-0001 here.`;
     const cs = detectCandidates(text, baseConfig);
-    const overflow = cs.find((c) => c.type === "overflow");
-    expect(overflow).toBeDefined();
-    if (overflow && overflow.type === "overflow") {
-      expect(overflow.reason).toBe("line-scan-exceeded");
-    }
+    assertOverflowReason(cs, "line-scan-exceeded");
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-fresh-review.test.ts
@@ -1,0 +1,289 @@
+// Fresh-review lexical ownership fixes: failing-first coverage.
+//
+// Each describe maps to a fresh-review case from the goal/code lane at
+// 23a076c4. These tests fail against the current code, then pass after
+// the authority-aware URL extractor, the bounded docs-path extractor,
+// and the ownership-before-cap rewrite land.
+//
+// Blocker map (fresh-review blocker -> describe):
+//   D1 authority parsing (mixed-case host)   -> "D1 authority"
+//   D2 host/path lookalike rejection         -> "D2 lookalikes"
+//   D3 scheme-less left boundary             -> "D3 scheme-less boundary"
+//   D4 docs-path concrete endpoint lexing    -> "D4 docs-path endpoint"
+//   D5 standalone left boundary              -> "D5 standalone boundary"
+//   D6 ownership-before-cap                  -> "D6 ownership-before-cap"
+
+import { describe, expect, test } from "bun:test";
+import {
+  classifyLine,
+  detectCandidates,
+  type Candidate,
+  type DetectorConfig,
+} from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function cls(text: string) {
+  return classifyLine({ text, lineNumber: 1, filePath: "f.md", projection: "source" }, baseConfig);
+}
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+function urls(cs: readonly Candidate[]) {
+  return cs.filter((c): c is Extract<typeof c, { type: "url" }> => c.type === "url");
+}
+function paths(cs: readonly Candidate[]) {
+  return cs.filter((c): c is Extract<typeof c, { type: "path" }> => c.type === "path");
+}
+function directs(cs: readonly Candidate[]) {
+  return cs.filter((c): c is Extract<typeof c, { type: "direct-id" }> => c.type === "direct-id");
+}
+
+// D1: authority parsing — mixed-case host must be normalized for classification.
+describe("D1 authority / mixed-case host is normalized", () => {
+  test("producer mixed-case host https://GITHUB.COM/yogata/agent-dev-flow/blob/main/scripts/install.ps1 fails", () => {
+    const text = "See https://GITHUB.COM/yogata/agent-dev-flow/blob/main/scripts/install.ps1 here.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs).length).toBe(1);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const fail = g.failures.find((d) => d.category === "fixed-url");
+    expect(fail?.classification).toBe("producer-internal");
+  });
+
+  test("external mixed-case host is one consumer-resolvable URL and passes", () => {
+    const text = "See https://GITHUB.COM/Vercel/Next.js/blob/main/x.md here.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs).length).toBe(1);
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const urlDet = g.failures.concat(g.errors).find((d) => d.category === "fixed-url");
+    // Consumer-resolvable URLs do NOT appear in failures/errors; they are allowed.
+    expect(urlDet).toBeUndefined();
+    const r = cls(text);
+    const fixed = r.detections.find((d) => d.category === "fixed-url");
+    expect(fixed?.classification).toBe("consumer-resolvable");
+  });
+});
+
+// D2: host/path lookalikes must NOT be misclassified as GitHub authority.
+describe("D2 lookalikes / not GitHub authority", () => {
+  const lookalikes: Array<[string, string]> = [
+    ["path lookalike", "See https://example.com/github.com/yogata/agent-dev-flow/blob/main/docs/x.md end."],
+    ["userinfo deception", "See https://github.com@evil.com/yogata/agent-dev-flow/blob/main/x.md end."],
+    ["host suffix", "See https://notgithub.com/yogata/agent-dev-flow/blob/main/x.md end."],
+    ["extra dot suffix", "See https://github.com.evil.com/yogata/agent-dev-flow/blob/main/x.md end."],
+    ["subdomain", "See https://evil.github.com/yogata/agent-dev-flow/blob/main/x.md end."],
+  ];
+  for (const [label, text] of lookalikes) {
+    test(`${label}: '${text.substring(0, 60)}...' is clean (no URL, no path, gate passes)`, () => {
+      const cs = detectCandidates(text, baseConfig);
+      expect(urls(cs).length).toBe(0);
+      expect(paths(cs).length).toBe(0);
+      expect(directs(cs).length).toBe(0);
+      expect(gateFor(text).pass).toBe(true);
+    });
+  }
+
+  test("GitHub host without owner/repo/blob-or-raw shape does not own contained IDs", () => {
+    const text = "See https://github.com/ADR-0001/docs/REQ-0001.md end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs)).toEqual([]);
+    expect(gateFor(text).pass).toBe(false);
+  });
+
+  test("GitHub host with unsupported action does not own contained IDs", () => {
+    const text = "See https://github.com/vercel/next.js/notblob/docs/ADR-0001.md end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs)).toEqual([]);
+    expect(gateFor(text).pass).toBe(false);
+  });
+
+  test("raw host without owner/repo/tail shape does not own contained IDs", () => {
+    const text = "See https://raw.githubusercontent.com/ADR-0001 end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs)).toEqual([]);
+    expect(gateFor(text).pass).toBe(false);
+  });
+});
+
+// D3: scheme-less forms are retained but require a valid left boundary.
+describe("D3 scheme-less boundary / lowercase + mixed-case retained at valid boundary", () => {
+  test("scheme-less lowercase github.com/yogata/agent-dev-flow/blob/main/x.md is extracted", () => {
+    const text = "See github.com/yogata/agent-dev-flow/blob/main/x.md here.";
+    expect(urls(detectCandidates(text, baseConfig)).length).toBe(1);
+  });
+
+  test("scheme-less mixed-case GITHUB.COM/yogata/agent-dev-flow/blob/main/x.md is extracted", () => {
+    const text = "See GITHUB.COM/yogata/agent-dev-flow/blob/main/x.md here.";
+    expect(urls(detectCandidates(text, baseConfig)).length).toBe(1);
+  });
+
+  test("scheme-less raw.githubusercontent.com/yogata/agent-dev-flow/main/x.md is extracted", () => {
+    const text = "See raw.githubusercontent.com/yogata/agent-dev-flow/main/x.md here.";
+    expect(urls(detectCandidates(text, baseConfig)).length).toBe(1);
+  });
+
+  test("scheme-less mixed-case RAW.GITHUBUSERCONTENT.COM/yogata/agent-dev-flow/main/x.md is extracted", () => {
+    const text = "See RAW.GITHUBUSERCONTENT.COM/yogata/agent-dev-flow/main/x.md here.";
+    expect(urls(detectCandidates(text, baseConfig)).length).toBe(1);
+  });
+
+  test("scheme-less 'Xgithub.com/...' is NOT extracted (no left boundary)", () => {
+    const text = "See Xgithub.com/yogata/agent-dev-flow/blob/main/x.md here.";
+    expect(urls(detectCandidates(text, baseConfig)).length).toBe(0);
+  });
+
+  test("scheme-less 'github.com.evil.com/...' is NOT extracted (host not exact)", () => {
+    const text = "See github.com.evil.com/yogata/agent-dev-flow/blob/main/x.md here.";
+    expect(urls(detectCandidates(text, baseConfig)).length).toBe(0);
+  });
+});
+
+// D4: docs-path extractor must terminate concrete evidence at the actual .md
+// endpoint. Trailing sentence punctuation, fragment, and query must NOT make
+// the path generic. Mixed `/`, `\`, `%2F` separators are supported throughout.
+// `.md.bak` is NOT matched.
+describe("D4 docs-path endpoint / lexing terminates at .md", () => {
+  test("docs/requirements/REQ-0001.md. (trailing period) is concrete producer-internal", () => {
+    const r = cls("See docs/requirements/REQ-0001.md.");
+    const path = r.detections.find((d) => d.category === "concrete-path");
+    expect(path?.classification).toBe("producer-internal");
+    expect(path?.matched).toBe("docs/requirements/REQ-0001.md");
+  });
+
+  test("comma/semicolon/colon/Japanese punctuation after .md is concrete", () => {
+    for (const punct of [",", ";", ":", "\u3002", "\u3001"]) {
+      const text = `See docs/requirements/REQ-0001.md${punct} after.`;
+      const path = cls(text).detections.find((d) => d.category === "concrete-path");
+      expect(path?.classification).toBe("producer-internal");
+      expect(path?.matched).toBe("docs/requirements/REQ-0001.md");
+    }
+  });
+
+  test("docs/specs/foo.md#acceptance is concrete (fragment does not hide .md)", () => {
+    const path = cls("See docs/specs/foo.md#acceptance for details.").detections.find((d) => d.category === "concrete-path");
+    expect(path?.classification).toBe("producer-internal");
+    expect(path?.matched).toBe("docs/specs/foo.md");
+  });
+
+  test("docs/specs/foo.md?x=1 is concrete (query does not hide .md)", () => {
+    const path = cls("See docs/specs/foo.md?x=1 for details.").detections.find((d) => d.category === "concrete-path");
+    expect(path?.classification).toBe("producer-internal");
+    expect(path?.matched).toBe("docs/specs/foo.md");
+  });
+
+  test("multi-level docs\\specs\\foundations\\system.md is concrete", () => {
+    const r = cls("See docs\\specs\\foundations\\system.md here.");
+    const path = r.detections.find((d) => d.category === "concrete-path");
+    expect(path?.classification).toBe("producer-internal");
+  });
+
+  test("mixed slash/backslash/percent docs%2Fspecs\\foundations/system.md is concrete", () => {
+    const r = cls("See docs%2Fspecs\\foundations/system.md here.");
+    const path = r.detections.find((d) => d.category === "concrete-path");
+    expect(path?.classification).toBe("producer-internal");
+  });
+
+  test("non-ASCII markdown filename is concrete", () => {
+    const path = cls("See docs/specs/foundations/設計.md here.").detections
+      .find((d) => d.category === "concrete-path");
+    expect(path?.classification).toBe("producer-internal");
+  });
+
+  test(".md.bak is NOT concrete (matched path rejects .md.bak as endpoint)", () => {
+    const r = cls("See docs/specs/foo.md.bak here.");
+    const concrete = r.detections.find((d) => d.category === "concrete-path" && d.classification === "producer-internal");
+    expect(concrete).toBeUndefined();
+  });
+});
+
+// D5: standalone left boundary for `docs`. Identifier-char and `/`/`\\`
+// predecessors are rejected (the URL/path owns the region).
+describe("D5 standalone boundary / docs preceded by identifier or separator is clean", () => {
+  test("mydocs/specs/public.md is clean (docs preceded by identifier char)", () => {
+    const r = cls("See mydocs/specs/public.md here.");
+    expect(r.detections.filter((d) => d.category === "concrete-path")).toEqual([]);
+  });
+
+  test("docs inside URL path (/docs/specs/x.md) is NOT extracted as a separate path", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/docs/specs/x.md end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(0);
+    // URL owns the docs span.
+    expect(urls(cs).length).toBe(1);
+  });
+});
+
+// D6: ownership-before-cap. Contained IDs/paths never consume the candidate
+// cap; URLs alone are one candidate; standalone IDs still cap/fail closed.
+describe("D6 ownership-before-cap / contained candidates do not consume cap", () => {
+  test("exactly 63 external URL owners do not overflow", () => {
+    const text = Array.from(
+      { length: 63 },
+      (_, i) => `https://github.com/ext${i}/repo/blob/main/x.md`,
+    ).join(" ");
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs)).toHaveLength(63);
+    expect(cs.some((c) => c.type === "overflow")).toBe(false);
+  });
+
+  test("64 external URL owners produce candidate overflow", () => {
+    const text = Array.from(
+      { length: 64 },
+      (_, i) => `https://github.com/ext${i}/repo/blob/main/x.md`,
+    ).join(" ");
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs)).toHaveLength(63);
+    expect(cs.some((c) => c.type === "overflow")).toBe(true);
+  });
+
+  test("external URL with 70+ producer-looking IDs is one consumer-resolvable URL, no overflow, passes", () => {
+    const ids = Array.from({ length: 75 }, (_, i) => `ADR-${String(i + 1).padStart(4, "0")}`).join("/");
+    const text = `See https://github.com/vercel/next.js/blob/main/${ids}/x.md end.`;
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs).length).toBe(1);
+    expect(directs(cs).length).toBe(0);
+    expect(cs.some((c) => c.type === "overflow")).toBe(false);
+    expect(gateFor(text).pass).toBe(true);
+  });
+
+  test("producer URL with 70+ producer-looking IDs is one producer-internal failure, no overflow", () => {
+    const ids = Array.from({ length: 75 }, (_, i) => `ADR-${String(i + 1).padStart(4, "0")}`).join("/");
+    const text = `See https://github.com/yogata/agent-dev-flow/blob/main/${ids}/x.md end.`;
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs).length).toBe(1);
+    expect(directs(cs).length).toBe(0);
+    expect(cs.some((c) => c.type === "overflow")).toBe(false);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.filter((d) => d.category === "fixed-url")).toHaveLength(1);
+  });
+
+  test("standalone ID adjacent to a URL is still detected", () => {
+    const text = "See ADR-0001 and https://github.com/vercel/next.js/blob/main/x.md end.";
+    const direct = directs(detectCandidates(text, baseConfig)).find((c) => c.value === "ADR-0001");
+    expect(direct).toBeDefined();
+  });
+
+  test("standalone docs path adjacent to a URL is still detected", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md and docs/requirements/REQ-0001.md end.";
+    const path = paths(detectCandidates(text, baseConfig));
+    expect(path.length).toBe(1);
+    expect(path[0]?.value).toBe("docs/requirements/REQ-0001.md");
+  });
+
+  test("100 standalone IDs outside URLs still cap/fail closed (overflow)", () => {
+    const text = Array.from({ length: 100 }, (_, i) => `ADR-${String(i + 1).padStart(4, "0")}`).join(" ");
+    const cs = detectCandidates(text, baseConfig);
+    expect(cs.length).toBeLessThanOrEqual(65);
+    expect(cs.some((c) => c.type === "overflow")).toBe(true);
+    expect(gateFor(text).pass).toBe(false);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-gate-bounds.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-gate-bounds.test.ts
@@ -1,0 +1,144 @@
+// Bounded processing at the pipeline entry and boundary-gate stage.
+//
+// Covers: detectCandidates line-scan cap firing BEFORE any regex extraction,
+// per-projection detection cap with typed overflow, cap/cap+1 boundary, and
+// CRLF/LF/empty/trailing-newline line numbering after the split→index rewrite.
+
+import { describe, expect, test } from "bun:test";
+import {
+  detectCandidates,
+  type DetectorConfig,
+} from "./boundary-pipeline.ts";
+import {
+  decideProjection,
+  type ClassifyFileInput,
+} from "./boundary-gate.ts";
+import { MAX_LINE_SCAN } from "./boundary-reconstruction.ts";
+
+const cfg: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string): ReturnType<typeof decideProjection>["gate"] {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", cfg).gate;
+}
+
+// G1: detectCandidates line-scan cap. A line over MAX_LINE_SCAN must return
+// ONLY a typed line-scan-exceeded overflow — regex/path/URL extraction must
+// NOT accumulate before the overflow fires.
+describe("G1 detectCandidates line-scan cap fires before regex extraction", () => {
+  test("huge line with many ADR IDs returns exactly one overflow candidate", () => {
+    const huge = "ADR-0001 ".repeat(10000);
+    expect(huge.length).toBeGreaterThan(MAX_LINE_SCAN);
+    const cs = detectCandidates(huge, cfg);
+    expect(cs).toHaveLength(1);
+    expect(cs[0]?.type).toBe("overflow");
+  });
+
+  test("huge line overflow reason is line-scan-exceeded", () => {
+    const huge = "x".repeat(MAX_LINE_SCAN + 100);
+    const cs = detectCandidates(huge, cfg);
+    const ov = cs.find((c): c is Extract<typeof c, { type: "overflow" }> => c.type === "overflow");
+    expect(ov?.reason).toBe("line-scan-exceeded");
+  });
+
+  test("huge line with path and URL tokens: no path/url candidates leak", () => {
+    const huge = "docs/adr/ADR-1.md https://github.com/yogata/agent-dev-flow/blob/main/x.md "
+      + "x".repeat(MAX_LINE_SCAN);
+    const cs = detectCandidates(huge, cfg);
+    expect(cs.every((c) => c.type === "overflow")).toBe(true);
+    expect(cs).toHaveLength(1);
+  });
+
+  test("line at exactly MAX_LINE_SCAN: normal extraction proceeds", () => {
+    const exactLen = "ADR-0001 " + "x".repeat(MAX_LINE_SCAN - 9);
+    expect(exactLen.length).toBe(MAX_LINE_SCAN);
+    const cs = detectCandidates(exactLen, cfg);
+    expect(cs.some((c) => c.type === "direct-id")).toBe(true);
+    expect(cs.some((c) => c.type === "overflow")).toBe(false);
+  });
+});
+
+// G2: per-projection detection cap. The combined failures+errors are bounded;
+// once the cap is reached, exactly one typed projection-overflow Detection is
+// appended and classification stops. The gate is false.
+describe("G2 per-projection detection cap with typed overflow", () => {
+  test("file over cap: bounded detections + exactly one projection overflow + gate false", () => {
+    const text = Array.from({ length: 2000 }, (_, i) => `ADR-${String(i + 1).padStart(4, "0")}`).join("\n");
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const total = g.failures.length + g.errors.length;
+    expect(total).toBeLessThanOrEqual(1025);
+    expect(total).toBeGreaterThanOrEqual(1024);
+    const ov = g.errors.find((d) => d.matched.includes("[overflow: projection"));
+    expect(ov).toBeDefined();
+    expect(ov?.classification).toBe("unclassified");
+    expect(ov?.category).toBe("evasion-attempt");
+  });
+
+  test("allowed detections over cap still stop processing and fail closed", () => {
+    const text = Array.from({ length: 1025 }, (_, i) => `STEP-${i + 1}`).join("\n");
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures).toEqual([]);
+    expect(g.errors).toHaveLength(1);
+    expect(g.errors[0]?.matched).toContain("[overflow: projection");
+  });
+});
+
+// G3: cap and cap+1 boundary behavior.
+describe("G3 projection cap boundary", () => {
+  test("exactly 1024 detections: no projection overflow", () => {
+    const ids = Array.from({ length: 1024 }, (_, i) => `ADR-${String(i + 1).padStart(4, "0")}`).join("\n");
+    const g = gateFor(ids);
+    expect(g.failures.length + g.errors.length).toBe(1024);
+    expect(g.errors.some((d) => d.matched.includes("[overflow: projection"))).toBe(false);
+  });
+
+  test("1025 detections: projection overflow appended, total bounded to 1025", () => {
+    const ids = Array.from({ length: 1025 }, (_, i) => `ADR-${String(i + 1).padStart(4, "0")}`).join("\n");
+    const g = gateFor(ids);
+    expect(g.failures.length + g.errors.length).toBe(1025);
+    expect(g.errors.some((d) => d.matched.includes("[overflow: projection"))).toBe(true);
+  });
+});
+
+// G4: line numbering under CRLF, LF, empty file, trailing newline.
+describe("G4 multi-line CRLF/LF/empty/trailing-newline line numbering", () => {
+  test("LF: line numbers are 1-based correct", () => {
+    const text = "clean line\nADR-0001\nclean";
+    const g = gateFor(text);
+    const det = g.failures[0];
+    expect(det?.line).toBe(2);
+  });
+
+  test("CRLF: line numbers are 1-based correct (\\r stripped, not counted)", () => {
+    const text = "clean line\r\nADR-0001\r\nclean";
+    const g = gateFor(text);
+    expect(g.failures[0]?.line).toBe(2);
+  });
+
+  test("empty file: gate passes with no detections", () => {
+    const g = gateFor("");
+    expect(g.pass).toBe(true);
+    expect(g.failures).toEqual([]);
+    expect(g.errors).toEqual([]);
+  });
+
+  test("trailing newline: no phantom empty last line detection", () => {
+    const text = "ADR-0001\n";
+    const g = gateFor(text);
+    expect(g.failures).toHaveLength(1);
+    expect(g.failures[0]?.line).toBe(1);
+  });
+
+  test("CRLF trailing newline: no phantom empty last line detection", () => {
+    const text = "ADR-0001\r\n";
+    const g = gateFor(text);
+    expect(g.failures).toHaveLength(1);
+    expect(g.failures[0]?.line).toBe(1);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-gate.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-gate.ts
@@ -2,10 +2,13 @@
 //
 // Extracted from boundary-pipeline.ts to keep that module under the 250
 // pure LOC ceiling (parent defect #12). This module owns the multi-file
-// gate decision: it splits each file into lines, runs the per-line
-// classifier (boundary-pipeline.classifyLine), and routes detections into
-// gate failures (producer-internal) or gate errors (unclassified). The
-// gate passes only when both buckets are empty.
+// gate decision: it scans file text by index (never split, never building
+// an unbounded line array), runs the per-line classifier, and routes
+// detections into gate failures (producer-internal) or gate errors
+// (unclassified). Combined detections per projection are bounded; once the
+// cap is reached exactly one typed projection-overflow Detection is
+// appended and classification stops. The gate passes only when both
+// buckets are empty.
 //
 // Side-effect-free: no I/O, pure over inputs and config.
 
@@ -15,17 +18,41 @@ import type {
   LineInput,
   Projection,
 } from "./types.ts";
-import { classifyLine, type DetectorConfig } from "./boundary-pipeline.ts";
+import { classifyLine, type DetectorConfig, type LineClassification } from "./boundary-pipeline.ts";
+import { MAX_LINE_SCAN } from "./boundary-reconstruction.ts";
+import { projectionOverflowDetection } from "./boundary-candidate-model.ts";
 
 export interface ClassifyFileInput {
   readonly filePath: string;
   readonly projection: Projection;
-  /** Text content (already validated UTF-8 by the text-binary module). */
   readonly text: string;
 }
 
 export interface DecideResult {
   readonly gate: GateResult;
+}
+
+// Per-projection combined detection cap. Once reached, classification stops
+// and one typed projection-overflow Detection is appended (total cap+1).
+const MAX_PROJECTION_DETECTIONS = 1024;
+
+function classifyLineBounded(
+  text: string,
+  start: number,
+  contentEnd: number,
+  lineNumber: number,
+  file: ClassifyFileInput,
+  cfg: DetectorConfig,
+): LineClassification {
+  const scanEnd = Math.min(contentEnd, start + MAX_LINE_SCAN + 1);
+  const lineText = text.substring(start, scanEnd);
+  const lineInput: LineInput = {
+    text: lineText,
+    lineNumber,
+    filePath: file.filePath,
+    projection: file.projection,
+  };
+  return classifyLine(lineInput, cfg);
 }
 
 export function decideProjection(
@@ -35,23 +62,45 @@ export function decideProjection(
 ): DecideResult {
   const failures: Detection[] = [];
   const errors: Detection[] = [];
+  const cap = MAX_PROJECTION_DETECTIONS;
+  let detectionCount = 0;
+  let projectionOverflow = false;
 
+  outer:
   for (const file of files) {
-    const lines = file.text.split(/\r?\n/);
-    for (let i = 0; i < lines.length; i++) {
-      const lineText = lines[i] ?? "";
-      const lineInput: LineInput = {
-        text: lineText,
-        lineNumber: i + 1,
-        filePath: file.filePath,
-        projection: file.projection,
-      };
-      const classified = classifyLine(lineInput, cfg);
+    const text = file.text;
+    const n = text.length;
+    let lineStart = 0;
+    let lineNumber = 1;
+    while (lineStart <= n) {
+      const nlIdx = text.indexOf("\n", lineStart);
+      const lineEnd = nlIdx === -1 ? n : nlIdx;
+      const hadNewline = nlIdx !== -1;
+      let contentEnd = lineEnd;
+      if (contentEnd > lineStart && text.charCodeAt(contentEnd - 1) === 0x0D) {
+        contentEnd -= 1;
+      }
+
+      const classified = classifyLineBounded(text, lineStart, contentEnd, lineNumber, file, cfg);
       for (const d of classified.detections) {
+        if (detectionCount >= cap) {
+          projectionOverflow = true;
+          break outer;
+        }
+        detectionCount += 1;
         if (d.classification === "producer-internal") failures.push(d);
         else if (d.classification === "unclassified") errors.push(d);
       }
+
+      if (!hadNewline) break;
+      lineStart = nlIdx + 1;
+      lineNumber += 1;
     }
+  }
+
+  if (projectionOverflow) {
+    const firstFile = files[0]?.filePath ?? "";
+    errors.push(projectionOverflowDetection(firstFile, projection));
   }
 
   const gate: GateResult = {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-gate.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-gate.ts
@@ -1,0 +1,64 @@
+// Pipeline stage 4: decide (gate over many lines).
+//
+// Extracted from boundary-pipeline.ts to keep that module under the 250
+// pure LOC ceiling (parent defect #12). This module owns the multi-file
+// gate decision: it splits each file into lines, runs the per-line
+// classifier (boundary-pipeline.classifyLine), and routes detections into
+// gate failures (producer-internal) or gate errors (unclassified). The
+// gate passes only when both buckets are empty.
+//
+// Side-effect-free: no I/O, pure over inputs and config.
+
+import type {
+  Detection,
+  GateResult,
+  LineInput,
+  Projection,
+} from "./types.ts";
+import { classifyLine, type DetectorConfig } from "./boundary-pipeline.ts";
+
+export interface ClassifyFileInput {
+  readonly filePath: string;
+  readonly projection: Projection;
+  /** Text content (already validated UTF-8 by the text-binary module). */
+  readonly text: string;
+}
+
+export interface DecideResult {
+  readonly gate: GateResult;
+}
+
+export function decideProjection(
+  files: readonly ClassifyFileInput[],
+  projection: Projection,
+  cfg: DetectorConfig,
+): DecideResult {
+  const failures: Detection[] = [];
+  const errors: Detection[] = [];
+
+  for (const file of files) {
+    const lines = file.text.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const lineText = lines[i] ?? "";
+      const lineInput: LineInput = {
+        text: lineText,
+        lineNumber: i + 1,
+        filePath: file.filePath,
+        projection: file.projection,
+      };
+      const classified = classifyLine(lineInput, cfg);
+      for (const d of classified.detections) {
+        if (d.classification === "producer-internal") failures.push(d);
+        else if (d.classification === "unclassified") errors.push(d);
+      }
+    }
+  }
+
+  const gate: GateResult = {
+    pass: failures.length === 0 && errors.length === 0,
+    failures,
+    errors,
+    projection,
+  };
+  return { gate };
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-ownership.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-ownership.test.ts
@@ -1,0 +1,99 @@
+// URL/path ownership and reconstructed-vs-direct dedup coverage.
+//
+// Ownership order: URL > path > reconstructed > direct. A higher-precedence
+// candidate suppresses lower-precedence candidates whose spans it contains
+// (URL/path) or overlaps (reconstructed over direct). Standalone IDs and
+// paths outside URLs are preserved.
+
+import { describe, expect, test } from "bun:test";
+import {
+  classifyLine,
+  detectCandidates,
+  type DetectorConfig,
+} from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+import { ownershipMask, type OwnershipEntry } from "./boundary-candidate-ownership.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function cls(text: string) {
+  return classifyLine({ text, lineNumber: 1, filePath: "f.md", projection: "source" }, baseConfig);
+}
+function gate(text: string) {
+  const f: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(f, "source", baseConfig).gate;
+}
+
+describe("URL ownership / external URL suppresses contained IDs and paths", () => {
+  test("external URL with embedded ADR + docs path is consumer-resolvable only", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/docs/specs/ADR-0001.md";
+    const cs = detectCandidates(text, baseConfig);
+    expect(cs.map((c) => c.type)).toEqual(["url"]);
+    const g = gate(text);
+    expect(g.pass).toBe(true);
+    const url = cs.find((c): c is Extract<typeof c, { type: "url" }> => c.type === "url");
+    expect(url).toBeDefined();
+  });
+
+  test("external URL keeps consumer-resolvable classification", () => {
+    const r = cls("See https://github.com/vercel/next.js/blob/main/docs/specs/ADR-0001.md");
+    const urlDet = r.detections.find((d) => d.category === "fixed-url");
+    expect(urlDet?.classification).toBe("consumer-resolvable");
+  });
+});
+
+describe("URL ownership / producer URL remains a producer failure", () => {
+  test("producer URL with embedded ADR + path: only URL candidate, producer-internal", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow/blob/main/docs/specs/ADR-0001.md";
+    const cs = detectCandidates(text, baseConfig);
+    expect(cs.map((c) => c.type)).toEqual(["url"]);
+    const g = gate(text);
+    expect(g.failures.some((f) => f.classification === "producer-internal" && f.category === "fixed-url")).toBe(true);
+  });
+});
+
+describe("URL ownership / standalone ID and path detection preserved", () => {
+  test("standalone ADR-0001 next to a URL is still detected", () => {
+    const text = "See ADR-0001 and https://github.com/vercel/next.js/blob/main/x.md";
+    const cs = detectCandidates(text, baseConfig);
+    const direct = cs.find((c): c is Extract<typeof c, { type: "direct-id" }> => c.type === "direct-id");
+    expect(direct?.value).toBe("ADR-0001");
+  });
+
+  test("standalone docs path next to a URL is still detected", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md and docs/requirements/REQ-0001.md";
+    const cs = detectCandidates(text, baseConfig);
+    const path = cs.find((c): c is Extract<typeof c, { type: "path" }> => c.type === "path");
+    expect(path).toBeDefined();
+  });
+});
+
+describe("ownershipMask / reconstructed suppresses overlapping direct", () => {
+  test("direct fully inside reconstructed span is suppressed", () => {
+    const entries: OwnershipEntry[] = [
+      { span: { start: 0, end: 10 }, precedence: "reconstructed" },
+      { span: { start: 0, end: 6 }, precedence: "direct" },
+    ];
+    expect(ownershipMask(entries)).toEqual([true, false]);
+  });
+
+  test("same-value reconstructed and direct (same span) dedup to reconstructed", () => {
+    const entries: OwnershipEntry[] = [
+      { span: { start: 0, end: 8 }, precedence: "reconstructed" },
+      { span: { start: 0, end: 8 }, precedence: "direct" },
+    ];
+    expect(ownershipMask(entries)).toEqual([true, false]);
+  });
+
+  test("non-overlapping direct and reconstructed both survive", () => {
+    const entries: OwnershipEntry[] = [
+      { span: { start: 0, end: 6 }, precedence: "direct" },
+      { span: { start: 10, end: 18 }, precedence: "reconstructed" },
+    ];
+    expect(ownershipMask(entries)).toEqual([true, true]);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-ownership.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-ownership.test.ts
@@ -75,24 +75,24 @@ describe("URL ownership / standalone ID and path detection preserved", () => {
 describe("ownershipMask / reconstructed suppresses overlapping direct", () => {
   test("direct fully inside reconstructed span is suppressed", () => {
     const entries: OwnershipEntry[] = [
-      { span: { start: 0, end: 10 }, precedence: "reconstructed" },
-      { span: { start: 0, end: 6 }, precedence: "direct" },
+      { span: { start: 0, end: 10 }, ownershipSpan: { start: 0, end: 10 }, precedence: "reconstructed" },
+      { span: { start: 0, end: 6 }, ownershipSpan: { start: 0, end: 6 }, precedence: "direct" },
     ];
     expect(ownershipMask(entries)).toEqual([true, false]);
   });
 
   test("same-value reconstructed and direct (same span) dedup to reconstructed", () => {
     const entries: OwnershipEntry[] = [
-      { span: { start: 0, end: 8 }, precedence: "reconstructed" },
-      { span: { start: 0, end: 8 }, precedence: "direct" },
+      { span: { start: 0, end: 8 }, ownershipSpan: { start: 0, end: 8 }, precedence: "reconstructed" },
+      { span: { start: 0, end: 8 }, ownershipSpan: { start: 0, end: 8 }, precedence: "direct" },
     ];
     expect(ownershipMask(entries)).toEqual([true, false]);
   });
 
   test("non-overlapping direct and reconstructed both survive", () => {
     const entries: OwnershipEntry[] = [
-      { span: { start: 0, end: 6 }, precedence: "direct" },
-      { span: { start: 10, end: 18 }, precedence: "reconstructed" },
+      { span: { start: 0, end: 6 }, ownershipSpan: { start: 0, end: 6 }, precedence: "direct" },
+      { span: { start: 10, end: 18 }, ownershipSpan: { start: 10, end: 18 }, precedence: "reconstructed" },
     ];
     expect(ownershipMask(entries)).toEqual([true, true]);
   });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-parser-bounds.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-parser-bounds.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { extractDocsPaths } from "./boundary-docs-path-parser.ts";
+
+describe("docs path owner cap", () => {
+  test("exact cap returns every path without overflow", () => {
+    const line = Array.from({ length: 63 }, (_, i) => `docs/specs/x${i}.md`).join(" ");
+    const result = extractDocsPaths(line, 63);
+    expect(result.paths).toHaveLength(63);
+    expect(result.overflow).toBe(false);
+  });
+
+  test("cap plus one returns capped paths with overflow", () => {
+    const line = Array.from({ length: 64 }, (_, i) => `docs/specs/x${i}.md`).join(" ");
+    const result = extractDocsPaths(line, 63);
+    expect(result.paths).toHaveLength(63);
+    expect(result.overflow).toBe(true);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-evasion.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-evasion.test.ts
@@ -1,0 +1,311 @@
+// Stage A vocabulary amendment / evasion regression coverage.
+//
+// Extracted from boundary-pipeline.test.ts and
+// boundary-pipeline-helpers.test.ts to keep every touched file <=250
+// pure LOC. Each describe maps to a reviewer blocker from the Stage A
+// trust-root 5-lane review.
+//
+// Bypass map (blocker -> describe):
+//   B1 wrapper bypass                -> "B1 wrapper bypass closed"
+//   B2 wildcard exemption            -> "B2 wildcard is a token boundary"
+//   B3 prefix escape                 -> "B3-B6 bounded reconstruction"
+//   B4 suffix digit concat           -> "B3-B6 bounded reconstruction"
+//   B5 escaped hyphen                -> "B3-B6 bounded reconstruction"
+//   B6 multiple mixed escapes        -> "B3-B6 bounded reconstruction"
+//   B7 producer/distributed overlap  -> "B7 overlap, producer wins"
+//   B8 classification precedence     -> "B8 precedence" + "B8 gate"
+//   B9 false positives               -> "B9 false positives"
+//   B10 malformed / out-of-scope     -> "B10 malformed"
+//   B11 non-discriminated candidate  -> exhaustive switch is exercised by
+//                                       every resolveCandidate/classifyLine
+//                                       call below.
+//   B12 maximal-token adjacency       -> "B12 maximal-token adjacency"
+
+import { describe, expect, test } from "bun:test";
+import {
+  classifyLine,
+  decideProjection,
+  detectCandidates,
+  resolveCandidate,
+  type Candidate,
+  type ClassifyFileInput,
+  type DetectorConfig,
+} from "./boundary-pipeline.ts";
+import type { DependencyClass, DetectionCategory } from "./types.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function cls(text: string, cfg: DetectorConfig = baseConfig) {
+  return classifyLine({ text, lineNumber: 1, filePath: "f.md", projection: "source" }, cfg);
+}
+
+describe("Stage A vocabulary / UTF encoding labels remain clean", () => {
+  for (const label of ["UTF-8", "UTF-16", "UTF-32"]) {
+    test(`${label} is not flagged`, () => {
+      expect(cls(`File encoded in ${label}.`).detections).toEqual([]);
+    });
+  }
+});
+
+describe("Stage A vocabulary / direct STEP and QG distributed-control", () => {
+  test("direct STEP-N is generic-or-template/distributed-control", () => {
+    const r = cls("See STEP-1 for requirements.");
+    expect(r.detections[0]?.classification).toBe("generic-or-template");
+    expect(r.detections[0]?.category).toBe("distributed-control");
+    expect(r.detections[0]?.matched).toBe("STEP-1");
+  });
+
+  test("direct QG-N is generic-or-template/distributed-control", () => {
+    const r = cls("See QG-2 for quality gate.");
+    expect(r.detections[0]?.classification).toBe("generic-or-template");
+    expect(r.detections[0]?.category).toBe("distributed-control");
+    expect(r.detections[0]?.matched).toBe("QG-2");
+  });
+
+  test("unknown ID prefix remains unclassified (fail-closed)", () => {
+    const r = cls("See MYSTERY-99.");
+    expect(r.detections[0]?.classification).toBe("unclassified");
+    expect(r.detections[0]?.category).toBe("unclassified-entry");
+  });
+});
+
+// B1: wrapper bypass closed. `<`, `>`, `{`, `}`, `*` are token boundaries.
+describe("B1 wrapper bypass closed", () => {
+  test("<ADR-\\u0041> wrapper: no concrete ID reconstructed (ADR-A has no digits)", () => {
+    expect(cls("See <ADR-\\u0041> for the decision.").detections).toEqual([]);
+  });
+
+  test("{REQ-\\x31} wrapper reconstructs REQ-1 and is flagged", () => {
+    const r = cls("See {REQ-\\x31} for the requirement.");
+    expect(r.detections[0]?.classification).toBe("producer-internal");
+    expect(r.detections[0]?.category).toBe("evasion-attempt");
+    expect(r.detections[0]?.matched).toBe("REQ-\\x31");
+  });
+
+  test("<STEP-0x31> wrapper reconstructs STEP-1 and is fail-closed", () => {
+    const r = cls("See <STEP-0x31> for the step.");
+    expect(r.detections[0]?.classification).toBe("unclassified");
+    expect(r.detections[0]?.category).toBe("evasion-attempt");
+    expect(r.detections[0]?.matched).toBe("STEP-0x31");
+  });
+
+  test("<STEP-0X31> uppercase 0X prefix reconstructs STEP-1 (case-insensitive 0[xX])", () => {
+    const r = cls("See <STEP-0X31> for the step.");
+    expect(r.detections).toHaveLength(1);
+    expect(r.detections[0]?.classification).toBe("unclassified");
+    expect(r.detections[0]?.category).toBe("evasion-attempt");
+    expect(r.detections[0]?.matched).toBe("STEP-0X31");
+  });
+});
+
+// B2: wildcard `*` is a token boundary, not an exemption.
+describe("B2 wildcard is a token boundary", () => {
+  test("REQ-123* detects direct ID REQ-123", () => {
+    const r = cls("Pattern REQ-123* suffix.");
+    const direct = r.detections.find((d) => d.category === "concrete-id");
+    expect(direct?.matched).toBe("REQ-123");
+    expect(direct?.classification).toBe("producer-internal");
+  });
+
+  test("REQ-* with no digits is not detected", () => {
+    expect(cls("Pattern REQ-* matches all.").detections).toEqual([]);
+  });
+});
+
+// B3-B6: prefix escape, suffix digit concat, escaped hyphen, multiple mixed.
+describe("B3-B6 bounded reconstruction of producer IDs", () => {
+  const producerCases: Array<[string, string]> = [
+    ["\\u0041DR-0001", "B3 prefix escape"],
+    ["ADR-\\u00310", "B4 suffix digit concat"],
+    ["ADR\\u002d0001", "B5 escaped hyphen"],
+    ["\\u0041DR\\u002d\\u0030\\u0030\\u0030\\u0031", "B6 multiple mixed escapes"],
+  ];
+  for (const [token, label] of producerCases) {
+    test(`${label}: ${token} reconstructs producer ID and is flagged`, () => {
+      const r = cls(`See ${token} here.`);
+      expect(r.detections).toHaveLength(1);
+      expect(r.detections[0]?.classification).toBe("producer-internal");
+      expect(r.detections[0]?.category).toBe("evasion-attempt");
+      expect(r.detections[0]?.matched).toBe(token);
+    });
+  }
+
+  test("STEP-\\u0031 (\\u0031='1') reconstructs STEP-1 and is fail-closed", () => {
+    const r = cls("See STEP-\\u0031 here.");
+    expect(r.detections[0]?.classification).toBe("unclassified");
+    expect(r.detections[0]?.category).toBe("evasion-attempt");
+  });
+
+  test("QG-\\u0032 reconstructs QG-2 and is fail-closed", () => {
+    const r = cls("See QG-\\u0032 here.");
+    expect(r.detections[0]?.classification).toBe("unclassified");
+    expect(r.detections[0]?.category).toBe("evasion-attempt");
+  });
+});
+
+// B7: producer/distributed overlap, producer wins.
+describe("B7 producer and distributed overlap, producer wins", () => {
+  const overlapCfg: DetectorConfig = {
+    ...baseConfig,
+    producer_internal_id_prefixes: [...baseConfig.producer_internal_id_prefixes, "STEP"],
+    distributed_workflow_control_prefixes: ["STEP", "QG"],
+  };
+
+  test("direct STEP-N with overlap => producer-internal/concrete-id", () => {
+    const r = resolveCandidate({ type: "direct-id", value: "STEP-1" }, overlapCfg);
+    expect(r.classification).toBe("producer-internal");
+    expect(r.category).toBe("concrete-id");
+  });
+
+  test("reconstructed STEP-N with overlap => producer-internal/evasion-attempt", () => {
+    const r = resolveCandidate(
+      { type: "reconstructed-id", value: "STEP-1", original: "STEP-\\u0031" },
+      overlapCfg,
+    );
+    expect(r.classification).toBe("producer-internal");
+    expect(r.category).toBe("evasion-attempt");
+  });
+
+  test("classifyLine under overlap => direct STEP-5 is producer-internal", () => {
+    const r = cls("See STEP-5.", overlapCfg);
+    expect(r.detections[0]?.classification).toBe("producer-internal");
+    expect(r.detections[0]?.category).toBe("concrete-id");
+  });
+});
+
+// B8: classification precedence through resolveCandidate.
+describe("B8 classification precedence through resolveCandidate", () => {
+  const cases: Array<[Candidate, DependencyClass, DetectionCategory]> = [
+    [{ type: "direct-id", value: "ADR-0001" }, "producer-internal", "concrete-id"],
+    [{ type: "reconstructed-id", value: "ADR-0001", original: "ADR-\\u0031" }, "producer-internal", "evasion-attempt"],
+    [{ type: "direct-id", value: "STEP-1" }, "generic-or-template", "distributed-control"],
+    [{ type: "reconstructed-id", value: "STEP-1", original: "STEP-\\u0031" }, "unclassified", "evasion-attempt"],
+    [{ type: "reconstructed-id", value: "MYSTERY-1", original: "MYSTERY-\\u0031" }, "unclassified", "evasion-attempt"],
+    [{ type: "direct-id", value: "UNKNOWN-99" }, "unclassified", "unclassified-entry"],
+  ];
+  for (const [c, classification, category] of cases) {
+    test(`${c.type} ${c.value} => ${classification}/${category}`, () => {
+      expect(resolveCandidate(c, baseConfig)).toEqual({ classification, category });
+    });
+  }
+});
+
+// B8: gate placement (failures vs errors).
+describe("B8 gate placement: failures vs errors", () => {
+  type GateShape = {
+    pass: boolean;
+    failures: number;
+    errors: number;
+    firstFailureCat?: string;
+    firstErrorCat?: string;
+  };
+  function gateFor(text: string): GateShape {
+    const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+    const r = decideProjection(files, "source", baseConfig).gate;
+    return {
+      pass: r.pass,
+      failures: r.failures.length,
+      errors: r.errors.length,
+      firstFailureCat: r.failures[0]?.category,
+      firstErrorCat: r.errors[0]?.category,
+    };
+  }
+
+  test("direct producer ID => gate failure (concrete-id)", () => {
+    expect(gateFor("See ADR-0001.")).toEqual({
+      pass: false, failures: 1, errors: 0, firstFailureCat: "concrete-id", firstErrorCat: undefined,
+    });
+  });
+
+  test("reconstructed producer ID => gate failure (evasion-attempt)", () => {
+    expect(gateFor("See \\u0041DR-0001.")).toEqual({
+      pass: false, failures: 1, errors: 0, firstFailureCat: "evasion-attempt", firstErrorCat: undefined,
+    });
+  });
+
+  test("reconstructed STEP/QG => gate error (evasion-attempt, fail-closed)", () => {
+    expect(gateFor("See <STEP-0x31>.")).toEqual({
+      pass: false, failures: 0, errors: 1, firstFailureCat: undefined, firstErrorCat: "evasion-attempt",
+    });
+  });
+
+  test("reconstructed unknown => gate error (evasion-attempt)", () => {
+    const r = gateFor("See FOO-\\u0031.");
+    expect(r.pass).toBe(false);
+    expect(r.errors).toBe(1);
+    expect(r.firstErrorCat).toBe("evasion-attempt");
+  });
+});
+
+// B9: false positives from the security reviewer stay clean (lowercase and uppercase 0x prefix).
+describe("B9 false positives remain clean", () => {
+  const cleanCases: Array<[string, string]> = [
+    ["byte 0x41 represents 'A'", "0x41 not in 30..39"],
+    ["Register CPU-0xFF.", "0xFF not in 30..39"],
+    ["Color COLOR-0xFFFFFF.", "more than 2 hex digits"],
+    ["Escape CTRL-\\x1B.", "decoded ESC is not a digit"],
+    ["Char UNICODE-\\u1234.", "decoded codepoint not a digit"],
+    ["byte 0X41 represents 'A'", "0X41 (uppercase) not in 30..39"],
+    ["Register CPU-0XFF.", "0XFF (uppercase) not in 30..39"],
+    ["Color COLOR-0XFFFFFF.", "0XFFFFFF (uppercase) more than 2 hex digits"],
+  ];
+  for (const [text, label] of cleanCases) {
+    test(`${label}: '${text}' is clean`, () => {
+      expect(cls(text).detections).toEqual([]);
+    });
+  }
+});
+
+// B10: malformed escapes and out-of-scope forms remain clean.
+describe("B10 out-of-scope and malformed escapes remain clean", () => {
+  const malformedCases: Array<[string, string]> = [
+    ["See ADR-\\u{0031} for the decision.", "\\u{...} curly-brace not supported"],
+    ["See ADR-\\u0041 here.", "\\u0041 decodes to non-digit 'A'"],
+    ["See REQ-\\x00 here.", "\\x00 NUL byte"],
+    ["See DEC-0x0032 here.", "0x0032 4 hex digits (not exactly 2)"],
+    ["See SPEC-0x1234 here.", "0x1234 not in 30..39 range"],
+  ];
+  for (const [text, label] of malformedCases) {
+    test(`${label}: '${text}' is clean`, () => {
+      expect(cls(text).detections).toEqual([]);
+    });
+  }
+});
+
+// B11: detectCandidates emits the reconstructed-id variant; exhaustive
+// switch in resolveCandidate handles every Candidate variant.
+describe("B11 detectCandidates emits reconstructed-id candidates", () => {
+  test("detectCandidates returns reconstructed-id for \\u0041DR-0001", () => {
+    const cs = detectCandidates("See \\u0041DR-0001 here.", baseConfig);
+    const r = cs.find((c): c is Extract<Candidate, { type: "reconstructed-id" }> => c.type === "reconstructed-id");
+    expect(r).toBeDefined();
+    expect(r?.value).toBe("ADR-0001");
+    expect(r?.original).toBe("\\u0041DR-0001");
+  });
+
+  test("detectCandidates returns direct-id for plain ADR-0001", () => {
+    const cs = detectCandidates("See ADR-0001 here.", baseConfig);
+    const r = cs.find((c): c is Extract<Candidate, { type: "direct-id" }> => c.type === "direct-id");
+    expect(r).toBeDefined();
+    expect(r?.value).toBe("ADR-0001");
+  });
+});
+
+// B12: maximal-token adjacency — escaped delimiter exposes adjacent literal ID.
+describe("B12 maximal-token adjacency: escaped delimiter exposes adjacent ID", () => {
+  test("STEP-1\\u0020ADR-0002 fails: escaped space exposes ADR-0002 (producer-internal/evasion-attempt)", () => {
+    const files: ClassifyFileInput[] = [
+      { filePath: "f.md", projection: "source", text: "See STEP-1\\u0020ADR-0002." },
+    ];
+    const result = decideProjection(files, "source", baseConfig);
+    expect(result.gate.pass).toBe(false);
+    const producerFailure = result.gate.failures.find(
+      (d) => d.classification === "producer-internal" && d.category === "evasion-attempt",
+    );
+    expect(producerFailure?.matched).toBe("STEP-1\\u0020ADR-0002");
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-evasion.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-evasion.test.ts
@@ -116,11 +116,13 @@ describe("B2 wildcard is a token boundary", () => {
   });
 });
 
-// B3-B6: prefix escape, suffix digit concat, escaped hyphen, multiple mixed.
+// B3-B6: prefix escape, escaped hyphen, multiple mixed. (B4 suffix digit
+// concat via \u is now clean per the \uXXXX exact-contract digit-continuation
+// rule — see boundary-span-overflow.test.ts C2. The \x form ADR-\x310 is
+// still caught — see C1.)
 describe("B3-B6 bounded reconstruction of producer IDs", () => {
   const producerCases: Array<[string, string]> = [
     ["\\u0041DR-0001", "B3 prefix escape"],
-    ["ADR-\\u00310", "B4 suffix digit concat"],
     ["ADR\\u002d0001", "B5 escaped hyphen"],
     ["\\u0041DR\\u002d\\u0030\\u0030\\u0030\\u0031", "B6 multiple mixed escapes"],
   ];
@@ -188,7 +190,8 @@ describe("B8 classification precedence through resolveCandidate", () => {
     [{ type: "direct-id", value: "UNKNOWN-99" }, "unclassified", "unclassified-entry"],
   ];
   for (const [c, classification, category] of cases) {
-    test(`${c.type} ${c.value} => ${classification}/${category}`, () => {
+    const label = "value" in c ? c.value : c.type;
+    test(`${c.type} ${label} => ${classification}/${category}`, () => {
       expect(resolveCandidate(c, baseConfig)).toEqual({ classification, category });
     });
   }
@@ -297,7 +300,7 @@ describe("B11 detectCandidates emits reconstructed-id candidates", () => {
 
 // B12: maximal-token adjacency — escaped delimiter exposes adjacent literal ID.
 describe("B12 maximal-token adjacency: escaped delimiter exposes adjacent ID", () => {
-  test("STEP-1\\u0020ADR-0002 fails: escaped space exposes ADR-0002 (producer-internal/evasion-attempt)", () => {
+  test("STEP-1\\u0020ADR-0002 fails: escaped space exposes ADR-0002 (producer-internal/evasion-attempt, minimal span)", () => {
     const files: ClassifyFileInput[] = [
       { filePath: "f.md", projection: "source", text: "See STEP-1\\u0020ADR-0002." },
     ];
@@ -306,6 +309,6 @@ describe("B12 maximal-token adjacency: escaped delimiter exposes adjacent ID", (
     const producerFailure = result.gate.failures.find(
       (d) => d.classification === "producer-internal" && d.category === "evasion-attempt",
     );
-    expect(producerFailure?.matched).toBe("STEP-1\\u0020ADR-0002");
+    expect(producerFailure?.matched).toBe("\\u0020ADR-0002");
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-evasion.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-evasion.test.ts
@@ -24,13 +24,12 @@
 import { describe, expect, test } from "bun:test";
 import {
   classifyLine,
-  decideProjection,
   detectCandidates,
   resolveCandidate,
   type Candidate,
-  type ClassifyFileInput,
   type DetectorConfig,
 } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
 import type { DependencyClass, DetectionCategory } from "./types.ts";
 
 const baseConfig: DetectorConfig = {
@@ -42,6 +41,10 @@ const baseConfig: DetectorConfig = {
 function cls(text: string, cfg: DetectorConfig = baseConfig) {
   return classifyLine({ text, lineNumber: 1, filePath: "f.md", projection: "source" }, cfg);
 }
+
+// resolveCandidate ignores span; tests use a fixed placeholder to satisfy the
+// typed Candidate union (span is exercised by detectCandidates/ownership).
+const SPAN = { start: 0, end: 1 };
 
 describe("Stage A vocabulary / UTF encoding labels remain clean", () => {
   for (const label of ["UTF-8", "UTF-16", "UTF-32"]) {
@@ -116,10 +119,10 @@ describe("B2 wildcard is a token boundary", () => {
   });
 });
 
-// B3-B6: prefix escape, escaped hyphen, multiple mixed. (B4 suffix digit
-// concat via \u is now clean per the \uXXXX exact-contract digit-continuation
-// rule — see boundary-span-overflow.test.ts C2. The \x form ADR-\x310 is
-// still caught — see C1.)
+// B3-B6: prefix escape, escaped hyphen, multiple mixed. The fixed-width
+// \uXXXX contract reconstructs all digit-continuation forms: \u00310
+// decodes to '1' + literal '0' = ADR-10 (see boundary-span-overflow.test.ts
+// C2). The \x form ADR-\x310 is also caught (see C1).
 describe("B3-B6 bounded reconstruction of producer IDs", () => {
   const producerCases: Array<[string, string]> = [
     ["\\u0041DR-0001", "B3 prefix escape"],
@@ -158,14 +161,14 @@ describe("B7 producer and distributed overlap, producer wins", () => {
   };
 
   test("direct STEP-N with overlap => producer-internal/concrete-id", () => {
-    const r = resolveCandidate({ type: "direct-id", value: "STEP-1" }, overlapCfg);
+    const r = resolveCandidate({ type: "direct-id", value: "STEP-1", span: SPAN }, overlapCfg);
     expect(r.classification).toBe("producer-internal");
     expect(r.category).toBe("concrete-id");
   });
 
   test("reconstructed STEP-N with overlap => producer-internal/evasion-attempt", () => {
     const r = resolveCandidate(
-      { type: "reconstructed-id", value: "STEP-1", original: "STEP-\\u0031" },
+      { type: "reconstructed-id", value: "STEP-1", original: "STEP-\\u0031", span: SPAN },
       overlapCfg,
     );
     expect(r.classification).toBe("producer-internal");
@@ -182,12 +185,12 @@ describe("B7 producer and distributed overlap, producer wins", () => {
 // B8: classification precedence through resolveCandidate.
 describe("B8 classification precedence through resolveCandidate", () => {
   const cases: Array<[Candidate, DependencyClass, DetectionCategory]> = [
-    [{ type: "direct-id", value: "ADR-0001" }, "producer-internal", "concrete-id"],
-    [{ type: "reconstructed-id", value: "ADR-0001", original: "ADR-\\u0031" }, "producer-internal", "evasion-attempt"],
-    [{ type: "direct-id", value: "STEP-1" }, "generic-or-template", "distributed-control"],
-    [{ type: "reconstructed-id", value: "STEP-1", original: "STEP-\\u0031" }, "unclassified", "evasion-attempt"],
-    [{ type: "reconstructed-id", value: "MYSTERY-1", original: "MYSTERY-\\u0031" }, "unclassified", "evasion-attempt"],
-    [{ type: "direct-id", value: "UNKNOWN-99" }, "unclassified", "unclassified-entry"],
+    [{ type: "direct-id", value: "ADR-0001", span: SPAN }, "producer-internal", "concrete-id"],
+    [{ type: "reconstructed-id", value: "ADR-0001", original: "ADR-\\u0031", span: SPAN }, "producer-internal", "evasion-attempt"],
+    [{ type: "direct-id", value: "STEP-1", span: SPAN }, "generic-or-template", "distributed-control"],
+    [{ type: "reconstructed-id", value: "STEP-1", original: "STEP-\\u0031", span: SPAN }, "unclassified", "evasion-attempt"],
+    [{ type: "reconstructed-id", value: "MYSTERY-1", original: "MYSTERY-\\u0031", span: SPAN }, "unclassified", "evasion-attempt"],
+    [{ type: "direct-id", value: "UNKNOWN-99", span: SPAN }, "unclassified", "unclassified-entry"],
   ];
   for (const [c, classification, category] of cases) {
     const label = "value" in c ? c.value : c.type;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-helpers.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-helpers.test.ts
@@ -20,6 +20,7 @@ const baseConfig: DetectorConfig = {
   producer_internal_id_prefixes: [
     "ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC",
   ],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
 };
 
 describe("boundary-pipeline helpers / normalizePathToken", () => {
@@ -115,5 +116,96 @@ describe("boundary-pipeline helpers / isConcreteDocsPath", () => {
   });
   test("accepts concrete markdown file", () => {
     expect(isConcreteDocsPath("docs/adr/ADR-0001.md")).toBe(true);
+  });
+});
+
+describe("Stage A vocabulary amendment - evasion detection helpers", () => {
+  const cfgWithStepQg: DetectorConfig = {
+    ...baseConfig,
+    distributed_workflow_control_prefixes: ["STEP", "QG"],
+  };
+
+  describe("ID-shaped evasion: \\uXXXX escape patterns", () => {
+    test("detects evasion with \\uXXXX after producer prefix", () => {
+      const r = resolveCandidate({ type: "evasion", value: "ADR-\\u0041" }, cfgWithStepQg);
+      expect(r.classification).toBe("unclassified");
+      expect(r.category).toBe("evasion-attempt");
+    });
+
+    test("detects evasion with \\uXXXX after unknown prefix", () => {
+      const r = resolveCandidate({ type: "evasion", value: "MYSTERY-\\u0041" }, cfgWithStepQg);
+      expect(r.classification).toBe("unclassified");
+      expect(r.category).toBe("evasion-attempt");
+    });
+
+    test("detects evasion with \\uXXXX after STEP/QG prefix", () => {
+      const r1 = resolveCandidate({ type: "evasion", value: "STEP-\\u0031" }, cfgWithStepQg);
+      expect(r1.classification).toBe("unclassified");
+      expect(r1.category).toBe("evasion-attempt");
+
+      const r2 = resolveCandidate({ type: "evasion", value: "QG-\\u0032" }, cfgWithStepQg);
+      expect(r2.classification).toBe("unclassified");
+      expect(r2.category).toBe("evasion-attempt");
+    });
+  });
+
+  describe("ID-shaped evasion: \\xXX escape patterns", () => {
+    test("detects evasion with \\xXX after producer prefix", () => {
+      const r = resolveCandidate({ type: "evasion", value: "REQ-\\x31" }, cfgWithStepQg);
+      expect(r.classification).toBe("unclassified");
+      expect(r.category).toBe("evasion-attempt");
+    });
+
+    test("detects evasion with \\xXX after unknown prefix", () => {
+      const r = resolveCandidate({ type: "evasion", value: "FOO-\\x42" }, cfgWithStepQg);
+      expect(r.classification).toBe("unclassified");
+      expect(r.category).toBe("evasion-attempt");
+    });
+  });
+
+  describe("ID-shaped evasion: 0xXX hex literal patterns", () => {
+    test("detects evasion with 0xXX after producer prefix", () => {
+      const r = resolveCandidate({ type: "evasion", value: "DEC-0x33" }, cfgWithStepQg);
+      expect(r.classification).toBe("unclassified");
+      expect(r.category).toBe("evasion-attempt");
+    });
+
+    test("detects evasion with 0xXX after unknown prefix", () => {
+      const r = resolveCandidate({ type: "evasion", value: "BAR-0x44" }, cfgWithStepQg);
+      expect(r.classification).toBe("unclassified");
+      expect(r.category).toBe("evasion-attempt");
+    });
+
+    test("detects evasion with 0xXXXX (4-digit)", () => {
+      const r = resolveCandidate({ type: "evasion", value: "SPEC-0x1234" }, cfgWithStepQg);
+      expect(r.classification).toBe("unclassified");
+      expect(r.category).toBe("evasion-attempt");
+    });
+  });
+
+  describe("distributed workflow control STEP/QG classification", () => {
+    test("STEP-N resolves to generic-or-template with distributed-control", () => {
+      const r = resolveCandidate({ type: "id", value: "STEP-1" }, cfgWithStepQg);
+      expect(r.classification).toBe("generic-or-template");
+      expect(r.category).toBe("distributed-control");
+    });
+
+    test("QG-N resolves to generic-or-template with distributed-control", () => {
+      const r = resolveCandidate({ type: "id", value: "QG-2" }, cfgWithStepQg);
+      expect(r.classification).toBe("generic-or-template");
+      expect(r.category).toBe("distributed-control");
+    });
+
+    test("unknown prefix remains unclassified (fail-closed)", () => {
+      const r = resolveCandidate({ type: "id", value: "UNKNOWN-99" }, cfgWithStepQg);
+      expect(r.classification).toBe("unclassified");
+      expect(r.category).toBe("unclassified-entry");
+    });
+
+    test("producer prefixes remain concrete violations", () => {
+      const r = resolveCandidate({ type: "id", value: "ADR-0001" }, cfgWithStepQg);
+      expect(r.classification).toBe("producer-internal");
+      expect(r.category).toBe("concrete-id");
+    });
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-helpers.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-helpers.test.ts
@@ -89,7 +89,7 @@ describe("boundary-pipeline helpers / resolveCandidate", () => {
 
   test("producer-owned URL resolves to producer-internal (parent defect #5)", () => {
     const r = resolveCandidate(
-      { type: "url", value: "https://github.com/yogata/agent-dev-flow/blob/main/x.md", span: S },
+      { type: "url", value: "https://github.com/yogata/agent-dev-flow/blob/main/x.md", span: S, malformed: false },
       baseConfig,
     );
     expect(r.classification).toBe("producer-internal");
@@ -98,7 +98,7 @@ describe("boundary-pipeline helpers / resolveCandidate", () => {
 
   test("external-repo URL resolves to consumer-resolvable (parent defect #5)", () => {
     const r = resolveCandidate(
-      { type: "url", value: "https://github.com/vercel/next.js/blob/main/docs/x.md", span: S },
+      { type: "url", value: "https://github.com/vercel/next.js/blob/main/docs/x.md", span: S, malformed: false },
       baseConfig,
     );
     expect(r.classification).toBe("consumer-resolvable");

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-helpers.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-helpers.test.ts
@@ -56,21 +56,23 @@ describe("boundary-pipeline helpers / detectCandidates", () => {
 });
 
 describe("boundary-pipeline helpers / resolveCandidate", () => {
+  // resolveCandidate ignores span; placeholder satisfies the typed union.
+  const S = { start: 0, end: 1 };
   test("known ID prefix resolves to producer-internal", () => {
-    const r = resolveCandidate({ type: "direct-id", value: "REQ-0001" }, baseConfig);
+    const r = resolveCandidate({ type: "direct-id", value: "REQ-0001", span: S }, baseConfig);
     expect(r.classification).toBe("producer-internal");
     expect(r.category).toBe("concrete-id");
   });
 
   test("unknown ID prefix resolves to unclassified (fail-closed)", () => {
-    const r = resolveCandidate({ type: "direct-id", value: "MYSTERY-99" }, baseConfig);
+    const r = resolveCandidate({ type: "direct-id", value: "MYSTERY-99", span: S }, baseConfig);
     expect(r.classification).toBe("unclassified");
     expect(r.category).toBe("unclassified-entry");
   });
 
   test("known path resolves to producer-internal (concrete)", () => {
     const r = resolveCandidate(
-      { type: "path", value: "docs/requirements/REQ-0001.md" },
+      { type: "path", value: "docs/requirements/REQ-0001.md", span: S },
       baseConfig,
     );
     expect(r.classification).toBe("producer-internal");
@@ -79,7 +81,7 @@ describe("boundary-pipeline helpers / resolveCandidate", () => {
 
   test("template path resolves to generic-or-template", () => {
     const r = resolveCandidate(
-      { type: "path", value: "docs/specs/<domain>/x.md" },
+      { type: "path", value: "docs/specs/<domain>/x.md", span: S },
       baseConfig,
     );
     expect(r.classification).toBe("generic-or-template");
@@ -87,7 +89,7 @@ describe("boundary-pipeline helpers / resolveCandidate", () => {
 
   test("producer-owned URL resolves to producer-internal (parent defect #5)", () => {
     const r = resolveCandidate(
-      { type: "url", value: "https://github.com/yogata/agent-dev-flow/blob/main/x.md" },
+      { type: "url", value: "https://github.com/yogata/agent-dev-flow/blob/main/x.md", span: S },
       baseConfig,
     );
     expect(r.classification).toBe("producer-internal");
@@ -96,7 +98,7 @@ describe("boundary-pipeline helpers / resolveCandidate", () => {
 
   test("external-repo URL resolves to consumer-resolvable (parent defect #5)", () => {
     const r = resolveCandidate(
-      { type: "url", value: "https://github.com/vercel/next.js/blob/main/docs/x.md" },
+      { type: "url", value: "https://github.com/vercel/next.js/blob/main/docs/x.md", span: S },
       baseConfig,
     );
     expect(r.classification).toBe("consumer-resolvable");

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-helpers.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-helpers.test.ts
@@ -89,7 +89,7 @@ describe("boundary-pipeline helpers / resolveCandidate", () => {
 
   test("producer-owned URL resolves to producer-internal (parent defect #5)", () => {
     const r = resolveCandidate(
-      { type: "url", value: "https://github.com/yogata/agent-dev-flow/blob/main/x.md", span: S, malformed: false },
+      { type: "url", value: "https://github.com/yogata/agent-dev-flow/blob/main/x.md", span: S, ownershipSpan: S, malformed: false },
       baseConfig,
     );
     expect(r.classification).toBe("producer-internal");
@@ -98,7 +98,7 @@ describe("boundary-pipeline helpers / resolveCandidate", () => {
 
   test("external-repo URL resolves to consumer-resolvable (parent defect #5)", () => {
     const r = resolveCandidate(
-      { type: "url", value: "https://github.com/vercel/next.js/blob/main/docs/x.md", span: S, malformed: false },
+      { type: "url", value: "https://github.com/vercel/next.js/blob/main/docs/x.md", span: S, ownershipSpan: S, malformed: false },
       baseConfig,
     );
     expect(r.classification).toBe("consumer-resolvable");

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-helpers.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline-helpers.test.ts
@@ -2,6 +2,9 @@
 // detectCandidates, resolveCandidate. Extracted from
 // boundary-pipeline.test.ts to keep that file under the 250 pure LOC
 // ceiling (parent defect #12).
+//
+// Stage A vocabulary amendment / evasion helper coverage lives in
+// boundary-pipeline-evasion.test.ts.
 
 import { describe, expect, test } from "bun:test";
 import {
@@ -47,20 +50,20 @@ describe("boundary-pipeline helpers / detectCandidates", () => {
     const cs = detectCandidates("See ADR-0001 and docs/specs/ADR-0002.md", baseConfig);
     expect(cs.length).toBeGreaterThanOrEqual(2);
     const types = cs.map((c) => c.type).sort();
-    expect(types).toContain("id");
+    expect(types).toContain("direct-id");
     expect(types).toContain("path");
   });
 });
 
 describe("boundary-pipeline helpers / resolveCandidate", () => {
   test("known ID prefix resolves to producer-internal", () => {
-    const r = resolveCandidate({ type: "id", value: "REQ-0001" }, baseConfig);
+    const r = resolveCandidate({ type: "direct-id", value: "REQ-0001" }, baseConfig);
     expect(r.classification).toBe("producer-internal");
     expect(r.category).toBe("concrete-id");
   });
 
   test("unknown ID prefix resolves to unclassified (fail-closed)", () => {
-    const r = resolveCandidate({ type: "id", value: "MYSTERY-99" }, baseConfig);
+    const r = resolveCandidate({ type: "direct-id", value: "MYSTERY-99" }, baseConfig);
     expect(r.classification).toBe("unclassified");
     expect(r.category).toBe("unclassified-entry");
   });
@@ -116,96 +119,5 @@ describe("boundary-pipeline helpers / isConcreteDocsPath", () => {
   });
   test("accepts concrete markdown file", () => {
     expect(isConcreteDocsPath("docs/adr/ADR-0001.md")).toBe(true);
-  });
-});
-
-describe("Stage A vocabulary amendment - evasion detection helpers", () => {
-  const cfgWithStepQg: DetectorConfig = {
-    ...baseConfig,
-    distributed_workflow_control_prefixes: ["STEP", "QG"],
-  };
-
-  describe("ID-shaped evasion: \\uXXXX escape patterns", () => {
-    test("detects evasion with \\uXXXX after producer prefix", () => {
-      const r = resolveCandidate({ type: "evasion", value: "ADR-\\u0041" }, cfgWithStepQg);
-      expect(r.classification).toBe("unclassified");
-      expect(r.category).toBe("evasion-attempt");
-    });
-
-    test("detects evasion with \\uXXXX after unknown prefix", () => {
-      const r = resolveCandidate({ type: "evasion", value: "MYSTERY-\\u0041" }, cfgWithStepQg);
-      expect(r.classification).toBe("unclassified");
-      expect(r.category).toBe("evasion-attempt");
-    });
-
-    test("detects evasion with \\uXXXX after STEP/QG prefix", () => {
-      const r1 = resolveCandidate({ type: "evasion", value: "STEP-\\u0031" }, cfgWithStepQg);
-      expect(r1.classification).toBe("unclassified");
-      expect(r1.category).toBe("evasion-attempt");
-
-      const r2 = resolveCandidate({ type: "evasion", value: "QG-\\u0032" }, cfgWithStepQg);
-      expect(r2.classification).toBe("unclassified");
-      expect(r2.category).toBe("evasion-attempt");
-    });
-  });
-
-  describe("ID-shaped evasion: \\xXX escape patterns", () => {
-    test("detects evasion with \\xXX after producer prefix", () => {
-      const r = resolveCandidate({ type: "evasion", value: "REQ-\\x31" }, cfgWithStepQg);
-      expect(r.classification).toBe("unclassified");
-      expect(r.category).toBe("evasion-attempt");
-    });
-
-    test("detects evasion with \\xXX after unknown prefix", () => {
-      const r = resolveCandidate({ type: "evasion", value: "FOO-\\x42" }, cfgWithStepQg);
-      expect(r.classification).toBe("unclassified");
-      expect(r.category).toBe("evasion-attempt");
-    });
-  });
-
-  describe("ID-shaped evasion: 0xXX hex literal patterns", () => {
-    test("detects evasion with 0xXX after producer prefix", () => {
-      const r = resolveCandidate({ type: "evasion", value: "DEC-0x33" }, cfgWithStepQg);
-      expect(r.classification).toBe("unclassified");
-      expect(r.category).toBe("evasion-attempt");
-    });
-
-    test("detects evasion with 0xXX after unknown prefix", () => {
-      const r = resolveCandidate({ type: "evasion", value: "BAR-0x44" }, cfgWithStepQg);
-      expect(r.classification).toBe("unclassified");
-      expect(r.category).toBe("evasion-attempt");
-    });
-
-    test("detects evasion with 0xXXXX (4-digit)", () => {
-      const r = resolveCandidate({ type: "evasion", value: "SPEC-0x1234" }, cfgWithStepQg);
-      expect(r.classification).toBe("unclassified");
-      expect(r.category).toBe("evasion-attempt");
-    });
-  });
-
-  describe("distributed workflow control STEP/QG classification", () => {
-    test("STEP-N resolves to generic-or-template with distributed-control", () => {
-      const r = resolveCandidate({ type: "id", value: "STEP-1" }, cfgWithStepQg);
-      expect(r.classification).toBe("generic-or-template");
-      expect(r.category).toBe("distributed-control");
-    });
-
-    test("QG-N resolves to generic-or-template with distributed-control", () => {
-      const r = resolveCandidate({ type: "id", value: "QG-2" }, cfgWithStepQg);
-      expect(r.classification).toBe("generic-or-template");
-      expect(r.category).toBe("distributed-control");
-    });
-
-    test("unknown prefix remains unclassified (fail-closed)", () => {
-      const r = resolveCandidate({ type: "id", value: "UNKNOWN-99" }, cfgWithStepQg);
-      expect(r.classification).toBe("unclassified");
-      expect(r.category).toBe("unclassified-entry");
-    });
-
-    test("producer prefixes remain concrete violations", () => {
-      const r = resolveCandidate({ type: "id", value: "ADR-0001" }, cfgWithStepQg);
-      expect(r.classification).toBe("producer-internal");
-      expect(r.category).toBe("concrete-id");
-    });
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.test.ts
@@ -5,13 +5,14 @@
 // backslash, URI-encoded), producer-repository fixed URLs (by configured
 // identity), generic/template allowances, and fail-closed on unclassified
 // input.
+//
+// Stage A vocabulary amendment / evasion regression coverage lives in
+// boundary-pipeline-evasion.test.ts.
 
 import { describe, expect, test } from "bun:test";
 import {
   classifyLine,
   type DetectorConfig,
-  type ClassifyFileInput,
-  decideProjection,
 } from "./boundary-pipeline.ts";
 
 const baseConfig: DetectorConfig = {
@@ -256,150 +257,5 @@ describe("boundary-pipeline / classifyLine", () => {
     // No identity configured: URL extraction itself is suppressed to avoid
     // false positives. fail-closed is via the empty identity contract.
     expect(urlDetection).toBeUndefined();
-  });
-
-  describe("Stage A vocabulary amendment - UTF-8/16/32 encoding labels", () => {
-    test("does NOT detect UTF-8 as an ID candidate (zero detections)", () => {
-      const r = classifyLine(
-        { text: "File encoded in UTF-8.", lineNumber: 1, filePath: "f.md", projection: "source" },
-        baseConfig,
-      );
-      expect(r.detections).toEqual([]);
-    });
-
-    test("does NOT detect UTF-16 as an ID candidate (zero detections)", () => {
-      const r = classifyLine(
-        { text: "File encoded in UTF-16.", lineNumber: 1, filePath: "f.md", projection: "source" },
-        baseConfig,
-      );
-      expect(r.detections).toEqual([]);
-    });
-
-    test("does NOT detect UTF-32 as an ID candidate (zero detections)", () => {
-      const r = classifyLine(
-        { text: "File encoded in UTF-32.", lineNumber: 1, filePath: "f.md", projection: "source" },
-        baseConfig,
-      );
-      expect(r.detections).toEqual([]);
-    });
-  });
-
-  describe("Stage A vocabulary amendment - distributed workflow control STEP/QG", () => {
-    const cfgWithStepQg: DetectorConfig = {
-      ...baseConfig,
-      distributed_workflow_control_prefixes: ["STEP", "QG"],
-    };
-
-    test("classifies STEP-N as generic-or-template with category distributed-control", () => {
-      const r = classifyLine(
-        { text: "See STEP-1 for requirements.", lineNumber: 1, filePath: "f.md", projection: "source" },
-        cfgWithStepQg,
-      );
-      expect(r.detections).toHaveLength(1);
-      expect(r.detections[0]?.classification).toBe("generic-or-template");
-      expect(r.detections[0]?.category).toBe("distributed-control");
-      expect(r.detections[0]?.matched).toBe("STEP-1");
-    });
-
-    test("classifies QG-N as generic-or-template with category distributed-control", () => {
-      const r = classifyLine(
-        { text: "See QG-2 for quality gate.", lineNumber: 1, filePath: "f.md", projection: "source" },
-        cfgWithStepQg,
-      );
-      expect(r.detections).toHaveLength(1);
-      expect(r.detections[0]?.classification).toBe("generic-or-template");
-      expect(r.detections[0]?.category).toBe("distributed-control");
-      expect(r.detections[0]?.matched).toBe("QG-2");
-    });
-
-    test("unknown ID prefix remains unclassified (fail-closed)", () => {
-      const r = classifyLine(
-        { text: "See MYSTERY-99.", lineNumber: 1, filePath: "f.md", projection: "source" },
-        cfgWithStepQg,
-      );
-      expect(r.detections).toHaveLength(1);
-      expect(r.detections[0]?.classification).toBe("unclassified");
-      expect(r.detections[0]?.category).toBe("unclassified-entry");
-    });
-  });
-
-  describe("Stage A vocabulary amendment - ID-shaped evasion detection", () => {
-    const cfgWithStepQg: DetectorConfig = {
-      ...baseConfig,
-      distributed_workflow_control_prefixes: ["STEP", "QG"],
-    };
-
-    test("detects ID-shaped evasion with \\uXXXX escape after hyphen", () => {
-      const r = classifyLine(
-        { text: "See ADR-\\u0041 for decision.", lineNumber: 1, filePath: "f.md", projection: "source" },
-        cfgWithStepQg,
-      );
-      expect(r.detections).toHaveLength(1);
-      expect(r.detections[0]?.classification).toBe("unclassified");
-      expect(r.detections[0]?.category).toBe("evasion-attempt");
-    });
-
-    test("detects ID-shaped evasion with \\xXX escape after hyphen", () => {
-      const r = classifyLine(
-        { text: "See REQ-\\x00 for details.", lineNumber: 1, filePath: "f.md", projection: "source" },
-        cfgWithStepQg,
-      );
-      expect(r.detections).toHaveLength(1);
-      expect(r.detections[0]?.classification).toBe("unclassified");
-      expect(r.detections[0]?.category).toBe("evasion-attempt");
-    });
-
-    test("detects ID-shaped evasion with 0xXX hex literal after hyphen", () => {
-      const r = classifyLine(
-        { text: "See DEC-0x0032 for context.", lineNumber: 1, filePath: "f.md", projection: "source" },
-        cfgWithStepQg,
-      );
-      expect(r.detections).toHaveLength(1);
-      expect(r.detections[0]?.classification).toBe("unclassified");
-      expect(r.detections[0]?.category).toBe("evasion-attempt");
-    });
-
-    test("does NOT classify unrelated hex prose as evasion", () => {
-      const r = classifyLine(
-        { text: "byte 0x41 represents 'A'", lineNumber: 1, filePath: "f.md", projection: "source" },
-        cfgWithStepQg,
-      );
-      const evasionDetection = r.detections.find((d) => d.category === "evasion-attempt");
-      expect(evasionDetection).toBeUndefined();
-      const idDetection = r.detections.find((d) => d.category === "concrete-id");
-      expect(idDetection).toBeUndefined();
-    });
-
-    test("escaped STEP/QG IDs are detected as evasion-attempt (fail-closed)", () => {
-      const r = classifyLine(
-        { text: "See STEP-\\u0031 and QG-\\x00.", lineNumber: 1, filePath: "f.md", projection: "source" },
-        cfgWithStepQg,
-      );
-      expect(r.detections).toHaveLength(2);
-      expect(r.detections.every((d) => d.category === "evasion-attempt")).toBe(true);
-      expect(r.detections.every((d) => d.classification === "unclassified")).toBe(true);
-    });
-  });
-
-  describe("Stage A vocabulary amendment - evasion gate failure", () => {
-    const cfgWithStepQg: DetectorConfig = {
-      ...baseConfig,
-      distributed_workflow_control_prefixes: ["STEP", "QG"],
-    };
-
-    test("evasion-attempt in errors causes decideProjection gate to fail", () => {
-      const files: ClassifyFileInput[] = [
-        {
-          filePath: "evasion.md",
-          projection: "source",
-          text: "See ADR-\\u0041 for decision.",
-        },
-      ];
-      const result = decideProjection(files, "source", cfgWithStepQg);
-      expect(result.gate.pass).toBe(false);
-      expect(result.gate.errors).toHaveLength(1);
-      expect(result.gate.errors[0]?.category).toBe("evasion-attempt");
-      expect(result.gate.errors[0]?.classification).toBe("unclassified");
-    });
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.test.ts
@@ -10,6 +10,8 @@ import { describe, expect, test } from "bun:test";
 import {
   classifyLine,
   type DetectorConfig,
+  type ClassifyFileInput,
+  decideProjection,
 } from "./boundary-pipeline.ts";
 
 const baseConfig: DetectorConfig = {
@@ -32,6 +34,7 @@ const baseConfig: DetectorConfig = {
     "OU",
     "EC",
   ],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
 };
 
 describe("boundary-pipeline / classifyLine", () => {
@@ -253,5 +256,150 @@ describe("boundary-pipeline / classifyLine", () => {
     // No identity configured: URL extraction itself is suppressed to avoid
     // false positives. fail-closed is via the empty identity contract.
     expect(urlDetection).toBeUndefined();
+  });
+
+  describe("Stage A vocabulary amendment - UTF-8/16/32 encoding labels", () => {
+    test("does NOT detect UTF-8 as an ID candidate (zero detections)", () => {
+      const r = classifyLine(
+        { text: "File encoded in UTF-8.", lineNumber: 1, filePath: "f.md", projection: "source" },
+        baseConfig,
+      );
+      expect(r.detections).toEqual([]);
+    });
+
+    test("does NOT detect UTF-16 as an ID candidate (zero detections)", () => {
+      const r = classifyLine(
+        { text: "File encoded in UTF-16.", lineNumber: 1, filePath: "f.md", projection: "source" },
+        baseConfig,
+      );
+      expect(r.detections).toEqual([]);
+    });
+
+    test("does NOT detect UTF-32 as an ID candidate (zero detections)", () => {
+      const r = classifyLine(
+        { text: "File encoded in UTF-32.", lineNumber: 1, filePath: "f.md", projection: "source" },
+        baseConfig,
+      );
+      expect(r.detections).toEqual([]);
+    });
+  });
+
+  describe("Stage A vocabulary amendment - distributed workflow control STEP/QG", () => {
+    const cfgWithStepQg: DetectorConfig = {
+      ...baseConfig,
+      distributed_workflow_control_prefixes: ["STEP", "QG"],
+    };
+
+    test("classifies STEP-N as generic-or-template with category distributed-control", () => {
+      const r = classifyLine(
+        { text: "See STEP-1 for requirements.", lineNumber: 1, filePath: "f.md", projection: "source" },
+        cfgWithStepQg,
+      );
+      expect(r.detections).toHaveLength(1);
+      expect(r.detections[0]?.classification).toBe("generic-or-template");
+      expect(r.detections[0]?.category).toBe("distributed-control");
+      expect(r.detections[0]?.matched).toBe("STEP-1");
+    });
+
+    test("classifies QG-N as generic-or-template with category distributed-control", () => {
+      const r = classifyLine(
+        { text: "See QG-2 for quality gate.", lineNumber: 1, filePath: "f.md", projection: "source" },
+        cfgWithStepQg,
+      );
+      expect(r.detections).toHaveLength(1);
+      expect(r.detections[0]?.classification).toBe("generic-or-template");
+      expect(r.detections[0]?.category).toBe("distributed-control");
+      expect(r.detections[0]?.matched).toBe("QG-2");
+    });
+
+    test("unknown ID prefix remains unclassified (fail-closed)", () => {
+      const r = classifyLine(
+        { text: "See MYSTERY-99.", lineNumber: 1, filePath: "f.md", projection: "source" },
+        cfgWithStepQg,
+      );
+      expect(r.detections).toHaveLength(1);
+      expect(r.detections[0]?.classification).toBe("unclassified");
+      expect(r.detections[0]?.category).toBe("unclassified-entry");
+    });
+  });
+
+  describe("Stage A vocabulary amendment - ID-shaped evasion detection", () => {
+    const cfgWithStepQg: DetectorConfig = {
+      ...baseConfig,
+      distributed_workflow_control_prefixes: ["STEP", "QG"],
+    };
+
+    test("detects ID-shaped evasion with \\uXXXX escape after hyphen", () => {
+      const r = classifyLine(
+        { text: "See ADR-\\u0041 for decision.", lineNumber: 1, filePath: "f.md", projection: "source" },
+        cfgWithStepQg,
+      );
+      expect(r.detections).toHaveLength(1);
+      expect(r.detections[0]?.classification).toBe("unclassified");
+      expect(r.detections[0]?.category).toBe("evasion-attempt");
+    });
+
+    test("detects ID-shaped evasion with \\xXX escape after hyphen", () => {
+      const r = classifyLine(
+        { text: "See REQ-\\x00 for details.", lineNumber: 1, filePath: "f.md", projection: "source" },
+        cfgWithStepQg,
+      );
+      expect(r.detections).toHaveLength(1);
+      expect(r.detections[0]?.classification).toBe("unclassified");
+      expect(r.detections[0]?.category).toBe("evasion-attempt");
+    });
+
+    test("detects ID-shaped evasion with 0xXX hex literal after hyphen", () => {
+      const r = classifyLine(
+        { text: "See DEC-0x0032 for context.", lineNumber: 1, filePath: "f.md", projection: "source" },
+        cfgWithStepQg,
+      );
+      expect(r.detections).toHaveLength(1);
+      expect(r.detections[0]?.classification).toBe("unclassified");
+      expect(r.detections[0]?.category).toBe("evasion-attempt");
+    });
+
+    test("does NOT classify unrelated hex prose as evasion", () => {
+      const r = classifyLine(
+        { text: "byte 0x41 represents 'A'", lineNumber: 1, filePath: "f.md", projection: "source" },
+        cfgWithStepQg,
+      );
+      const evasionDetection = r.detections.find((d) => d.category === "evasion-attempt");
+      expect(evasionDetection).toBeUndefined();
+      const idDetection = r.detections.find((d) => d.category === "concrete-id");
+      expect(idDetection).toBeUndefined();
+    });
+
+    test("escaped STEP/QG IDs are detected as evasion-attempt (fail-closed)", () => {
+      const r = classifyLine(
+        { text: "See STEP-\\u0031 and QG-\\x00.", lineNumber: 1, filePath: "f.md", projection: "source" },
+        cfgWithStepQg,
+      );
+      expect(r.detections).toHaveLength(2);
+      expect(r.detections.every((d) => d.category === "evasion-attempt")).toBe(true);
+      expect(r.detections.every((d) => d.classification === "unclassified")).toBe(true);
+    });
+  });
+
+  describe("Stage A vocabulary amendment - evasion gate failure", () => {
+    const cfgWithStepQg: DetectorConfig = {
+      ...baseConfig,
+      distributed_workflow_control_prefixes: ["STEP", "QG"],
+    };
+
+    test("evasion-attempt in errors causes decideProjection gate to fail", () => {
+      const files: ClassifyFileInput[] = [
+        {
+          filePath: "evasion.md",
+          projection: "source",
+          text: "See ADR-\\u0041 for decision.",
+        },
+      ];
+      const result = decideProjection(files, "source", cfgWithStepQg);
+      expect(result.gate.pass).toBe(false);
+      expect(result.gate.errors).toHaveLength(1);
+      expect(result.gate.errors[0]?.category).toBe("evasion-attempt");
+      expect(result.gate.errors[0]?.classification).toBe("unclassified");
+    });
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
@@ -123,7 +123,7 @@ export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[]
   }
 
   if (overflowReason === null) {
-    const recon = detectReconstructedIds(line);
+    const recon = detectReconstructedIds(line, ownedSpans);
     if (recon.overflow) overflowReason = recon.overflowReason ?? "token-ids-exceeded";
     if (overflowReason === null) {
       for (const r of recon.ids) {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
@@ -21,6 +21,7 @@ import { detectReconstructedIds, MAX_LINE_SCAN } from "./boundary-reconstruction
 import {
   ownershipMask,
   type OwnershipEntry,
+  type Span,
 } from "./boundary-candidate-ownership.ts";
 import {
   matchedForCandidate,
@@ -29,10 +30,9 @@ import {
   type Candidate,
   type DetectorConfig,
   type OverflowReason,
-  DOCS_PATH_PATTERN,
-  DOCS_PATH_PERCENT_PATTERN,
-  URL_CANDIDATE_PATTERN,
 } from "./boundary-candidate-model.ts";
+import { extractUrls } from "./boundary-url-parser.ts";
+import { extractDocsPaths } from "./boundary-docs-path-parser.ts";
 
 // Re-export so consumers import from the pipeline barrel without a cycle.
 export type {
@@ -75,83 +75,79 @@ const MAX_CANDIDATES_PER_LINE = 64;
 
 type SpannedCandidate = Exclude<Candidate, { type: "overflow" }>;
 
-function pushSpanned(
-  raw: Candidate[],
-  entries: OwnershipEntry[],
-  c: SpannedCandidate,
-): void {
-  raw.push(c);
-  entries.push({ span: c.span, precedence: precedenceFor(c.type) });
+function isInsideAnySpan(span: Span, keepers: readonly Span[]): boolean {
+  for (const k of keepers) {
+    if (k.start <= span.start && span.end <= k.end) return true;
+  }
+  return false;
 }
 
 export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[] {
-  // Line-scan cap: checked BEFORE any matchAll/regex extraction so a
-  // pathological >64KiB line cannot accumulate direct/path/url candidates.
-  // Returns only a typed line-scan-exceeded overflow (fail-closed).
+  // Line-scan cap fires BEFORE any extraction (fail-closed contract).
   if (line.length > MAX_LINE_SCAN) {
     return [{ type: "overflow", reason: "line-scan-exceeded" }];
   }
 
-  const raw: Candidate[] = [];
-  const entries: OwnershipEntry[] = [];
-  let overflowReason: OverflowReason | null = null;
   const cap = MAX_CANDIDATES_PER_LINE - 1;
+  const owners: SpannedCandidate[] = [];
+  const lows: SpannedCandidate[] = [];
+  let overflowReason: OverflowReason | null = null;
 
-  for (const m of line.matchAll(GENERIC_ID_PATTERN)) {
-    if (UTF_ENCODING_LABELS.has(m[0])) continue;
-    if (raw.length >= cap) { overflowReason = "candidate-cap-exceeded"; break; }
-    const idx = m.index ?? 0;
-    pushSpanned(raw, entries, {
-      type: "direct-id", value: m[0], span: { start: idx, end: idx + m[0].length },
-    });
+  // Stage 1a: extract bounded URL owners (identity-gated).
+  if (cfg.repository_identity.owner_slash_name.length > 0) {
+    const r = extractUrls(line, cap - owners.length);
+    for (const u of r.urls) owners.push({ type: "url", value: u.value, span: u.span });
+    if (r.overflow) overflowReason = "candidate-cap-exceeded";
+  }
+
+  // Stage 1b: extract bounded docs-path owners. Overflow never suppressed.
+  if (overflowReason === null) {
+    const r = extractDocsPaths(line, cap - owners.length);
+    for (const p of r.paths) owners.push({ type: "path", value: p.value, span: p.span });
+    if (r.overflow) overflowReason = "candidate-cap-exceeded";
+  }
+
+  // Stage 1c: contained low-priority candidates (IDs inside owner spans)
+  // are skipped so they never consume the candidate cap.
+  const ownedSpans: Span[] = owners.map((o) => o.span);
+
+  if (overflowReason === null) {
+    for (const m of line.matchAll(GENERIC_ID_PATTERN)) {
+      if (UTF_ENCODING_LABELS.has(m[0])) continue;
+      const idx = m.index ?? 0;
+      const span: Span = { start: idx, end: idx + m[0].length };
+      if (isInsideAnySpan(span, ownedSpans)) continue;
+      if (owners.length + lows.length >= cap) { overflowReason = "candidate-cap-exceeded"; break; }
+      lows.push({ type: "direct-id", value: m[0], span });
+    }
   }
 
   if (overflowReason === null) {
     const recon = detectReconstructedIds(line);
     if (recon.overflow) overflowReason = recon.overflowReason ?? "token-ids-exceeded";
-    for (const r of recon.ids) {
-      if (raw.length >= cap) { overflowReason = "candidate-cap-exceeded"; break; }
-      pushSpanned(raw, entries, {
-        type: "reconstructed-id", value: r.decoded, original: r.original,
-        span: { start: r.srcStart, end: r.srcEnd },
-      });
-    }
-  }
-
-  if (overflowReason === null) {
-    for (const pat of [DOCS_PATH_PATTERN, DOCS_PATH_PERCENT_PATTERN]) {
-      for (const m of line.matchAll(pat)) {
-        if (raw.length >= cap) { overflowReason = "candidate-cap-exceeded"; break; }
-        const idx = m.index ?? 0;
-        pushSpanned(raw, entries, {
-          type: "path", value: m[0], span: { start: idx, end: idx + m[0].length },
-        });
+    if (overflowReason === null) {
+      for (const r of recon.ids) {
+        const span: Span = { start: r.srcStart, end: r.srcEnd };
+        if (isInsideAnySpan(span, ownedSpans)) continue;
+        if (owners.length + lows.length >= cap) { overflowReason = "candidate-cap-exceeded"; break; }
+        lows.push({ type: "reconstructed-id", value: r.decoded, original: r.original, span });
       }
-      if (overflowReason === "candidate-cap-exceeded") break;
     }
   }
 
-  // URLs only when identity is configured: no identity => no URL extraction.
-  if (overflowReason === null && cfg.repository_identity.owner_slash_name.length > 0) {
-    for (const m of line.matchAll(URL_CANDIDATE_PATTERN)) {
-      if (raw.length >= cap) { overflowReason = "candidate-cap-exceeded"; break; }
-      const idx = m.index ?? 0;
-      pushSpanned(raw, entries, {
-        type: "url", value: m[0], span: { start: idx, end: idx + m[0].length },
-      });
-    }
-  }
-
-  // Ownership: URL > path > reconstructed > direct. Overflow never suppressed.
+  // Stage 2: ownership mask resolves recon-vs-direct overlap. Overflow is
+  // appended AFTER the mask so ownership never suppresses the typed signal.
+  const entries: OwnershipEntry[] = [];
+  for (const o of owners) entries.push({ span: o.span, precedence: precedenceFor(o.type) });
+  for (const c of lows) entries.push({ span: c.span, precedence: precedenceFor(c.type) });
+  const all = [...owners, ...lows];
   const mask = ownershipMask(entries);
   const out: Candidate[] = [];
-  for (let i = 0; i < raw.length; i++) {
-    const c = raw[i];
+  for (let i = 0; i < all.length; i++) {
+    const c = all[i];
     if (c !== undefined && mask[i]) out.push(c);
   }
-  if (overflowReason !== null) {
-    out.push({ type: "overflow", reason: overflowReason });
-  }
+  if (overflowReason !== null) out.push({ type: "overflow", reason: overflowReason });
   return out;
 }
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
@@ -44,6 +44,11 @@ export interface DetectorConfig {
   readonly repository_identity: RepositoryIdentity;
   /** Producer-internal ID prefixes (UPPER-CASE letters only). */
   readonly producer_internal_id_prefixes: readonly string[];
+  /**
+   * Distributed workflow control ID prefixes (e.g. STEP, QG). These are
+   * classified as generic-or-template with category distributed-control.
+   */
+  readonly distributed_workflow_control_prefixes: readonly string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -54,9 +59,16 @@ export interface DetectorConfig {
 // and 1+ digits. Captures ADR/REQ/DEC/SPEC/IR/RU/TS/AG/OU/EC AND any future
 // family. Classification stage decides producer-internal vs unclassified.
 //
+// UTF-8, UTF-16, UTF-32 are encoding labels and must NOT match as IDs.
 // Template placeholders ({NNNN}, <NNNN>, *) do not match because \d requires
 // actual digits and the placeholder wrappers are not uppercase letters.
 export const GENERIC_ID_PATTERN = /\b([A-Z]{2,})-(\d{1,})\b/g;
+
+// ID-shaped evasion patterns: uppercase prefix + hyphen + \uXXXX, \xXX, or 0xXX
+const EVASION_PATTERN = /\b([A-Z]{2,})-(\\u[0-9A-Fa-f]{4}|\\x[0-9A-Fa-f]{2}|0x[0-9A-Fa-f]{2,})\b/g;
+
+// UTF encoding labels that should NOT be treated as ID candidates.
+const UTF_ENCODING_LABELS = new Set(["UTF-8", "UTF-16", "UTF-32"]);
 
 // Candidate docs path token, allowing mixed slash/backslash/percent-encoding.
 // Captures the broad token; resolution normalizes and inspects.
@@ -150,7 +162,7 @@ function trimSnippet(line: string, maxLen: number): string {
 // Pipeline stage 1: extract
 // ---------------------------------------------------------------------------
 
-export type CandidateType = "id" | "path" | "url";
+export type CandidateType = "id" | "path" | "url" | "evasion";
 
 export interface Candidate {
   readonly type: CandidateType;
@@ -183,7 +195,17 @@ export function detectCandidates(line: string, _cfg: DetectorConfig): Candidate[
     const start = m.index ?? 0;
     const end = start + m[0].length;
     if (isTemplateWrappedId(line, start, end)) continue;
+    // UTF-8, UTF-16, UTF-32 are encoding labels, not ID candidates.
+    if (UTF_ENCODING_LABELS.has(m[0])) continue;
     out.push({ type: "id", value: m[0] });
+  }
+
+  // ID-shaped evasion patterns: uppercase prefix + hyphen + \uXXXX, \xXX, or 0xXX
+  for (const m of line.matchAll(EVASION_PATTERN)) {
+    const start = m.index ?? 0;
+    const end = start + m[0].length;
+    if (isTemplateWrappedId(line, start, end)) continue;
+    out.push({ type: "evasion", value: m[0] });
   }
 
   // Docs path (slash and backslash).
@@ -218,6 +240,11 @@ export function resolveCandidate(c: Candidate, cfg: DetectorConfig): {
   classification: DependencyClass;
   category: DetectionCategory;
 } {
+  if (c.type === "evasion") {
+    // Evasion attempts must fail closed as unclassified.
+    return { classification: "unclassified", category: "evasion-attempt" };
+  }
+
   if (c.type === "id") {
     // Extract the UPPER prefix to classify.
     const m = /^([A-Z]{2,})-\d{1,}$/.exec(c.value);
@@ -226,6 +253,12 @@ export function resolveCandidate(c: Candidate, cfg: DetectorConfig): {
       return { classification: "unclassified", category: "unclassified-entry" };
     }
     const prefix = m[1] ?? "";
+
+    // Distributed workflow control: STEP-N, QG-N are generic-or-template.
+    if (cfg.distributed_workflow_control_prefixes.includes(prefix)) {
+      return { classification: "generic-or-template", category: "distributed-control" };
+    }
+
     if (cfg.producer_internal_id_prefixes.includes(prefix)) {
       return { classification: "producer-internal", category: "concrete-id" };
     }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
@@ -98,15 +98,21 @@ export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[]
   let overflowReason: OverflowReason | null = null;
 
   // Stage 1a: extract bounded URL owners (identity-gated).
+  const urlSpans: Span[] = [];
   if (cfg.repository_identity.owner_slash_name.length > 0) {
     const r = extractUrls(line, cap - owners.length);
-    for (const u of r.urls) owners.push({ type: "url", value: u.value, span: u.span, malformed: u.malformed });
+    for (const u of r.urls) {
+      owners.push({ type: "url", value: u.value, span: u.span, malformed: u.malformed });
+      urlSpans.push(u.span);
+    }
     if (r.overflow) overflowReason = "candidate-cap-exceeded";
   }
 
   // Stage 1b: extract bounded docs-path owners. Overflow never suppressed.
+  // Pass URL spans so docs paths fully contained by valid URLs are skipped
+  // before the cap check (D7: URL ownership prevents cap consumption).
   if (overflowReason === null) {
-    const r = extractDocsPaths(line, cap - owners.length);
+    const r = extractDocsPaths(line, cap - owners.length, urlSpans);
     for (const p of r.paths) owners.push({ type: "path", value: p.value, span: p.span });
     if (r.overflow) overflowReason = "candidate-cap-exceeded";
   }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
@@ -100,7 +100,7 @@ export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[]
   // Stage 1a: extract bounded URL owners (identity-gated).
   if (cfg.repository_identity.owner_slash_name.length > 0) {
     const r = extractUrls(line, cap - owners.length);
-    for (const u of r.urls) owners.push({ type: "url", value: u.value, span: u.span });
+    for (const u of r.urls) owners.push({ type: "url", value: u.value, span: u.span, malformed: u.malformed });
     if (r.overflow) overflowReason = "candidate-cap-exceeded";
   }
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
@@ -62,7 +62,7 @@ export {
 
 // Generic ID family: any UPPER-CASE prefix of 2+ letters, hyphen, 1+ digits.
 // UTF-8, UTF-16, UTF-32 are encoding labels and must NOT match as IDs.
-export const GENERIC_ID_PATTERN = /\b([A-Z]{2,})-(\d{1,})\b/g;
+export const GENERIC_ID_PATTERN = /\b([A-Z]{2,})-(\d{1,})\b/;
 const UTF_ENCODING_LABELS = new Set(["UTF-8", "UTF-16", "UTF-32"]);
 
 function trimSnippet(line: string, maxLen: number): string {
@@ -126,7 +126,7 @@ export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[]
   ).filter((s): s is Span => s !== null);
 
   if (overflowReason === null) {
-    for (const m of line.matchAll(GENERIC_ID_PATTERN)) {
+    for (const m of line.matchAll(new RegExp(GENERIC_ID_PATTERN.source, "g"))) {
       if (UTF_ENCODING_LABELS.has(m[0])) continue;
       const idx = m.index ?? 0;
       const span: Span = { start: idx, end: idx + m[0].length };

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
@@ -103,7 +103,9 @@ export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[]
     const r = extractUrls(line, cap - owners.length);
     for (const u of r.urls) {
       owners.push({ type: "url", value: u.value, span: u.span, malformed: u.malformed });
-      urlSpans.push(u.span);
+      if (!u.malformed) {
+        urlSpans.push(u.span);
+      }
     }
     if (r.overflow) overflowReason = "candidate-cap-exceeded";
   }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
@@ -102,17 +102,17 @@ export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[]
   if (cfg.repository_identity.owner_slash_name.length > 0) {
     const r = extractUrls(line, cap - owners.length);
     for (const u of r.urls) {
-      owners.push({ type: "url", value: u.value, span: u.span, malformed: u.malformed });
-      if (!u.malformed) {
-        urlSpans.push(u.span);
+      owners.push({ type: "url", value: u.value, span: u.span, ownershipSpan: u.ownershipSpan, malformed: u.malformed });
+      if (u.ownershipSpan !== null) {
+        urlSpans.push(u.ownershipSpan);
       }
     }
     if (r.overflow) overflowReason = "candidate-cap-exceeded";
   }
 
   // Stage 1b: extract bounded docs-path owners. Overflow never suppressed.
-  // Pass URL spans so docs paths fully contained by valid URLs are skipped
-  // before the cap check (D7: URL ownership prevents cap consumption).
+  // Pass URL ownership spans so docs paths fully contained by valid URLs are
+  // skipped before the cap check (D7: URL ownership prevents cap consumption).
   if (overflowReason === null) {
     const r = extractDocsPaths(line, cap - owners.length, urlSpans);
     for (const p of r.paths) owners.push({ type: "path", value: p.value, span: p.span });
@@ -121,7 +121,9 @@ export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[]
 
   // Stage 1c: contained low-priority candidates (IDs inside owner spans)
   // are skipped so they never consume the candidate cap.
-  const ownedSpans: Span[] = owners.map((o) => o.span);
+  const ownedSpans: Span[] = owners.map((o) =>
+    o.type === "url" ? (o.ownershipSpan ?? null) : o.span,
+  ).filter((s): s is Span => s !== null);
 
   if (overflowReason === null) {
     for (const m of line.matchAll(GENERIC_ID_PATTERN)) {
@@ -150,8 +152,14 @@ export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[]
   // Stage 2: ownership mask resolves recon-vs-direct overlap. Overflow is
   // appended AFTER the mask so ownership never suppresses the typed signal.
   const entries: OwnershipEntry[] = [];
-  for (const o of owners) entries.push({ span: o.span, precedence: precedenceFor(o.type) });
-  for (const c of lows) entries.push({ span: c.span, precedence: precedenceFor(c.type) });
+  for (const o of owners) {
+    entries.push({
+      span: o.span,
+      ownershipSpan: o.type === "url" ? o.ownershipSpan : o.span,
+      precedence: precedenceFor(o.type),
+    });
+  }
+  for (const c of lows) entries.push({ span: c.span, ownershipSpan: c.span, precedence: precedenceFor(c.type) });
   const all = [...owners, ...lows];
   const mask = ownershipMask(entries);
   const out: Candidate[] = [];

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
@@ -29,6 +29,7 @@ import type {
   LineInput,
   Projection,
 } from "./types.ts";
+import { detectReconstructedIds } from "./boundary-reconstruction.ts";
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -63,9 +64,6 @@ export interface DetectorConfig {
 // Template placeholders ({NNNN}, <NNNN>, *) do not match because \d requires
 // actual digits and the placeholder wrappers are not uppercase letters.
 export const GENERIC_ID_PATTERN = /\b([A-Z]{2,})-(\d{1,})\b/g;
-
-// ID-shaped evasion patterns: uppercase prefix + hyphen + \uXXXX, \xXX, or 0xXX
-const EVASION_PATTERN = /\b([A-Z]{2,})-(\\u[0-9A-Fa-f]{4}|\\x[0-9A-Fa-f]{2}|0x[0-9A-Fa-f]{2,})\b/g;
 
 // UTF encoding labels that should NOT be treated as ID candidates.
 const UTF_ENCODING_LABELS = new Set(["UTF-8", "UTF-16", "UTF-32"]);
@@ -162,50 +160,58 @@ function trimSnippet(line: string, maxLen: number): string {
 // Pipeline stage 1: extract
 // ---------------------------------------------------------------------------
 
-export type CandidateType = "id" | "path" | "url" | "evasion";
+// Candidate is a discriminated object union so the resolver can switch
+// exhaustively at compile time. Wrapper characters (`<`, `>`, `{`, `}`, `*`)
+// are token boundaries, never exemptions for reconstructed IDs.
+export type Candidate =
+  | { readonly type: "direct-id"; readonly value: string }
+  | {
+    readonly type: "reconstructed-id";
+    /** Decoded concrete ID form, e.g. "ADR-0001". */
+    readonly value: string;
+    /** Source-form token, e.g. "\\u0041DR-0001". Used as `matched` evidence. */
+    readonly original: string;
+  }
+  | { readonly type: "path"; readonly value: string }
+  | { readonly type: "url"; readonly value: string };
 
-export interface Candidate {
-  readonly type: CandidateType;
-  readonly value: string;
+export type CandidateType = Candidate["type"];
+
+function assertNeverCandidate(c: never): never {
+  throw new Error(`unhandled candidate: ${JSON.stringify(c)}`);
 }
 
-/**
- * Skip line-level extraction for placeholder-only ID forms.
- * `REQ-{NNNN}`, `<REQ-NNNN>`, `REQ-*` etc. are template forms that should
- * not be flagged. We test whether an ID candidate is wrapped in or adjacent
- * to placeholder markers.
- */
-function isTemplateWrappedId(text: string, matchStart: number, matchEnd: number): boolean {
-  // Check immediately before the match for `{` or `<`.
-  const before = text.charAt(matchStart - 1);
-  // Check immediately after the match for `}` or `>`.
-  const after = text.charAt(matchEnd);
-  if (before === "{" && after === "}") return true;
-  if (before === "<" && after === ">") return true;
-  // Glob wildcard immediately after the digits means template.
-  if (after === "*") return true;
-  return false;
+function matchedForCandidate(c: Candidate): string {
+  switch (c.type) {
+    case "direct-id":
+      return c.value;
+    case "reconstructed-id":
+      return c.original;
+    case "path":
+      return c.value;
+    case "url":
+      return c.value;
+    default:
+      return assertNeverCandidate(c);
+  }
 }
 
-export function detectCandidates(line: string, _cfg: DetectorConfig): Candidate[] {
+export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[] {
   const out: Candidate[] = [];
 
-  // IDs: generic UPPER-DIGITS family.
+  // Direct IDs: generic UPPER-DIGITS family. UTF-8/16/32 are encoding labels.
   for (const m of line.matchAll(GENERIC_ID_PATTERN)) {
-    const start = m.index ?? 0;
-    const end = start + m[0].length;
-    if (isTemplateWrappedId(line, start, end)) continue;
-    // UTF-8, UTF-16, UTF-32 are encoding labels, not ID candidates.
     if (UTF_ENCODING_LABELS.has(m[0])) continue;
-    out.push({ type: "id", value: m[0] });
+    out.push({ type: "direct-id", value: m[0] });
   }
 
-  // ID-shaped evasion patterns: uppercase prefix + hyphen + \uXXXX, \xXX, or 0xXX
-  for (const m of line.matchAll(EVASION_PATTERN)) {
-    const start = m.index ?? 0;
-    const end = start + m[0].length;
-    if (isTemplateWrappedId(line, start, end)) continue;
-    out.push({ type: "evasion", value: m[0] });
+  // Reconstructed IDs from bounded escape atoms. Wrappers and `*` are
+  // token boundaries inside detectReconstructedIds; they never exempt a
+  // reconstructed ID. A candidate is emitted for every concrete-ID match
+  // in a decoded token that contains at least one escape atom — including
+  // atoms that reconstruct delimiters exposing adjacent IDs.
+  for (const r of detectReconstructedIds(line)) {
+    out.push({ type: "reconstructed-id", value: r.decoded, original: r.original });
   }
 
   // Docs path (slash and backslash).
@@ -223,7 +229,7 @@ export function detectCandidates(line: string, _cfg: DetectorConfig): Candidate[
   // emit unclassified URL detections that would mask real violations, and
   // we MUST NOT silently allow them either. The contract is: no identity
   // => no URL extraction; the launcher rejects input contract upstream.
-  if (_cfg.repository_identity.owner_slash_name.length > 0) {
+  if (cfg.repository_identity.owner_slash_name.length > 0) {
     for (const m of line.matchAll(URL_CANDIDATE_PATTERN)) {
       out.push({ type: "url", value: m[0] });
     }
@@ -240,50 +246,58 @@ export function resolveCandidate(c: Candidate, cfg: DetectorConfig): {
   classification: DependencyClass;
   category: DetectionCategory;
 } {
-  if (c.type === "evasion") {
-    // Evasion attempts must fail closed as unclassified.
-    return { classification: "unclassified", category: "evasion-attempt" };
-  }
-
-  if (c.type === "id") {
-    // Extract the UPPER prefix to classify.
-    const m = /^([A-Z]{2,})-\d{1,}$/.exec(c.value);
-    if (!m) {
-      // Should not happen because extraction guarantees shape; fail closed.
+  switch (c.type) {
+    case "direct-id": {
+      const m = /^([A-Z]{2,})-\d{1,}$/.exec(c.value);
+      if (!m) {
+        return { classification: "unclassified", category: "unclassified-entry" };
+      }
+      const prefix = m[1] ?? "";
+      // Producer precedence: producer wins over distributed on overlap.
+      if (cfg.producer_internal_id_prefixes.includes(prefix)) {
+        return { classification: "producer-internal", category: "concrete-id" };
+      }
+      if (cfg.distributed_workflow_control_prefixes.includes(prefix)) {
+        return { classification: "generic-or-template", category: "distributed-control" };
+      }
       return { classification: "unclassified", category: "unclassified-entry" };
     }
-    const prefix = m[1] ?? "";
-
-    // Distributed workflow control: STEP-N, QG-N are generic-or-template.
-    if (cfg.distributed_workflow_control_prefixes.includes(prefix)) {
-      return { classification: "generic-or-template", category: "distributed-control" };
+    case "reconstructed-id": {
+      const m = /^([A-Z]{2,})-\d{1,}$/.exec(c.value);
+      if (!m) {
+        return { classification: "unclassified", category: "evasion-attempt" };
+      }
+      const prefix = m[1] ?? "";
+      // Reconstructed producer ID: producer-internal/evasion-attempt.
+      // Producer wins over distributed on overlap.
+      if (cfg.producer_internal_id_prefixes.includes(prefix)) {
+        return { classification: "producer-internal", category: "evasion-attempt" };
+      }
+      // Reconstructed STEP/QG or unknown reconstructed: fail closed.
+      return { classification: "unclassified", category: "evasion-attempt" };
     }
-
-    if (cfg.producer_internal_id_prefixes.includes(prefix)) {
-      return { classification: "producer-internal", category: "concrete-id" };
+    case "path": {
+      if (isConcreteDocsPath(c.value)) {
+        return { classification: "producer-internal", category: "concrete-path" };
+      }
+      return { classification: "generic-or-template", category: "concrete-path" };
     }
-    return { classification: "unclassified", category: "unclassified-entry" };
-  }
-
-  if (c.type === "path") {
-    if (isConcreteDocsPath(c.value)) {
-      return { classification: "producer-internal", category: "concrete-path" };
+    case "url": {
+      // Classify by repository identity, NOT by path content. A URL into
+      // the producer repo is producer-internal at any path (docs, scripts,
+      // src). A URL into a different repo is consumer-resolvable. An empty
+      // identity means the caller did not pin a producer; fail closed.
+      if (cfg.repository_identity.owner_slash_name.length === 0) {
+        return { classification: "unclassified", category: "unclassified-entry" };
+      }
+      if (isProducerOwnedUrl(c.value, cfg.repository_identity)) {
+        return { classification: "producer-internal", category: "fixed-url" };
+      }
+      return { classification: "consumer-resolvable", category: "fixed-url" };
     }
-    return { classification: "generic-or-template", category: "concrete-path" };
+    default:
+      return assertNeverCandidate(c);
   }
-
-  // url: classify by repository identity, NOT by path content. A URL into
-  // the producer repo is producer-internal at any path (docs, scripts, src).
-  // A URL into a different repo is consumer-resolvable, even if it points
-  // at that project's docs. An empty identity means the caller did not pin
-  // a producer; the resolution stage fail-closes by returning unclassified.
-  if (cfg.repository_identity.owner_slash_name.length === 0) {
-    return { classification: "unclassified", category: "unclassified-entry" };
-  }
-  if (isProducerOwnedUrl(c.value, cfg.repository_identity)) {
-    return { classification: "producer-internal", category: "fixed-url" };
-  }
-  return { classification: "consumer-resolvable", category: "fixed-url" };
 }
 
 // ---------------------------------------------------------------------------
@@ -305,7 +319,7 @@ export function classifyLine(line: LineInput, cfg: DetectorConfig): LineClassifi
       file: line.filePath,
       projection: line.projection,
       classification,
-      matched: c.value,
+      matched: matchedForCandidate(c),
       snippet: trimSnippet(line.text, 80),
       category,
     });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
@@ -25,9 +25,7 @@ import type {
   DependencyClass,
   Detection,
   DetectionCategory,
-  GateResult,
   LineInput,
-  Projection,
 } from "./types.ts";
 import { detectReconstructedIds } from "./boundary-reconstruction.ts";
 
@@ -160,6 +158,15 @@ function trimSnippet(line: string, maxLen: number): string {
 // Pipeline stage 1: extract
 // ---------------------------------------------------------------------------
 
+// Bounding constants. A pathological one-line input (e.g. hundreds of escape
+// tokens) must not amplify per-detection evidence or grow the candidate list
+// without bound. Detection.text is capped so a long line cannot be copied
+// verbatim into every detection; candidate count is capped and an explicit
+// overflow candidate fails the gate closed.
+const MAX_TEXT_LEN = 200;
+const MAX_CANDIDATES_PER_LINE = 64;
+const OVERFLOW_REASON = "[overflow: candidate bound exceeded]";
+
 // Candidate is a discriminated object union so the resolver can switch
 // exhaustively at compile time. Wrapper characters (`<`, `>`, `{`, `}`, `*`)
 // are token boundaries, never exemptions for reconstructed IDs.
@@ -173,7 +180,8 @@ export type Candidate =
     readonly original: string;
   }
   | { readonly type: "path"; readonly value: string }
-  | { readonly type: "url"; readonly value: string };
+  | { readonly type: "url"; readonly value: string }
+  | { readonly type: "overflow"; readonly reason: string };
 
 export type CandidateType = Candidate["type"];
 
@@ -191,6 +199,8 @@ function matchedForCandidate(c: Candidate): string {
       return c.value;
     case "url":
       return c.value;
+    case "overflow":
+      return c.reason;
     default:
       return assertNeverCandidate(c);
   }
@@ -198,30 +208,46 @@ function matchedForCandidate(c: Candidate): string {
 
 export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[] {
   const out: Candidate[] = [];
+  let overflow = false;
+  const cap = MAX_CANDIDATES_PER_LINE - 1;
+
+  const directSpans: Array<{ start: number; end: number }> = [];
 
   // Direct IDs: generic UPPER-DIGITS family. UTF-8/16/32 are encoding labels.
   for (const m of line.matchAll(GENERIC_ID_PATTERN)) {
     if (UTF_ENCODING_LABELS.has(m[0])) continue;
+    if (out.length >= cap) { overflow = true; break; }
+    const idx = m.index ?? 0;
+    directSpans.push({ start: idx, end: idx + m[0].length });
     out.push({ type: "direct-id", value: m[0] });
   }
 
-  // Reconstructed IDs from bounded escape atoms. Wrappers and `*` are
-  // token boundaries inside detectReconstructedIds; they never exempt a
-  // reconstructed ID. A candidate is emitted for every concrete-ID match
-  // in a decoded token that contains at least one escape atom — including
-  // atoms that reconstruct delimiters exposing adjacent IDs.
-  for (const r of detectReconstructedIds(line)) {
-    out.push({ type: "reconstructed-id", value: r.decoded, original: r.original });
+  // Reconstructed IDs from bounded escape atoms. Deduplicated against direct
+  // IDs by overlapping source span so a literal ID is never double-counted as
+  // both direct and reconstructed.
+  if (!overflow) {
+    for (const r of detectReconstructedIds(line)) {
+      if (out.length >= cap) { overflow = true; break; }
+      const overlaps = directSpans.some((s) => r.srcStart < s.end && s.start < r.srcEnd);
+      if (overlaps) continue;
+      out.push({ type: "reconstructed-id", value: r.decoded, original: r.original });
+    }
   }
 
   // Docs path (slash and backslash).
-  for (const m of line.matchAll(DOCS_PATH_PATTERN)) {
-    out.push({ type: "path", value: m[0] });
+  if (!overflow) {
+    for (const m of line.matchAll(DOCS_PATH_PATTERN)) {
+      if (out.length >= cap) { overflow = true; break; }
+      out.push({ type: "path", value: m[0] });
+    }
   }
 
   // Docs path (percent-encoded).
-  for (const m of line.matchAll(DOCS_PATH_PERCENT_PATTERN)) {
-    out.push({ type: "path", value: m[0] });
+  if (!overflow) {
+    for (const m of line.matchAll(DOCS_PATH_PERCENT_PATTERN)) {
+      if (out.length >= cap) { overflow = true; break; }
+      out.push({ type: "path", value: m[0] });
+    }
   }
 
   // URLs — only extract when a repository identity is configured. An empty
@@ -229,12 +255,14 @@ export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[]
   // emit unclassified URL detections that would mask real violations, and
   // we MUST NOT silently allow them either. The contract is: no identity
   // => no URL extraction; the launcher rejects input contract upstream.
-  if (cfg.repository_identity.owner_slash_name.length > 0) {
+  if (!overflow && cfg.repository_identity.owner_slash_name.length > 0) {
     for (const m of line.matchAll(URL_CANDIDATE_PATTERN)) {
+      if (out.length >= cap) { overflow = true; break; }
       out.push({ type: "url", value: m[0] });
     }
   }
 
+  if (overflow) out.push({ type: "overflow", reason: OVERFLOW_REASON });
   return out;
 }
 
@@ -295,6 +323,11 @@ export function resolveCandidate(c: Candidate, cfg: DetectorConfig): {
       }
       return { classification: "consumer-resolvable", category: "fixed-url" };
     }
+    case "overflow": {
+      // Pathological input: fail closed. The overflow marker is a non-ID
+      // string so it cannot accidentally classify as an allowed prefix.
+      return { classification: "unclassified", category: "evasion-attempt" };
+    }
     default:
       return assertNeverCandidate(c);
   }
@@ -311,10 +344,11 @@ export interface LineClassification {
 export function classifyLine(line: LineInput, cfg: DetectorConfig): LineClassification {
   const candidates = detectCandidates(line.text, cfg);
   const detections: Detection[] = [];
+  const boundedText = line.text.length <= MAX_TEXT_LEN ? line.text : line.text.substring(0, MAX_TEXT_LEN);
   for (const c of candidates) {
     const { classification, category } = resolveCandidate(c, cfg);
     detections.push({
-      text: line.text,
+      text: boundedText,
       line: line.lineNumber,
       file: line.filePath,
       projection: line.projection,
@@ -327,52 +361,8 @@ export function classifyLine(line: LineInput, cfg: DetectorConfig): LineClassifi
   return { detections };
 }
 
-// ---------------------------------------------------------------------------
-// Pipeline stage 4: decide (gate over many lines)
-// ---------------------------------------------------------------------------
-
-export interface ClassifyFileInput {
-  readonly filePath: string;
-  readonly projection: Projection;
-  /** Text content (already validated UTF-8 by the text-binary module). */
-  readonly text: string;
-}
-
-export interface DecideResult {
-  readonly gate: GateResult;
-}
-
-export function decideProjection(
-  files: readonly ClassifyFileInput[],
-  projection: Projection,
-  cfg: DetectorConfig,
-): DecideResult {
-  const failures: Detection[] = [];
-  const errors: Detection[] = [];
-
-  for (const file of files) {
-    const lines = file.text.split(/\r?\n/);
-    for (let i = 0; i < lines.length; i++) {
-      const lineText = lines[i] ?? "";
-      const lineInput: LineInput = {
-        text: lineText,
-        lineNumber: i + 1,
-        filePath: file.filePath,
-        projection: file.projection,
-      };
-      const cls = classifyLine(lineInput, cfg);
-      for (const d of cls.detections) {
-        if (d.classification === "producer-internal") failures.push(d);
-        else if (d.classification === "unclassified") errors.push(d);
-      }
-    }
-  }
-
-  const gate: GateResult = {
-    pass: failures.length === 0 && errors.length === 0,
-    failures,
-    errors,
-    projection,
-  };
-  return { gate };
-}
+export {
+  decideProjection,
+  type ClassifyFileInput,
+  type DecideResult,
+} from "./boundary-gate.ts";

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
@@ -51,6 +51,10 @@ export {
   isConcreteDocsPath,
   normalizePathToken,
 } from "./boundary-candidate-model.ts";
+export {
+  detectReconstructedIds,
+  MAX_LINE_SCAN,
+} from "./boundary-reconstruction.ts";
 
 // ---------------------------------------------------------------------------
 // Detection patterns (pipeline-local)

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-pipeline.ts
@@ -7,147 +7,59 @@
 // producer-repository fixed URLs (by configured repository identity),
 // generic/template allowances, and fail-closed on unclassified entries.
 //
-// Side-effect-free contract:
-//   - No imports of `fs`, `path`, `os`, `child_process`, or any I/O module.
-//   - All functions are pure: same input => same output, no mutation, no
-//     external observation.
-//   - Classification never throws for input-shape reasons; the gate layer
-//     treats `unclassified` as gate-not-passed (fail-closed).
+// Pipeline stages (owned here):
+//   1. extract  — detectCandidates: regex + reconstruction + ownership
+//   2. classify — classifyLine: assemble Detection records
+// Resolution (candidate -> classification) and the candidate model live in
+// boundary-candidate-model.ts; the gate (decideProjection) lives in
+// boundary-gate.ts.
 //
-// Pipeline stages:
-//   1. extract  — broad regex captures candidate matches per line
-//   2. resolve  — per-candidate classification under consumer-runtime assumptions
-//   3. classify — assemble Detection records
-//   4. decide   — gate layer (see launcher.ts) treats producer-internal and
-//                 unclassified as gate-not-passed
+// Side-effect-free: no I/O imports; all functions pure.
 
-import type {
-  DependencyClass,
-  Detection,
-  DetectionCategory,
-  LineInput,
-} from "./types.ts";
-import { detectReconstructedIds } from "./boundary-reconstruction.ts";
+import type { Detection, LineInput } from "./types.ts";
+import { detectReconstructedIds, MAX_LINE_SCAN } from "./boundary-reconstruction.ts";
+import {
+  ownershipMask,
+  type OwnershipEntry,
+} from "./boundary-candidate-ownership.ts";
+import {
+  matchedForCandidate,
+  precedenceFor,
+  resolveCandidate,
+  type Candidate,
+  type DetectorConfig,
+  type OverflowReason,
+  DOCS_PATH_PATTERN,
+  DOCS_PATH_PERCENT_PATTERN,
+  URL_CANDIDATE_PATTERN,
+} from "./boundary-candidate-model.ts";
+
+// Re-export so consumers import from the pipeline barrel without a cycle.
+export type {
+  Candidate,
+  CandidateType,
+  DetectorConfig,
+  RepositoryIdentity,
+  OverflowReason,
+} from "./boundary-candidate-model.ts";
+export {
+  matchedForCandidate,
+  precedenceFor,
+  resolveCandidate,
+  extractOwnerRepo,
+  isProducerOwnedUrl,
+  isConcreteDocsPath,
+  normalizePathToken,
+} from "./boundary-candidate-model.ts";
 
 // ---------------------------------------------------------------------------
-// Configuration
+// Detection patterns (pipeline-local)
 // ---------------------------------------------------------------------------
 
-export interface RepositoryIdentity {
-  /** e.g. "yogata/agent-dev-flow". Empty string disables URL extraction. */
-  readonly owner_slash_name: string;
-  readonly default_branch: string;
-}
-
-export interface DetectorConfig {
-  readonly repository_identity: RepositoryIdentity;
-  /** Producer-internal ID prefixes (UPPER-CASE letters only). */
-  readonly producer_internal_id_prefixes: readonly string[];
-  /**
-   * Distributed workflow control ID prefixes (e.g. STEP, QG). These are
-   * classified as generic-or-template with category distributed-control.
-   */
-  readonly distributed_workflow_control_prefixes: readonly string[];
-}
-
-// ---------------------------------------------------------------------------
-// Detection patterns
-// ---------------------------------------------------------------------------
-
-// Generic ID family: any UPPER-CASE prefix of 2+ letters followed by a hyphen
-// and 1+ digits. Captures ADR/REQ/DEC/SPEC/IR/RU/TS/AG/OU/EC AND any future
-// family. Classification stage decides producer-internal vs unclassified.
-//
+// Generic ID family: any UPPER-CASE prefix of 2+ letters, hyphen, 1+ digits.
 // UTF-8, UTF-16, UTF-32 are encoding labels and must NOT match as IDs.
-// Template placeholders ({NNNN}, <NNNN>, *) do not match because \d requires
-// actual digits and the placeholder wrappers are not uppercase letters.
 export const GENERIC_ID_PATTERN = /\b([A-Z]{2,})-(\d{1,})\b/g;
-
-// UTF encoding labels that should NOT be treated as ID candidates.
 const UTF_ENCODING_LABELS = new Set(["UTF-8", "UTF-16", "UTF-32"]);
-
-// Candidate docs path token, allowing mixed slash/backslash/percent-encoding.
-// Captures the broad token; resolution normalizes and inspects.
-export const DOCS_PATH_PATTERN = /docs[\\/](?:adr|requirements|specs|decisions)[\\/][^\s)\]\|\\"'`<>{}]+/g;
-
-// Also capture percent-encoded forms: docs%2F...
-export const DOCS_PATH_PERCENT_PATTERN = /docs%2[Ff](?:adr|requirements|specs|decisions)%2[Ff][^\s)\]\|\\"'`<>{}]+/g;
-
-// Candidate GitHub blob/raw URLs. The resolution stage parses owner/repo
-// from each candidate URL and compares to the configured repository
-// identity. URLs pointing into the producer repo (any path) are
-// producer-internal; URLs into a different repo (including docs paths of
-// external projects) are consumer-resolvable.
-export const URL_CANDIDATE_PATTERN =
-  /(?:github\.com\/[A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+\/(?:blob|raw)\/|raw\.githubusercontent\.com\/[A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+\/)[^\s)\]\\"'`<>{}]+/g;
-
-// ---------------------------------------------------------------------------
-// URL ownership: parse the `owner/repo` segment from a GitHub blob/raw URL
-// ---------------------------------------------------------------------------
-
-/**
- * Extract the `owner/repo` segment from a GitHub blob/raw URL. Returns null
- * when the URL does not match the expected shape (in which case the caller
- * fail-closes by treating the URL as unclassified).
- *
- * Examples:
- *   https://github.com/yogata/agent-dev-flow/blob/main/docs/foo.md
- *     -> "yogata/agent-dev-flow"
- *   raw.githubusercontent.com/yogata/agent-dev-flow/main/x.md
- *     -> "yogata/agent-dev-flow"
- *   https://github.com/vercel/next.js/blob/main/src/index.ts
- *     -> "vercel/next.js"
- */
-export function extractOwnerRepo(url: string): string | null {
-  const m = /(?:github\.com\/|raw\.githubusercontent\.com\/)([A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+)\//.exec(url);
-  if (!m) return null;
-  return m[1] ?? null;
-}
-
-/**
- * Decide whether a candidate URL points into the producer's own repository
- * (any path), based on the configured repository identity. Pure: same input
- * and config => same output. Returns false when identity is empty (caller
- * must fail-closed upstream).
- */
-export function isProducerOwnedUrl(url: string, identity: RepositoryIdentity): boolean {
-  if (identity.owner_slash_name.length === 0) return false;
-  const ownerRepo = extractOwnerRepo(url);
-  if (ownerRepo === null) return false;
-  // Case-insensitive compare: GitHub owner/repo names are case-insensitive
-  // (legacy). We lowercase both sides so `Yogata/Agent-Dev-Flow` matches
-  // `yogata/agent-dev-flow`.
-  return ownerRepo.toLowerCase() === identity.owner_slash_name.toLowerCase();
-}
-
-// ---------------------------------------------------------------------------
-// Helpers (pure)
-// ---------------------------------------------------------------------------
-
-/**
- * Normalize a path token: convert backslashes and percent-encoded slashes
- * to forward slashes. Pure; does not touch the filesystem.
- */
-export function normalizePathToken(token: string): string {
-  return token.replace(/\\/g, "/").replace(/%2[fF]/g, "/");
-}
-
-/**
- * Decide whether a (already-normalized) docs path token is a CONCRETE file
- * reference. Returns true => violation; false => allowed (template/glob/index).
- */
-export function isConcreteDocsPath(token: string): boolean {
-  const normalized = normalizePathToken(token);
-  // README.md is an index, not an individual document. Always allowed.
-  if (normalized.endsWith("/README.md")) return false;
-  // Template placeholders anywhere in the token mean it is not concrete.
-  if (/[<>{}]/.test(normalized)) return false;
-  // Glob wildcard means it is not concrete.
-  if (normalized.includes("*")) return false;
-  // Must end with .md to be a doc reference at all.
-  if (!normalized.endsWith(".md")) return false;
-  return true;
-}
 
 function trimSnippet(line: string, maxLen: number): string {
   const t = line.trim();
@@ -158,183 +70,93 @@ function trimSnippet(line: string, maxLen: number): string {
 // Pipeline stage 1: extract
 // ---------------------------------------------------------------------------
 
-// Bounding constants. A pathological one-line input (e.g. hundreds of escape
-// tokens) must not amplify per-detection evidence or grow the candidate list
-// without bound. Detection.text is capped so a long line cannot be copied
-// verbatim into every detection; candidate count is capped and an explicit
-// overflow candidate fails the gate closed.
 const MAX_TEXT_LEN = 200;
 const MAX_CANDIDATES_PER_LINE = 64;
-const OVERFLOW_REASON = "[overflow: candidate bound exceeded]";
 
-// Candidate is a discriminated object union so the resolver can switch
-// exhaustively at compile time. Wrapper characters (`<`, `>`, `{`, `}`, `*`)
-// are token boundaries, never exemptions for reconstructed IDs.
-export type Candidate =
-  | { readonly type: "direct-id"; readonly value: string }
-  | {
-    readonly type: "reconstructed-id";
-    /** Decoded concrete ID form, e.g. "ADR-0001". */
-    readonly value: string;
-    /** Source-form token, e.g. "\\u0041DR-0001". Used as `matched` evidence. */
-    readonly original: string;
-  }
-  | { readonly type: "path"; readonly value: string }
-  | { readonly type: "url"; readonly value: string }
-  | { readonly type: "overflow"; readonly reason: string };
+type SpannedCandidate = Exclude<Candidate, { type: "overflow" }>;
 
-export type CandidateType = Candidate["type"];
-
-function assertNeverCandidate(c: never): never {
-  throw new Error(`unhandled candidate: ${JSON.stringify(c)}`);
-}
-
-function matchedForCandidate(c: Candidate): string {
-  switch (c.type) {
-    case "direct-id":
-      return c.value;
-    case "reconstructed-id":
-      return c.original;
-    case "path":
-      return c.value;
-    case "url":
-      return c.value;
-    case "overflow":
-      return c.reason;
-    default:
-      return assertNeverCandidate(c);
-  }
+function pushSpanned(
+  raw: Candidate[],
+  entries: OwnershipEntry[],
+  c: SpannedCandidate,
+): void {
+  raw.push(c);
+  entries.push({ span: c.span, precedence: precedenceFor(c.type) });
 }
 
 export function detectCandidates(line: string, cfg: DetectorConfig): Candidate[] {
-  const out: Candidate[] = [];
-  let overflow = false;
+  // Line-scan cap: checked BEFORE any matchAll/regex extraction so a
+  // pathological >64KiB line cannot accumulate direct/path/url candidates.
+  // Returns only a typed line-scan-exceeded overflow (fail-closed).
+  if (line.length > MAX_LINE_SCAN) {
+    return [{ type: "overflow", reason: "line-scan-exceeded" }];
+  }
+
+  const raw: Candidate[] = [];
+  const entries: OwnershipEntry[] = [];
+  let overflowReason: OverflowReason | null = null;
   const cap = MAX_CANDIDATES_PER_LINE - 1;
 
-  const directSpans: Array<{ start: number; end: number }> = [];
-
-  // Direct IDs: generic UPPER-DIGITS family. UTF-8/16/32 are encoding labels.
   for (const m of line.matchAll(GENERIC_ID_PATTERN)) {
     if (UTF_ENCODING_LABELS.has(m[0])) continue;
-    if (out.length >= cap) { overflow = true; break; }
+    if (raw.length >= cap) { overflowReason = "candidate-cap-exceeded"; break; }
     const idx = m.index ?? 0;
-    directSpans.push({ start: idx, end: idx + m[0].length });
-    out.push({ type: "direct-id", value: m[0] });
+    pushSpanned(raw, entries, {
+      type: "direct-id", value: m[0], span: { start: idx, end: idx + m[0].length },
+    });
   }
 
-  // Reconstructed IDs from bounded escape atoms. Deduplicated against direct
-  // IDs by overlapping source span so a literal ID is never double-counted as
-  // both direct and reconstructed.
-  if (!overflow) {
-    for (const r of detectReconstructedIds(line)) {
-      if (out.length >= cap) { overflow = true; break; }
-      const overlaps = directSpans.some((s) => r.srcStart < s.end && s.start < r.srcEnd);
-      if (overlaps) continue;
-      out.push({ type: "reconstructed-id", value: r.decoded, original: r.original });
+  if (overflowReason === null) {
+    const recon = detectReconstructedIds(line);
+    if (recon.overflow) overflowReason = recon.overflowReason ?? "token-ids-exceeded";
+    for (const r of recon.ids) {
+      if (raw.length >= cap) { overflowReason = "candidate-cap-exceeded"; break; }
+      pushSpanned(raw, entries, {
+        type: "reconstructed-id", value: r.decoded, original: r.original,
+        span: { start: r.srcStart, end: r.srcEnd },
+      });
     }
   }
 
-  // Docs path (slash and backslash).
-  if (!overflow) {
-    for (const m of line.matchAll(DOCS_PATH_PATTERN)) {
-      if (out.length >= cap) { overflow = true; break; }
-      out.push({ type: "path", value: m[0] });
+  if (overflowReason === null) {
+    for (const pat of [DOCS_PATH_PATTERN, DOCS_PATH_PERCENT_PATTERN]) {
+      for (const m of line.matchAll(pat)) {
+        if (raw.length >= cap) { overflowReason = "candidate-cap-exceeded"; break; }
+        const idx = m.index ?? 0;
+        pushSpanned(raw, entries, {
+          type: "path", value: m[0], span: { start: idx, end: idx + m[0].length },
+        });
+      }
+      if (overflowReason === "candidate-cap-exceeded") break;
     }
   }
 
-  // Docs path (percent-encoded).
-  if (!overflow) {
-    for (const m of line.matchAll(DOCS_PATH_PERCENT_PATTERN)) {
-      if (out.length >= cap) { overflow = true; break; }
-      out.push({ type: "path", value: m[0] });
-    }
-  }
-
-  // URLs — only extract when a repository identity is configured. An empty
-  // owner_slash_name means the consumer did not pin a producer; we MUST NOT
-  // emit unclassified URL detections that would mask real violations, and
-  // we MUST NOT silently allow them either. The contract is: no identity
-  // => no URL extraction; the launcher rejects input contract upstream.
-  if (!overflow && cfg.repository_identity.owner_slash_name.length > 0) {
+  // URLs only when identity is configured: no identity => no URL extraction.
+  if (overflowReason === null && cfg.repository_identity.owner_slash_name.length > 0) {
     for (const m of line.matchAll(URL_CANDIDATE_PATTERN)) {
-      if (out.length >= cap) { overflow = true; break; }
-      out.push({ type: "url", value: m[0] });
+      if (raw.length >= cap) { overflowReason = "candidate-cap-exceeded"; break; }
+      const idx = m.index ?? 0;
+      pushSpanned(raw, entries, {
+        type: "url", value: m[0], span: { start: idx, end: idx + m[0].length },
+      });
     }
   }
 
-  if (overflow) out.push({ type: "overflow", reason: OVERFLOW_REASON });
+  // Ownership: URL > path > reconstructed > direct. Overflow never suppressed.
+  const mask = ownershipMask(entries);
+  const out: Candidate[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw[i];
+    if (c !== undefined && mask[i]) out.push(c);
+  }
+  if (overflowReason !== null) {
+    out.push({ type: "overflow", reason: overflowReason });
+  }
   return out;
 }
 
 // ---------------------------------------------------------------------------
-// Pipeline stage 2: resolve
-// ---------------------------------------------------------------------------
-
-export function resolveCandidate(c: Candidate, cfg: DetectorConfig): {
-  classification: DependencyClass;
-  category: DetectionCategory;
-} {
-  switch (c.type) {
-    case "direct-id": {
-      const m = /^([A-Z]{2,})-\d{1,}$/.exec(c.value);
-      if (!m) {
-        return { classification: "unclassified", category: "unclassified-entry" };
-      }
-      const prefix = m[1] ?? "";
-      // Producer precedence: producer wins over distributed on overlap.
-      if (cfg.producer_internal_id_prefixes.includes(prefix)) {
-        return { classification: "producer-internal", category: "concrete-id" };
-      }
-      if (cfg.distributed_workflow_control_prefixes.includes(prefix)) {
-        return { classification: "generic-or-template", category: "distributed-control" };
-      }
-      return { classification: "unclassified", category: "unclassified-entry" };
-    }
-    case "reconstructed-id": {
-      const m = /^([A-Z]{2,})-\d{1,}$/.exec(c.value);
-      if (!m) {
-        return { classification: "unclassified", category: "evasion-attempt" };
-      }
-      const prefix = m[1] ?? "";
-      // Reconstructed producer ID: producer-internal/evasion-attempt.
-      // Producer wins over distributed on overlap.
-      if (cfg.producer_internal_id_prefixes.includes(prefix)) {
-        return { classification: "producer-internal", category: "evasion-attempt" };
-      }
-      // Reconstructed STEP/QG or unknown reconstructed: fail closed.
-      return { classification: "unclassified", category: "evasion-attempt" };
-    }
-    case "path": {
-      if (isConcreteDocsPath(c.value)) {
-        return { classification: "producer-internal", category: "concrete-path" };
-      }
-      return { classification: "generic-or-template", category: "concrete-path" };
-    }
-    case "url": {
-      // Classify by repository identity, NOT by path content. A URL into
-      // the producer repo is producer-internal at any path (docs, scripts,
-      // src). A URL into a different repo is consumer-resolvable. An empty
-      // identity means the caller did not pin a producer; fail closed.
-      if (cfg.repository_identity.owner_slash_name.length === 0) {
-        return { classification: "unclassified", category: "unclassified-entry" };
-      }
-      if (isProducerOwnedUrl(c.value, cfg.repository_identity)) {
-        return { classification: "producer-internal", category: "fixed-url" };
-      }
-      return { classification: "consumer-resolvable", category: "fixed-url" };
-    }
-    case "overflow": {
-      // Pathological input: fail closed. The overflow marker is a non-ID
-      // string so it cannot accidentally classify as an allowed prefix.
-      return { classification: "unclassified", category: "evasion-attempt" };
-    }
-    default:
-      return assertNeverCandidate(c);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Pipeline stage 3: classify
+// Pipeline stage 2: classify
 // ---------------------------------------------------------------------------
 
 export interface LineClassification {
@@ -360,9 +182,3 @@ export function classifyLine(line: LineInput, cfg: DetectorConfig): LineClassifi
   }
   return { detections };
 }
-
-export {
-  decideProjection,
-  type ClassifyFileInput,
-  type DecideResult,
-} from "./boundary-gate.ts";

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-reconstruction.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-reconstruction.ts
@@ -9,7 +9,11 @@
 //
 // Supported atoms inside a bounded token:
 //   - literal `[A-Za-z0-9_-]`
-//   - `\uXXXX`  exactly four hex digits (decode to one UTF-16 code unit)
+//   - `\uXXXX`  exactly four hex digits (fixed width; decode to one UTF-16
+//               code unit). The four-hex-digit contract is unconditional:
+//               `\u00310` decodes to '1' and the trailing '0' is a literal,
+//               reconstructing `ADR-10`. There is no digit-continuation
+//               rejection.
 //   - `\xXX`    exactly two hex digits (decode to one byte char)
 //   - `0[xX]HH` exactly two hex digits in ASCII digit range (0x30..0x39)
 //               and NOT part of a longer hex run; decodes to the digit char.
@@ -19,20 +23,35 @@
 // Out-of-scope forms (`\u{XXXX}`, `\uXXXXXX` with 6 hex, malformed
 // escapes) are left as literal text and produce no detection unless a
 // normal direct ID is independently present.
+//
+// Bounding: the scan is capped at MAX_LINE_SCAN UTF-16 code units per line
+// and MAX_IDS_PER_TOKEN reconstructed IDs per token. Either limit turning a
+// typed overflow signal that the pipeline maps to a fail-closed candidate.
+// Regex matching uses sticky (`y`) regexes against the full line so there is
+// no per-character `substring(i)` allocation.
 
 const BOUNDED_LITERAL = /[A-Za-z0-9_-]/;
-const U_ESCAPE = /^\\u([0-9A-Fa-f]{4})/;
-// `\xXX` is fixed width 2: consume exactly two hex digits regardless of what
-// follows. A trailing hex char is a coincidental literal (e.g. the `D` in
-// `\x41DR`), not a longer escape run.
-const X_ESCAPE = /^\\x([0-9A-Fa-f]{2})/;
+// Sticky regexes: match must start exactly at lastIndex. No `^` anchor
+// (sticky already pins the start); the four/two-hex-digit width is exact.
+const U_ESCAPE = /\\u([0-9A-Fa-f]{4})/y;
+const X_ESCAPE = /\\x([0-9A-Fa-f]{2})/y;
 // `0[xX]HH` digit-reconstruction atom: case-insensitive `0x` prefix,
 // exactly two hex digits, value in ASCII digit range (0x30..0x39), and
 // not part of a longer hex run.
-const HEX_DIGIT_ATOM = /^0[xX](3[0-9])(?![0-9A-Fa-f])/;
-const HEX_DIGIT = /[0-9A-Fa-f]/;
+const HEX_DIGIT_ATOM = /0[xX](3[0-9])(?![0-9A-Fa-f])/y;
 const ID_PATTERN = /\b([A-Z]{2,})-(\d{1,})\b/g;
+const UTF_ENCODING_LABELS = new Set(["UTF-8", "UTF-16", "UTF-32"]);
+
+// Per-token cap. Closing the exploit ("STEP-1\u0032-").repeat(16) +
+// "\u0041DR-1": a single token cannot hide its 17th ID behind the cap.
+// When the cap turns, a typed overflow propagates so the gate fails closed
+// even if earlier reconstructed candidates are later deduped/owned.
 const MAX_IDS_PER_TOKEN = 16;
+// Scan budget: bounds per-line work to avoid O(n^2) blowup on pathological
+// input. A line longer than this is scanned up to the limit and then
+// signals line-scan-exceeded overflow (fail-closed). Exported so the
+// pipeline entry and the gate share one authoritative cap.
+export const MAX_LINE_SCAN = 65536;
 
 interface DecodedAtom {
   readonly char: string;
@@ -55,16 +74,15 @@ export interface ReconstructedId {
   readonly srcEnd: number;
 }
 
-// `\uXXXX` exact-contract gate. A digit-valued escape (decodes to '0'..'9')
-// immediately followed by another hex digit is a malformed digit-continuation
-// run (e.g. `\u00310`); it is left as literal text and produces no decode.
-// A non-digit-valued escape is always accepted, so `\u0041D` (decodes to 'A',
-// followed by hex 'D') still decodes and reconstructs `\u0041DR-0001`.
-function uEscapeAccepts(hex: string, line: string, escapeEnd: number): boolean {
-  const decoded = String.fromCharCode(parseInt(hex, 16));
-  if (decoded < "0" || decoded > "9") return true;
-  const nextCh = line.charAt(escapeEnd);
-  return nextCh === "" || !HEX_DIGIT.test(nextCh);
+/** Exhaustive reasons the reconstruction scan turned a typed overflow. */
+export type ReconstructionOverflowReason =
+  | "token-ids-exceeded"
+  | "line-scan-exceeded";
+
+export interface ReconstructionResult {
+  readonly ids: readonly ReconstructedId[];
+  readonly overflow: boolean;
+  readonly overflowReason: ReconstructionOverflowReason | null;
 }
 
 interface BoundedToken {
@@ -74,49 +92,43 @@ interface BoundedToken {
   readonly hasEscape: boolean;
 }
 
-function tokenizeBoundedToken(line: string, start: number): BoundedToken | null {
+function tokenizeBoundedToken(line: string, start: number, limit: number): BoundedToken | null {
   const atoms: DecodedAtom[] = [];
   let hasEscape = false;
   let i = start;
-  while (i < line.length) {
-    const rest = line.substring(i);
-
-    const u = U_ESCAPE.exec(rest);
+  while (i < limit) {
+    U_ESCAPE.lastIndex = i;
+    const u = U_ESCAPE.exec(line);
     if (u && u[0] !== undefined) {
-      const hex = u[1] ?? "";
-      const consumed = u[0].length;
-      if (uEscapeAccepts(hex, line, i + consumed)) {
-        const code = parseInt(hex, 16);
-        atoms.push({ char: String.fromCharCode(code), srcStart: i, srcEnd: i + consumed, fromEscape: true });
-        hasEscape = true;
-        i += consumed;
-        continue;
-      }
-    }
-
-    const x = X_ESCAPE.exec(rest);
-    if (x && x[0] !== undefined) {
-      const hex = x[1] ?? "";
-      const consumed = x[0].length;
-      const code = parseInt(hex, 16);
-      atoms.push({ char: String.fromCharCode(code), srcStart: i, srcEnd: i + consumed, fromEscape: true });
+      const code = parseInt(u[1] ?? "", 16);
+      atoms.push({ char: String.fromCharCode(code), srcStart: i, srcEnd: i + u[0].length, fromEscape: true });
       hasEscape = true;
-      i += consumed;
+      i += u[0].length;
       continue;
     }
 
-    const h = HEX_DIGIT_ATOM.exec(rest);
+    X_ESCAPE.lastIndex = i;
+    const x = X_ESCAPE.exec(line);
+    if (x && x[0] !== undefined) {
+      const code = parseInt(x[1] ?? "", 16);
+      atoms.push({ char: String.fromCharCode(code), srcStart: i, srcEnd: i + x[0].length, fromEscape: true });
+      hasEscape = true;
+      i += x[0].length;
+      continue;
+    }
+
+    HEX_DIGIT_ATOM.lastIndex = i;
+    const h = HEX_DIGIT_ATOM.exec(line);
     if (h && h[1] !== undefined && h[0] !== undefined) {
       const pair = h[1];
-      const consumed = h[0].length;
       // 0[xX]3N -> digit char 'N' (ASCII 0x30..0x39 == '0'..'9')
-      atoms.push({ char: pair.charAt(1), srcStart: i, srcEnd: i + consumed, fromEscape: true });
+      atoms.push({ char: pair.charAt(1), srcStart: i, srcEnd: i + h[0].length, fromEscape: true });
       hasEscape = true;
-      i += consumed;
+      i += h[0].length;
       continue;
     }
 
-    const ch = rest.charAt(0);
+    const ch = line.charAt(i);
     if (BOUNDED_LITERAL.test(ch)) {
       atoms.push({ char: ch, srcStart: i, srcEnd: i + 1, fromEscape: false });
       i += 1;
@@ -131,43 +143,62 @@ function tokenizeBoundedToken(line: string, start: number): BoundedToken | null 
 
 /**
  * Scan a line for bounded tokens that decode to expose concrete IDs. An ID
- * is emitted only when its own decoded span includes an escape atom (the ID
- * is reconstructed from escapes) OR an escape atom creates the word boundary
- * that exposes an adjacent literal ID (e.g. `STEP-1\u0020ADR-0002` exposes
- * ADR-0002 via the escaped space). A literal ID that merely shares a token
- * with an unrelated escape is NOT emitted. `matched`/`original` is the
+ * is emitted when its own decoded span includes an escape atom (ownEscape),
+ * OR an escape atom creates the word boundary that exposes it on either
+ * side — left (escape immediately before the ID) or right (escape
+ * immediately after). Left and right escape-created boundaries are
+ * symmetric. A literal ID that merely shares a token with an unrelated
+ * escape is NOT emitted. UTF-8/16/32 encoding labels are never emitted as
+ * reconstructed IDs (preserved exclusion). `matched`/`original` is the
  * minimal relevant source span, never the maximal token.
  *
- * Pure: same input always yields the same output.
+ * Pure: same input always yields the same output. The typed overflow signal
+ * MUST propagate to a fail-closed candidate even if the emitted ids are
+ * later deduped or owned by the pipeline.
  */
-export function detectReconstructedIds(line: string): ReconstructedId[] {
-  const out: ReconstructedId[] = [];
+export function detectReconstructedIds(line: string): ReconstructionResult {
+  const ids: ReconstructedId[] = [];
+  const limit = Math.min(line.length, MAX_LINE_SCAN);
   let i = 0;
-  while (i < line.length) {
-    const token = tokenizeBoundedToken(line, i);
+  while (i < limit) {
+    const token = tokenizeBoundedToken(line, i, limit);
     if (token === null) {
       i += 1;
       continue;
     }
     if (token.hasEscape) {
       const decoded = token.atoms.map((a) => a.char).join("");
-      const idPattern = new RegExp(ID_PATTERN.source, "g");
+      ID_PATTERN.lastIndex = 0;
       let m: RegExpExecArray | null;
       let emitted = 0;
-      while ((m = idPattern.exec(decoded)) !== null) {
-        if (emitted >= MAX_IDS_PER_TOKEN) break;
+      let tokenOverflow = false;
+      while ((m = ID_PATTERN.exec(decoded)) !== null) {
+        if (UTF_ENCODING_LABELS.has(m[0])) continue;
         const idStart = m.index;
         const idEnd = m.index + m[0].length;
         const startAtom = token.atoms.at(idStart);
         const endAtom = token.atoms.at(idEnd - 1);
         const leftAtom = idStart > 0 ? token.atoms.at(idStart - 1) : undefined;
+        const rightAtom = token.atoms.at(idEnd);
         if (startAtom === undefined || endAtom === undefined) continue;
         const ownEscape = token.atoms.slice(idStart, idEnd).some((a) => a.fromEscape);
-        const boundaryEscape = leftAtom !== undefined && leftAtom.fromEscape;
-        if (!ownEscape && !boundaryEscape) continue;
-        const spanStart = ownEscape ? startAtom.srcStart : (leftAtom?.srcStart ?? startAtom.srcStart);
-        const spanEnd = endAtom.srcEnd;
-        out.push({
+        const leftBoundary = leftAtom !== undefined && leftAtom.fromEscape;
+        const rightBoundary = rightAtom !== undefined && rightAtom.fromEscape;
+        if (!ownEscape && !leftBoundary && !rightBoundary) continue;
+        if (emitted >= MAX_IDS_PER_TOKEN) { tokenOverflow = true; break; }
+        let spanStart: number;
+        let spanEnd: number;
+        if (ownEscape) {
+          spanStart = startAtom.srcStart;
+          spanEnd = endAtom.srcEnd;
+        } else if (leftBoundary) {
+          spanStart = leftAtom?.srcStart ?? startAtom.srcStart;
+          spanEnd = endAtom.srcEnd;
+        } else {
+          spanStart = startAtom.srcStart;
+          spanEnd = rightAtom?.srcEnd ?? endAtom.srcEnd;
+        }
+        ids.push({
           decoded: m[0],
           original: line.substring(spanStart, spanEnd),
           srcStart: spanStart,
@@ -175,8 +206,14 @@ export function detectReconstructedIds(line: string): ReconstructedId[] {
         });
         emitted += 1;
       }
+      if (tokenOverflow) {
+        return { ids, overflow: true, overflowReason: "token-ids-exceeded" };
+      }
     }
     i += token.length;
   }
-  return out;
+  if (line.length > MAX_LINE_SCAN) {
+    return { ids, overflow: true, overflowReason: "line-scan-exceeded" };
+  }
+  return { ids, overflow: false, overflowReason: null };
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-reconstruction.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-reconstruction.ts
@@ -30,6 +30,8 @@
 // Regex matching uses sticky (`y`) regexes against the full line so there is
 // no per-character `substring(i)` allocation.
 
+import type { Span } from "./boundary-candidate-ownership.ts";
+
 const BOUNDED_LITERAL = /[A-Za-z0-9_-]/;
 // Sticky regexes: match must start exactly at lastIndex. No `^` anchor
 // (sticky already pins the start); the four/two-hex-digit width is exact.
@@ -155,8 +157,15 @@ function tokenizeBoundedToken(line: string, start: number, limit: number): Bound
  * Pure: same input always yields the same output. The typed overflow signal
  * MUST propagate to a fail-closed candidate even if the emitted ids are
  * later deduped or owned by the pipeline.
+ *
+ * @param ownedSpans - Optional readonly structural spans (URL/path owners).
+ * Tokens fully contained in these spans are skipped before reconstruction,
+ * preventing them from consuming the token-ids-exceeded cap.
  */
-export function detectReconstructedIds(line: string): ReconstructionResult {
+export function detectReconstructedIds(
+  line: string,
+  ownedSpans: readonly Span[] = []
+): ReconstructionResult {
   const ids: ReconstructedId[] = [];
   const limit = Math.min(line.length, MAX_LINE_SCAN);
   let i = 0;
@@ -166,7 +175,16 @@ export function detectReconstructedIds(line: string): ReconstructionResult {
       i += 1;
       continue;
     }
-    if (token.hasEscape) {
+    
+    // Skip tokens fully contained in owned spans (owned-span suppression).
+    // This prevents owned regions from consuming the token-ids-exceeded cap.
+    const tokenStart = i;
+    const tokenEnd = i + token.length;
+    const isFullyOwned = ownedSpans.some(
+      (owned) => owned.start <= tokenStart && tokenEnd <= owned.end
+    );
+    
+    if (token.hasEscape && !isFullyOwned) {
       const decoded = token.atoms.map((a) => a.char).join("");
       ID_PATTERN.lastIndex = 0;
       let m: RegExpExecArray | null;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-reconstruction.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-reconstruction.ts
@@ -1,0 +1,138 @@
+// Bounded lexical token reconstruction for evasion detection.
+//
+// Wrappers (`<`, `>`, `{`, `}`, `*`) and whitespace are token boundaries,
+// never exemptions: an ID reconstructed from escape atoms is flagged even
+// when the attacker wraps it in template-like markers. This module exists
+// because the prior broad regex evasion match missed prefix escapes,
+// suffix digit concatenation, and escaped hyphens while also flagging
+// unrelated technical prose (byte 0x41, CPU-0xFF, etc.).
+//
+// Supported atoms inside a bounded token:
+//   - literal `[A-Za-z0-9_-]`
+//   - `\uXXXX`  exactly four hex digits (decode to one UTF-16 code unit)
+//   - `\xXX`    exactly two hex digits (decode to one byte char)
+//   - `0[xX]HH` exactly two hex digits in ASCII digit range (0x30..0x39)
+//               and NOT part of a longer hex run; decodes to the digit char.
+//               `0[xX]31` decodes to '1'; `0[xX]3F`, `0[xX]41`, `0[xX]FF`,
+//               `0[xX]FFFFFF` do NOT match.
+//
+// Out-of-scope forms (`\u{XXXX}`, `\uXXXXXX` with 6 hex, malformed
+// escapes) are left as literal text and produce no detection unless a
+// normal direct ID is independently present.
+
+const BOUNDED_LITERAL = /[A-Za-z0-9_-]/;
+const U_ESCAPE = /^\\u([0-9A-Fa-f]{4})/;
+// `\xXX` must be exactly two hex digits; the negative lookahead prevents
+// consuming a longer hex run like `\x123`.
+const X_ESCAPE = /^\\x([0-9A-Fa-f]{2})(?![0-9A-Fa-f])/;
+// `0[xX]HH` digit-reconstruction atom: case-insensitive `0x` prefix,
+// exactly two hex digits, value in ASCII digit range (0x30..0x39), and
+// not part of a longer hex run.
+const HEX_DIGIT_ATOM = /^0[xX](3[0-9])(?![0-9A-Fa-f])/;
+
+interface BoundedToken {
+  readonly original: string;
+  readonly decoded: string;
+  readonly hasEscape: boolean;
+}
+
+export interface ReconstructedId {
+  /** Decoded concrete ID (e.g. "ADR-0001"). */
+  readonly decoded: string;
+  /** Source-form token (e.g. "\\u0041DR-0001"). */
+  readonly original: string;
+}
+
+function tokenizeBoundedToken(line: string, start: number): BoundedToken | null {
+  let original = "";
+  let decoded = "";
+  let hasEscape = false;
+  let i = start;
+  while (i < line.length) {
+    const rest = line.substring(i);
+
+    const u = U_ESCAPE.exec(rest);
+    if (u) {
+      const hex = u[1] ?? "";
+      if (hex) {
+        const code = parseInt(hex, 16);
+        decoded += String.fromCharCode(code);
+        original += u[0];
+        i += u[0].length;
+        hasEscape = true;
+        continue;
+      }
+    }
+
+    const x = X_ESCAPE.exec(rest);
+    if (x) {
+      const hex = x[1] ?? "";
+      if (hex) {
+        const code = parseInt(hex, 16);
+        decoded += String.fromCharCode(code);
+        original += x[0];
+        i += x[0].length;
+        hasEscape = true;
+        continue;
+      }
+    }
+
+    const h = HEX_DIGIT_ATOM.exec(rest);
+    if (h) {
+      const pair = h[1] ?? "";
+      if (pair.length === 2) {
+        // 0[xX]3N -> digit char 'N' (ASCII 0x30..0x39 == '0'..'9')
+        const digitChar = pair.charAt(1);
+        decoded += digitChar;
+        original += h[0];
+        i += h[0].length;
+        hasEscape = true;
+        continue;
+      }
+    }
+
+    const ch = rest.charAt(0);
+    if (BOUNDED_LITERAL.test(ch)) {
+      decoded += ch;
+      original += ch;
+      i += 1;
+      continue;
+    }
+
+    break;
+  }
+  if (original.length === 0) return null;
+  return { original, decoded, hasEscape };
+}
+
+/**
+ * Scan a line for bounded tokens that decode to expose one or more
+ * concrete IDs. A candidate is emitted for every concrete-ID match in the
+ * decoded token when the token contains at least one escape atom. The
+ * escape atom may decode INTO the matched ID (prefix/suffix/hyphen
+ * reconstruction) OR reconstruct a delimiter that creates the word
+ * boundary exposing an adjacent literal ID (e.g. `STEP-1\u0020ADR-0002`).
+ *
+ * Pure: same input always yields the same output.
+ */
+export function detectReconstructedIds(line: string): ReconstructedId[] {
+  const out: ReconstructedId[] = [];
+  let i = 0;
+  while (i < line.length) {
+    const token = tokenizeBoundedToken(line, i);
+    if (token === null) {
+      i += 1;
+      continue;
+    }
+    if (token.hasEscape) {
+      const idPattern = /\b([A-Z]{2,})-(\d{1,})\b/g;
+      let m: RegExpExecArray | null;
+      while ((m = idPattern.exec(token.decoded)) !== null) {
+        out.push({ decoded: m[0], original: token.original });
+      }
+    }
+    i += token.original.length;
+  }
+  return out;
+}
+

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-reconstruction.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-reconstruction.ts
@@ -175,7 +175,7 @@ export function detectReconstructedIds(
       i += 1;
       continue;
     }
-    
+
     // Skip tokens fully contained in owned spans (owned-span suppression).
     // This prevents owned regions from consuming the token-ids-exceeded cap.
     const tokenStart = i;
@@ -183,7 +183,7 @@ export function detectReconstructedIds(
     const isFullyOwned = ownedSpans.some(
       (owned) => owned.start <= tokenStart && tokenEnd <= owned.end
     );
-    
+
     if (token.hasEscape && !isFullyOwned) {
       const decoded = token.atoms.map((a) => a.char).join("");
       ID_PATTERN.lastIndex = 0;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-reconstruction.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-reconstruction.ts
@@ -22,96 +22,121 @@
 
 const BOUNDED_LITERAL = /[A-Za-z0-9_-]/;
 const U_ESCAPE = /^\\u([0-9A-Fa-f]{4})/;
-// `\xXX` must be exactly two hex digits; the negative lookahead prevents
-// consuming a longer hex run like `\x123`.
-const X_ESCAPE = /^\\x([0-9A-Fa-f]{2})(?![0-9A-Fa-f])/;
+// `\xXX` is fixed width 2: consume exactly two hex digits regardless of what
+// follows. A trailing hex char is a coincidental literal (e.g. the `D` in
+// `\x41DR`), not a longer escape run.
+const X_ESCAPE = /^\\x([0-9A-Fa-f]{2})/;
 // `0[xX]HH` digit-reconstruction atom: case-insensitive `0x` prefix,
 // exactly two hex digits, value in ASCII digit range (0x30..0x39), and
 // not part of a longer hex run.
 const HEX_DIGIT_ATOM = /^0[xX](3[0-9])(?![0-9A-Fa-f])/;
+const HEX_DIGIT = /[0-9A-Fa-f]/;
+const ID_PATTERN = /\b([A-Z]{2,})-(\d{1,})\b/g;
+const MAX_IDS_PER_TOKEN = 16;
 
-interface BoundedToken {
-  readonly original: string;
-  readonly decoded: string;
-  readonly hasEscape: boolean;
+interface DecodedAtom {
+  readonly char: string;
+  /** Source start index (inclusive) in the original line. */
+  readonly srcStart: number;
+  /** Source end index (exclusive). */
+  readonly srcEnd: number;
+  /** True when this atom was decoded from an escape (`\u`, `\x`, `0x`). */
+  readonly fromEscape: boolean;
 }
 
 export interface ReconstructedId {
   /** Decoded concrete ID (e.g. "ADR-0001"). */
   readonly decoded: string;
-  /** Source-form token (e.g. "\\u0041DR-0001"). */
+  /** Minimal relevant source-form span (e.g. "\\u0041DR-0001"). */
   readonly original: string;
+  /** Source start index (inclusive) of `original`. */
+  readonly srcStart: number;
+  /** Source end index (exclusive) of `original`. */
+  readonly srcEnd: number;
+}
+
+// `\uXXXX` exact-contract gate. A digit-valued escape (decodes to '0'..'9')
+// immediately followed by another hex digit is a malformed digit-continuation
+// run (e.g. `\u00310`); it is left as literal text and produces no decode.
+// A non-digit-valued escape is always accepted, so `\u0041D` (decodes to 'A',
+// followed by hex 'D') still decodes and reconstructs `\u0041DR-0001`.
+function uEscapeAccepts(hex: string, line: string, escapeEnd: number): boolean {
+  const decoded = String.fromCharCode(parseInt(hex, 16));
+  if (decoded < "0" || decoded > "9") return true;
+  const nextCh = line.charAt(escapeEnd);
+  return nextCh === "" || !HEX_DIGIT.test(nextCh);
+}
+
+interface BoundedToken {
+  readonly atoms: readonly DecodedAtom[];
+  /** Source chars consumed (start..start+length). */
+  readonly length: number;
+  readonly hasEscape: boolean;
 }
 
 function tokenizeBoundedToken(line: string, start: number): BoundedToken | null {
-  let original = "";
-  let decoded = "";
+  const atoms: DecodedAtom[] = [];
   let hasEscape = false;
   let i = start;
   while (i < line.length) {
     const rest = line.substring(i);
 
     const u = U_ESCAPE.exec(rest);
-    if (u) {
+    if (u && u[0] !== undefined) {
       const hex = u[1] ?? "";
-      if (hex) {
+      const consumed = u[0].length;
+      if (uEscapeAccepts(hex, line, i + consumed)) {
         const code = parseInt(hex, 16);
-        decoded += String.fromCharCode(code);
-        original += u[0];
-        i += u[0].length;
+        atoms.push({ char: String.fromCharCode(code), srcStart: i, srcEnd: i + consumed, fromEscape: true });
         hasEscape = true;
+        i += consumed;
         continue;
       }
     }
 
     const x = X_ESCAPE.exec(rest);
-    if (x) {
+    if (x && x[0] !== undefined) {
       const hex = x[1] ?? "";
-      if (hex) {
-        const code = parseInt(hex, 16);
-        decoded += String.fromCharCode(code);
-        original += x[0];
-        i += x[0].length;
-        hasEscape = true;
-        continue;
-      }
+      const consumed = x[0].length;
+      const code = parseInt(hex, 16);
+      atoms.push({ char: String.fromCharCode(code), srcStart: i, srcEnd: i + consumed, fromEscape: true });
+      hasEscape = true;
+      i += consumed;
+      continue;
     }
 
     const h = HEX_DIGIT_ATOM.exec(rest);
-    if (h) {
-      const pair = h[1] ?? "";
-      if (pair.length === 2) {
-        // 0[xX]3N -> digit char 'N' (ASCII 0x30..0x39 == '0'..'9')
-        const digitChar = pair.charAt(1);
-        decoded += digitChar;
-        original += h[0];
-        i += h[0].length;
-        hasEscape = true;
-        continue;
-      }
+    if (h && h[1] !== undefined && h[0] !== undefined) {
+      const pair = h[1];
+      const consumed = h[0].length;
+      // 0[xX]3N -> digit char 'N' (ASCII 0x30..0x39 == '0'..'9')
+      atoms.push({ char: pair.charAt(1), srcStart: i, srcEnd: i + consumed, fromEscape: true });
+      hasEscape = true;
+      i += consumed;
+      continue;
     }
 
     const ch = rest.charAt(0);
     if (BOUNDED_LITERAL.test(ch)) {
-      decoded += ch;
-      original += ch;
+      atoms.push({ char: ch, srcStart: i, srcEnd: i + 1, fromEscape: false });
       i += 1;
       continue;
     }
 
     break;
   }
-  if (original.length === 0) return null;
-  return { original, decoded, hasEscape };
+  if (atoms.length === 0) return null;
+  return { atoms, length: i - start, hasEscape };
 }
 
 /**
- * Scan a line for bounded tokens that decode to expose one or more
- * concrete IDs. A candidate is emitted for every concrete-ID match in the
- * decoded token when the token contains at least one escape atom. The
- * escape atom may decode INTO the matched ID (prefix/suffix/hyphen
- * reconstruction) OR reconstruct a delimiter that creates the word
- * boundary exposing an adjacent literal ID (e.g. `STEP-1\u0020ADR-0002`).
+ * Scan a line for bounded tokens that decode to expose concrete IDs. An ID
+ * is emitted only when its own decoded span includes an escape atom (the ID
+ * is reconstructed from escapes) OR an escape atom creates the word boundary
+ * that exposes an adjacent literal ID (e.g. `STEP-1\u0020ADR-0002` exposes
+ * ADR-0002 via the escaped space). A literal ID that merely shares a token
+ * with an unrelated escape is NOT emitted. `matched`/`original` is the
+ * minimal relevant source span, never the maximal token.
  *
  * Pure: same input always yields the same output.
  */
@@ -125,13 +150,33 @@ export function detectReconstructedIds(line: string): ReconstructedId[] {
       continue;
     }
     if (token.hasEscape) {
-      const idPattern = /\b([A-Z]{2,})-(\d{1,})\b/g;
+      const decoded = token.atoms.map((a) => a.char).join("");
+      const idPattern = new RegExp(ID_PATTERN.source, "g");
       let m: RegExpExecArray | null;
-      while ((m = idPattern.exec(token.decoded)) !== null) {
-        out.push({ decoded: m[0], original: token.original });
+      let emitted = 0;
+      while ((m = idPattern.exec(decoded)) !== null) {
+        if (emitted >= MAX_IDS_PER_TOKEN) break;
+        const idStart = m.index;
+        const idEnd = m.index + m[0].length;
+        const startAtom = token.atoms.at(idStart);
+        const endAtom = token.atoms.at(idEnd - 1);
+        const leftAtom = idStart > 0 ? token.atoms.at(idStart - 1) : undefined;
+        if (startAtom === undefined || endAtom === undefined) continue;
+        const ownEscape = token.atoms.slice(idStart, idEnd).some((a) => a.fromEscape);
+        const boundaryEscape = leftAtom !== undefined && leftAtom.fromEscape;
+        if (!ownEscape && !boundaryEscape) continue;
+        const spanStart = ownEscape ? startAtom.srcStart : (leftAtom?.srcStart ?? startAtom.srcStart);
+        const spanEnd = endAtom.srcEnd;
+        out.push({
+          decoded: m[0],
+          original: line.substring(spanStart, spanEnd),
+          srcStart: spanStart,
+          srcEnd: spanEnd,
+        });
+        emitted += 1;
       }
     }
-    i += token.original.length;
+    i += token.length;
   }
   return out;
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-reconstruction.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-reconstruction.ts
@@ -135,4 +135,3 @@ export function detectReconstructedIds(line: string): ReconstructedId[] {
   }
   return out;
 }
-

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-authority.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-authority.test.ts
@@ -1,0 +1,241 @@
+// Review-v5 URL authority malformedness: default ports, invalid ports,
+// and backslash authorities (C3).
+//
+// Scope:
+//   - Default GitHub ports (https:443, http:80) classify normally.
+//   - Non-default / invalid / scheme-less ports fail closed (evasion-attempt).
+//   - Backslash authorities (evil.com\@github.com, user\name@github.com)
+//     fail closed and cannot own/hide contained producer references.
+//   - Regression controls: normal userinfo, userinfo deception, ordinary
+//     external/producer/scheme-less behavior preserved.
+//
+// Each test was RED against the pre-C3 baseline (ports were rejected
+// outright; backslash authorities were silently dropped) and is GREEN
+// after C3.
+
+import { describe, expect, test } from "bun:test";
+import { extractUrls } from "./boundary-url-parser.ts";
+import { classifyAuthority, parseUrlHost } from "./boundary-url-authority.ts";
+import {
+  detectCandidates,
+  resolveCandidate,
+  type Candidate,
+  type DetectorConfig,
+} from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+const SPAN = { start: 0, end: 1 };
+
+function urlType(cs: readonly Candidate[]) {
+  return cs.filter((c): c is Extract<Candidate, { type: "url" }> => c.type === "url");
+}
+
+// C3.1: default ports classify normally.
+describe("C3.1 default ports / https:443 and http:80 classify normally", () => {
+  test("https://github.com:443/producer/... is producer-internal, gate fails", () => {
+    const text = "See https://github.com:443/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(false);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.find((d) => d.category === "fixed-url")?.classification).toBe("producer-internal");
+  });
+
+  test("http://github.com:80/producer/... is producer-internal, gate fails", () => {
+    const text = "See http://github.com:80/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(false);
+    expect(gateFor(text).pass).toBe(false);
+  });
+
+  test("https://github.com:443/external/... is consumer-resolvable, gate passes", () => {
+    const text = "See https://github.com:443/vercel/next.js/blob/main/x.md end.";
+    expect(extractUrls(text, 64).urls).toHaveLength(1);
+    expect(gateFor(text).pass).toBe(true);
+  });
+});
+
+// C3.2: non-default / invalid / out-of-range ports fail closed.
+describe("C3.2 non-default ports / fail closed via evasion-attempt", () => {
+  const cases: Array<[string, string]> = [
+    ["https :8080", "See https://github.com:8080/yogata/agent-dev-flow/blob/main/x.md end."],
+    ["https :80 (wrong scheme-default)", "See https://github.com:80/yogata/agent-dev-flow/blob/main/x.md end."],
+    ["http :443 (wrong scheme-default)", "See http://github.com:443/yogata/agent-dev-flow/blob/main/x.md end."],
+    ["https :abc (non-numeric)", "See https://github.com:abc/yogata/agent-dev-flow/blob/main/x.md end."],
+    ["https :99999 (out-of-range)", "See https://github.com:99999/yogata/agent-dev-flow/blob/main/x.md end."],
+  ];
+  for (const [label, text] of cases) {
+    test(`${label}: gate fails with evasion-attempt error`, () => {
+      const g = gateFor(text);
+      expect(g.pass).toBe(false);
+      expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+    });
+  }
+
+  test("resolveCandidate classifies malformed URL as unclassified/evasion-attempt", () => {
+    const r = resolveCandidate(
+      { type: "url", value: "https://github.com:8080", span: SPAN, malformed: true },
+      baseConfig,
+    );
+    expect(r.classification).toBe("unclassified");
+    expect(r.category).toBe("evasion-attempt");
+  });
+});
+
+// C3.3: scheme-less port fail-closed.
+describe("C3.3 scheme-less port / fail closed", () => {
+  test("github.com:8080/producer/... fails with evasion-attempt", () => {
+    const text = "See github.com:8080/yogata/agent-dev-flow/blob/main/x.md end.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+  });
+});
+
+// C3.4: backslash authority — recognized host inside a malformed backslash
+// authority never passes clean and cannot own/hide contained references.
+describe("C3.4 backslash authority / fail closed and cannot own ADR", () => {
+  test("https://evil.com\\@github.com/.../ADR-0001: gate fails, ADR independently visible", () => {
+    const text = "See https://evil.com\\@github.com/vercel/next.js/blob/main/ADR-0001 end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urlType(cs).find((c) => c.malformed)).toBeDefined();
+    const adr = cs.find(
+      (c): c is Extract<Candidate, { type: "direct-id" }> => c.type === "direct-id" && c.value === "ADR-0001",
+    );
+    expect(adr).toBeDefined();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+    expect(g.failures.find((d) => d.classification === "producer-internal")).toBeDefined();
+  });
+
+  test("malformed URL span does NOT cover the path (ADR outside authority)", () => {
+    const text = "https://evil.com\\@github.com/vercel/next.js/blob/main/ADR-0001";
+    const { urls } = extractUrls(text, 64);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected malformed url");
+    expect(u.malformed).toBe(true);
+    const adrIdx = text.indexOf("ADR-0001");
+    expect(u.span.end).toBeLessThanOrEqual(adrIdx);
+  });
+});
+
+// C3.5: backslash authority with reconstructed ADR and docs path independently visible.
+describe("C3.5 backslash authority / reconstructed ADR and docs path visible", () => {
+  test("reconstructed \\u0041DR-0001 near malformed URL is independently visible", () => {
+    const text = "See \\u0041DR-0001 in https://evil.com\\@github.com/vercel/next.js/blob/main/x.md end.";
+    const cs = detectCandidates(text, baseConfig);
+    const recon = cs.find(
+      (c): c is Extract<Candidate, { type: "reconstructed-id" }> =>
+        c.type === "reconstructed-id" && c.value === "ADR-0001",
+    );
+    expect(recon).toBeDefined();
+    expect(gateFor(text).pass).toBe(false);
+  });
+
+  test("docs/requirements/REQ-0001.md near malformed URL is independently visible", () => {
+    const text = "See https://evil.com\\@github.com/vercel/next.js/blob/main/x.md docs/requirements/REQ-0001.md end.";
+    const cs = detectCandidates(text, baseConfig);
+    const path = cs.find(
+      (c): c is Extract<Candidate, { type: "path" }> =>
+        c.type === "path" && c.value === "docs/requirements/REQ-0001.md",
+    );
+    expect(path).toBeDefined();
+    expect(gateFor(text).pass).toBe(false);
+  });
+});
+
+// C3.6: userinfo backslash fail-closed.
+describe("C3.6 userinfo backslash / fail closed", () => {
+  test("https://user\\name@github.com/producer/... fails with evasion-attempt", () => {
+    const text = "See https://user\\name@github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+  });
+});
+
+// C3.7: regression controls — pre-existing behavior preserved.
+describe("C3.7 regression controls", () => {
+  test("normal userinfo https://user@github.com/producer/... is producer-internal", () => {
+    const text = "See https://user@github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(false);
+    expect(gateFor(text).pass).toBe(false);
+  });
+
+  test("userinfo deception github.com@evil.com is NOT GitHub authority", () => {
+    const text = "See https://github.com@evil.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    expect(extractUrls(text, 64).urls).toHaveLength(0);
+    expect(gateFor(text).pass).toBe(true);
+  });
+
+  test("ordinary https producer URL without port is producer-internal", () => {
+    expect(gateFor("See https://github.com/yogata/agent-dev-flow/blob/main/x.md end.").pass).toBe(false);
+  });
+
+  test("ordinary external URL without port is consumer-resolvable, gate passes", () => {
+    expect(gateFor("See https://github.com/vercel/next.js/blob/main/x.md end.").pass).toBe(true);
+  });
+
+  test("valid bare scheme-less github.com producer URL is extracted (not malformed)", () => {
+    const text = "See github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(false);
+  });
+});
+
+// C3.8: parseUrlHost expected results.
+describe("C3.8 parseUrlHost / authority host extraction", () => {
+  const cases: Array<[string, string | null]> = [
+    ["https://github.com:443/o/r/blob/main/x.md", "github.com"],
+    ["http://github.com:80/o/r/blob/main/x.md", "github.com"],
+    ["https://github.com/o/r/blob/main/x.md", "github.com"],
+    ["github.com/o/r/blob/main/x.md", "github.com"],
+    ["https://github.com:8080/o/r/blob/main/x.md", null],
+    ["https://github.com:80/o/r/blob/main/x.md", null],
+    ["github.com:8080/o/r/blob/main/x.md", null],
+    ["https://evil.com\\@github.com/o/r/blob/main/x.md", null],
+    ["https://github.com@evil.com/o/r/blob/main/x.md", null],
+    ["https://notgithub.com/o/r/blob/main/x.md", null],
+  ];
+  for (const [url, expected] of cases) {
+    test(`parseUrlHost('${url.substring(0, 50)}') === ${expected}`, () => {
+      expect(parseUrlHost(url)).toBe(expected);
+    });
+  }
+});
+
+// C3.9: classifyAuthority three-way classification.
+describe("C3.9 classifyAuthority / valid / malformed / rejected", () => {
+  const cases: Array<[string, "valid" | "malformed" | "rejected"]> = [
+    ["https://github.com:443/o/r/blob/main/x.md", "valid"],
+    ["http://github.com:80/o/r/blob/main/x.md", "valid"],
+    ["https://github.com:8080/o/r/blob/main/x.md", "malformed"],
+    ["github.com:8080/o/r/blob/main/x.md", "malformed"],
+    ["https://evil.com\\@github.com/o/r/blob/main/x.md", "malformed"],
+    ["https://user\\name@github.com/o/r/blob/main/x.md", "malformed"],
+    ["https://github.com@evil.com/o/r/blob/main/x.md", "rejected"],
+    ["https://notgithub.com/o/r/blob/main/x.md", "rejected"],
+  ];
+  for (const [url, expected] of cases) {
+    test(`classifyAuthority('${url.substring(0, 50)}') === ${expected}`, () => {
+      expect(classifyAuthority(url).kind).toBe(expected);
+    });
+  }
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-authority.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-authority.test.ts
@@ -87,7 +87,7 @@ describe("C3.2 non-default ports / fail closed via evasion-attempt", () => {
 
   test("resolveCandidate classifies malformed URL as unclassified/evasion-attempt", () => {
     const r = resolveCandidate(
-      { type: "url", value: "https://github.com:8080", span: SPAN, malformed: true },
+      { type: "url", value: "https://github.com:8080", span: SPAN, ownershipSpan: null, malformed: true },
       baseConfig,
     );
     expect(r.classification).toBe("unclassified");

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-depth.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-depth.test.ts
@@ -3,7 +3,7 @@
 // Part 1 scope (C1.1-C1.3):
 //   - ../../docs/... (arbitrary dot-segment depth) classifies as producer-internal
 //   - Deeper slash/backslash/mixed prefixes classify as producer-internal
-//   - a/../../docs is rejected (identifier before dot-segments)
+//   - a/../../docs is detected (dot-segment collapse resolves to docs)
 
 import { describe, expect, test } from "bun:test";
 import { detectCandidates, type DetectorConfig, type Candidate } from "./boundary-pipeline.ts";
@@ -103,34 +103,36 @@ describe("C1.2 deeper slash/backslash/mixed prefixes classify as producer-intern
   });
 });
 
-describe("C1.3 a/../../docs is rejected (identifier before dot-segments)", () => {
-  test("a/../../docs/specs/foo.md does NOT become a candidate", () => {
+// C1.3: identifier + dot-segment prefix normalizes to docs.
+// dot-segment collapse後に通常segmentが残らず、docsへ解決されるためfail-closedで検出する
+describe("C1.3 identifier + dot-segment prefix normalizes to docs", () => {
+  test("a/../../docs/specs/foo.md becomes a candidate", () => {
     const text = "See a/../../docs/specs/foo.md here.";
     const g = gateFor(text);
-    expect(g.pass).toBe(true);
+    expect(g.pass).toBe(false);
     const pathFail = findFailureByCategory(g, "concrete-path");
-    expect(pathFail).toBeUndefined();
+    expect(pathFail?.classification).toBe("producer-internal");
     const cs = detectCandidates(text, baseConfig);
-    expect(paths(cs).length).toBe(0);
+    expect(paths(cs).length).toBe(1);
   });
 
-  test("foo/bar/../../docs/specs/foo.md does NOT become a candidate", () => {
+  test("foo/bar/../../docs/specs/foo.md becomes a candidate", () => {
     const text = "See foo/bar/../../docs/specs/foo.md here.";
     const g = gateFor(text);
-    expect(g.pass).toBe(true);
+    expect(g.pass).toBe(false);
     const pathFail = findFailureByCategory(g, "concrete-path");
-    expect(pathFail).toBeUndefined();
+    expect(pathFail?.classification).toBe("producer-internal");
     const cs = detectCandidates(text, baseConfig);
-    expect(paths(cs).length).toBe(0);
+    expect(paths(cs).length).toBe(1);
   });
 
-  test("x/../../../docs/specs/foo.md does NOT become a candidate", () => {
+  test("x/../../../docs/specs/foo.md becomes a candidate", () => {
     const text = "See x/../../../docs/specs/foo.md here.";
     const g = gateFor(text);
-    expect(g.pass).toBe(true);
+    expect(g.pass).toBe(false);
     const pathFail = findFailureByCategory(g, "concrete-path");
-    expect(pathFail).toBeUndefined();
+    expect(pathFail?.classification).toBe("producer-internal");
     const cs = detectCandidates(text, baseConfig);
-    expect(paths(cs).length).toBe(0);
+    expect(paths(cs).length).toBe(1);
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-depth.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-depth.test.ts
@@ -1,0 +1,136 @@
+// Review-v5 path lexical fixes: Part 1 - arbitrary-depth relative path detection.
+//
+// Part 1 scope (C1.1-C1.3):
+//   - ../../docs/... (arbitrary dot-segment depth) classifies as producer-internal
+//   - Deeper slash/backslash/mixed prefixes classify as producer-internal
+//   - a/../../docs is rejected (identifier before dot-segments)
+
+import { describe, expect, test } from "bun:test";
+import { detectCandidates, type DetectorConfig, type Candidate } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+import type { Detection, GateResult } from "./types.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+function paths(cs: readonly Candidate[]) {
+  return cs.filter((c) => c.type === "path");
+}
+
+function findFailureByCategory(gate: GateResult, category: Detection["category"]): Detection | undefined {
+  return gate.failures.find((d: Detection) => d.category === category);
+}
+
+describe("C1.1 arbitrary-depth relative docs paths / ../../docs...", () => {
+  test("../../docs/specs/foo.md becomes concrete producer path and gate fails", () => {
+    const text = "See ../../docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("../../../docs/adr/ADR-0001.md becomes concrete producer path and gate fails", () => {
+    const text = "See ../../../docs/adr/ADR-0001.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("../../../../docs/specs/foundation/system.md becomes concrete producer path and gate fails", () => {
+    const text = "See ../../../../docs/specs/foundation/system.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+});
+
+describe("C1.2 deeper slash/backslash/mixed prefixes classify as producer-internal", () => {
+  test("../../\\docs/specs/foo.md (mixed separators) becomes concrete producer path", () => {
+    const text = "See ../../\\docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("..\\..\\docs/specs/foo.md (backslash depth) becomes concrete producer path", () => {
+    const text = "See ..\\..\\docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("..\\../../docs/specs/foo.md (mixed backslash/slash depth) becomes concrete producer path", () => {
+    const text = "See ..\\../../docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("../../docs\\adr\\ADR-0001.md (mixed after docs) becomes concrete producer path", () => {
+    const text = "See ../../docs\\adr\\ADR-0001.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+});
+
+describe("C1.3 a/../../docs is rejected (identifier before dot-segments)", () => {
+  test("a/../../docs/specs/foo.md does NOT become a candidate", () => {
+    const text = "See a/../../docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail).toBeUndefined();
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(0);
+  });
+
+  test("foo/bar/../../docs/specs/foo.md does NOT become a candidate", () => {
+    const text = "See foo/bar/../../docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail).toBeUndefined();
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(0);
+  });
+
+  test("x/../../../docs/specs/foo.md does NOT become a candidate", () => {
+    const text = "See x/../../../docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail).toBeUndefined();
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(0);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-encoded.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-encoded.test.ts
@@ -108,13 +108,14 @@ describe("C1.6 percent-encoded backslash separators %5C/%5c", () => {
     expect(paths(cs).length).toBe(0);
   });
 
-  test("a/../../docs%5Cspecs%5Cfoo.md (identifier before) does NOT become a candidate", () => {
+  // dot-segment collapse後に通常segmentが残らず、docsへ解決されるためfail-closedで検出する
+  test("a/../../docs%5Cspecs%5Cfoo.md (identifier before) becomes a candidate", () => {
     const text = "See a/../../docs%5Cspecs%5Cfoo.md here.";
     const g = gateFor(text);
-    expect(g.pass).toBe(true);
+    expect(g.pass).toBe(false);
     const pathFail = findFailureByCategory(g, "concrete-path");
-    expect(pathFail).toBeUndefined();
+    expect(pathFail?.classification).toBe("producer-internal");
     const cs = detectCandidates(text, baseConfig);
-    expect(paths(cs).length).toBe(0);
+    expect(paths(cs).length).toBe(1);
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-encoded.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-encoded.test.ts
@@ -1,0 +1,120 @@
+// Review-v5 path lexical fixes: Part 3 - percent-encoded backslash separators.
+//
+// Part 3 scope (C1.6):
+//   - %5C/%5c separators are normalized and gate rejects on invalid prefix
+
+import { describe, expect, test } from "bun:test";
+import { detectCandidates, type DetectorConfig, type Candidate } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+import type { Detection, GateResult } from "./types.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+function paths(cs: readonly Candidate[]) {
+  return cs.filter((c) => c.type === "path");
+}
+
+function findFailureByCategory(gate: GateResult, category: Detection["category"]): Detection | undefined {
+  return gate.failures.find((d: Detection) => d.category === category);
+}
+
+describe("C1.6 percent-encoded backslash separators %5C/%5c", () => {
+  test("docs%5Cspecs%5Cfoo.md (no prefix) becomes concrete producer path", () => {
+    const text = "See docs%5Cspecs%5Cfoo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("./docs%5Cspecs%5Cfoo.md (./ prefix) becomes concrete producer path", () => {
+    const text = "See ./docs%5Cspecs%5Cfoo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("../docs%5Cspecs%5Cfoo.md (../ prefix) becomes concrete producer path", () => {
+    const text = "See ../docs%5Cspecs%5Cfoo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("../../docs%5Cspecs%5Cfoo.md (arbitrary depth) becomes concrete producer path", () => {
+    const text = "See ../../docs%5Cspecs%5Cfoo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("docs%5Cspecs/foo.md (mixed %5C and /) becomes concrete producer path", () => {
+    const text = "See docs%5Cspecs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("docs/specs%5Cfoo.md (mixed / and %5C) becomes concrete producer path", () => {
+    const text = "See docs/specs%5Cfoo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("/docs%5Cspecs%5Cfoo.md (absolute with %5C) does NOT become a candidate", () => {
+    const text = "See /docs%5Cspecs%5Cfoo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail).toBeUndefined();
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(0);
+  });
+
+  test(".docs%5Cspecs%5Cfoo.md (no prefix with %5C) does NOT become a candidate", () => {
+    const text = "See .docs%5Cspecs%5Cfoo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail).toBeUndefined();
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(0);
+  });
+
+  test("a/../../docs%5Cspecs%5Cfoo.md (identifier before) does NOT become a candidate", () => {
+    const text = "See a/../../docs%5Cspecs%5Cfoo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail).toBeUndefined();
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(0);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-rejection.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-rejection.test.ts
@@ -1,0 +1,106 @@
+// Review-v5 path lexical fixes: Part 2 - .docs and /docs rejection, regression guard.
+//
+// Part 2 scope (C1.4-C1.5, C1.7):
+//   - .docs is rejected (no prefix separator)
+//   - /docs is rejected (absolute path)
+//   - Preserve ./ and ../ behavior (regression guard)
+
+import { describe, expect, test } from "bun:test";
+import { detectCandidates, type DetectorConfig, type Candidate } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+import type { Detection, GateResult } from "./types.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+function paths(cs: readonly Candidate[]) {
+  return cs.filter((c) => c.type === "path");
+}
+
+function findFailureByCategory(gate: GateResult, category: Detection["category"]): Detection | undefined {
+  return gate.failures.find((d: Detection) => d.category === category);
+}
+
+describe("C1.4 .docs is rejected (no prefix separator)", () => {
+  test(".docs/specs/foo.md does NOT become a candidate", () => {
+    const text = "See .docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail).toBeUndefined();
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(0);
+  });
+});
+
+describe("C1.5 /docs is rejected (absolute path)", () => {
+  test("/docs/specs/foo.md does NOT become a candidate", () => {
+    const text = "See /docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail).toBeUndefined();
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(0);
+  });
+
+  test("///docs/specs/foo.md does NOT become a candidate", () => {
+    const text = "See ///docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail).toBeUndefined();
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(0);
+  });
+});
+
+describe("C1.7 preserve ./ and ../ behavior (regression guard)", () => {
+  test("./docs/specs/foo.md remains concrete producer path", () => {
+    const text = "See ./docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("../docs/specs/foo.md remains concrete producer path", () => {
+    const text = "See ../docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test(".\\docs/specs/foo.md (backslash) remains concrete producer path", () => {
+    const text = "See .\\docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+
+  test("..\\docs/specs/foo.md (backslash) remains concrete producer path", () => {
+    const text = "See ..\\docs/specs/foo.md here.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const pathFail = findFailureByCategory(g, "concrete-path");
+    expect(pathFail?.classification).toBe("producer-internal");
+    const cs = detectCandidates(text, baseConfig);
+    expect(paths(cs).length).toBe(1);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-url-ownership-path.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-url-ownership-path.test.ts
@@ -1,0 +1,164 @@
+// Review-v5 URL ownership of docs paths: URL spans fully contain docs-path
+// candidates, and the path extraction must skip those contained candidates
+// BEFORE checking/incrementing the cap (D7).
+//
+// Scope:
+//   - D7.1 docs-path without owner span is emitted; fully contained by owner span is omitted.
+//   - D7.2 partial overlap does NOT suppress (path is not fully contained).
+//   - D7.3 valid URL with embedded docs-looking path yields URL only (no path candidate).
+//   - D7.4 flood regression: 5 valid URLs (each with embedded docs substring) + 55 standalone docs paths = 5 URLs + 55 paths, no overflow.
+//   - D7.5 standalone cap exact/cap+1 behavior remains unchanged.
+//   - D7.6 malformed authority path remains independently visible (small authority span cannot contain later path).
+
+import { describe, expect, test } from "bun:test";
+import { extractDocsPaths } from "./boundary-docs-path-parser.ts";
+import { extractUrls } from "./boundary-url-parser.ts";
+import type { Span } from "./boundary-candidate-ownership.ts";
+
+// D7.1: containment skip behavior.
+describe("D7.1 containment skip / omitted when fully contained by owner span", () => {
+  test("same docs path emitted without owner span", () => {
+    const line = "docs/specs/REQ-0001.md";
+    const result = extractDocsPaths(line, 64);
+    expect(result.paths).toHaveLength(1);
+    expect(result.paths[0]?.value).toBe("docs/specs/REQ-0001.md");
+    expect(result.overflow).toBe(false);
+  });
+
+  test("same docs path omitted when fully contained by owner span", () => {
+    const line = "https://github.com/vercel/next.js/blob/main/docs/specs/REQ-0001.md end.";
+    const { urls } = extractUrls(line, 64);
+    expect(urls).toHaveLength(1);
+    const urlSpan: Span = urls[0]?.span ?? { start: 0, end: 1 };
+    const result = extractDocsPaths(line, 64, [urlSpan]);
+    expect(result.paths).toHaveLength(0);
+    expect(result.overflow).toBe(false);
+  });
+});
+
+// D7.2: partial overlap does NOT suppress.
+describe("D7.2 partial overlap does NOT suppress path", () => {
+  test("path starting before URL span end is not fully contained", () => {
+    const line = "docs/specs/REQ-0001.md https://github.com/vercel/next.js/blob/main/x.md end.";
+    const { urls } = extractUrls(line, 64);
+    expect(urls).toHaveLength(1);
+    const urlSpan: Span = urls[0]?.span ?? { start: 0, end: 1 };
+    const result = extractDocsPaths(line, 64, [urlSpan]);
+    // Path starts at 0, URL starts later, path is NOT contained
+    expect(result.paths).toHaveLength(1);
+    expect(result.paths[0]?.value).toBe("docs/specs/REQ-0001.md");
+  });
+
+  test("path ending after URL span start is not fully contained", () => {
+    const line = "https://github.com/vercel/next.js/docs/specs/REQ-0001.md more text";
+    const { urls: _ } = extractUrls(line, 64);
+    // This line doesn't have a valid URL structure (no owner/repo/blob/main)
+    // So we skip this test - partial overlap is covered by the first test above
+  });
+});
+
+// D7.3: valid URL with embedded docs-looking path yields URL only.
+describe("D7.3 valid URL with embedded docs path / URL only, no path candidate", () => {
+  test("URL contains docs/specs/ADR-0001.md - only URL emitted", () => {
+    const line = "See https://github.com/vercel/next.js/blob/main/docs/specs/ADR-0001.md end.";
+    const { urls } = extractUrls(line, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(false);
+    const urlSpan: Span = urls[0]?.span ?? { start: 0, end: 1 };
+    const result = extractDocsPaths(line, 64, [urlSpan]);
+    expect(result.paths).toHaveLength(0);
+    expect(result.overflow).toBe(false);
+  });
+
+  test("external URL with docs/requirements/REQ-0001.md - only URL emitted", () => {
+    const line = "See https://github.com/external/repo/blob/main/docs/requirements/REQ-0001.md end.";
+    const { urls } = extractUrls(line, 64);
+    expect(urls).toHaveLength(1);
+    const urlSpan: Span = urls[0]?.span ?? { start: 0, end: 1 };
+    const result = extractDocsPaths(line, 64, [urlSpan]);
+    expect(result.paths).toHaveLength(0);
+  });
+});
+
+// D7.4: flood regression - 5 URLs with embedded docs + 55 standalone = 5 + 55, no overflow.
+describe("D7.4 flood regression / 5 embedded + 55 standalone = 5 URLs + 55 paths, no overflow", () => {
+  test("exact flood scenario: 5 URLs with embedded docs paths + 55 standalone paths", () => {
+    // Build line with 5 URLs each containing docs/specs and 55 standalone paths
+    const embeddedParts = Array.from({ length: 5 }, (_, i) =>
+      `https://github.com/external${i}/repo${i}/blob/main/docs/specs/REQ-${String(i).padStart(4, "0")}.md`,
+    ).join(" ");
+    const standaloneParts = Array.from({ length: 55 }, (_, i) =>
+      `docs/specs/REQ-${String(i + 100).padStart(4, "0")}.md`,
+    ).join(" ");
+    const line = `See ${embeddedParts} ${standaloneParts} end.`;
+
+    const { urls } = extractUrls(line, 64);
+    expect(urls).toHaveLength(5);
+
+    const urlSpans: Span[] = urls.map((u) => u.span);
+    const result = extractDocsPaths(line, 64, urlSpans);
+
+    // All 5 embedded docs paths are skipped (contained by URL spans)
+    // All 55 standalone paths are emitted
+    expect(result.paths).toHaveLength(55);
+    expect(result.overflow).toBe(false);
+  });
+});
+
+// D7.5: standalone cap exact/cap+1 behavior remains unchanged.
+describe("D7.5 standalone cap behavior / exact and cap+1 unchanged", () => {
+  test("exact cap returns every path without overflow (no owner spans)", () => {
+    const line = Array.from({ length: 63 }, (_, i) => `docs/specs/x${i}.md`).join(" ");
+    const result = extractDocsPaths(line, 63, []);
+    expect(result.paths).toHaveLength(63);
+    expect(result.overflow).toBe(false);
+  });
+
+  test("cap plus one returns capped paths with overflow (no owner spans)", () => {
+    const line = Array.from({ length: 64 }, (_, i) => `docs/specs/x${i}.md`).join(" ");
+    const result = extractDocsPaths(line, 63, []);
+    expect(result.paths).toHaveLength(63);
+    expect(result.overflow).toBe(true);
+  });
+
+  test("cap behavior with non-containing owner spans unchanged", () => {
+    const line = Array.from({ length: 64 }, (_, i) => `docs/specs/x${i}.md`).join(" ");
+    // Owner span at position 100, doesn't contain any path
+    const nonContainingSpan: Span = { start: 100, end: 110 };
+    const result = extractDocsPaths(line, 63, [nonContainingSpan]);
+    expect(result.paths).toHaveLength(63);
+    expect(result.overflow).toBe(true);
+  });
+});
+
+// D7.6: malformed authority path remains independently visible.
+describe("D7.6 malformed authority / small authority span cannot contain later path", () => {
+  test("backslash authority malformed URL has small span, docs path after is visible", () => {
+    const line = "See https://evil.com\\@github.com/vercel/next.js/blob/main/x.md docs/requirements/REQ-0001.md end.";
+    const { urls } = extractUrls(line, 64);
+    expect(urls).toHaveLength(1);
+    const url = urls[0];
+    expect(url?.malformed).toBe(true);
+
+    // Malformed authority span covers only the authority region, not the path
+    const urlSpan: Span = url?.span ?? { start: 0, end: 1 };
+    const result = extractDocsPaths(line, 64, [urlSpan]);
+
+    // Path is NOT contained in the small authority span, so it is emitted
+    expect(result.paths).toHaveLength(1);
+    expect(result.paths[0]?.value).toBe("docs/requirements/REQ-0001.md");
+  });
+
+  test("malformed authority with embedded-looking path does NOT suppress real docs path", () => {
+    const line = "https://evil.com\\@github.com/vercel/next.js/blob/main/docs/specs/REQ-0001.md docs/requirements/REQ-9999.md end.";
+    const { urls } = extractUrls(line, 64);
+    expect(urls).toHaveLength(1);
+    const urlSpan: Span = urls[0]?.span ?? { start: 0, end: 1 };
+
+    const result = extractDocsPaths(line, 64, [urlSpan]);
+
+    // The docs/requirements/REQ-9999.md is outside the malformed authority span
+    expect(result.paths).toHaveLength(1);
+    expect(result.paths[0]?.value).toBe("docs/requirements/REQ-9999.md");
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-url-ownership-path.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-url-ownership-path.test.ts
@@ -49,11 +49,21 @@ describe("D7.2 partial overlap does NOT suppress path", () => {
     expect(result.paths[0]?.value).toBe("docs/specs/REQ-0001.md");
   });
 
-  test("path ending after URL span start is not fully contained", () => {
-    const line = "https://github.com/vercel/next.js/docs/specs/REQ-0001.md more text";
-    const { urls: _ } = extractUrls(line, 64);
-    // This line doesn't have a valid URL structure (no owner/repo/blob/main)
-    // So we skip this test - partial overlap is covered by the first test above
+  test("explicit partially overlapping span does NOT suppress path", () => {
+    const line = "See docs/specs/REQ-0001.md and more text";
+    const partialSpan: Span = { start: 10, end: 40 };
+    const result = extractDocsPaths(line, 64, [partialSpan]);
+    expect(result.paths).toHaveLength(1);
+    expect(result.paths[0]?.value).toBe("docs/specs/REQ-0001.md");
+    expect(result.paths[0]?.span).toEqual({ start: 4, end: 26 });
+  });
+
+  test("path ending after owner span start is not fully contained", () => {
+    const lineWithPath = "docs/specs/REQ-0001.md https://github.com/vercel/next.js/blob/main/x.md";
+    const { urls: urlsWithPath } = extractUrls(lineWithPath, 64);
+    const pathResult = extractDocsPaths(lineWithPath, 64, [urlsWithPath[0]?.span ?? { start: 0, end: 1 }]);
+    expect(pathResult.paths).toHaveLength(1);
+    expect(pathResult.paths[0]?.value).toBe("docs/specs/REQ-0001.md");
   });
 });
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-url-ownership-pipeline.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-url-ownership-pipeline.test.ts
@@ -1,0 +1,140 @@
+// End-to-end pipeline tests for URL ownership of docs paths (D7).
+//
+// These tests exercise the full detectCandidates pipeline to ensure
+// valid URL spans are correctly passed as exclusions to docs path extraction,
+// while malformed URL spans are NOT treated as exclusions.
+//
+// Scope:
+//   - D7.4 E2E flood: 5 valid external URLs with embedded docs + 55 standalone paths = 5 url + 55 path, no overflow.
+//   - D7.6 E2E malformed authority: malformed URL does NOT suppress docs path, evasion-attempt error present.
+
+import { describe, expect, test } from "bun:test";
+import {
+  detectCandidates,
+  type Candidate,
+  type DetectorConfig,
+} from "./boundary-pipeline.ts";
+import { resolveCandidate } from "./boundary-candidate-model.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function getUrl(cs: readonly Candidate[]) {
+  return cs.filter((c): c is Extract<Candidate, { type: "url" }> => c.type === "url");
+}
+
+function getPath(cs: readonly Candidate[]) {
+  return cs.filter((c): c is Extract<Candidate, { type: "path" }> => c.type === "path");
+}
+
+function getOverflow(cs: readonly Candidate[]) {
+  return cs.filter((c): c is Extract<Candidate, { type: "overflow" }> => c.type === "overflow");
+}
+
+// D7.4 E2E: flood regression through full pipeline.
+describe("D7.4 E2E flood regression / 5 valid URLs + 55 standalone paths = 5 url + 55 path, no overflow", () => {
+  test("flood scenario: 5 URLs with embedded docs paths + 55 standalone paths", () => {
+    const embeddedParts = Array.from({ length: 5 }, (_, i) =>
+      `https://github.com/external${i}/repo${i}/blob/main/docs/specs/REQ-${String(i).padStart(4, "0")}.md`,
+    ).join(" ");
+    const standaloneParts = Array.from({ length: 55 }, (_, i) =>
+      `docs/specs/REQ-${String(i + 100).padStart(4, "0")}.md`,
+    ).join(" ");
+    const line = `See ${embeddedParts} ${standaloneParts} end.`;
+
+    const candidates = detectCandidates(line, baseConfig);
+    const urls = getUrl(candidates);
+    const paths = getPath(candidates);
+    const overflows = getOverflow(candidates);
+
+    // Exactly 5 URLs from embedded paths
+    expect(urls).toHaveLength(5);
+    expect(urls.every((u) => u.malformed === false)).toBe(true);
+
+    // Exactly 55 standalone paths (embedded docs paths excluded by URL spans)
+    expect(paths).toHaveLength(55);
+
+    // No overflow candidates
+    expect(overflows).toHaveLength(0);
+  });
+});
+
+// D7.6 E2E: malformed authority does NOT suppress docs path.
+describe("D7.6 E2E malformed authority / path remains visible, evasion-attempt error present", () => {
+  test("backslash authority malformed URL + docs path after: both present, evasion-attempt on URL", () => {
+    const line = "See https://evil.com\\@github.com/vercel/next.js/blob/main/x.md docs/requirements/REQ-0001.md end.";
+    const candidates = detectCandidates(line, baseConfig);
+    const urls = getUrl(candidates);
+    const paths = getPath(candidates);
+
+    // Malformed URL is emitted as evasion-attempt
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(true);
+
+    if (urls[0] !== undefined) {
+      const urlResult = resolveCandidate(urls[0], baseConfig);
+      expect(urlResult.category).toBe("evasion-attempt");
+    }
+
+    // Docs path is NOT suppressed by malformed URL span
+    expect(paths).toHaveLength(1);
+    expect(paths[0]?.value).toBe("docs/requirements/REQ-0001.md");
+  });
+
+  test("malformed authority with docs path in path region + standalone docs path: both visible", () => {
+    const line = "https://evil.com\\@github.com/vercel/next.js/blob/main/docs/specs/REQ-0001.md docs/requirements/REQ-9999.md end.";
+    const candidates = detectCandidates(line, baseConfig);
+    const urls = getUrl(candidates);
+    const paths = getPath(candidates);
+
+    // Malformed URL is emitted
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(true);
+
+    // The standalone docs path must be visible (not suppressed by malformed span)
+    const standalonePath = paths.find((p) => p.value === "docs/requirements/REQ-9999.md");
+    expect(standalonePath).toBeDefined();
+  });
+
+  test("malformed authority URL span MUST NOT act as exclusion: explicit span containment test", () => {
+    const line = "https://evil.com\\@github.com/owner/repo/blob/main/x.md docs/specs/REQ-0001.md";
+    const candidates = detectCandidates(line, baseConfig);
+    const urls = getUrl(candidates);
+    const paths = getPath(candidates);
+
+    expect(urls).toHaveLength(1);
+    const url0 = urls[0];
+    if (url0 === undefined) {
+      throw new Error("expected url0 to be defined");
+    }
+    expect(url0.malformed).toBe(true);
+    expect(url0.value).toBe("https://evil.com\\@github.com");
+
+    expect(paths).toHaveLength(1);
+    expect(paths[0]?.value).toBe("docs/specs/REQ-0001.md");
+  });
+
+  test("valid URL DOES suppress embedded docs path; malformed URL does NOT", () => {
+    const validLine = "See https://github.com/vercel/next.js/blob/main/docs/specs/REQ-0001.md end.";
+    const validCandidates = detectCandidates(validLine, baseConfig);
+    const validUrls = getUrl(validCandidates);
+    const validPaths = getPath(validCandidates);
+
+    expect(validUrls).toHaveLength(1);
+    expect(validUrls[0]?.malformed).toBe(false);
+    expect(validPaths).toHaveLength(0);
+
+    const malformedLine = "See https://evil.com\\@github.com/vercel/next.js/blob/main/x.md docs/specs/REQ-0001.md end.";
+    const malformedCandidates = detectCandidates(malformedLine, baseConfig);
+    const malformedUrls = getUrl(malformedCandidates);
+    const malformedPaths = getPath(malformedCandidates);
+
+    expect(malformedUrls).toHaveLength(1);
+    expect(malformedUrls[0]?.malformed).toBe(true);
+    expect(malformedPaths).toHaveLength(1);
+    expect(malformedPaths[0]?.value).toBe("docs/specs/REQ-0001.md");
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-url-scheme.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-url-scheme.test.ts
@@ -1,0 +1,134 @@
+// Review-v5 URL scheme boundary fixes: multi-URL span independence and
+// unsupported composite-scheme handling (C2).
+//
+// Scope:
+//   - Two GitHub URLs on one line keep independent, non-overlapping spans;
+//     a later bare host never grabs an earlier URL's scheme prefix.
+//   - `git+https://` is an unsupported composite scheme: it cannot own or
+//     hide contained producer references (fail-closed).
+//   - Regression controls: ordinary https, userinfo, userinfo deception,
+//     unsupported evil/ftp, and valid bare scheme-less hosts stay correct.
+
+import { describe, expect, test } from "bun:test";
+import { extractUrls } from "./boundary-url-parser.ts";
+import { detectCandidates, type DetectorConfig } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+// C2.1: two GitHub URLs on one line keep independent, non-overlapping spans.
+describe("C2.1 multi-URL span independence", () => {
+  test("two scheme URLs separated by space have non-overlapping spans", () => {
+    const text = "https://github.com/vercel/next.js/blob/main/a.md https://github.com/yogata/agent-dev-flow/blob/main/b.md";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(2);
+    const u1 = urls[0];
+    const u2 = urls[1];
+    if (u1 === undefined || u2 === undefined) throw new Error("expected two urls");
+    expect(u1.span.end).toBeLessThanOrEqual(u2.span.start);
+    expect(u1.value).toBe("https://github.com/vercel/next.js/blob/main/a.md");
+    expect(u2.value).toBe("https://github.com/yogata/agent-dev-flow/blob/main/b.md");
+  });
+
+  test("scheme URL followed by bare host: bare URL never grabs earlier scheme", () => {
+    const text = "https://github.com/vercel/next.js/blob/main/a.md github.com/yogata/agent-dev-flow/blob/main/b.md";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(2);
+    const u1 = urls[0];
+    const u2 = urls[1];
+    if (u1 === undefined || u2 === undefined) throw new Error("expected two urls");
+    expect(u1.span.end).toBeLessThanOrEqual(u2.span.start);
+    expect(u2.value.startsWith("https://")).toBe(false);
+    expect(u2.value).toBe("github.com/yogata/agent-dev-flow/blob/main/b.md");
+  });
+
+  test("scheme URL + text + bare host: bare URL stays independent after the text", () => {
+    const text = "https://github.com/vercel/next.js/blob/main/a.md then github.com/yogata/agent-dev-flow/blob/main/b.md";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(2);
+    const u1 = urls[0];
+    const u2 = urls[1];
+    if (u1 === undefined || u2 === undefined) throw new Error("expected two urls");
+    expect(u1.span.end).toBeLessThanOrEqual(u2.span.start);
+    expect(u2.value).toBe("github.com/yogata/agent-dev-flow/blob/main/b.md");
+  });
+});
+
+// C2.2: a non-GitHub URL before a bare GitHub host — the bare host is its own URL.
+describe("C2.2 example.com then bare GitHub host", () => {
+  test("http://example.com and github.com/producer/... keeps bare GitHub URL independent", () => {
+    const text = "http://example.com and github.com/yogata/agent-dev-flow/blob/main/x.md";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.value).toBe("github.com/yogata/agent-dev-flow/blob/main/x.md");
+    expect(u.value.startsWith("http://")).toBe(false);
+  });
+});
+
+// C2.3: unsupported composite scheme git+https cannot own/hide producer refs.
+describe("C2.3 git+https unsupported composite scheme fails closed", () => {
+  test("git+https://github.com/vercel/.../ADR-1.md exposes contained reference (no URL owner, gate fails)", () => {
+    const text = "See git+https://github.com/vercel/next.js/blob/main/docs/ADR-1.md here.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(0);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    const producerFail = g.failures.find((d) => d.classification === "producer-internal");
+    expect(producerFail).toBeDefined();
+  });
+
+  test("detectCandidates yields no url candidate for git+https producer path", () => {
+    const text = "See git+https://github.com/yogata/agent-dev-flow/blob/main/docs/ADR-1.md here.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(cs.filter((c) => c.type === "url")).toHaveLength(0);
+  });
+});
+
+// C2.4: regression controls — pre-existing behavior preserved.
+describe("C2.4 regression controls", () => {
+  test("ordinary https producer URL is producer-internal", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(gateFor(text).pass).toBe(false);
+  });
+
+  test("userinfo producer URL is producer-internal and keeps scheme prefix", () => {
+    const text = "See https://user@github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.value.startsWith("https://")).toBe(true);
+  });
+
+  test("userinfo deception github.com@evil.com is NOT a GitHub authority", () => {
+    const text = "See https://github.com@evil.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    expect(extractUrls(text, 64).urls).toHaveLength(0);
+  });
+
+  test("unsupported evil:// and ftp:// are NOT GitHub authorities", () => {
+    expect(extractUrls("See evil://github.com/yogata/agent-dev-flow/blob/main/x.md end.", 64).urls).toHaveLength(0);
+    expect(extractUrls("See ftp://github.com/yogata/agent-dev-flow/blob/main/x.md end.", 64).urls).toHaveLength(0);
+  });
+
+  test("valid bare scheme-less github.com producer URL is extracted", () => {
+    const text = "See github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.value).toBe("github.com/yogata/agent-dev-flow/blob/main/x.md");
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-url-scheme.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-url-scheme.test.ts
@@ -76,22 +76,25 @@ describe("C2.2 example.com then bare GitHub host", () => {
   });
 });
 
-// C2.3: unsupported composite scheme git+https cannot own/hide producer refs.
-describe("C2.3 git+https unsupported composite scheme fails closed", () => {
-  test("git+https://github.com/vercel/.../ADR-1.md exposes contained reference (no URL owner, gate fails)", () => {
+// C2.3: unsupported composite scheme git+https emits a malformed candidate
+// (fail-closed). Historical intent was "0 URLs, gate PASS" but per
+// distribution-boundary.md the detector must fail-closed on evasion forms.
+describe("C2.3 git+https unsupported composite scheme emits malformed", () => {
+  test("git+https://github.com/vercel/.../ADR-1.md → 1 malformed URL (ownershipSpan null), ADR visible, gate fails", () => {
     const text = "See git+https://github.com/vercel/next.js/blob/main/docs/ADR-1.md here.";
     const { urls } = extractUrls(text, 64);
-    expect(urls).toHaveLength(0);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(true);
+    expect(urls[0]?.ownershipSpan).toBeNull();
     const g = gateFor(text);
     expect(g.pass).toBe(false);
-    const producerFail = g.failures.find((d) => d.classification === "producer-internal");
-    expect(producerFail).toBeDefined();
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
   });
 
-  test("detectCandidates yields no url candidate for git+https producer path", () => {
+  test("detectCandidates yields 1 malformed url candidate for git+https producer path", () => {
     const text = "See git+https://github.com/yogata/agent-dev-flow/blob/main/docs/ADR-1.md here.";
     const cs = detectCandidates(text, baseConfig);
-    expect(cs.filter((c) => c.type === "url")).toHaveLength(0);
+    expect(cs.filter((c) => c.type === "url")).toHaveLength(1);
   });
 });
 
@@ -118,9 +121,15 @@ describe("C2.4 regression controls", () => {
     expect(extractUrls(text, 64).urls).toHaveLength(0);
   });
 
-  test("unsupported evil:// and ftp:// are NOT GitHub authorities", () => {
-    expect(extractUrls("See evil://github.com/yogata/agent-dev-flow/blob/main/x.md end.", 64).urls).toHaveLength(0);
-    expect(extractUrls("See ftp://github.com/yogata/agent-dev-flow/blob/main/x.md end.", 64).urls).toHaveLength(0);
+  test("unsupported evil:// and ftp:// emit 1 malformed each (fail-closed per distribution-boundary.md)", () => {
+    const eu = extractUrls("See evil://github.com/yogata/agent-dev-flow/blob/main/x.md end.", 64).urls;
+    expect(eu).toHaveLength(1);
+    expect(eu[0]?.malformed).toBe(true);
+    expect(eu[0]?.ownershipSpan).toBeNull();
+    const fu = extractUrls("See ftp://github.com/yogata/agent-dev-flow/blob/main/x.md end.", 64).urls;
+    expect(fu).toHaveLength(1);
+    expect(fu[0]?.malformed).toBe(true);
+    expect(fu[0]?.ownershipSpan).toBeNull();
   });
 
   test("valid bare scheme-less github.com producer URL is extracted", () => {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-url-terminator.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v5-url-terminator.test.ts
@@ -1,0 +1,145 @@
+// Review-v5 URL terminator strictness: conditional ASCII colon (path-only),
+// unconditional full-width colon U+FF1A, and opening delimiters `(`, `[`, `{`
+// terminate URL ownership so an adjacent docs path or producer ID is
+// independently detected.
+//
+// Scope:
+//   - C4.1 ASCII colon after path terminates; adjacent docs path / ID visible.
+//   - C4.2 full-width colon U+FF1A terminates unconditionally.
+//   - C4.3 opening delimiters `(`, `[`, `{` terminate unconditionally.
+//   - C4.4 colons inside query (`?`) or fragment (`#`) stay in the URL.
+//   - C4.5 default-port authority colon (`:443`) preserved (regression).
+//   - C4.6 prior punctuation controls (comma, CJK, semicolon) remain green.
+
+import { describe, expect, test } from "bun:test";
+import { extractUrls } from "./boundary-url-parser.ts";
+import { detectCandidates, type Candidate, type DetectorConfig } from "./boundary-pipeline.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function findPath(cs: readonly Candidate[], value: string) {
+  return cs.find((c): c is Extract<Candidate, { type: "path" }> => c.type === "path" && c.value === value);
+}
+
+function findDirectId(cs: readonly Candidate[], value: string) {
+  return cs.find((c): c is Extract<Candidate, { type: "direct-id" }> => c.type === "direct-id" && c.value === value);
+}
+
+const FW_COLON = "\uFF1A";
+const FW_COMMA = "\uFF0C";
+
+// C4.1: ASCII colon after path terminates URL ownership.
+describe("C4.1 ASCII colon after path terminates URL", () => {
+  test("scheme-less URL then :docs/specs/foo.md - URL ends at .md, path independently visible", () => {
+    const text = "See github.com/vercel/next.js/blob/main/x.md:docs/specs/foo.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("github.com/vercel/next.js/blob/main/x.md");
+    expect(findPath(detectCandidates(text, baseConfig), "docs/specs/foo.md")).toBeDefined();
+  });
+
+  test("scheme URL then :ADR-0001 - URL ends at .md, ADR independently visible", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md:ADR-0001 end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("https://github.com/vercel/next.js/blob/main/x.md");
+    expect(findDirectId(detectCandidates(text, baseConfig), "ADR-0001")).toBeDefined();
+  });
+});
+
+// C4.2: full-width colon U+FF1A terminates unconditionally.
+describe("C4.2 full-width colon terminates URL", () => {
+  test("scheme-less URL then U+FF1A + docs/specs/foo.md - URL ends at .md", () => {
+    const text = `See github.com/vercel/next.js/blob/main/x.md${FW_COLON}docs/specs/foo.md end.`;
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("github.com/vercel/next.js/blob/main/x.md");
+  });
+});
+
+// C4.3: opening delimiters terminate URL unconditionally.
+describe("C4.3 opening delimiters terminate URL", () => {
+  test("( terminates URL", () => {
+    const text = "See github.com/vercel/next.js/blob/main/x.md(docs/specs/foo.md) end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("github.com/vercel/next.js/blob/main/x.md");
+  });
+
+  test("[ terminates URL", () => {
+    const text = "See github.com/vercel/next.js/blob/main/x.md[docs/specs/foo.md] end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("github.com/vercel/next.js/blob/main/x.md");
+  });
+
+  test("{ terminates URL (regression control)", () => {
+    const text = "See github.com/vercel/next.js/blob/main/x.md{docs/specs/foo.md} end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("github.com/vercel/next.js/blob/main/x.md");
+  });
+});
+
+// C4.4: colons inside query or fragment stay in the URL.
+describe("C4.4 query/fragment colons stay in URL", () => {
+  test("query ?q=a:b - colon stays in URL", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md?q=a:b end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("https://github.com/vercel/next.js/blob/main/x.md?q=a:b");
+  });
+
+  test("fragment #frag:c - colon stays in URL", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md#frag:c end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("https://github.com/vercel/next.js/blob/main/x.md#frag:c");
+  });
+
+  test("query and fragment ?q=a:b#frag:c - both colons stay", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md?q=a:b#frag:c end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("https://github.com/vercel/next.js/blob/main/x.md?q=a:b#frag:c");
+  });
+});
+
+// C4.5: default-port authority colon preserved (regression).
+describe("C4.5 authority colon preserved", () => {
+  test("https://github.com:443/... - port colon does NOT terminate", () => {
+    const text = "See https://github.com:443/vercel/next.js/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("https://github.com:443/vercel/next.js/blob/main/x.md");
+    expect(urls[0]?.malformed).toBe(false);
+  });
+});
+
+// C4.6: prior punctuation controls remain green.
+describe("C4.6 prior punctuation controls", () => {
+  test("comma terminates URL", () => {
+    const text = "See github.com/vercel/next.js/blob/main/x.md,docs/specs/foo.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("github.com/vercel/next.js/blob/main/x.md");
+  });
+
+  test("full-width comma U+FF0C terminates URL", () => {
+    const text = `See github.com/vercel/next.js/blob/main/x.md${FW_COMMA}docs/specs/foo.md end.`;
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("github.com/vercel/next.js/blob/main/x.md");
+  });
+
+  test("semicolon terminates URL", () => {
+    const text = "See github.com/vercel/next.js/blob/main/x.md;docs/specs/foo.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.value).toBe("github.com/vercel/next.js/blob/main/x.md");
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-docs-prefix.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-docs-prefix.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "bun:test";
+import { extractDocsPaths } from "./boundary-docs-path-parser";
+
+describe("boundary-docs-path-parser v6 docs prefix strict grammar", () => {
+  const CAP = 10;
+
+  describe("Markdown links and brackets", () => {
+    it("should detect docs path in Markdown link [text](docs/specs/foo.md)", () => {
+      const result = extractDocsPaths("[text](docs/specs/foo.md)", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toContain("docs/specs/foo.md");
+    });
+
+    it("should detect docs path in Markdown bracket [docs/specs/foo.md](url)", () => {
+      const result = extractDocsPaths("[docs/specs/foo.md](url)", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toContain("docs/specs/foo.md");
+    });
+  });
+
+  describe("URL query assignments", () => {
+    it("should detect docs path in query assignment path=docs/specs/foo.md", () => {
+      const result = extractDocsPaths("path=docs/specs/foo.md", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toContain("docs/specs/foo.md");
+    });
+
+    it("should detect docs path after ampersand ref=other&docs/specs/foo.md", () => {
+      const result = extractDocsPaths("ref=other&docs/specs/foo.md", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toContain("docs/specs/foo.md");
+    });
+  });
+
+  describe("Strict dot-segment patterns", () => {
+    it("should detect single-dot prefix ./docs/specs/foo.md", () => {
+      const result = extractDocsPaths("./docs/specs/foo.md", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toBe("docs/specs/foo.md");
+    });
+
+    it("should detect double-dot prefix ../docs/specs/foo.md", () => {
+      const result = extractDocsPaths("../docs/specs/foo.md", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toBe("docs/specs/foo.md");
+    });
+
+    it("should detect triple-dot-segment prefix ../../docs/specs/foo.md", () => {
+      const result = extractDocsPaths("../../docs/specs/foo.md", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toBe("docs/specs/foo.md");
+    });
+  });
+
+  describe("Reject invalid dot patterns", () => {
+    it("should NOT detect .../docs (three dots is invalid)", () => {
+      const result = extractDocsPaths(".../docs/specs/foo.md", CAP);
+      expect(result.paths.length).toBe(0);
+    });
+
+    it("should NOT detect ..../docs (four dots is invalid)", () => {
+      const result = extractDocsPaths(".... /docs/specs/foo.md", CAP);
+      expect(result.paths.length).toBe(0);
+    });
+  });
+
+  describe("Encoded separators in relative prefix", () => {
+    it("should detect ..%2Fdocs/specs/foo.md (encoded forward slash)", () => {
+      const result = extractDocsPaths("..%2Fdocs/specs/foo.md", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toBe("docs/specs/foo.md");
+    });
+
+    it("should detect .%5Cdocs/specs/foo.md (encoded backslash)", () => {
+      const result = extractDocsPaths(".%5Cdocs/specs/foo.md", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toBe("docs/specs/foo.md");
+    });
+  });
+
+  describe("Reject patterns without dot prefix", () => {
+    it("should NOT detect %2Fdocs/... (no dot prefix)", () => {
+      const result = extractDocsPaths("%2Fdocs/specs/foo.md", CAP);
+      expect(result.paths.length).toBe(0);
+    });
+
+    it("should NOT detect a/../docs/... (identifier prefix)", () => {
+      const result = extractDocsPaths("a/../docs/specs/foo.md", CAP);
+      expect(result.paths.length).toBe(0);
+    });
+  });
+
+  describe("Reject absolute paths", () => {
+    it("should NOT detect /docs/... (absolute path)", () => {
+      const result = extractDocsPaths("/docs/specs/foo.md", CAP);
+      expect(result.paths.length).toBe(0);
+    });
+
+    it("should NOT detect \\docs\\... (absolute path on Windows)", () => {
+      const result = extractDocsPaths("\\docs\\specs\\foo.md", CAP);
+      expect(result.paths.length).toBe(0);
+    });
+  });
+
+  describe("Control: plain docs at line start", () => {
+    it("should detect plain docs/specs/foo.md at line start", () => {
+      const result = extractDocsPaths("docs/specs/foo.md", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toBe("docs/specs/foo.md");
+    });
+  });
+
+  describe("Case-insensitive percent encoding", () => {
+    it("should detect .%2fdocs with lowercase f", () => {
+      const result = extractDocsPaths(".%2fdocs/specs/foo.md", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toBe("docs/specs/foo.md");
+    });
+
+    it("should detect .%5cdocs with lowercase hex", () => {
+      const result = extractDocsPaths(".%5cdocs/specs/foo.md", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toBe("docs/specs/foo.md");
+    });
+
+    it("should detect ..%2fdocs with lowercase hex", () => {
+      const result = extractDocsPaths("..%2fdocs/specs/foo.md", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toBe("docs/specs/foo.md");
+    });
+
+    it("should detect ..%5cdocs with lowercase hex", () => {
+      const result = extractDocsPaths("..%5cdocs/specs/foo.md", CAP);
+      expect(result.paths.length).toBeGreaterThan(0);
+      expect(result.paths[0]?.value).toBe("docs/specs/foo.md");
+    });
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-docs-prefix.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-docs-prefix.test.ts
@@ -50,6 +50,12 @@ describe("boundary-docs-path-parser v6 docs prefix strict grammar", () => {
       expect(result.paths.length).toBeGreaterThan(0);
       expect(result.paths[0]?.value).toBe("docs/specs/foo.md");
     });
+
+    // dot-segment collapse後に通常segmentが残らず、docsへ解決されるためfail-closedで検出する
+    it("should detect a/../docs/... (dot-segment collapse)", () => {
+      const result = extractDocsPaths("a/../docs/specs/foo.md", CAP);
+      expect(result.paths.length).toBe(1);
+    });
   });
 
   describe("Reject invalid dot patterns", () => {
@@ -81,11 +87,6 @@ describe("boundary-docs-path-parser v6 docs prefix strict grammar", () => {
   describe("Reject patterns without dot prefix", () => {
     it("should NOT detect %2Fdocs/... (no dot prefix)", () => {
       const result = extractDocsPaths("%2Fdocs/specs/foo.md", CAP);
-      expect(result.paths.length).toBe(0);
-    });
-
-    it("should NOT detect a/../docs/... (identifier prefix)", () => {
-      const result = extractDocsPaths("a/../docs/specs/foo.md", CAP);
       expect(result.paths.length).toBe(0);
     });
   });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-id-state.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-id-state.test.ts
@@ -1,0 +1,134 @@
+// Tests for GENERIC_ID_PATTERN stateful behavior fix.
+//
+// Bug: The /g flag on GENERIC_ID_PATTERN causes .test() to advance lastIndex,
+// making subsequent detectCandidates calls return empty results (call-order-dependent fail-open).
+//
+// This test file verifies that:
+// 1. GENERIC_ID_PATTERN.test() can be called multiple times with consistent results
+// 2. detectCandidates() can be called multiple times with consistent results
+// 3. Multiple IDs are extracted (not just the first)
+// 4. GENERIC_ID_PATTERN.test() and detectCandidates() don't interfere with each other
+
+import { describe, expect, test } from "bun:test";
+import {
+  detectCandidates,
+  GENERIC_ID_PATTERN,
+  type DetectorConfig,
+} from "./boundary-pipeline.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: {
+    owner_slash_name: "yogata/agent-dev-flow",
+    default_branch: "main",
+  },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+describe("GENERIC_ID_PATTERN stateful behavior", () => {
+  test("test() returns true twice in a row for same input", () => {
+    // Bug: second call returns false due to lastIndex advance
+    const text = "ADR-0001";
+    const first = GENERIC_ID_PATTERN.test(text);
+    const second = GENERIC_ID_PATTERN.test(text);
+
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+  });
+
+  test("test() can be called repeatedly on different inputs", () => {
+    const text1 = "REQ-1234";
+    const text2 = "DEC-5678";
+    const text3 = "SPEC-9999";
+
+    expect(GENERIC_ID_PATTERN.test(text1)).toBe(true);
+    expect(GENERIC_ID_PATTERN.test(text2)).toBe(true);
+    expect(GENERIC_ID_PATTERN.test(text3)).toBe(true);
+    // All should work regardless of call order
+  });
+
+  test("detectCandidates returns same results on repeated calls with same input", () => {
+    const line = "See ADR-0001 and REQ-0002 for details.";
+    const first = detectCandidates(line, baseConfig);
+    const second = detectCandidates(line, baseConfig);
+
+    // Both calls should return identical results
+    expect(first).toEqual(second);
+    // Both should find the IDs
+    expect(first.length).toBeGreaterThan(0);
+  });
+
+  test("detectCandidates extracts all IDs in a line", () => {
+    const line = "ADR-0001 REQ-0002 DEC-0003 SPEC-0004";
+    const result = detectCandidates(line, baseConfig);
+
+    // Should find all 4 IDs, not just the first
+    const directIds = result.filter((c) => c.type === "direct-id");
+    expect(directIds.length).toBe(4);
+    expect(directIds[0]?.value).toBe("ADR-0001");
+    expect(directIds[1]?.value).toBe("REQ-0002");
+    expect(directIds[2]?.value).toBe("DEC-0003");
+    expect(directIds[3]?.value).toBe("SPEC-0004");
+  });
+
+  test("GENERIC_ID_PATTERN.test() then detectCandidates() both work correctly", () => {
+    const line = "ADR-0001 REQ-0002";
+
+    // First call test()
+    const testResult = GENERIC_ID_PATTERN.test(line);
+    expect(testResult).toBe(true);
+
+    // Then call detectCandidates()
+    const detectResult = detectCandidates(line, baseConfig);
+    const directIds = detectResult.filter((c) => c.type === "direct-id");
+
+    // Should still find all IDs, not affected by test() call
+    expect(directIds.length).toBe(2);
+  });
+
+  test("detectCandidates() then GENERIC_ID_PATTERN.test() both work correctly", () => {
+    const line = "ADR-0001 REQ-0002";
+
+    // First call detectCandidates()
+    const detectResult = detectCandidates(line, baseConfig);
+    const directIds = detectResult.filter((c) => c.type === "direct-id");
+    expect(directIds.length).toBe(2);
+
+    // Then call test()
+    const testResult = GENERIC_ID_PATTERN.test(line);
+    // test() should still work
+    expect(testResult).toBe(true);
+  });
+
+  test("test() returns false for non-matching input consistently", () => {
+    const text = "no-ids-here";
+    const first = GENERIC_ID_PATTERN.test(text);
+    const second = GENERIC_ID_PATTERN.test(text);
+
+    expect(first).toBe(false);
+    expect(second).toBe(false);
+  });
+
+  test("detectCandidates handles line with no IDs consistently", () => {
+    const line = "Just prose, no references.";
+    const first = detectCandidates(line, baseConfig);
+    const second = detectCandidates(line, baseConfig);
+
+    expect(first).toEqual(second);
+    expect(first).toEqual([]);
+  });
+
+  test("multiple detectCandidates calls with different inputs work correctly", () => {
+    const line1 = "ADR-0001";
+    const line2 = "REQ-0002";
+    const line3 = "Both ADR-0003 and REQ-0004";
+
+    const result1 = detectCandidates(line1, baseConfig);
+    const result2 = detectCandidates(line2, baseConfig);
+    const result3 = detectCandidates(line3, baseConfig);
+
+    expect(result1.filter((c) => c.type === "direct-id").length).toBe(1);
+    expect(result2.filter((c) => c.type === "direct-id").length).toBe(1);
+    expect(result3.filter((c) => c.type === "direct-id").length).toBe(2);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-url-lexical.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-url-lexical.test.ts
@@ -1,0 +1,225 @@
+// Review-v6 URL lexical evasion: GitHub URL evasion forms must fail closed.
+//
+// Per distribution-boundary.md, the detector must never let an evasion-form
+// GitHub URL pass clean. Each evasion form emits one malformed URL candidate
+// (ownershipSpan: null) so contained producer references stay independently
+// visible and the gate fails. This replaces the historical "unsupported
+// scheme → 0 URLs, gate PASS" contract, which was fail-open.
+//
+// Scope:
+//   - L1 unsupported schemes (ftp://, evil://, git+https://) → 1 malformed.
+//   - L2 composite scheme (abchttps://) → 1 malformed.
+//   - L3 percent-encoded host (%67ithub.com, github%2ecom) → 1 malformed.
+//   - L4 Unicode dot host (github\u3002com) → 1 malformed.
+//   - L5 excessive slashes (https:////) → 1 malformed.
+//   - L6 backslash in path → 1 malformed, lexical-extent span.
+//   - L7 dot segments (.., %2e%2e) in owner/repo → 1 malformed.
+//   - L8 assignment URL (url=https://...) → 1 valid producer URL.
+//   - L9 em dash U+2014 terminates URL; trailing ID independently visible.
+//   - L10 controls: valid URL stays valid; github.com@evil.com → no candidate.
+
+import { describe, expect, test } from "bun:test";
+import { extractUrls } from "./boundary-url-parser.ts";
+import { detectCandidates, type Candidate, type DetectorConfig } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+function findDirectId(cs: readonly Candidate[], value: string) {
+  return cs.find((c): c is Extract<Candidate, { type: "direct-id" }> => c.type === "direct-id" && c.value === value);
+}
+
+// L1: unsupported schemes ftp://, evil://, git+https:// each yield 1 malformed.
+describe("L1 unsupported schemes / 1 malformed candidate, gate fail", () => {
+  for (const scheme of ["ftp://", "evil://", "git+https://"]) {
+    test(`${scheme}github.com/yogata/agent-dev-flow/blob/main/x.md → 1 malformed, ownershipSpan null`, () => {
+      const text = `See ${scheme}github.com/yogata/agent-dev-flow/blob/main/x.md end.`;
+      const { urls } = extractUrls(text, 64);
+      expect(urls).toHaveLength(1);
+      const u = urls[0];
+      if (u === undefined) throw new Error("expected one malformed url");
+      expect(u.malformed).toBe(true);
+      expect(u.ownershipSpan).toBeNull();
+      expect(u.span.start).toBe(text.indexOf(scheme));
+      const g = gateFor(text);
+      expect(g.pass).toBe(false);
+      expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+    });
+  }
+});
+
+// L2: composite scheme abchttps:// → malformed.
+describe("L2 composite scheme / abchttps fails closed", () => {
+  test("abchttps://github.com/... → 1 malformed, ownershipSpan null", () => {
+    const text = "See abchttps://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    expect(u.span.start).toBe(text.indexOf("abchttps"));
+    expect(gateFor(text).pass).toBe(false);
+  });
+});
+
+// L3: percent-encoded host → malformed.
+describe("L3 percent-encoded host / canonicalizes to github.com", () => {
+  test("%67ithub.com/... → 1 malformed (%67 = 'g')", () => {
+    const text = "See %67ithub.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    expect(gateFor(text).pass).toBe(false);
+  });
+
+  test("github%2ecom/... → 1 malformed (%2e = '.')", () => {
+    const text = "See github%2ecom/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    expect(gateFor(text).pass).toBe(false);
+  });
+});
+
+// L4: Unicode dot host (U+3002) → malformed.
+describe("L4 Unicode dot host / U+3002 canonicalizes to ASCII dot", () => {
+  test("github\\u3002com/... → 1 malformed", () => {
+    const text = "See github\u3002com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    expect(gateFor(text).pass).toBe(false);
+  });
+});
+
+// L5: excessive slashes https://// → malformed.
+describe("L5 excessive slashes / https://// fails closed", () => {
+  test("https:////github.com/... → 1 malformed", () => {
+    const text = "See https:////github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    expect(u.span.start).toBe(text.indexOf("https"));
+    expect(gateFor(text).pass).toBe(false);
+  });
+});
+
+// L6: backslash in path → malformed with lexical-extent span.
+describe("L6 backslash in path / lexical-extent malformed", () => {
+  test("https://github.com/yogata/agent-dev-flow\\\\blob/main/x.md → 1 malformed, span covers backslash", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow\\blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    // Span must extend past the backslash (lexical extent).
+    const bsIdx = text.indexOf("\\");
+    expect(u.span.end).toBeGreaterThan(bsIdx);
+    expect(gateFor(text).pass).toBe(false);
+  });
+});
+
+// L7: dot segments in owner/repo path → malformed.
+describe("L7 dot segments / .. and %2e%2e in path fail closed", () => {
+  test("https://github.com/yogata/../agent-dev-flow/blob/main/x.md → 1 malformed", () => {
+    const text = "See https://github.com/yogata/../agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    expect(gateFor(text).pass).toBe(false);
+  });
+
+  test("https://github.com/%2e%2e/yogata/agent-dev-flow/blob/main/x.md → 1 malformed", () => {
+    const text = "See https://github.com/%2e%2e/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    expect(gateFor(text).pass).toBe(false);
+  });
+});
+
+// L8: assignment URL url=https://... → 1 valid producer URL (gate fails on producer-internal).
+describe("L8 assignment URL / url= left boundary accepted for scheme", () => {
+  test("url=https://github.com/yogata/agent-dev-flow/blob/main/x.md → 1 valid producer URL", () => {
+    const text = "See url=https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one valid url");
+    expect(u.malformed).toBe(false);
+    expect(u.value).toBe("https://github.com/yogata/agent-dev-flow/blob/main/x.md");
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.find((d) => d.category === "fixed-url")?.classification).toBe("producer-internal");
+  });
+});
+
+// L9: em dash U+2014 terminates URL; trailing ID independently visible.
+describe("L9 em dash U+2014 / URL terminates, trailing ID visible", () => {
+  test("https://github.com/vercel/next.js/blob/main/x.md\\u2014ADR-0001 → URL ends before U+2014, ADR visible", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md\u2014ADR-0001 end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    const dashIdx = text.indexOf("\u2014");
+    expect(u.span.end).toBeLessThanOrEqual(dashIdx);
+    expect(u.value).toBe("https://github.com/vercel/next.js/blob/main/x.md");
+    const cs = detectCandidates(text, baseConfig);
+    expect(findDirectId(cs, "ADR-0001")).toBeDefined();
+  });
+});
+
+// L10: controls — valid URL stays valid; github.com@evil.com → no candidate.
+describe("L10 controls / valid URL and userinfo deception unchanged", () => {
+  test("valid https://github.com/yogata/agent-dev-flow/blob/main/x.md → 1 valid producer URL", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.malformed).toBe(false);
+    expect(u.value).toBe("https://github.com/yogata/agent-dev-flow/blob/main/x.md");
+  });
+
+  test("github.com@evil.com → no URL candidate", () => {
+    const text = "See github.com@evil.com end.";
+    expect(extractUrls(text, 64).urls).toHaveLength(0);
+    expect(gateFor(text).pass).toBe(true);
+  });
+
+  test("https://github.com@evil.com/yogata/... → no URL candidate (userinfo deception)", () => {
+    const text = "See https://github.com@evil.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    expect(extractUrls(text, 64).urls).toHaveLength(0);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-url-linear.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-url-linear.test.ts
@@ -1,0 +1,97 @@
+// Review-v6 URL scanner linear-complexity bound and behavior preservation.
+//
+// The backward authority scan walked, per host hit, from `hostStart - 1`
+// back through the lexical authority region. Although each individual
+// walk was bounded, the structure was awkward to reason about and could
+// not surface a step count for a linear-complexity contract. The forward
+// scanner advances a cursor from the previous match position up to the
+// current `hostStart`, so total work is bounded by line length.
+//
+// Scope:
+//   - V6.1 step-count linear bound: a single large authority, many URLs
+//     on one line, and cap+1 URLs each stay within `16 * text.length + 64`
+//     scanner operations.
+//   - V6.2 classification behavior preserved: valid producer URL still
+//     extracted; backslash authority malformed; default port accepted;
+//     non-default port malformed.
+
+import { describe, expect, test } from "bun:test";
+import { extractUrls } from "./boundary-url-parser.ts";
+
+const LINEAR_K = 16;
+const LINEAR_C = 64;
+
+function assertLinearBound(label: string, text: string, cap: number): void {
+  const result = extractUrls(text, cap);
+  const bound = LINEAR_K * text.length + LINEAR_C;
+  expect(
+    result.steps,
+    `${label}: steps=${result.steps} must be <= bound=${bound} (text.length=${text.length})`,
+  ).toBeLessThanOrEqual(bound);
+}
+
+// V6.1: step-count linear bound across adversarial inputs.
+describe("V6.1 URL scan linear-step bound", () => {
+  test("single large authority stays within linear bound", () => {
+    const text = "https://user" + "a".repeat(50000) + "@github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    assertLinearBound("single-large-authority", text, 64);
+  });
+
+  test("multiple URLs on one line stay within linear bound", () => {
+    const parts: string[] = [];
+    for (let i = 0; i < 100; i++) {
+      parts.push("https://github.com/o" + i + "/r/blob/main/x.md");
+    }
+    const text = parts.join(" ") + " end.";
+    assertLinearBound("multi-url-one-line", text, 64);
+  });
+
+  test("cap+1 URLs stay within linear bound", () => {
+    const cap = 32;
+    const parts: string[] = [];
+    for (let i = 0; i <= cap; i++) {
+      parts.push("https://github.com/o" + i + "/r/blob/main/x.md");
+    }
+    const text = parts.join(" ") + " end.";
+    assertLinearBound("cap-plus-one", text, cap);
+  });
+});
+
+// V6.2: classification behavior preserved (regression controls for the
+// forward-scan rewrite).
+describe("V6.2 classification behavior preserved", () => {
+  test("valid http(s) producer URL is extracted as non-malformed", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.malformed).toBe(false);
+    expect(u.value).toBe("https://github.com/yogata/agent-dev-flow/blob/main/x.md");
+  });
+
+  test("backslash authority is classified malformed", () => {
+    const text = "See https://evil.com\\@github.com/vercel/next.js/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected malformed url");
+    expect(u.malformed).toBe(true);
+  });
+
+  test("default port accepted (non-malformed)", () => {
+    const text = "See https://github.com:443/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.malformed).toBe(false);
+  });
+
+  test("non-default port is malformed", () => {
+    const text = "See https://github.com:8080/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected malformed url");
+    expect(u.malformed).toBe(true);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-url-ownership.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-url-ownership.test.ts
@@ -1,0 +1,244 @@
+// Review-v6 URL ownership span separation: classification evidence (`span`)
+// is split from ownership suppression scope (`ownershipSpan`). The full URL
+// span (including query/fragment) used to suppress contained IDs/docs paths.
+// After v6, only the path portion (before `?`/`#`) owns; query/fragment refs
+// are independently visible.
+//
+// Scope:
+//   - V6.1 External URL `?ref=ADR-1` → ADR-1 independently visible as
+//     direct-id → gate fail.
+//   - V6.2 External URL `#docs/specs/foo.md` → docs path independently
+//     visible → gate fail.
+//   - V6.3 External URL `?next=https://github.com/yogata/agent-dev-flow/...`
+//     → nested producer URL independently visible as url candidate →
+//     gate fail.
+//   - V6.4 External URL without query/fragment → path ownership preserved
+//     (control). Embedded refs stay suppressed.
+//   - V6.5 Malformed URL → ownershipSpan: null, contained refs visible.
+//   - V6.6 Valid producer URL → ownershipSpan covers path; gate still
+//     fails on producer-internal.
+//   - V6.7 Cap flood: 1 external URL with 62 query IDs → 63 candidates,
+//     no overflow. 1 + 63 → overflow (fail-closed).
+
+import { describe, expect, test } from "bun:test";
+import { extractUrls } from "./boundary-url-parser.ts";
+import {
+  detectCandidates,
+  type Candidate,
+  type DetectorConfig,
+} from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+function urlsOf(cs: readonly Candidate[]) {
+  return cs.filter((c): c is Extract<Candidate, { type: "url" }> => c.type === "url");
+}
+function directsOf(cs: readonly Candidate[]) {
+  return cs.filter((c): c is Extract<Candidate, { type: "direct-id" }> => c.type === "direct-id");
+}
+function pathsOf(cs: readonly Candidate[]) {
+  return cs.filter((c): c is Extract<Candidate, { type: "path" }> => c.type === "path");
+}
+function hasOverflow(cs: readonly Candidate[]) {
+  return cs.some((c) => c.type === "overflow");
+}
+
+// V6.1: query-ref ADR-1 independently visible as direct-id.
+describe("V6.1 external URL ?ref=ADR-1 / ADR-1 visible as direct-id, gate fails", () => {
+  test("extractUrls ownershipSpan ends at first ?", () => {
+    const text = "See https://github.com/external/repo/blob/main/x.md?ref=ADR-1 end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.malformed).toBe(false);
+    expect(u.ownershipSpan).not.toBeNull();
+    const qIdx = text.indexOf("?");
+    expect(u.ownershipSpan?.end).toBe(qIdx);
+  });
+
+  test("detectCandidates emits URL + direct-id ADR-1", () => {
+    const text = "See https://github.com/external/repo/blob/main/x.md?ref=ADR-1 end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urlsOf(cs)).toHaveLength(1);
+    const adr = directsOf(cs).find((c) => c.value === "ADR-1");
+    expect(adr).toBeDefined();
+  });
+
+  test("gate fails on producer-internal ADR-1 (not hidden by external URL query)", () => {
+    const text = "See https://github.com/external/repo/blob/main/x.md?ref=ADR-1 end.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.some((d) => d.classification === "producer-internal" && d.matched === "ADR-1")).toBe(true);
+  });
+});
+
+// V6.2: fragment-embedded docs path independently visible.
+describe("V6.2 external URL #docs/specs/foo.md / docs path visible, gate fails", () => {
+  test("extractUrls ownershipSpan ends at first #", () => {
+    const text = "See https://github.com/external/repo/blob/main/x.md#docs/specs/foo.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.ownershipSpan).not.toBeNull();
+    const hashIdx = text.indexOf("#");
+    expect(u.ownershipSpan?.end).toBe(hashIdx);
+  });
+
+  test("detectCandidates emits URL + path docs/specs/foo.md", () => {
+    const text = "See https://github.com/external/repo/blob/main/x.md#docs/specs/foo.md end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urlsOf(cs)).toHaveLength(1);
+    const p = pathsOf(cs).find((c) => c.value === "docs/specs/foo.md");
+    expect(p).toBeDefined();
+  });
+
+  test("gate fails on producer-internal docs path", () => {
+    const text = "See https://github.com/external/repo/blob/main/x.md#docs/specs/foo.md end.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.some((d) => d.classification === "producer-internal" && d.matched === "docs/specs/foo.md")).toBe(true);
+  });
+});
+
+// V6.3: nested producer URL independently visible.
+describe("V6.3 external URL ?next=<producer URL> / nested URL visible, gate fails", () => {
+  test("extractUrls emits both outer and nested URLs", () => {
+    const text = "See https://github.com/external/repo/blob/main/x.md?next=https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls.length).toBeGreaterThanOrEqual(2);
+    const values = urls.map((u) => u.value);
+    expect(values.some((v) => v === "https://github.com/yogata/agent-dev-flow/blob/main/x.md")).toBe(true);
+  });
+
+  test("detectCandidates emits nested producer URL candidate", () => {
+    const text = "See https://github.com/external/repo/blob/main/x.md?next=https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const cs = detectCandidates(text, baseConfig);
+    const nested = urlsOf(cs).find((c) => c.value === "https://github.com/yogata/agent-dev-flow/blob/main/x.md");
+    expect(nested).toBeDefined();
+  });
+
+  test("gate fails on producer-internal nested URL", () => {
+    const text = "See https://github.com/external/repo/blob/main/x.md?next=https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.some((d) => d.classification === "producer-internal" && d.category === "fixed-url")).toBe(true);
+  });
+});
+
+// V6.4: external URL without query/fragment — path ownership preserved.
+describe("V6.4 external URL without ?/# / path ownership preserved (control)", () => {
+  test("extractUrls ownershipSpan equals span when no ?/#", () => {
+    const text = "See https://github.com/external/repo/blob/main/docs/specs/ADR-0001.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.ownershipSpan).toEqual(u.span);
+  });
+
+  test("detectCandidates emits only URL (no path, no direct-id)", () => {
+    const text = "See https://github.com/external/repo/blob/main/docs/specs/ADR-0001.md end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urlsOf(cs)).toHaveLength(1);
+    expect(pathsOf(cs)).toHaveLength(0);
+    expect(directsOf(cs)).toHaveLength(0);
+  });
+
+  test("gate passes (URL consumer-resolvable, embedded refs suppressed)", () => {
+    const text = "See https://github.com/external/repo/blob/main/docs/specs/ADR-0001.md end.";
+    expect(gateFor(text).pass).toBe(true);
+  });
+});
+
+// V6.5: malformed URL ownershipSpan is null.
+describe("V6.5 malformed URL / ownershipSpan null, contained refs visible", () => {
+  test("backslash authority malformed URL ownershipSpan is null", () => {
+    const text = "See https://evil.com\\@github.com/vercel/next.js/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+  });
+
+  test("non-default-port malformed URL ownershipSpan is null", () => {
+    const text = "See https://github.com:8080/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+  });
+
+  test("docs path after malformed URL is independently visible", () => {
+    const text = "See https://evil.com\\@github.com/vercel/next.js/blob/main/x.md docs/requirements/REQ-0001.md end.";
+    const cs = detectCandidates(text, baseConfig);
+    const p = pathsOf(cs).find((c) => c.value === "docs/requirements/REQ-0001.md");
+    expect(p).toBeDefined();
+  });
+});
+
+// V6.6: valid producer URL ownershipSpan covers path; gate still fails.
+describe("V6.6 valid producer URL / ownershipSpan covers path, gate fails on producer-internal", () => {
+  test("extractUrls ownershipSpan ends at first ? for producer URL", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md?ref=ADR-1 end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.malformed).toBe(false);
+    const qIdx = text.indexOf("?");
+    expect(u.ownershipSpan?.end).toBe(qIdx);
+  });
+
+  test("producer URL with embedded ADR + query-ref ADR-1 → URL + 1 direct-id", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow/blob/main/docs/specs/ADR-0001.md?ref=ADR-1 end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urlsOf(cs)).toHaveLength(1);
+    const adr = directsOf(cs).find((c) => c.value === "ADR-1");
+    expect(adr).toBeDefined();
+    // The embedded ADR-0001 in the URL path is suppressed by ownershipSpan.
+    expect(directsOf(cs).find((c) => c.value === "ADR-0001")).toBeUndefined();
+  });
+
+  test("gate fails on producer-internal URL (path-owned ADR-0001 hidden, query ADR-1 visible)", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow/blob/main/docs/specs/ADR-0001.md?ref=ADR-1 end.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.some((d) => d.category === "fixed-url")).toBe(true);
+  });
+});
+
+// V6.7: cap flood — query IDs visible, candidate cap enforced.
+describe("V6.7 cap flood / 1 URL + 62 query IDs = 63 no overflow; +63 = overflow", () => {
+  test("1 external URL + 62 producer IDs in query → 63 candidates, no overflow", () => {
+    const ids = Array.from({ length: 62 }, (_, i) => `ADR-${i + 1}`).join("/");
+    const text = `See https://github.com/external/repo/blob/main/x.md?ids=${ids} end.`;
+    const cs = detectCandidates(text, baseConfig);
+    expect(urlsOf(cs)).toHaveLength(1);
+    expect(directsOf(cs)).toHaveLength(62);
+    expect(hasOverflow(cs)).toBe(false);
+  });
+
+  test("1 external URL + 63 producer IDs in query → overflow (fail-closed)", () => {
+    const ids = Array.from({ length: 63 }, (_, i) => `ADR-${i + 1}`).join("/");
+    const text = `See https://github.com/external/repo/blob/main/x.md?ids=${ids} end.`;
+    const cs = detectCandidates(text, baseConfig);
+    expect(hasOverflow(cs)).toBe(true);
+    expect(gateFor(text).pass).toBe(false);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-url-ownership.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v6-url-ownership.test.ts
@@ -138,14 +138,20 @@ describe("V6.3 external URL ?next=<producer URL> / nested URL visible, gate fail
 });
 
 // V6.4: external URL without query/fragment — path ownership preserved.
+// After the v7 path-ownership fix, ownershipSpan.start is authorityEnd
+// (the first path slash after the host), not urlStart. The end is still
+// the URL end when no `?`/`#` is present.
 describe("V6.4 external URL without ?/# / path ownership preserved (control)", () => {
-  test("extractUrls ownershipSpan equals span when no ?/#", () => {
+  test("extractUrls ownershipSpan starts at path slash (authorityEnd), end at URL end", () => {
     const text = "See https://github.com/external/repo/blob/main/docs/specs/ADR-0001.md end.";
     const { urls } = extractUrls(text, 64);
     expect(urls).toHaveLength(1);
     const u = urls[0];
     if (u === undefined) throw new Error("expected one url");
-    expect(u.ownershipSpan).toEqual(u.span);
+    expect(u.ownershipSpan).not.toBeNull();
+    const pathSlashIdx = text.indexOf("github.com/") + "github.com".length;
+    expect(u.ownershipSpan?.start).toBe(pathSlashIdx);
+    expect(u.ownershipSpan?.end).toBe(u.span.end);
   });
 
   test("detectCandidates emits only URL (no path, no direct-id)", () => {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v7-authority.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v7-authority.test.ts
@@ -1,0 +1,113 @@
+// Review-v7 authority blockers: malicious authority forms must fail closed.
+//
+// Review-v7 found three blockers in the trusted-distribution detector that
+// let malicious authority forms pass the gate clean. This file pins each
+// remediation as a regression test, plus GREEN controls for unchanged
+// producer / consumer / deception behavior.
+//
+// Scope:
+//   - B1 backslash before rejected authority (P0):
+//       https://github.com\@evil.com/...  → 1 malformed, gate FAIL
+//       https://github.com\evil.com/...   → 1 malformed, gate FAIL
+//     Root cause: HOST_SCAN lookahead missed `\`, and the rejected branch
+//     short-circuited before the pathHasBackslash malformed check.
+//   - B9 scheme-less userinfo+port left boundary:
+//       user@github.com:443/... → 1 malformed, gate FAIL
+//     Root cause: `@` is in LEFT_REJECT_CHAR, so the scheme-less host was
+//     rejected at the left boundary without emitting a malformed candidate.
+//   - B10 extractOwnerRepo host branching: the RecognizedHost type narrows
+//     the host so the implicit `else` (non-github host) becomes a
+//     compile-time unreachable branch via assertNever. This contract is
+//     enforced by `bun run typecheck` (tsc --noEmit) succeeding — there is
+//     no runtime assertion in this file. The GREEN controls below exercise
+//     both host branches at runtime so a regression in either branch
+//     surfaces as a test failure.
+
+import { describe, expect, test } from "bun:test";
+import { extractUrls } from "./boundary-url-parser.ts";
+import type { DetectorConfig } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+// B1: backslash before rejected authority must fail closed.
+describe("B1 backslash before rejected authority / fail closed (P0)", () => {
+  test("https://github.com\\@evil.com/yogata/agent-dev-flow/blob/main/x.md → 1 malformed, gate FAIL", () => {
+    const text = "See https://github.com\\@evil.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+    expect(g.errors.find((d) => d.classification === "unclassified")).toBeDefined();
+  });
+
+  test("https://github.com\\evil.com/yogata/agent-dev-flow/blob/main/x.md (no @) → 1 malformed, gate FAIL", () => {
+    const text = "See https://github.com\\evil.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    expect(gateFor(text).pass).toBe(false);
+  });
+});
+
+// B9: scheme-less userinfo + port left boundary must fail closed.
+describe("B9 scheme-less userinfo+port / fail closed", () => {
+  test("user@github.com:443/yogata/agent-dev-flow/blob/main/x.md → 1 malformed, gate FAIL", () => {
+    const text = "See user@github.com:443/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    expect(gateFor(text).pass).toBe(false);
+  });
+});
+
+// Controls: producer-internal, userinfo deception, consumer-resolvable.
+describe("controls / producer, deception, consumer unchanged", () => {
+  test("https://github.com/yogata/agent-dev-flow/blob/main/x.md → valid producer URL, gate FAIL (producer-internal)", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one valid url");
+    expect(u.malformed).toBe(false);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.find((d) => d.category === "fixed-url")?.classification).toBe("producer-internal");
+  });
+
+  test("https://github.com@evil.com/yogata/agent-dev-flow/blob/main/x.md → 0 candidates, gate PASS (userinfo deception)", () => {
+    const text = "See https://github.com@evil.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    expect(extractUrls(text, 64).urls).toHaveLength(0);
+    expect(gateFor(text).pass).toBe(true);
+  });
+
+  test("https://github.com/vercel/next.js/blob/main/x.md → consumer-resolvable, gate PASS", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.malformed).toBe(false);
+    expect(gateFor(text).pass).toBe(true);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v7-docs-path.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v7-docs-path.test.ts
@@ -1,0 +1,161 @@
+// Review-v7 docs-path blockers: CJK punctuation left boundary (#5) and
+// dot-segment prefix normalization (#11).
+//
+// #5 root cause: URL_STOP_CHAR in url-parser includes CJK punctuation
+// (\uFF1A, \uFF1B, \uFF0C, \uFF1F, \u2014) but the docs-path parser's
+// left-boundary set did NOT. After a URL terminated at these characters,
+// a following docs/specs/... path was rejected because the preceding
+// char was outside the accepted boundary set.
+//
+// #11 root cause: the strict relative prefix grammar only accepted
+// pure dot-segment prefixes (../, ./). Identifier segments before ../
+// (e.g. x/../docs) were rejected even though x/../ normalizes to the
+// empty prefix in standard path semantics, resolving to docs.
+//
+// Both blockers let a hidden producer reference pass the gate clean.
+// Each RED case now expects detection (1 path / gate FAIL).
+
+import { describe, expect, test } from "bun:test";
+import { extractDocsPaths } from "./boundary-docs-path-parser.ts";
+import { detectCandidates, type DetectorConfig, type Candidate } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+import type { Detection, GateResult } from "./types.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string): GateResult {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+function paths(cs: readonly Candidate[]): readonly Candidate[] {
+  return cs.filter((c) => c.type === "path");
+}
+
+function urls(cs: readonly Candidate[]): readonly Candidate[] {
+  return cs.filter((c) => c.type === "url");
+}
+
+function findFailureByCategory(gate: GateResult, category: Detection["category"]): Detection | undefined {
+  return gate.failures.find((d: Detection) => d.category === category);
+}
+
+// #5: docs path hidden behind CJK punctuation must be detected.
+describe("#5 CJK punctuation left boundary / docs path detected", () => {
+  test("text\uFF1Adocs/specs/foo.md (fullwidth colon U+FF1A) -> 1 path, gate FAIL", () => {
+    const text = "text\uFF1Adocs/specs/foo.md";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(findFailureByCategory(g, "concrete-path")?.classification).toBe("producer-internal");
+  });
+
+  test("text\uFF1Bdocs/specs/foo.md (fullwidth semicolon U+FF1B) -> 1 path, gate FAIL", () => {
+    const text = "text\uFF1Bdocs/specs/foo.md";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+  });
+
+  test("text\uFF0Cdocs/specs/foo.md (fullwidth comma U+FF0C) -> 1 path, gate FAIL", () => {
+    const text = "text\uFF0Cdocs/specs/foo.md";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+  });
+
+  test("text\uFF1Fdocs/specs/foo.md (fullwidth question mark U+FF1F) -> 1 path, gate FAIL", () => {
+    const text = "text\uFF1Fdocs/specs/foo.md";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+  });
+
+  test("text\u2014docs/specs/foo.md (em dash U+2014) -> 1 path, gate FAIL", () => {
+    const text = "text\u2014docs/specs/foo.md";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+  });
+
+  test("consumer URL then fullwidth colon then docs path -> 1 URL + 1 path, gate FAIL", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md\uFF1Adocs/specs/foo.md end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urls(cs)).toHaveLength(1);
+    expect(paths(cs)).toHaveLength(1);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+  });
+});
+
+// #11: dot-segment prefix that normalizes to docs must be detected.
+describe("#11 dot-segment prefix normalization / docs path detected", () => {
+  test("x/../docs/specs/foo.md -> 1 path, gate FAIL", () => {
+    const text = "See x/../docs/specs/foo.md here.";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(findFailureByCategory(g, "concrete-path")?.classification).toBe("producer-internal");
+  });
+
+  test("../../x/../docs/specs/foo.md -> 1 path, gate FAIL", () => {
+    const text = "See ../../x/../docs/specs/foo.md here.";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+  });
+});
+
+// GREEN controls: already-correct behavior must remain unchanged.
+describe("controls / already-correct behavior unchanged", () => {
+  test("docs/specs/foo.md -> 1 path (plain)", () => {
+    const r = extractDocsPaths("docs/specs/foo.md", 10);
+    expect(r.paths).toHaveLength(1);
+  });
+
+  test("./docs/specs/foo.md -> 1 path (single-dot prefix)", () => {
+    const r = extractDocsPaths("./docs/specs/foo.md", 10);
+    expect(r.paths).toHaveLength(1);
+  });
+
+  test("../docs/specs/foo.md -> 1 path (double-dot prefix)", () => {
+    const r = extractDocsPaths("../docs/specs/foo.md", 10);
+    expect(r.paths).toHaveLength(1);
+  });
+
+  test("../../docs/specs/foo.md -> 1 path (arbitrary depth)", () => {
+    const r = extractDocsPaths("../../docs/specs/foo.md", 10);
+    expect(r.paths).toHaveLength(1);
+  });
+
+  test(".docs/specs/foo.md -> 0 paths (hostname form, rejected)", () => {
+    const r = extractDocsPaths(".docs/specs/foo.md", 10);
+    expect(r.paths).toHaveLength(0);
+  });
+
+  test("/docs/specs/foo.md -> 0 paths (absolute, rejected)", () => {
+    const r = extractDocsPaths("/docs/specs/foo.md", 10);
+    expect(r.paths).toHaveLength(0);
+  });
+
+  test(".../docs/specs/foo.md -> 0 paths (three-dot segment, rejected)", () => {
+    const r = extractDocsPaths(".../docs/specs/foo.md", 10);
+    expect(r.paths).toHaveLength(0);
+  });
+
+  test("mydocs/specs/foo.md -> 0 paths (identifier prefix, rejected)", () => {
+    const r = extractDocsPaths("mydocs/specs/foo.md", 10);
+    expect(r.paths).toHaveLength(0);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v7-url-normalization.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v7-url-normalization.test.ts
@@ -1,0 +1,131 @@
+// Review-v7 URL normalization blockers: host/scheme/dot evasion must fail closed.
+//
+// Review-v7 found three blockers that let URL normalization-evasion forms pass
+// the gate clean (0 candidates). Each form canonicalizes to a recognized
+// GitHub host or a valid-looking URL but bypasses the detector's evasion
+// filters, so a hidden producer reference could ride inside. This file pins
+// each remediation as a RED test (now failing) plus GREEN controls proving
+// already-correct behavior is preserved.
+//
+// Scope:
+//   - B2 host normalization gaps / canonicalizeHostEvasion pipeline:
+//       github\uFF61com          (halfwidth ideographic full stop)
+//       github%E3%80%82com       (UTF-8 percent-encoded U+3002)
+//       %2567ithub.com           (double percent-encoding)
+//       GITHUB\u3002COM          (uppercase after Unicode dot)
+//     Root cause: one ASCII percent-decode pass + U+3002/U+FF0E replacement
+//     only; no UTF-8 decode, no second round, no post-canonical lowercase.
+//   - B3 scheme slash variants / scanAuthorityForward colon branch:
+//       https:github.com  (0 slashes after colon — WHATWG-valid)
+//       https:/github.com (1 slash  — WHATWG-valid)
+//     Root cause: scheme detection required exact "://"; the 0/1-slash forms
+//     fell through and the leading ":" rejected the host at the left boundary.
+//   - B4 mixed-encoded dot segments / hasDotSegment normalization:
+//       decoy/.%2e/  and  decoy/%2e./  (literal dot + encoded %2e = "..")
+//     Root cause: hasDotSegment matched ".", "..", "%2e", "%2e%2e" at the
+//     segment level but not the mixed literal+encoded combinations.
+
+import { describe, expect, test } from "bun:test";
+import { extractUrls } from "./boundary-url-parser.ts";
+import type { DetectorConfig } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+// Shared shape for every RED case: exactly one malformed URL whose ownership
+// span is null, and a gate that fails with an evasion-attempt / unclassified
+// error (malformed URLs resolve to unclassified/evasion-attempt per
+// resolveCandidate, routed into gate.errors).
+function expectMalformedEvasion(text: string): void {
+  const { urls } = extractUrls(text, 64);
+  expect(urls).toHaveLength(1);
+  const u = urls[0];
+  if (u === undefined) throw new Error("expected one malformed url");
+  expect(u.malformed).toBe(true);
+  expect(u.ownershipSpan).toBeNull();
+  const g = gateFor(text);
+  expect(g.pass).toBe(false);
+  expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+  expect(g.errors.find((d) => d.classification === "unclassified")).toBeDefined();
+}
+
+// B2: host normalization gaps must fail closed.
+describe("B2 host normalization gaps / canonicalizeHostEvasion fail closed", () => {
+  test("github\uFF61com/... (halfwidth ideographic full stop U+FF61) → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See github\uFF61com/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+
+  test("github%E3%80%82com/... (UTF-8 percent-encoded U+3002) → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See github%E3%80%82com/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+
+  test("%2567ithub.com/... (double percent-encoding: %25→% then %67→g) → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See %2567ithub.com/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+
+  test("GITHUB\u3002COM/... (uppercase after Unicode dot) → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See GITHUB\u3002COM/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+});
+
+// B3: scheme slash variants (WHATWG-valid 0/1-slash forms) must fail closed.
+describe("B3 scheme slash variants / 0-or-1 slash fail closed", () => {
+  test("https:github.com/... (0 slashes after colon) → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See https:github.com/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+
+  test("https:/github.com/... (1 slash after colon) → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See https:/github.com/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+});
+
+// B4: mixed literal+encoded dot segments must fail closed.
+describe("B4 mixed-encoded dot segments / .%2e and %2e. fail closed", () => {
+  test("https://github.com/decoy/.%2e/... (.%2e = ..) → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See https://github.com/decoy/.%2e/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+
+  test("https://github.com/decoy/%2e./... (%2e. = ..) → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See https://github.com/decoy/%2e./yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+});
+
+// GREEN controls: already-correct behavior must remain green.
+describe("controls / already-correct behavior unchanged", () => {
+  test("https://github.com/yogata/agent-dev-flow/blob/main/x.md → valid producer URL, gate FAIL (producer-internal)", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one valid url");
+    expect(u.malformed).toBe(false);
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.find((d) => d.category === "fixed-url")?.classification).toBe("producer-internal");
+  });
+
+  test("%67ithub.com/... (single percent-decode, %67 = 'g') → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See %67ithub.com/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+
+  test("github\u3002com/... (Unicode dot U+3002) → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See github\u3002com/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+
+  test("github\uFF0Ecom/... (Unicode dot U+FF0E) → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See github\uFF0Ecom/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+
+  test("https://github.com/decoy/../yogata/agent-dev-flow/blob/main/x.md (literal .. segment) → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See https://github.com/decoy/../yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v7-url-span-linear.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v7-url-span-linear.test.ts
@@ -1,0 +1,151 @@
+// Review-v7 URL ownership-span and linear-scan remediation.
+//
+// Three blockers found in review-v7 across the URL extractor:
+//   - #6 evasion dedup used the full URL `span` instead of `ownershipSpan`,
+//     so a percent-encoded evasion host placed in an external URL's query
+//     was suppressed by the outer URL's full span (which extends past the
+//     query) and never emitted.
+//   - #7 each HOST_SCAN hit re-scanned the entire URL value to its end.
+//     For `"github.com/".repeat(1000)` (a single 11KB token) each hit
+//     re-walked the remaining ~11K chars, giving quadratic step counts.
+//   - #8 valid URL `ownershipSpan.start` was `urlStart` (includes scheme +
+//     authority + userinfo), so a producer-internal ID embedded in the
+//     userinfo (`https://ADR-0001@github.com/...`) was hidden inside the
+//     ownership span and never surfaced as a direct-id.
+//
+// Each blocker is pinned as a RED→GREEN test. GREEN controls verify that
+// consumer-resolvable URLs still pass the gate and that V6 query behavior
+// is preserved (no regression from the dedup / ownershipSpan changes).
+
+import { describe, expect, test } from "bun:test";
+import { extractUrls } from "./boundary-url-parser.ts";
+import {
+  detectCandidates,
+  type Candidate,
+  type DetectorConfig,
+} from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+function urlsOf(cs: readonly Candidate[]) {
+  return cs.filter((c): c is Extract<Candidate, { type: "url" }> => c.type === "url");
+}
+function directsOf(cs: readonly Candidate[]) {
+  return cs.filter((c): c is Extract<Candidate, { type: "direct-id" }> => c.type === "direct-id");
+}
+
+const LINEAR_K = 16;
+const LINEAR_C = 64;
+
+// #6: evasion host in external URL query is independently detected.
+describe("#6 evasion dedup uses ownershipSpan / evasion host in query detected", () => {
+  test("https://...x.md?next=%67ithub.com/yogata/agent-dev-flow/... → 1 external URL + 1 malformed evasion URL", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md?next=%67ithub.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    // The vercel/next.js URL is the consumer-resolvable outer URL.
+    const outer = urls.find((u) => !u.malformed);
+    expect(outer).toBeDefined();
+    // The percent-encoded host (`%67ithub.com` decodes to `github.com`) is a
+    // separate malformed evasion URL placed in the outer URL's query.
+    const evasion = urls.find((u) => u.malformed);
+    expect(evasion).toBeDefined();
+    expect(urls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("gate FAIL (producer-internal evasion URL independently visible)", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md?next=%67ithub.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    // The evasion URL itself is malformed → unclassified evasion-attempt.
+    expect(g.errors.some((d) => d.category === "evasion-attempt")).toBe(true);
+  });
+});
+
+// #7: linear step bound on adversarial repeated hosts.
+describe("#7 linear step bound on repeated hosts in path", () => {
+  test("\"github.com/\".repeat(1000) → steps within linear bound", () => {
+    const text = "github.com/".repeat(1000);
+    const result = extractUrls(text, 64);
+    const bound = LINEAR_K * text.length + LINEAR_C;
+    expect(
+      result.steps,
+      `steps=${result.steps} must be <= bound=${bound} (text.length=${text.length})`,
+    ).toBeLessThanOrEqual(bound);
+  });
+
+  test("\"github.com/\".repeat(500) + \" ADR-0001\" → steps within linear bound AND gate FAIL", () => {
+    const text = "github.com/".repeat(500) + " ADR-0001";
+    const result = extractUrls(text, 64);
+    const bound = LINEAR_K * text.length + LINEAR_C;
+    expect(
+      result.steps,
+      `steps=${result.steps} must be <= bound=${bound} (text.length=${text.length})`,
+    ).toBeLessThanOrEqual(bound);
+    // The ADR-0001 outside the URL region is independently visible.
+    const cs = detectCandidates(text, baseConfig);
+    const adr = directsOf(cs).find((c) => c.value === "ADR-0001");
+    expect(adr).toBeDefined();
+    expect(gateFor(text).pass).toBe(false);
+  });
+});
+
+// #8: valid URL ownershipSpan starts at path (authorityEnd), not urlStart.
+describe("#8 valid URL ownershipSpan starts at authorityEnd (path), not urlStart", () => {
+  test("https://ADR-0001@github.com/vercel/... → ownershipSpan.start at first path slash", () => {
+    const text = "See https://ADR-0001@github.com/vercel/next.js/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.malformed).toBe(false);
+    expect(u.ownershipSpan).not.toBeNull();
+    // ownershipSpan.start = position of `/` after `github.com` (path start).
+    const pathSlashIdx = text.indexOf("github.com/") + "github.com".length;
+    expect(u.ownershipSpan?.start).toBe(pathSlashIdx);
+    // ownershipSpan.end = same as span.end when no ?/#.
+    expect(u.ownershipSpan?.end).toBe(u.span.end);
+  });
+
+  test("https://ADR-0001@github.com/vercel/... → 1 valid URL + 1 direct-id ADR-0001, gate FAIL", () => {
+    const text = "See https://ADR-0001@github.com/vercel/next.js/blob/main/x.md end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urlsOf(cs)).toHaveLength(1);
+    const adr = directsOf(cs).find((c) => c.value === "ADR-0001");
+    expect(adr).toBeDefined();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.some((d) => d.classification === "producer-internal" && d.matched === "ADR-0001")).toBe(true);
+  });
+});
+
+// GREEN controls: existing behavior must not regress.
+describe("controls / consumer URL and query-direct-id behavior preserved", () => {
+  test("https://github.com/vercel/next.js/blob/main/x.md → 1 consumer URL, gate PASS", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one url");
+    expect(u.malformed).toBe(false);
+    expect(gateFor(text).pass).toBe(true);
+  });
+
+  test("https://github.com/vercel/next.js/blob/main/x.md?q=ADR-0001 → 1 consumer URL + 1 direct-id, gate FAIL", () => {
+    const text = "See https://github.com/vercel/next.js/blob/main/x.md?q=ADR-0001 end.";
+    const cs = detectCandidates(text, baseConfig);
+    expect(urlsOf(cs)).toHaveLength(1);
+    const adr = directsOf(cs).find((c) => c.value === "ADR-0001");
+    expect(adr).toBeDefined();
+    expect(gateFor(text).pass).toBe(false);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v8-cjk-path-stop.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v8-cjk-path-stop.test.ts
@@ -1,0 +1,95 @@
+// Review-v8 blocker #1: CJK punctuation as path STOP char.
+//
+// ROOT CAUSE: boundary-docs-path-parser.ts LEFT_BOUNDARY (line ~100)
+// includes U+FF1A, U+FF1B, U+FF0C, U+FF1F, U+2014 for left-boundary
+// acceptance, but PATH_STOP_CHAR (line ~34) does NOT include these as
+// content terminators. So `docs/specs/foo.md\uFF1Aend` — the U+FF1A is
+// not in PATH_STOP_CHAR, so the content scan runs past `.md` through
+// U+FF1A, making content `foo.md\uFF1Aend`. findMdEndpoint then sees
+// the suffix `\uFF1Aend` after `.md`, which is not all `.` chars, so
+// it returns -1. Result: 0 path candidates and the gate PASSes — a
+// producer-internal reference leak.
+//
+// FIX: Add U+FF1A, U+FF1B, U+FF0C, U+FF1F, U+2014 to PATH_STOP_CHAR so
+// the content scan terminates at these punctuation chars exactly as it
+// terminates at ASCII `,;:?`. These are the same five characters that
+// LEFT_BOUNDARY already accepts.
+//
+// Each RED case below expects detection (1 path / gate FAIL) for a
+// docs-path whose trailing punctuation is one of the five CJK chars.
+
+import { describe, expect, test } from "bun:test";
+import { extractDocsPaths } from "./boundary-docs-path-parser.ts";
+import { type DetectorConfig } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+import type { Detection, GateResult } from "./types.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string): GateResult {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+function findFailureByCategory(gate: GateResult, category: Detection["category"]): Detection | undefined {
+  return gate.failures.find((d: Detection) => d.category === category);
+}
+
+describe("v8 #1 CJK punctuation as path STOP char / docs path detected", () => {
+  test("docs/specs/foo.md\uFF1Aend (fullwidth colon U+FF1A) -> 1 path, gate FAIL", () => {
+    const text = "docs/specs/foo.md\uFF1Aend";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    expect(r.paths[0]?.value).toBe("docs/specs/foo.md");
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(findFailureByCategory(g, "concrete-path")?.classification).toBe("producer-internal");
+  });
+
+  test("docs/specs/foo.md\uFF1Bend (fullwidth semicolon U+FF1B) -> 1 path, gate FAIL", () => {
+    const text = "docs/specs/foo.md\uFF1Bend";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    expect(r.paths[0]?.value).toBe("docs/specs/foo.md");
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+  });
+
+  test("docs/specs/foo.md\uFF0Cend (fullwidth comma U+FF0C) -> 1 path, gate FAIL", () => {
+    const text = "docs/specs/foo.md\uFF0Cend";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    expect(r.paths[0]?.value).toBe("docs/specs/foo.md");
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+  });
+
+  test("docs/specs/foo.md\uFF1Fend (fullwidth question mark U+FF1F) -> 1 path, gate FAIL", () => {
+    const text = "docs/specs/foo.md\uFF1Fend";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    expect(r.paths[0]?.value).toBe("docs/specs/foo.md");
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+  });
+
+  test("docs/specs/foo.md\u2014end (em dash U+2014) -> 1 path, gate FAIL", () => {
+    const text = "docs/specs/foo.md\u2014end";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    expect(r.paths[0]?.value).toBe("docs/specs/foo.md");
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+  });
+
+  test("control: docs/specs/foo.md end (ASCII space) -> 1 path, unchanged", () => {
+    const text = "docs/specs/foo.md end";
+    const r = extractDocsPaths(text, 10);
+    expect(r.paths).toHaveLength(1);
+    expect(r.paths[0]?.value).toBe("docs/specs/foo.md");
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v8-docs-prefix-perf.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v8-docs-prefix-perf.test.ts
@@ -1,0 +1,48 @@
+// Review-v8 blocker #4: docs prefix scan linearization (performance).
+//
+// ROOT CAUSE: boundary-docs-path-parser.ts prefixResolvesToDocs scans
+// backward for every `docs` occurrence to find the start of the prefix
+// region, then dot-segment-normalizes the prefix. On adversarial input
+// where `docs` appears many times in one line with no left boundary
+// (e.g. ("a/docs").repeat(8000) = 48K chars, 8000 docs occurrences),
+// each occurrence re-scans the entire prefix, giving O(n^2) total work.
+// Measured baseline: ~3.2s for n=8000, ~24s for n=16000.
+//
+// FIX: Replace the per-doc backward scan with a single forward pass
+// that incrementally maintains the dot-segment normalization state.
+// Each docs candidate is answered in O(1) from the running state, so
+// the total scan is linear in line.length.
+//
+// RED: the perf case must complete under the 1000ms budget AND emit
+// zero path candidates (none of the `a/docs` occurrences resolve to
+// docs). Two functional controls verify the linearized scanner still
+// accepts real dot-segment prefixes.
+
+import { describe, expect, test } from "bun:test";
+import { extractDocsPaths } from "./boundary-docs-path-parser.ts";
+
+describe("v8 #4 docs prefix scan linearization", () => {
+  test("('a/docs').repeat(8000) completes under 1000ms and emits 0 paths", () => {
+    const text = "a/docs".repeat(8000);
+    expect(text.length).toBe(48000);
+    const t0 = performance.now();
+    const r = extractDocsPaths(text, 100);
+    const t1 = performance.now();
+    expect(r.paths).toHaveLength(0);
+    expect(r.overflow).toBe(false);
+    const elapsedMs = t1 - t0;
+    expect(elapsedMs).toBeLessThan(1000);
+  });
+
+  test("control: ../../docs/specs/foo.md -> 1 path (value starts at docs token)", () => {
+    const r = extractDocsPaths("../../docs/specs/foo.md", 10);
+    expect(r.paths).toHaveLength(1);
+    expect(r.paths[0]?.value).toBe("docs/specs/foo.md");
+  });
+
+  test("control: a/b/c/../../../docs/specs/foo.md -> 1 path (dot-segment cancel)", () => {
+    const r = extractDocsPaths("a/b/c/../../../docs/specs/foo.md", 10);
+    expect(r.paths).toHaveLength(1);
+    expect(r.paths[0]?.value).toBe("docs/specs/foo.md");
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v8-triple-decode.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v8-triple-decode.test.ts
@@ -1,0 +1,72 @@
+// Review-v8 blocker: triple percent-encoded hosts must be detected as evasion.
+//
+// Blocker #3: canonicalizeHostEvasion does ≤2 decodeURIComponent rounds.
+// Triple-encoded hosts like %252567ithub.com need 3 rounds to fully resolve:
+//   %252567ithub.com → %2567ithub.com → %67ithub.com → github.com
+// With only 2 rounds, the loop stops at %67ithub.com, which is NOT recognized
+// as github.com, so no evasion candidate is emitted → gate FAIL bypass.
+//
+// Scope:
+//   - Triple-encoded host: %252567ithub.com → 1 malformed, gate FAIL (evasion-attempt)
+//   - Double-encoded control: %2567ithub.com → still detected (2 rounds sufficient), 1 malformed, gate FAIL
+//   - Single-encoded control: %67ithub.com → still detected, 1 malformed, gate FAIL
+//   - Plain control: github.com → 1 valid producer URL, gate FAIL (producer-internal), no malformed
+
+import { describe, expect, test } from "bun:test";
+import { extractUrls } from "./boundary-url-parser.ts";
+import type { DetectorConfig } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+// Triple percent-encoding requires 3 decode rounds.
+describe("triple percent-encoding / evasion detection (B3)", () => {
+  test("%252567ithub.com/yogata/agent-dev-flow/blob/main/x.md → 1 malformed, gate FAIL (evasion-attempt)", () => {
+    const text = "See %252567ithub.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+    expect(g.errors.find((d) => d.classification === "unclassified")).toBeDefined();
+  });
+
+  test("%2567ithub.com/yogata/agent-dev-flow/blob/main/x.md (double-encoded control) → 1 malformed, gate FAIL", () => {
+    const text = "See %2567ithub.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+  });
+
+  test("%67ithub.com/yogata/agent-dev-flow/blob/main/x.md (single-encoded control) → 1 malformed, gate FAIL", () => {
+    const text = "See %67ithub.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v8-url-query-assignment.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v8-url-query-assignment.test.ts
@@ -1,0 +1,108 @@
+// Review-v8 blocker #2: query-assignment scheme-less URL must fail closed.
+//
+// isValidLeftBoundary accepts `=` and `&` ONLY for scheme URLs (hasScheme=true).
+// For scheme-less URLs, `=` sits in LEFT_REJECT_CHAR, so a recognized host that
+// appears right after a query-assignment delimiter (`?next=github.com/...`,
+// `&link=github.com/...`, bare `=github.com/...`) is rejected at the left
+// boundary and skipped via `continue`. The candidate vanishes, the gate sees
+// 0 candidates, and a producer reference hidden in a query value passes clean.
+//
+// Remediation: when `!hasScheme` and the char before the host is `=` or `&`,
+// emit a MALFORMED candidate (ownershipSpan null) instead of skipping. The gate
+// then resolves it to evasion-attempt / unclassified and FAILs. Scheme URLs are
+// unaffected (`!hasScheme` guard), so `url=https://github.com/...` still yields
+// a valid producer URL (control L8 in boundary-review-v6-url-lexical).
+//
+// Scope:
+//   - B2a: `?next=github.com/...`            → 1 malformed, gate FAIL
+//   - B2b: `?ref=github.com/...`             → 1 malformed, gate FAIL
+//   - B2c: `&link=github.com/...`            → 1 malformed, gate FAIL
+//   - C1 : `https://example.com/?next=...`   → embedded scheme-less host malformed, gate FAIL
+//   - C2 : bare `=github.com/...`            → 1 malformed, gate FAIL
+//   - C3 : `https://github.com/...` (scheme) → 1 valid producer URL, gate FAIL (producer-internal), no malformed
+
+import { describe, expect, test } from "bun:test";
+import { extractUrls } from "./boundary-url-parser.ts";
+import type { DetectorConfig } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+// Shared shape for every blocker case: exactly one malformed URL whose ownership
+// span is null, and a gate that FAILs with an evasion-attempt / unclassified
+// error (malformed URLs resolve to unclassified/evasion-attempt per
+// resolveCandidate, routed into gate.errors).
+function expectMalformedEvasion(text: string): void {
+  const { urls } = extractUrls(text, 64);
+  expect(urls).toHaveLength(1);
+  const u = urls[0];
+  if (u === undefined) throw new Error("expected one malformed url");
+  expect(u.malformed).toBe(true);
+  expect(u.ownershipSpan).toBeNull();
+  const g = gateFor(text);
+  expect(g.pass).toBe(false);
+  expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+  expect(g.errors.find((d) => d.classification === "unclassified")).toBeDefined();
+}
+
+// B2: scheme-less recognized host after a query-assignment delimiter must fail closed.
+describe("B2 query-assignment scheme-less URL / fail closed", () => {
+  test("?next=github.com/yogata/agent-dev-flow/blob/main/x.md → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See ?next=github.com/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+
+  test("?ref=github.com/yogata/agent-dev-flow/blob/main/x.md → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See ?ref=github.com/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+
+  test("&link=github.com/yogata/agent-dev-flow/blob/main/x.md → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See prev &link=github.com/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+});
+
+// Controls: already-correct or adjacent behavior must remain sound.
+describe("controls / scheme context unchanged", () => {
+  test("https://example.com/?next=github.com/... → embedded scheme-less host malformed, gate FAIL", () => {
+    // example.com is not a recognized host, so only the embedded scheme-less
+    // github.com (after `=`) is scanned. Its `?` resets the authority scan, so
+    // the embedded host is scheme-less and must be caught as malformed rather
+    // than hidden behind the outer URL.
+    const text = "See https://example.com/?next=github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one malformed url");
+    expect(u.malformed).toBe(true);
+    expect(u.ownershipSpan).toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+  });
+
+  test("=github.com/yogata/agent-dev-flow/blob/main/x.md (standalone) → 1 malformed, gate FAIL", () => {
+    expectMalformedEvasion("See =github.com/yogata/agent-dev-flow/blob/main/x.md end.");
+  });
+
+  test("https://github.com/yogata/agent-dev-flow/blob/main/x.md (scheme URL) → 1 valid producer URL, gate FAIL (producer-internal), no malformed", () => {
+    const text = "See https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    const u = urls[0];
+    if (u === undefined) throw new Error("expected one valid url");
+    expect(u.malformed).toBe(false);
+    expect(u.ownershipSpan).not.toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.find((d) => d.category === "fixed-url")?.classification).toBe("producer-internal");
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeUndefined();
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v9-delimiter-host.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-review-v9-delimiter-host.test.ts
@@ -1,0 +1,160 @@
+// Review-v9 security blocker: `:`/`?`/`#` delimited producer URLs pass clean.
+//
+// isValidLeftBoundary accepts `=` and `&` ONLY for scheme URLs (hasScheme=true).
+// For scheme-less URLs, commit v8-C3 (`2be3671e`) added malformed emission
+// when prevChar is `=` or `&`. The symmetric treatment for `:`, `?`, and `#`
+// was NOT applied, leaving these fail-open holes:
+//   - `label:github.com/yogata/agent-dev-flow/blob/main/secret.md` (scheme-less, `:`)
+//   - `?github.com/yogata/agent-dev-flow/blob/main/x.md` (scheme-less, `?`)
+//   - `#github.com/yogata/agent-dev-flow/blob/main/x.md` (scheme-less, `#`)
+//   - `label:https://github.com/yogata/...` (schemed, `:` before scheme start)
+//
+// Remediation: extend commit v8-C3's malformed emission to also cover `:`, `?`,
+// `#` for scheme-less URLs. For schemed URLs, add `:`, `?`, `#` to the accepted
+// left-boundary chars (the scheme token is unambiguous).
+//
+// Scope:
+//   D1: `label:github.com/...` (scheme-less)  -> 1 malformed, gate FAIL
+//   D2: `?github.com/...` (scheme-less)        -> 1 malformed, gate FAIL
+//   D3: `#github.com/...` (scheme-less)        -> 1 malformed, gate FAIL
+//   D4: `http://external.com/p?github.com/...` -> 1 malformed, gate FAIL
+//   D5: `http://external.com/p#github.com/...` -> 1 malformed, gate FAIL
+//   D6: `label:https://github.com/yogata/...`  -> 1 valid producer, gate FAIL
+//   D7: `?https://github.com/yogata/...`        -> 1 valid producer, gate FAIL
+//   D8: `#https://github.com/yogata/...`        -> 1 valid producer, gate FAIL
+//   C1: `label:https://github.com/vercel/...`  -> 1 valid consumer, gate PASS
+//   C2: `?https://github.com/vercel/...`        -> 1 valid consumer, gate PASS
+
+import { describe, expect, test } from "bun:test";
+import { extractUrls } from "./boundary-url-parser.ts";
+import type { DetectorConfig } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+// D1-D5: scheme-less host after `:` `?` `#` must emit malformed and FAIL gate.
+describe("D scheme-less host after : ? # / fail closed", () => {
+  test("D1 label:github.com/yogata/agent-dev-flow/blob/main/secret.md -> 1 malformed, gate FAIL", () => {
+    const text = "See label:github.com/yogata/agent-dev-flow/blob/main/secret.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(true);
+    expect(urls[0]?.ownershipSpan).toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+  });
+
+  test("D2 ?github.com/yogata/agent-dev-flow/blob/main/x.md -> 1 malformed, gate FAIL", () => {
+    const text = "See ?github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(true);
+    expect(urls[0]?.ownershipSpan).toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+  });
+
+  test("D3 #github.com/yogata/agent-dev-flow/blob/main/x.md -> 1 malformed, gate FAIL", () => {
+    const text = "See #github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(true);
+    expect(urls[0]?.ownershipSpan).toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+  });
+
+  test("D4 http://external.com/p?github.com/yogata/... -> 1 malformed, gate FAIL", () => {
+    const text = "See http://external.com/p?github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(true);
+    expect(urls[0]?.ownershipSpan).toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+  });
+
+  test("D5 http://external.com/p#github.com/yogata/... -> 1 malformed, gate FAIL", () => {
+    const text = "See http://external.com/p#github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(true);
+    expect(urls[0]?.ownershipSpan).toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeDefined();
+  });
+});
+
+// D6-D8: schemed URL after `:` `?` `#` must be accepted and classified.
+describe("D schemed URL after : ? # / accepted and classified", () => {
+  test("D6 label:https://github.com/yogata/agent-dev-flow/blob/main/x.md -> 1 valid producer, gate FAIL", () => {
+    const text = "See label:https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(false);
+    expect(urls[0]?.ownershipSpan).not.toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.find((d) => d.category === "fixed-url")?.classification).toBe("producer-internal");
+    expect(g.errors.find((d) => d.category === "evasion-attempt")).toBeUndefined();
+  });
+
+  test("D7 ?https://github.com/yogata/agent-dev-flow/blob/main/x.md -> 1 valid producer, gate FAIL", () => {
+    const text = "See ?https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(false);
+    expect(urls[0]?.ownershipSpan).not.toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.find((d) => d.category === "fixed-url")?.classification).toBe("producer-internal");
+  });
+
+  test("D8 #https://github.com/yogata/agent-dev-flow/blob/main/x.md -> 1 valid producer, gate FAIL", () => {
+    const text = "See #https://github.com/yogata/agent-dev-flow/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(false);
+    expect(urls[0]?.ownershipSpan).not.toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(false);
+    expect(g.failures.find((d) => d.category === "fixed-url")?.classification).toBe("producer-internal");
+  });
+});
+
+// C1-C2: external URLs after delimiters should still PASS gate.
+describe("C external URLs after delimiters / gate PASS", () => {
+  test("C1 label:https://github.com/vercel/next.js/blob/main/x.md -> 1 valid consumer, gate PASS", () => {
+    const text = "See label:https://github.com/vercel/next.js/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(false);
+    expect(urls[0]?.ownershipSpan).not.toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+  });
+
+  test("C2 ?https://github.com/vercel/next.js/blob/main/x.md -> 1 valid consumer, gate PASS", () => {
+    const text = "See ?https://github.com/vercel/next.js/blob/main/x.md end.";
+    const { urls } = extractUrls(text, 64);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]?.malformed).toBe(false);
+    expect(urls[0]?.ownershipSpan).not.toBeNull();
+    const g = gateFor(text);
+    expect(g.pass).toBe(true);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-runner.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-runner.ts
@@ -23,8 +23,8 @@ import type { LoadedBlob } from "./blob-loader.ts";
 import {
   decideProjection,
   type ClassifyFileInput,
-  type DetectorConfig,
-} from "./boundary-pipeline.ts";
+} from "./boundary-gate.ts";
+import type { DetectorConfig } from "./boundary-pipeline.ts";
 import { mapRuntimeToLinkPath } from "./manifest.ts";
 
 const PROJECTIONS: readonly Projection[] = [

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-span-overflow.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-span-overflow.test.ts
@@ -17,7 +17,7 @@ import {
   detectCandidates,
   type DetectorConfig,
 } from "./boundary-pipeline.ts";
-import { decideProjection, type ClassifyFileInput } from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-gate.ts";
 
 const baseConfig: DetectorConfig = {
   repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
@@ -60,23 +60,28 @@ describe("C1 X fixed-width catches valid fixed-width x escapes", () => {
   });
 
   test("detectReconstructedIds decodes all three X forms", () => {
-    expect(detectReconstructedIds("\\x41DR-0001").map((x) => x.decoded)).toContain("ADR-0001");
-    expect(detectReconstructedIds("ADR\\x2d0001").map((x) => x.decoded)).toContain("ADR-0001");
-    expect(detectReconstructedIds("ADR-\\x310").map((x) => x.decoded)).toContain("ADR-10");
+    expect(detectReconstructedIds("\\x41DR-0001").ids.map((x) => x.decoded)).toContain("ADR-0001");
+    expect(detectReconstructedIds("ADR\\x2d0001").ids.map((x) => x.decoded)).toContain("ADR-0001");
+    expect(detectReconstructedIds("ADR-\\x310").ids.map((x) => x.decoded)).toContain("ADR-10");
   });
 });
 
-// C2: \uXXXX is exact contract. A digit-valued escape immediately followed
-// by another hex digit is a malformed digit-continuation run and must NOT
-// decode (left as literal text -> clean). Non-digit escapes followed by a
-// hex-looking literal still decode.
-describe("C2 U exact-contract rejects malformed digit-continuation", () => {
-  test("ADR-\\u00310 is clean (digit-continuation rejected)", () => {
-    expect(cls("See ADR-\\u00310 here.").detections).toEqual([]);
+// C2: \uXXXX is fixed-width four hex digits. The digit-continuation
+// rejection is removed: \u00310 decodes to '1' and the trailing '0' is a
+// literal, reconstructing ADR-10. \u{...} remains unsupported/clean.
+describe("C2 U fixed-width four-hex reconstruction", () => {
+  test("ADR-\\u00310 reconstructs ADR-10 and fails (producer-internal/evasion-attempt)", () => {
+    const r = cls("See ADR-\\u00310 here.");
+    expect(r.detections).toHaveLength(1);
+    expect(r.detections[0]?.classification).toBe("producer-internal");
+    expect(r.detections[0]?.category).toBe("evasion-attempt");
+    expect(r.detections[0]?.matched).toBe("ADR-\\u00310");
   });
 
-  test("detectReconstructedIds yields nothing for ADR-\\u00310", () => {
-    expect(detectReconstructedIds("ADR-\\u00310")).toEqual([]);
+  test("detectReconstructedIds decodes ADR-\\u00310 to ADR-10", () => {
+    const res = detectReconstructedIds("ADR-\\u00310");
+    expect(res.ids.map((x) => x.decoded)).toEqual(["ADR-10"]);
+    expect(res.overflow).toBe(false);
   });
 
   test("\\u0041DR-0001 still reconstructs (non-digit escape + hex literal)", () => {
@@ -95,35 +100,39 @@ describe("C2 U exact-contract rejects malformed digit-continuation", () => {
     const qg = cls("See QG-\\u0032 here.").detections.find((d) => d.category === "evasion-attempt");
     expect(qg?.classification).toBe("unclassified");
   });
+
+  test("\\u{0031} curly-brace form remains unsupported (clean)", () => {
+    expect(cls("See ADR-\\u{0031} here.").detections).toEqual([]);
+  });
 });
 
-// C3: span-aware reconstruction. An ID is emitted only when its own decoded
-// span includes an escape atom, or an escape atom creates the boundary that
-// exposes it. A literal ID sharing a token with an unrelated escape is NOT
-// emitted as reconstructed. `matched` is the minimal relevant source span.
-describe("C3 span-aware reconstruction", () => {
-  test("STEP-1\\u0020ADR-0002 emits only reconstructed ADR-0002, minimal span", () => {
+// C3: span-aware reconstruction with symmetric escape-created boundaries.
+// An escape atom creates a word boundary on EITHER side of an ID: left
+// (escape immediately before) or right (escape immediately after). Both are
+// evasion-attempt. UTF-8/16/32 labels stay clean. `matched` is minimal.
+describe("C3 span-aware reconstruction, symmetric boundaries", () => {
+  test("STEP-1\\u0020ADR-0002 emits reconstructed STEP-1 (error) and ADR-0002 (failure)", () => {
     const g = gateFor("See STEP-1\\u0020ADR-0002.");
     expect(g.failures).toHaveLength(1);
-    expect(g.errors).toHaveLength(0);
-    const f = g.failures[0];
-    expect(f?.category).toBe("evasion-attempt");
-    expect(f?.matched).toBe("\\u0020ADR-0002");
+    expect(g.errors).toHaveLength(1);
+    expect(g.failures[0]?.category).toBe("evasion-attempt");
+    expect(g.failures[0]?.matched).toBe("\\u0020ADR-0002");
+    expect(g.errors[0]?.matched).toBe("STEP-1\\u0020");
   });
 
-  test("STEP-1\\u0020text stays clean at the gate (direct STEP-1 allowed, no reconstructed false positive)", () => {
+  test("STEP-1\\u0020text fails (right-boundary escape exposes STEP-1)", () => {
     const g = gateFor("See STEP-1\\u0020text here.");
-    expect(g.pass).toBe(true);
-    expect(g.failures).toEqual([]);
-    expect(g.errors).toEqual([]);
+    expect(g.pass).toBe(false);
+    expect(g.errors.some((e) => e.category === "evasion-attempt" && e.matched === "STEP-1\\u0020")).toBe(true);
   });
 
-  test("QG-2\\x20prose stays clean at the gate", () => {
+  test("QG-2\\x20prose fails (right-boundary escape exposes QG-2)", () => {
     const g = gateFor("See QG-2\\x20prose here.");
-    expect(g.pass).toBe(true);
+    expect(g.pass).toBe(false);
+    expect(g.errors.some((e) => e.category === "evasion-attempt" && e.matched === "QG-2\\x20")).toBe(true);
   });
 
-  test("UTF-8\\u0020text stays clean (no detection at all)", () => {
+  test("UTF-8\\u0020text stays clean (UTF label excluded from reconstruction)", () => {
     const g = gateFor("See UTF-8\\u0020text here.");
     expect(g.pass).toBe(true);
     expect(g.failures).toEqual([]);
@@ -171,5 +180,66 @@ describe("C4 bounded evidence and fail-closed overflow", () => {
     const rep = "\\u0041DR-0001 ".repeat(300);
     const cs = detectCandidates(rep, baseConfig);
     expect(cs.length).toBeLessThanOrEqual(65);
+  });
+});
+
+// C5: reconstructed wins over direct on a conflicting overlap. STEP-1\x32
+// reconstructs STEP-12; the shorter direct STEP-1 is dropped, not the
+// reconstructed. Same for QG-2\u0033 -> QG-23.
+describe("C5 reconstructed wins conflicting overlap", () => {
+  test("STEP-1\\x32 reconstructs STEP-12 and fails closed (direct STEP-1 dropped)", () => {
+    const cs = detectCandidates("See STEP-1\\x32 here.", baseConfig);
+    expect(cs.map((c) => c.type)).toContain("reconstructed-id");
+    const recon = cs.find((c): c is Extract<typeof c, { type: "reconstructed-id" }> => c.type === "reconstructed-id");
+    expect(recon?.value).toBe("STEP-12");
+    expect(cs.some((c) => c.type === "direct-id")).toBe(false);
+    const g = gateFor("See STEP-1\\x32 here.");
+    expect(g.pass).toBe(false);
+    expect(g.errors.some((e) => e.category === "evasion-attempt")).toBe(true);
+  });
+
+  test("QG-2\\u0033 reconstructs QG-23 and fails closed", () => {
+    const g = gateFor("See QG-2\\u0033 here.");
+    expect(g.pass).toBe(false);
+    const recon = detectCandidates("See QG-2\\u0033 here.", baseConfig)
+      .find((c): c is Extract<typeof c, { type: "reconstructed-id" }> => c.type === "reconstructed-id");
+    expect(recon?.value).toBe("QG-23");
+  });
+});
+
+// C6: per-token ID cap. 16 IDs in one token are all emitted; a 17th turns a
+// typed overflow that propagates to a fail-closed candidate even if earlier
+// reconstructed candidates are later deduped/owned. Closes the exploit
+// ("STEP-1\u0032-").repeat(16) + "\u0041DR-1".
+describe("C6 per-token ID cap overflow", () => {
+  test("16 IDs in one token: all emitted, no overflow", () => {
+    const token = "STEP-1\\u0032-".repeat(16);
+    const res = detectReconstructedIds(token);
+    expect(res.ids.length).toBe(16);
+    expect(res.overflow).toBe(false);
+  });
+
+  test("exploit (17th hidden ID): overflow propagates, gate fails closed", () => {
+    const exploit = "STEP-1\\u0032-".repeat(16) + "\\u0041DR-1";
+    const g = gateFor(exploit);
+    expect(g.pass).toBe(false);
+    const overflow = g.errors.concat(g.failures).find((d) => d.matched.includes("[overflow"));
+    expect(overflow).toBeDefined();
+  });
+});
+
+// C7: pathological large input is bounded by the scan budget and fails
+// closed (typed line-scan-exceeded overflow).
+describe("C7 pathological large input bounded", () => {
+  test("huge escape run is bounded and fails closed", () => {
+    const huge = "\\x41".repeat(50000);
+    const g = gateFor(huge);
+    expect(g.pass).toBe(false);
+  });
+
+  test("detectReconstructedIds signals line-scan overflow for huge input", () => {
+    const res = detectReconstructedIds("\\x41".repeat(50000));
+    expect(res.overflow).toBe(true);
+    expect(res.overflowReason).toBe("line-scan-exceeded");
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-span-overflow.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-span-overflow.test.ts
@@ -1,0 +1,175 @@
+// Stage A fresh-review blocker coverage: X fixed-width, U exact-contract,
+// span-aware reconstruction, and bounded evidence. Extracted into its own
+// module so boundary-pipeline-evasion.test.ts stays under the 250 pure LOC
+// ceiling (parent defect #12). Each describe maps to one fresh-review
+// blocker from the goal/code/security lanes.
+//
+// Blocker map (fresh-review blocker -> describe):
+//   C1 X fixed-width misses valid escapes  -> "C1 X fixed-width"
+//   C2 U exact-contract malformed digit-run -> "C2 U exact-contract"
+//   C3 span-aware reconstruction           -> "C3 span-aware reconstruction"
+//   C4 bounded evidence / fail-closed      -> "C4 bounded evidence"
+
+import { describe, expect, test } from "bun:test";
+import { detectReconstructedIds } from "./boundary-reconstruction.ts";
+import {
+  classifyLine,
+  detectCandidates,
+  type DetectorConfig,
+} from "./boundary-pipeline.ts";
+import { decideProjection, type ClassifyFileInput } from "./boundary-pipeline.ts";
+
+const baseConfig: DetectorConfig = {
+  repository_identity: { owner_slash_name: "yogata/agent-dev-flow", default_branch: "main" },
+  producer_internal_id_prefixes: ["ADR", "REQ", "DEC", "SPEC", "IR", "RU", "TS", "AG", "OU", "EC"],
+  distributed_workflow_control_prefixes: ["STEP", "QG"],
+};
+
+function cls(text: string) {
+  return classifyLine({ text, lineNumber: 1, filePath: "f.md", projection: "source" }, baseConfig);
+}
+
+function gateFor(text: string) {
+  const files: ClassifyFileInput[] = [{ filePath: "f.md", projection: "source", text }];
+  return decideProjection(files, "source", baseConfig).gate;
+}
+
+// C1: \xXX is fixed width 2. The old negative lookahead (?![0-9A-Fa-f])
+// rejected every case where the char after the two hex digits was itself a
+// hex letter/digit, which is exactly the reconstructed-ID shape.
+describe("C1 X fixed-width catches valid fixed-width x escapes", () => {
+  test("\\x41DR-0001 reconstructs ADR-0001 (prefix via \\x41)", () => {
+    const r = cls("See \\x41DR-0001 here.");
+    const ev = r.detections.find((d) => d.category === "evasion-attempt");
+    expect(ev?.classification).toBe("producer-internal");
+    expect(ev?.matched).toBe("\\x41DR-0001");
+  });
+
+  test("ADR\\x2d0001 reconstructs ADR-0001 (escaped hyphen via \\x2d)", () => {
+    const r = cls("See ADR\\x2d0001 here.");
+    const ev = r.detections.find((d) => d.category === "evasion-attempt");
+    expect(ev?.classification).toBe("producer-internal");
+    expect(ev?.matched).toBe("ADR\\x2d0001");
+  });
+
+  test("ADR-\\x310 reconstructs ADR-10 (suffix digit via \\x31 + literal 0)", () => {
+    const r = cls("See ADR-\\x310 here.");
+    const ev = r.detections.find((d) => d.category === "evasion-attempt");
+    expect(ev?.classification).toBe("producer-internal");
+    expect(ev?.matched).toBe("ADR-\\x310");
+  });
+
+  test("detectReconstructedIds decodes all three X forms", () => {
+    expect(detectReconstructedIds("\\x41DR-0001").map((x) => x.decoded)).toContain("ADR-0001");
+    expect(detectReconstructedIds("ADR\\x2d0001").map((x) => x.decoded)).toContain("ADR-0001");
+    expect(detectReconstructedIds("ADR-\\x310").map((x) => x.decoded)).toContain("ADR-10");
+  });
+});
+
+// C2: \uXXXX is exact contract. A digit-valued escape immediately followed
+// by another hex digit is a malformed digit-continuation run and must NOT
+// decode (left as literal text -> clean). Non-digit escapes followed by a
+// hex-looking literal still decode.
+describe("C2 U exact-contract rejects malformed digit-continuation", () => {
+  test("ADR-\\u00310 is clean (digit-continuation rejected)", () => {
+    expect(cls("See ADR-\\u00310 here.").detections).toEqual([]);
+  });
+
+  test("detectReconstructedIds yields nothing for ADR-\\u00310", () => {
+    expect(detectReconstructedIds("ADR-\\u00310")).toEqual([]);
+  });
+
+  test("\\u0041DR-0001 still reconstructs (non-digit escape + hex literal)", () => {
+    const r = cls("See \\u0041DR-0001 here.");
+    const ev = r.detections.find((d) => d.category === "evasion-attempt");
+    expect(ev?.classification).toBe("producer-internal");
+  });
+
+  test("ADR\\u002d0001 still reconstructs (escaped hyphen, non-digit)", () => {
+    expect(gateFor("See ADR\\u002d0001.").pass).toBe(false);
+  });
+
+  test("STEP-\\u0031 and QG-\\u0032 still fail-closed (digit, non-hex follower)", () => {
+    const step = cls("See STEP-\\u0031 here.").detections.find((d) => d.category === "evasion-attempt");
+    expect(step?.classification).toBe("unclassified");
+    const qg = cls("See QG-\\u0032 here.").detections.find((d) => d.category === "evasion-attempt");
+    expect(qg?.classification).toBe("unclassified");
+  });
+});
+
+// C3: span-aware reconstruction. An ID is emitted only when its own decoded
+// span includes an escape atom, or an escape atom creates the boundary that
+// exposes it. A literal ID sharing a token with an unrelated escape is NOT
+// emitted as reconstructed. `matched` is the minimal relevant source span.
+describe("C3 span-aware reconstruction", () => {
+  test("STEP-1\\u0020ADR-0002 emits only reconstructed ADR-0002, minimal span", () => {
+    const g = gateFor("See STEP-1\\u0020ADR-0002.");
+    expect(g.failures).toHaveLength(1);
+    expect(g.errors).toHaveLength(0);
+    const f = g.failures[0];
+    expect(f?.category).toBe("evasion-attempt");
+    expect(f?.matched).toBe("\\u0020ADR-0002");
+  });
+
+  test("STEP-1\\u0020text stays clean at the gate (direct STEP-1 allowed, no reconstructed false positive)", () => {
+    const g = gateFor("See STEP-1\\u0020text here.");
+    expect(g.pass).toBe(true);
+    expect(g.failures).toEqual([]);
+    expect(g.errors).toEqual([]);
+  });
+
+  test("QG-2\\x20prose stays clean at the gate", () => {
+    const g = gateFor("See QG-2\\x20prose here.");
+    expect(g.pass).toBe(true);
+  });
+
+  test("UTF-8\\u0020text stays clean (no detection at all)", () => {
+    const g = gateFor("See UTF-8\\u0020text here.");
+    expect(g.pass).toBe(true);
+    expect(g.failures).toEqual([]);
+    expect(g.errors).toEqual([]);
+  });
+
+  test("matched is minimal relevant span, not maximal token", () => {
+    const r = cls("See STEP-1\\u0020ADR-0002.");
+    const ev = r.detections.find((d) => d.category === "evasion-attempt" && d.classification === "producer-internal");
+    expect(ev?.matched).toBe("\\u0020ADR-0002");
+    expect(ev?.matched).not.toContain("STEP-1");
+  });
+});
+
+// C4: bounded evidence. Per-line/per-token candidate counts are bounded; on
+// overflow a single typed overflow candidate fails the gate closed.
+// Detection.text is bounded so a long line cannot amplify per detection.
+describe("C4 bounded evidence and fail-closed overflow", () => {
+  test("Detection.text is bounded below the full line length", () => {
+    const long = "x".repeat(5000) + " ADR-0001";
+    const d = cls(long).detections;
+    const det = d.find((x) => x.matched === "ADR-0001");
+    expect(det).toBeDefined();
+    expect((det?.text.length ?? 9999) < long.length).toBe(true);
+    expect((det?.text.length ?? 9999) <= 200).toBe(true);
+  });
+
+  test("moderate repeated payload is bounded and fails closed (no amplification)", () => {
+    const rep = "\\u0041DR-0001 ".repeat(300);
+    const g = gateFor(rep);
+    const total = g.failures.length + g.errors.length;
+    expect(g.pass).toBe(false);
+    expect(total).toBeLessThanOrEqual(65);
+    expect(total).toBeGreaterThanOrEqual(1);
+  });
+
+  test("overflow yields exactly one unclassified/evasion-attempt error", () => {
+    const rep = "\\u0041DR-0001 ".repeat(300);
+    const g = gateFor(rep);
+    const overflow = g.errors.find((e) => e.category === "evasion-attempt" && e.classification === "unclassified");
+    expect(overflow).toBeDefined();
+  });
+
+  test("detectCandidates bounds candidate count on pathological input", () => {
+    const rep = "\\u0041DR-0001 ".repeat(300);
+    const cs = detectCandidates(rep, baseConfig);
+    expect(cs.length).toBeLessThanOrEqual(65);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
@@ -2,7 +2,7 @@
 //
 // Extracted from boundary-url-parser.ts to keep that module under the 250
 // pure LOC ceiling. One responsibility: classify a URL value's authority
-// as valid / malformed / rejected, and expose the backward authority scan
+// as valid / malformed / rejected, and expose the forward authority scan
 // used to locate the scheme and detect backslash malformedness.
 //
 // Classification rules:
@@ -38,6 +38,9 @@ const AUTHORITY_CHAR = /[A-Za-z0-9._~!$&'()*+,;=:@%]/;
 
 /** One character of an RFC 3986 scheme token: ALPHA / DIGIT / "+" / "-" / ".". */
 const SCHEME_CHAR = /[A-Za-z0-9+\-.]/;
+
+/** First character of a scheme must be ALPHA (RFC 3986). */
+const ALPHA = /[A-Za-z]/;
 
 export type AuthorityKind = "valid" | "malformed" | "rejected";
 
@@ -112,46 +115,105 @@ export function parseUrlHost(url: string): string | null {
 export interface AuthorityScan {
   /** Start index of an http(s):// scheme whose authority ends at hostStart, or -1. */
   readonly schemeStart: number;
-  /** True when a backslash was crossed during the backward walk. */
+  /** True when a backslash was crossed during the forward walk. */
   readonly hasBackslash: boolean;
   /** Leftmost index reached by the walk (start of the authority evidence). */
   readonly authorityLeft: number;
 }
 
 /**
- * Walk backward from `hostStart - 1` through the lexical authority region
- * (RFC 3986 authority chars AND backslash) to locate an http(s):// scheme
- * and detect backslash malformedness. The walk stops at any char that is
- * neither an authority char nor a backslash (whitespace, a path separator
- * from a DIFFERENT token, etc.), so a later bare host never grabs an
- * earlier URL's scheme. Crossing a backslash sets hasBackslash so the
- * caller emits a malformed candidate rather than silently dropping it.
+ * Forward authority-scan cursor. Carries scheme and backslash evidence
+ * accumulated from line start (or the previous host hit) up to `pos`,
+ * so a HOST_SCAN hit at the next `hostStart` can be answered by walking
+ * forward through `(pos, hostStart)` only. Across all calls with
+ * monotonically increasing `hostStart`, total work is O(line.length):
+ * every index is visited at most once.
  */
-export function scanAuthorityBackward(line: string, hostStart: number): AuthorityScan {
-  let i = hostStart - 1;
-  let hasBackslash = false;
-  while (i >= 0) {
+export interface AuthorityScanCursor {
+  /** Last index processed (exclusive lower bound for the next call). */
+  readonly pos: number;
+  readonly schemeStart: number;
+  readonly authorityLeft: number;
+  readonly hasBackslash: boolean;
+}
+
+export const INITIAL_AUTHORITY_SCAN_CURSOR: AuthorityScanCursor = {
+  pos: -1,
+  schemeStart: -1,
+  authorityLeft: 0,
+  hasBackslash: false,
+};
+
+export interface AuthorityScanResult {
+  readonly cursor: AuthorityScanCursor;
+  readonly scan: AuthorityScan;
+  /** Number of characters processed in this call (for step-count bound). */
+  readonly steps: number;
+}
+
+/**
+ * Advance the cursor forward through `(cursor.pos, hostStart)`, updating
+ * scheme and backslash evidence. Returns the cursor state valid at
+ * `hostStart - 1` (the index just before the host), the AuthorityScan
+ * snapshot, and the number of characters processed.
+ *
+ * Per-index transition (let `i` be the index just consumed, `c = line[i]`):
+ *   - `c === "\\"`: a backslash inside the live region sets hasBackslash;
+ *     the walk continues (backslash never terminates the region).
+ *   - `c === "/"` and `line[i-2..i] === "://"`: a scheme terminator. Probe
+ *     backward within the scheme-char run (bounded by scheme length) to
+ *     recover the scheme name; accept only `http` / `https`. The probe is
+ *     short (scheme length ≤ 10), so total work stays linear.
+ *   - any other non-AUTHORITY_CHAR: invalidates the live region (resets
+ *     schemeStart to -1, hasBackslash to false, advances authorityLeft).
+ *   - AUTHORITY_CHAR: state persists.
+ *
+ * The scheme-char probe is the only "backward" piece, and it is bounded
+ * by the scheme token length, not by the authority length, so the per-call
+ * cost is O(distance advanced) + O(scheme length) and the cross-call
+ * total is O(line.length).
+ */
+export function scanAuthorityForward(
+  line: string,
+  hostStart: number,
+  cursor: AuthorityScanCursor,
+): AuthorityScanResult {
+  let pos = cursor.pos;
+  let schemeStart = cursor.schemeStart;
+  let authorityLeft = cursor.authorityLeft;
+  let hasBackslash = cursor.hasBackslash;
+  let steps = 0;
+  while (pos + 1 < hostStart) {
+    pos++;
+    steps++;
+    const i = pos;
     const c = line.charAt(i);
-    if (c === "\\") { hasBackslash = true; i--; continue; }
-    if (i >= 2 && line.substring(i - 2, i + 1) === "://") {
+    if (c === "\\") {
+      hasBackslash = true;
+      continue;
+    }
+    if (c === "/" && i >= 2 && line.charAt(i - 1) === "/" && line.charAt(i - 2) === ":") {
       const schemeEnd = i - 2;
       let j = schemeEnd - 1;
-      if (j < 0 || !/[A-Za-z]/.test(line.charAt(j))) {
-        return { schemeStart: -1, hasBackslash, authorityLeft: i + 1 };
+      if (j < 0 || !ALPHA.test(line.charAt(j))) {
+        schemeStart = -1; authorityLeft = i + 1; hasBackslash = false;
+        continue;
       }
       while (j > 0 && SCHEME_CHAR.test(line.charAt(j - 1))) j--;
       const scheme = line.substring(j, schemeEnd).toLowerCase();
       if (scheme === "http" || scheme === "https") {
-        return { schemeStart: j, hasBackslash, authorityLeft: j };
+        schemeStart = j; authorityLeft = j; hasBackslash = false;
+      } else {
+        schemeStart = -1; authorityLeft = i + 1; hasBackslash = false;
       }
-      return { schemeStart: -1, hasBackslash, authorityLeft: i + 1 };
+      continue;
     }
     if (!AUTHORITY_CHAR.test(c)) {
-      return { schemeStart: -1, hasBackslash, authorityLeft: i + 1 };
+      schemeStart = -1; authorityLeft = i + 1; hasBackslash = false;
     }
-    i--;
   }
-  return { schemeStart: -1, hasBackslash, authorityLeft: 0 };
+  const nextCursor: AuthorityScanCursor = { pos, schemeStart, authorityLeft, hasBackslash };
+  return { cursor: nextCursor, scan: { schemeStart, hasBackslash, authorityLeft }, steps };
 }
 
 /**

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
@@ -45,8 +45,12 @@ const AUTHORITY_TERMINATOR = /[/?#]/;
 /** Port must be all decimal digits (non-digit port => malformed). */
 const PORT_DIGITS = /^[0-9]+$/;
 
-/** Characters allowed inside a URL authority (userinfo) region (RFC 3986). */
-const AUTHORITY_CHAR = /[A-Za-z0-9._~!$&'()*+,;=:@%]/;
+/** Characters allowed inside a URL authority (userinfo) region (RFC 3986
+ *  unreserved + sub-delims + pct-encoded + `:` / `@`). Hyphen is included
+ *  because it is RFC 3986 unreserved: without it, a userinfo like
+ *  `ADR-0001` stops the backward authority scan at the `-` and the scheme
+ *  `://` is never reached (blocker #8). */
+const AUTHORITY_CHAR = /[A-Za-z0-9._~!$&'()*+,;=:@%-]/;
 
 /** One character of an RFC 3986 scheme token: ALPHA / DIGIT / "+" / "-" / ".". */
 const SCHEME_CHAR = /[A-Za-z0-9+\-.]/;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
@@ -238,6 +238,27 @@ export function scanAuthorityForward(
       }
       continue;
     }
+    // Scheme-terminator colon: WHATWG also accepts `https:` (0 slashes) and
+    // `https:/` (1 slash) as scheme URLs, but those forms hide the scheme
+    // from the "://" detector above and let a producer URL slip through as
+    // scheme-less. Treat 0/1-slash http(s) colons as rejected (malformed) by
+    // pointing rejectedSchemeStart at the scheme token start. The 2-slash
+    // valid case and the 3+-slash malformed case defer to the "://" branch
+    // (slashCount >= 2 falls through; `:` is an AUTHORITY_CHAR so the
+    // generic fallthrough is a no-op for it).
+    if (c === ":" && i >= 1 && ALPHA.test(line.charAt(i - 1))) {
+      let j = i - 1;
+      while (j > 0 && SCHEME_CHAR.test(line.charAt(j - 1))) j--;
+      const scheme = line.substring(j, i).toLowerCase();
+      if (scheme === "http" || scheme === "https") {
+        let slashCount = 0, k = i + 1;
+        while (slashCount < 3 && k < line.length && line.charAt(k) === "/") { slashCount++; k++; }
+        if (slashCount <= 1) {
+          rejectedSchemeStart = j; schemeStart = -1; authorityLeft = i + 1; hasBackslash = false;
+          continue;
+        }
+      }
+    }
     if (!AUTHORITY_CHAR.test(c)) {
       schemeStart = -1; authorityLeft = i + 1; hasBackslash = false;
       if (c !== "/") rejectedSchemeStart = -1;
@@ -261,12 +282,28 @@ export function findAuthorityEnd(line: string, from: number, urlEnd: number): nu
   return end;
 }
 
-/** Canonicalize a host token for evasion detection only: one ASCII
- * percent-decode pass + Unicode dot (U+3002, U+FF0E) replacement. Used to
- * detect percent-encoded / Unicode-dot hosts that canonicalize to a
- * recognized GitHub host. NOT used for producer/external classification. */
+/** Canonicalize a host token for evasion detection only: iterative UTF-8
+ *  percent-decode (up to 2 rounds, like decodeURIComponent) + Unicode dot
+ *  (U+3002, U+FF0E, U+FF61) replacement + ASCII lowercase. Used to detect
+ *  percent-encoded / Unicode-dot / double-encoded / case-variant hosts that
+ *  canonicalize to a recognized GitHub host. NOT used for producer/external
+ *  classification.
+ *
+ *  Decode rounds: round 1 resolves single encoding (`%67`->`g`) and exposes
+ *  UTF-8 sequences (`%E3%80%82`->U+3002); round 2 resolves double
+ *  percent-encoding (`%2567`->`%67`->`g`). Stops early when no `%` remains,
+ *  a round yields no change, or decodeURIComponent throws (invalid sequence)
+ *  -- the last successful result is kept, so a malformed tail never aborts
+ *  an otherwise-recognized host. Unicode-dot replacement and lowercasing
+ *  run AFTER decoding so encoded dots (`%E3%80%82`) and case variants
+ *  (`GITHUB\u3002COM`) both collapse to the lowercase ASCII form. */
 export function canonicalizeHostEvasion(raw: string): string {
-  return raw
-    .replace(/%([0-9A-Fa-f]{2})/g, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)))
-    .replace(/[\u3002\uFF0E]/g, ".");
+  let s = raw;
+  for (let round = 0; round < 2 && s.includes("%"); round++) {
+    let decoded: string;
+    try { decoded = decodeURIComponent(s); } catch { break; }
+    if (decoded === s) break;
+    s = decoded;
+  }
+  return s.replace(/[\u3002\uFF0E\uFF61]/g, ".").toLowerCase();
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
@@ -119,6 +119,11 @@ export interface AuthorityScan {
   readonly hasBackslash: boolean;
   /** Leftmost index reached by the walk (start of the authority evidence). */
   readonly authorityLeft: number;
+  /** Start index of a scheme token that cannot serve as a live http(s) scheme
+   * but precedes the host: unsupported scheme (ftp, evil, git+https), or a
+   * valid http(s) scheme invalidated by excessive slashes (`https:////`).
+   * The caller emits a malformed candidate from this index. -1 when none. */
+  readonly rejectedSchemeStart: number;
 }
 
 /**
@@ -135,6 +140,7 @@ export interface AuthorityScanCursor {
   readonly schemeStart: number;
   readonly authorityLeft: number;
   readonly hasBackslash: boolean;
+  readonly rejectedSchemeStart: number;
 }
 
 export const INITIAL_AUTHORITY_SCAN_CURSOR: AuthorityScanCursor = {
@@ -142,6 +148,7 @@ export const INITIAL_AUTHORITY_SCAN_CURSOR: AuthorityScanCursor = {
   schemeStart: -1,
   authorityLeft: 0,
   hasBackslash: false,
+  rejectedSchemeStart: -1,
 };
 
 export interface AuthorityScanResult {
@@ -182,6 +189,7 @@ export function scanAuthorityForward(
   let schemeStart = cursor.schemeStart;
   let authorityLeft = cursor.authorityLeft;
   let hasBackslash = cursor.hasBackslash;
+  let rejectedSchemeStart = cursor.rejectedSchemeStart;
   let steps = 0;
   while (pos + 1 < hostStart) {
     pos++;
@@ -196,24 +204,26 @@ export function scanAuthorityForward(
       const schemeEnd = i - 2;
       let j = schemeEnd - 1;
       if (j < 0 || !ALPHA.test(line.charAt(j))) {
-        schemeStart = -1; authorityLeft = i + 1; hasBackslash = false;
+        schemeStart = -1; authorityLeft = i + 1; hasBackslash = false; rejectedSchemeStart = -1;
         continue;
       }
       while (j > 0 && SCHEME_CHAR.test(line.charAt(j - 1))) j--;
       const scheme = line.substring(j, schemeEnd).toLowerCase();
       if (scheme === "http" || scheme === "https") {
         schemeStart = j; authorityLeft = j; hasBackslash = false;
+        rejectedSchemeStart = (i + 1 < line.length && line.charAt(i + 1) === "/") ? j : -1;
       } else {
-        schemeStart = -1; authorityLeft = i + 1; hasBackslash = false;
+        schemeStart = -1; authorityLeft = i + 1; hasBackslash = false; rejectedSchemeStart = j;
       }
       continue;
     }
     if (!AUTHORITY_CHAR.test(c)) {
       schemeStart = -1; authorityLeft = i + 1; hasBackslash = false;
+      if (c !== "/") rejectedSchemeStart = -1;
     }
   }
-  const nextCursor: AuthorityScanCursor = { pos, schemeStart, authorityLeft, hasBackslash };
-  return { cursor: nextCursor, scan: { schemeStart, hasBackslash, authorityLeft }, steps };
+  const nextCursor: AuthorityScanCursor = { pos, schemeStart, authorityLeft, hasBackslash, rejectedSchemeStart };
+  return { cursor: nextCursor, scan: { schemeStart, hasBackslash, authorityLeft, rejectedSchemeStart }, steps };
 }
 
 /**
@@ -228,4 +238,14 @@ export function findAuthorityEnd(line: string, from: number, urlEnd: number): nu
     end++;
   }
   return end;
+}
+
+/** Canonicalize a host token for evasion detection only: one ASCII
+ * percent-decode pass + Unicode dot (U+3002, U+FF0E) replacement. Used to
+ * detect percent-encoded / Unicode-dot hosts that canonicalize to a
+ * recognized GitHub host. NOT used for producer/external classification. */
+export function canonicalizeHostEvasion(raw: string): string {
+  return raw
+    .replace(/%([0-9A-Fa-f]{2})/g, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/[\u3002\uFF0E]/g, ".");
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
@@ -22,10 +22,22 @@
 //
 // Side-effect-free: pure over inputs.
 
-/** Recognized GitHub authority hosts. */
+/** Recognized GitHub authority hosts. The literal set is also the type
+ *  narrow: consumers branch exhaustively on `host === "github.com"` /
+ *  `"raw.githubusercontent.com"` with an `assertNever` final branch, so
+ *  adding a host here is a compile-breaking change surfaced at every
+ *  branch site (blocker #10: closes the silent implicit-else hole). */
 const GITHUB_HOST = "github.com";
 const RAW_HOST = "raw.githubusercontent.com";
-const RECOGNIZED_HOSTS: ReadonlySet<string> = new Set([GITHUB_HOST, RAW_HOST]);
+export type RecognizedHost = "github.com" | "raw.githubusercontent.com";
+
+/** Type guard: narrows `s` to RecognizedHost so the discriminated-union
+ *  variants below carry a typed host rather than `string`. Replaces the
+ *  prior `Set<string>.has` lookup, which left the host typed as `string`
+ *  and let an unreachable third-host branch compile silently. */
+function isRecognizedHost(s: string): s is RecognizedHost {
+  return s === GITHUB_HOST || s === RAW_HOST;
+}
 
 /** Authority terminator: first of these ends the authority region. */
 const AUTHORITY_TERMINATOR = /[/?#]/;
@@ -44,11 +56,15 @@ const ALPHA = /[A-Za-z]/;
 
 export type AuthorityKind = "valid" | "malformed" | "rejected";
 
-export interface AuthorityClassification {
-  readonly kind: AuthorityKind;
-  /** Lowercased recognized host when kind is valid or malformed; null otherwise. */
-  readonly host: string | null;
-}
+/** Discriminated by `kind`. The `valid` and `malformed` variants carry a
+ *  typed `RecognizedHost` (the host is by definition recognized for those
+ *  kinds); the `rejected` variant carries `null`. The narrow host type is
+ *  what makes the implicit-else branch in extractOwnerRepo a compile
+ *  error rather than a silent fallthrough (blocker #10). */
+export type AuthorityClassification =
+  | { readonly kind: "valid"; readonly host: RecognizedHost }
+  | { readonly kind: "malformed"; readonly host: RecognizedHost }
+  | { readonly kind: "rejected"; readonly host: null };
 
 /** Default port for a scheme: 443 for https, 80 for http, null otherwise. */
 function defaultPortForScheme(scheme: string | null): number | null {
@@ -81,7 +97,7 @@ export function classifyAuthority(url: string): AuthorityClassification {
     const colonIdx = seg.indexOf(":");
     const host = colonIdx === -1 ? seg : seg.substring(0, colonIdx);
     const hostLower = host.toLowerCase();
-    if (host.length > 0 && RECOGNIZED_HOSTS.has(hostLower)) {
+    if (host.length > 0 && isRecognizedHost(hostLower)) {
       return { kind: "malformed", host: hostLower };
     }
     return { kind: "rejected", host: null };
@@ -92,7 +108,7 @@ export function classifyAuthority(url: string): AuthorityClassification {
   const host = colonIdx === -1 ? hostPort : hostPort.substring(0, colonIdx);
   const portStr = colonIdx === -1 ? null : hostPort.substring(colonIdx + 1);
   const hostLower = host.toLowerCase();
-  if (!RECOGNIZED_HOSTS.has(hostLower)) return { kind: "rejected", host: null };
+  if (!isRecognizedHost(hostLower)) return { kind: "rejected", host: null };
   if (portStr !== null) {
     if (!PORT_DIGITS.test(portStr)) return { kind: "malformed", host: hostLower };
     const port = parseInt(portStr, 10);
@@ -106,6 +122,11 @@ export function classifyAuthority(url: string): AuthorityClassification {
  * Return the lowercased host of a URL whose authority is VALID, or null.
  * Malformed and rejected authorities return null so legacy callers
  * (extractOwnerRepo, isProducerOwnedUrl) treat them as non-GitHub.
+ *
+ * Kept as `string | null` (not `RecognizedHost | null`) so legacy callers
+ * that compare against `string` literals keep typechecking. New code that
+ * needs the narrow host should call `classifyAuthority` directly and read
+ * `cls.host` from the discriminated union (see extractOwnerRepo).
  */
 export function parseUrlHost(url: string): string | null {
   const cls = classifyAuthority(url);

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
@@ -287,23 +287,25 @@ export function findAuthorityEnd(line: string, from: number, urlEnd: number): nu
 }
 
 /** Canonicalize a host token for evasion detection only: iterative UTF-8
- *  percent-decode (up to 2 rounds, like decodeURIComponent) + Unicode dot
- *  (U+3002, U+FF0E, U+FF61) replacement + ASCII lowercase. Used to detect
- *  percent-encoded / Unicode-dot / double-encoded / case-variant hosts that
- *  canonicalize to a recognized GitHub host. NOT used for producer/external
- *  classification.
+ *  percent-decode (up to 3 rounds, extended from 2 for triple encoding)
+ *  + Unicode dot (U+3002, U+FF0E, U+FF61) replacement + ASCII lowercase.
+ *  Used to detect percent-encoded / Unicode-dot / double-encoded / case-variant
+ *  hosts that canonicalize to a recognized GitHub host. NOT used for
+ *  producer/external classification.
  *
  *  Decode rounds: round 1 resolves single encoding (`%67`->`g`) and exposes
  *  UTF-8 sequences (`%E3%80%82`->U+3002); round 2 resolves double
- *  percent-encoding (`%2567`->`%67`->`g`). Stops early when no `%` remains,
- *  a round yields no change, or decodeURIComponent throws (invalid sequence)
- *  -- the last successful result is kept, so a malformed tail never aborts
- *  an otherwise-recognized host. Unicode-dot replacement and lowercasing
- *  run AFTER decoding so encoded dots (`%E3%80%82`) and case variants
- *  (`GITHUB\u3002COM`) both collapse to the lowercase ASCII form. */
+ *  percent-encoding (`%2567`->`%67`->`g`); round 3 resolves triple
+ *  percent-encoding (`%252567`->`%2567`->`%67`->`g`). Stops early when
+ *  no `%` remains, a round yields no change, or decodeURIComponent throws
+ *  (invalid sequence) -- the last successful result is kept, so a malformed
+ *  tail never aborts an otherwise-recognized host. Unicode-dot replacement
+ *  and lowercasing run AFTER decoding so encoded dots (`%E3%80%82`) and
+ *  case variants (`GITHUB\u3002COM`) both collapse to the lowercase ASCII
+ *  form. */
 export function canonicalizeHostEvasion(raw: string): string {
   let s = raw;
-  for (let round = 0; round < 2 && s.includes("%"); round++) {
+  for (let round = 0; round < 3 && s.includes("%"); round++) {
     let decoded: string;
     try { decoded = decodeURIComponent(s); } catch { break; }
     if (decoded === s) break;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-authority.ts
@@ -1,0 +1,169 @@
+// Authority classification for the boundary URL extractor.
+//
+// Extracted from boundary-url-parser.ts to keep that module under the 250
+// pure LOC ceiling. One responsibility: classify a URL value's authority
+// as valid / malformed / rejected, and expose the backward authority scan
+// used to locate the scheme and detect backslash malformedness.
+//
+// Classification rules:
+//   - valid:     recognized host, no port OR port equals the scheme default
+//                (443 for https, 80 for http), no backslash in authority.
+//   - malformed: recognized host but the authority contains a backslash, OR
+//                a port is present that is not the scheme default (including
+//                any port on a scheme-less URL — without a scheme the port
+//                cannot be verified and the URL is treated as malformed).
+//   - rejected:  host is not a recognized GitHub authority (lookalike,
+//                userinfo-deception to a non-GitHub host, empty host, etc.).
+//
+// A malformed authority NEVER silently passes clean: the caller emits it as
+// a separate candidate (resolveCandidate -> unclassified/evasion-attempt)
+// whose ownership span covers only the authority region, so contained path
+// references stay independently visible.
+//
+// Side-effect-free: pure over inputs.
+
+/** Recognized GitHub authority hosts. */
+const GITHUB_HOST = "github.com";
+const RAW_HOST = "raw.githubusercontent.com";
+const RECOGNIZED_HOSTS: ReadonlySet<string> = new Set([GITHUB_HOST, RAW_HOST]);
+
+/** Authority terminator: first of these ends the authority region. */
+const AUTHORITY_TERMINATOR = /[/?#]/;
+
+/** Port must be all decimal digits (non-digit port => malformed). */
+const PORT_DIGITS = /^[0-9]+$/;
+
+/** Characters allowed inside a URL authority (userinfo) region (RFC 3986). */
+const AUTHORITY_CHAR = /[A-Za-z0-9._~!$&'()*+,;=:@%]/;
+
+/** One character of an RFC 3986 scheme token: ALPHA / DIGIT / "+" / "-" / ".". */
+const SCHEME_CHAR = /[A-Za-z0-9+\-.]/;
+
+export type AuthorityKind = "valid" | "malformed" | "rejected";
+
+export interface AuthorityClassification {
+  readonly kind: AuthorityKind;
+  /** Lowercased recognized host when kind is valid or malformed; null otherwise. */
+  readonly host: string | null;
+}
+
+/** Default port for a scheme: 443 for https, 80 for http, null otherwise. */
+function defaultPortForScheme(scheme: string | null): number | null {
+  if (scheme === "https") return 443;
+  if (scheme === "http") return 80;
+  return null;
+}
+
+/**
+ * Classify the authority of a URL value. The URL is the substring the scanner
+ * considers a candidate (scheme prefix when present, forward to the URL stop
+ * char). Classification is pure over this value.
+ */
+export function classifyAuthority(url: string): AuthorityClassification {
+  const schemeMatch = /^https?:\/\//i.exec(url);
+  const scheme = schemeMatch
+    ? schemeMatch[0].substring(0, schemeMatch[0].length - 3).toLowerCase()
+    : null;
+  const afterScheme = schemeMatch ? url.substring(schemeMatch[0].length) : url;
+  let authorityEnd = afterScheme.length;
+  for (let i = 0; i < afterScheme.length; i++) {
+    if (AUTHORITY_TERMINATOR.test(afterScheme.charAt(i))) { authorityEnd = i; break; }
+  }
+  const authority = afterScheme.substring(0, authorityEnd);
+  // Backslash makes the host position ambiguous. Classify by the segment
+  // after the last @ to decide recognized (malformed) vs rejected.
+  if (authority.includes("\\")) {
+    const atIdx = authority.lastIndexOf("@");
+    const seg = atIdx === -1 ? authority : authority.substring(atIdx + 1);
+    const colonIdx = seg.indexOf(":");
+    const host = colonIdx === -1 ? seg : seg.substring(0, colonIdx);
+    const hostLower = host.toLowerCase();
+    if (host.length > 0 && RECOGNIZED_HOSTS.has(hostLower)) {
+      return { kind: "malformed", host: hostLower };
+    }
+    return { kind: "rejected", host: null };
+  }
+  const atIdx = authority.lastIndexOf("@");
+  const hostPort = atIdx === -1 ? authority : authority.substring(atIdx + 1);
+  const colonIdx = hostPort.indexOf(":");
+  const host = colonIdx === -1 ? hostPort : hostPort.substring(0, colonIdx);
+  const portStr = colonIdx === -1 ? null : hostPort.substring(colonIdx + 1);
+  const hostLower = host.toLowerCase();
+  if (!RECOGNIZED_HOSTS.has(hostLower)) return { kind: "rejected", host: null };
+  if (portStr !== null) {
+    if (!PORT_DIGITS.test(portStr)) return { kind: "malformed", host: hostLower };
+    const port = parseInt(portStr, 10);
+    const def = defaultPortForScheme(scheme);
+    if (def === null || port !== def) return { kind: "malformed", host: hostLower };
+  }
+  return { kind: "valid", host: hostLower };
+}
+
+/**
+ * Return the lowercased host of a URL whose authority is VALID, or null.
+ * Malformed and rejected authorities return null so legacy callers
+ * (extractOwnerRepo, isProducerOwnedUrl) treat them as non-GitHub.
+ */
+export function parseUrlHost(url: string): string | null {
+  const cls = classifyAuthority(url);
+  return cls.kind === "valid" ? cls.host : null;
+}
+
+export interface AuthorityScan {
+  /** Start index of an http(s):// scheme whose authority ends at hostStart, or -1. */
+  readonly schemeStart: number;
+  /** True when a backslash was crossed during the backward walk. */
+  readonly hasBackslash: boolean;
+  /** Leftmost index reached by the walk (start of the authority evidence). */
+  readonly authorityLeft: number;
+}
+
+/**
+ * Walk backward from `hostStart - 1` through the lexical authority region
+ * (RFC 3986 authority chars AND backslash) to locate an http(s):// scheme
+ * and detect backslash malformedness. The walk stops at any char that is
+ * neither an authority char nor a backslash (whitespace, a path separator
+ * from a DIFFERENT token, etc.), so a later bare host never grabs an
+ * earlier URL's scheme. Crossing a backslash sets hasBackslash so the
+ * caller emits a malformed candidate rather than silently dropping it.
+ */
+export function scanAuthorityBackward(line: string, hostStart: number): AuthorityScan {
+  let i = hostStart - 1;
+  let hasBackslash = false;
+  while (i >= 0) {
+    const c = line.charAt(i);
+    if (c === "\\") { hasBackslash = true; i--; continue; }
+    if (i >= 2 && line.substring(i - 2, i + 1) === "://") {
+      const schemeEnd = i - 2;
+      let j = schemeEnd - 1;
+      if (j < 0 || !/[A-Za-z]/.test(line.charAt(j))) {
+        return { schemeStart: -1, hasBackslash, authorityLeft: i + 1 };
+      }
+      while (j > 0 && SCHEME_CHAR.test(line.charAt(j - 1))) j--;
+      const scheme = line.substring(j, schemeEnd).toLowerCase();
+      if (scheme === "http" || scheme === "https") {
+        return { schemeStart: j, hasBackslash, authorityLeft: j };
+      }
+      return { schemeStart: -1, hasBackslash, authorityLeft: i + 1 };
+    }
+    if (!AUTHORITY_CHAR.test(c)) {
+      return { schemeStart: -1, hasBackslash, authorityLeft: i + 1 };
+    }
+    i--;
+  }
+  return { schemeStart: -1, hasBackslash, authorityLeft: 0 };
+}
+
+/**
+ * Find the end index (exclusive) of the authority region: the first `/`,
+ * `?`, or `#` at or after `from`, or `urlEnd` when none is found.
+ */
+export function findAuthorityEnd(line: string, from: number, urlEnd: number): number {
+  let end = from;
+  while (end < urlEnd) {
+    const c = line.charAt(end);
+    if (c === "/" || c === "?" || c === "#") break;
+    end++;
+  }
+  return end;
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -30,6 +30,7 @@
 
 import type { Span } from "./boundary-candidate-ownership.ts";
 import {
+  canonicalizeHostEvasion,
   classifyAuthority,
   findAuthorityEnd,
   INITIAL_AUTHORITY_SCAN_CURSOR,
@@ -44,12 +45,19 @@ const REPO_PATTERN = /^[A-Za-z0-9_.-]+$/;
 /** Scan pattern: case-insensitive recognized host followed by `/` or `:`. */
 const HOST_SCAN = /(?:github\.com|raw\.githubusercontent\.com)(?=[/:])/gi;
 
+/** Evasion host scan: bounded run of host-like chars (including percent-encoded
+ * and Unicode dots) followed by `/` or `:`. Bounded to 80 to prevent O(n²)
+ * backtracking on adversarial long runs; longest recognized host fully
+ * percent-encoded is 72 chars. Post-filtered by canonicalization. */
+const EVASION_HOST_TOKEN = /(?:%[0-9A-Fa-f]{2}|[A-Za-z0-9.\u3002\uFF0E-]){1,80}(?=[/:])/g;
+
 /** URL end exclusion set: terminates URL ownership at boundary markers.
- * Includes opening delimiters `(` `[` `{` and full-width colon U+FF1A.
+ * Backslash is NOT here (it sets pathHasBackslash and extends the URL, marking
+ * it malformed). Em dash U+2014 terminates so trailing IDs stay visible.
  * ASCII `:` is conditional (handled in the forward scan): it terminates
  * only in the path component, not in the authority (`:port`) or inside
  * a query (`?...`) / fragment (`#...`). */
-const URL_STOP_CHAR = /[\s()\[\]|\\"'`<>{},;\u3001\u3002\uFF1B\uFF0C\uFF01\uFF1F\uFF1A]/;
+const URL_STOP_CHAR = /[\s()\[\]|"'`<>{},;\u3001\u3002\uFF1B\uFF0C\uFF01\uFF1F\uFF1A\u2014]/;
 
 /** Preceding char rejects the left boundary (host/path/query continuation). */
 const LEFT_REJECT_CHAR = /[A-Za-z0-9._@:?#&=\\/-]/;
@@ -143,10 +151,12 @@ export function extractUrls(line: string, cap: number): {
     let inPath = false;
     let inQueryOrFrag = false;
     let firstQueryOrFrag = -1;
+    let pathHasBackslash = false;
     while (urlEnd < line.length) {
       steps++;
       const c = line.charAt(urlEnd);
       if (URL_STOP_CHAR.test(c)) break;
+      if (c === "\\") { pathHasBackslash = true; urlEnd++; continue; }
       if (c === "?" || c === "#") {
         if (firstQueryOrFrag === -1) firstQueryOrFrag = urlEnd;
         inQueryOrFrag = true;
@@ -161,34 +171,45 @@ export function extractUrls(line: string, cap: number): {
       out.push({ value: line.substring(aStart, authorityEnd), span: { start: aStart, end: authorityEnd }, malformed: true, ownershipSpan: null });
       continue;
     }
-    if (scan.schemeStart !== -1) {
-      if (!isValidLeftBoundary(line, scan.schemeStart, true)) continue;
-      const value = line.substring(scan.schemeStart, urlEnd);
-      const cls = classifyAuthority(value);
-      if (cls.kind === "rejected") continue;
-      if (cls.kind === "malformed") {
-        if (out.length >= cap) return { urls: out, overflow: true, steps };
-        out.push({ value: line.substring(scan.schemeStart, authorityEnd), span: { start: scan.schemeStart, end: authorityEnd }, malformed: true, ownershipSpan: null });
-        continue;
-      }
-      if (extractOwnerRepo(value) === null) continue;
+    if (scan.rejectedSchemeStart !== -1) {
       if (out.length >= cap) return { urls: out, overflow: true, steps };
-      out.push({ value, span: { start: scan.schemeStart, end: urlEnd }, malformed: false, ownershipSpan: ownershipSpanFor(scan.schemeStart, urlEnd, firstQueryOrFrag) });
+      out.push({ value: line.substring(scan.rejectedSchemeStart, urlEnd), span: { start: scan.rejectedSchemeStart, end: urlEnd }, malformed: true, ownershipSpan: null });
       continue;
     }
-    // Scheme-less host.
-    if (!isValidLeftBoundary(line, hostStart, false)) continue;
-    const value = line.substring(hostStart, urlEnd);
+    const urlStart = scan.schemeStart !== -1 ? scan.schemeStart : hostStart;
+    const hasScheme = scan.schemeStart !== -1;
+    if (!isValidLeftBoundary(line, urlStart, hasScheme)) continue;
+    const value = line.substring(urlStart, urlEnd);
     const cls = classifyAuthority(value);
     if (cls.kind === "rejected") continue;
-    if (cls.kind === "malformed") {
+    if (cls.kind === "malformed" || pathHasBackslash || hasDotSegment(value)) {
+      const mEnd = cls.kind === "malformed" ? authorityEnd : urlEnd;
       if (out.length >= cap) return { urls: out, overflow: true, steps };
-      out.push({ value: line.substring(hostStart, authorityEnd), span: { start: hostStart, end: authorityEnd }, malformed: true, ownershipSpan: null });
+      out.push({ value: line.substring(urlStart, mEnd), span: { start: urlStart, end: mEnd }, malformed: true, ownershipSpan: null });
       continue;
     }
     if (extractOwnerRepo(value) === null) continue;
     if (out.length >= cap) return { urls: out, overflow: true, steps };
-    out.push({ value, span: { start: hostStart, end: urlEnd }, malformed: false, ownershipSpan: ownershipSpanFor(hostStart, urlEnd, firstQueryOrFrag) });
+    out.push({ value, span: { start: urlStart, end: urlEnd }, malformed: false, ownershipSpan: ownershipSpanFor(urlStart, urlEnd, firstQueryOrFrag) });
+  }
+  EVASION_HOST_TOKEN.lastIndex = 0;
+  for (let em: RegExpExecArray | null; (em = EVASION_HOST_TOKEN.exec(line)) !== null;) {
+    const raw = em[0];
+    const lower = raw.toLowerCase();
+    if (lower === "github.com" || lower === "raw.githubusercontent.com") continue;
+    const canonical = canonicalizeHostEvasion(raw);
+    if (canonical !== "github.com" && canonical !== "raw.githubusercontent.com") continue;
+    const ts = em.index;
+    if (out.some((u) => u.span.start <= ts && ts < u.span.end)) continue;
+    if (out.length >= cap) return { urls: out, overflow: true, steps };
+    let ue = ts + raw.length;
+    while (ue < line.length) {
+      steps++;
+      const ch = line.charAt(ue);
+      if (URL_STOP_CHAR.test(ch) || ch === "\\") break;
+      ue++;
+    }
+    out.push({ value: line.substring(ts, ue), span: { start: ts, end: ue }, malformed: true, ownershipSpan: null });
   }
   return { urls: out, overflow: false, steps };
 }
@@ -206,4 +227,17 @@ function isValidLeftBoundary(line: string, pos: number, hasScheme: boolean): boo
   // (param separator) so a URL nested in a parent URL's query is detected.
   if (hasScheme && (prev === "=" || prev === "&")) return true;
   return !LEFT_REJECT_CHAR.test(prev);
+}
+
+/** True when the URL path contains a dot-segment (`.`, `..`, `%2e`, `%2E`,
+ * `%2e%2e`, `%2E%2E`) in the owner/repo/tail position. RFC 3986 reserves these
+ * for relative-path resolution; they never appear in a concrete GitHub URL. */
+function hasDotSegment(url: string): boolean {
+  const m = /^([A-Za-z][A-Za-z0-9.+-]*:\/\/)?[^/]+\//.exec(url);
+  if (!m) return false;
+  for (const seg of url.substring(m[0].length).split("/")) {
+    const lower = seg.toLowerCase();
+    if (seg === "." || seg === ".." || lower === "%2e" || lower === "%2e%2e") return true;
+  }
+  return false;
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -46,11 +46,6 @@ const HOST_SCAN = /(?:github\.com|raw\.githubusercontent\.com)\//gi;
  */
 const URL_STOP_CHAR = /[\s)\]|\\"'`<>{},;\u3001\u3002\uFF1B\uFF0C\uFF01\uFF1F]/;
 
-/** Scheme prefix lookbehind: accept when the 3 chars before the host are `://`. */
-function precededBySchemeSeparator(line: string, hostStart: number): boolean {
-  return hostStart >= 3 && line.substring(hostStart - 3, hostStart) === "://";
-}
-
 /** Preceding char rejects the left boundary (host/path/query continuation). */
 const LEFT_REJECT_CHAR = /[A-Za-z0-9._@:?#&=\\/-]/;
 
@@ -160,7 +155,6 @@ export function extractUrls(line: string, cap: number): {
 } {
   const out: ExtractedUrl[] = [];
   HOST_SCAN.lastIndex = 0;
-  let m: RegExpExecArray | null;
   for (let m: RegExpExecArray | null; (m = HOST_SCAN.exec(line)) !== null;) {
     const matchEnd = m.index + m[0].length; // index right after the trailing `/`
     // The host starts at m.index. But the regex may have matched a host
@@ -181,22 +175,6 @@ export function extractUrls(line: string, cap: number): {
     out.push({ value, span: { start, end } });
   }
   return { urls: out, overflow: false };
-}
-
-/** Find the start index of an `http(s)://` scheme ending exactly at `end`. */
-function findSchemeStart(line: string, end: number): number {
-  // `end` points at the `g` of `github.com` (or `r` of `raw.`), so
-  // line.substring(end-3, end) === "://". The scheme name precedes `://`.
-  const schemeSearchEnd = end - 3; // position of `:`
-  // Walk back from schemeSearchEnd-1 over scheme-name chars `[A-Za-z]`.
-  let i = schemeSearchEnd - 1;
-  while (i >= 0 && /[A-Za-z]/.test(line.charAt(i))) i--;
-  // i is now one position before the first scheme char. The scheme is
-  // line.substring(i+1, schemeSearchEnd). Accept only http/https (no
-  // credential-bearing schemes like password://).
-  const scheme = line.substring(i + 1, schemeSearchEnd).toLowerCase();
-  if (scheme === "http" || scheme === "https") return i + 1;
-  return -1;
 }
 
 /** Find the start index of an `http(s)://` scheme before the host position.

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -36,8 +36,12 @@ const REPO_PATTERN = /^[A-Za-z0-9_.-]+$/;
 /** Scan pattern: case-insensitive recognized host followed by `/` or `:`. */
 const HOST_SCAN = /(?:github\.com|raw\.githubusercontent\.com)(?=[/:])/gi;
 
-/** URL end exclusion set: terminates URL ownership at boundary markers. */
-const URL_STOP_CHAR = /[\s)\]|\\"'`<>{},;\u3001\u3002\uFF1B\uFF0C\uFF01\uFF1F]/;
+/** URL end exclusion set: terminates URL ownership at boundary markers.
+ * Includes opening delimiters `(` `[` `{` and full-width colon U+FF1A.
+ * ASCII `:` is conditional (handled in the forward scan): it terminates
+ * only in the path component, not in the authority (`:port`) or inside
+ * a query (`?...`) / fragment (`#...`). */
+const URL_STOP_CHAR = /[\s()\[\]|\\"'`<>{},;\u3001\u3002\uFF1B\uFF0C\uFF01\uFF1F\uFF1A]/;
 
 /** Preceding char rejects the left boundary (host/path/query continuation). */
 const LEFT_REJECT_CHAR = /[A-Za-z0-9._@:?#&=\\/-]/;
@@ -111,7 +115,16 @@ export function extractUrls(line: string, cap: number): {
     const hostEnd = hostStart + m[0].length;
     const scan = scanAuthorityBackward(line, hostStart);
     let urlEnd = hostEnd;
-    while (urlEnd < line.length && !URL_STOP_CHAR.test(line.charAt(urlEnd))) urlEnd++;
+    let inPath = false;
+    let inQueryOrFrag = false;
+    while (urlEnd < line.length) {
+      const c = line.charAt(urlEnd);
+      if (URL_STOP_CHAR.test(c)) break;
+      if (c === "?" || c === "#") inQueryOrFrag = true;
+      else if (c === "/") { if (!inQueryOrFrag) inPath = true; }
+      else if (c === ":" && inPath && !inQueryOrFrag) break;
+      urlEnd++;
+    }
     const authorityEnd = findAuthorityEnd(line, hostEnd, urlEnd);
     if (scan.hasBackslash) {
       const aStart = scan.schemeStart !== -1 ? scan.schemeStart : scan.authorityLeft;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -9,6 +9,13 @@
 //   - Scheme form: `https?://[userinfo@]host[:port][/path][?query][#frag]`.
 //     Port is NOT supported: `host:port` is rejected (host with `:` is not
 //     a valid hostname for the GitHub authority).
+//   - Scheme discovery walks only the lexical authority/userinfo region
+//     immediately preceding the host and parses the full RFC 3986 scheme
+//     token. Only exactly `http`/`https` is accepted, so composite schemes
+//     such as `git+https://` are unsupported and cannot own/hide contained
+//     producer references. The walk never crosses whitespace, a path
+//     separator, or another token, so a later bare host never grabs an
+//     earlier URL's scheme.
 //   - Userinfo is stripped via the LAST `@` so `https://github.com@evil.com`
 //     is parsed as userinfo=`github.com`, host=`evil.com` — not a GitHub
 //     authority.
@@ -49,13 +56,19 @@ const URL_STOP_CHAR = /[\s)\]|\\"'`<>{},;\u3001\u3002\uFF1B\uFF0C\uFF01\uFF1F]/;
 /** Preceding char rejects the left boundary (host/path/query continuation). */
 const LEFT_REJECT_CHAR = /[A-Za-z0-9._@:?#&=\\/-]/;
 
+/** Characters allowed inside a URL authority (userinfo) region (RFC 3986). */
+const AUTHORITY_CHAR = /[A-Za-z0-9._~!$&'()*+,;=:@%]/;
+
+/** One character of an RFC 3986 scheme token: ALPHA / DIGIT / "+" / "-" / ".". */
+const SCHEME_CHAR = /[A-Za-z0-9+\-.]/;
+
 /**
  * Decide whether `hostStart` is a valid left boundary for a scheme-less
  * authority. Returns true when the host begins the URL (start of line,
  * whitespace, opening punctuation, etc.) or is preceded by `://`.
  *
  * When the host is preceded by `://`, the scheme must be http or https.
- * Unsupported schemes (evil://, ftp://, etc.) cause rejection.
+ * Unsupported schemes (evil://, ftp://, git+https://, etc.) cause rejection.
  *
  * For scheme URLs, we validate the boundary at the scheme start, not at
  * the host start, to correctly handle userinfo.
@@ -177,20 +190,29 @@ export function extractUrls(line: string, cap: number): {
   return { urls: out, overflow: false };
 }
 
-/** Find the start index of an `http(s)://` scheme before the host position.
- * Returns -1 if the scheme is not http/https.
+/**
+ * Find the start index of an `http(s)://` scheme whose authority ends at
+ * `hostStart`. Walks backward ONLY through the lexical authority/userinfo
+ * region, so whitespace, a path separator, or another token halts the walk
+ * and yields -1 — a later bare host can never grab an earlier URL's scheme.
+ * When `://` is reached, the full RFC-style scheme token is parsed and
+ * accepted only when it is exactly `http` or `https`; composite schemes
+ * such as `git+https` are unsupported and return -1.
  */
 function findSchemeStartBeforeHost(line: string, hostStart: number): number {
-  // Look for `://` pattern before the host. The scheme is immediately before `://`.
-  for (let i = hostStart - 1; i >= 3; i--) {
+  let i = hostStart - 1;
+  while (i >= 3) {
     if (line.substring(i - 2, i + 1) === "://") {
-      // Found `://` at positions i-2, i-1, i. Check if the preceding chars form http or https.
       const schemeEnd = i - 2;
       let j = schemeEnd - 1;
-      while (j >= 0 && /[A-Za-z]/.test(line.charAt(j))) j--;
-      const scheme = line.substring(j + 1, schemeEnd).toLowerCase();
-      if (scheme === "http" || scheme === "https") return j + 1;
+      if (j < 0 || !/[A-Za-z]/.test(line.charAt(j))) return -1;
+      while (j > 0 && SCHEME_CHAR.test(line.charAt(j - 1))) j--;
+      const scheme = line.substring(j, schemeEnd).toLowerCase();
+      if (scheme === "http" || scheme === "https") return j;
+      return -1;
     }
+    if (!AUTHORITY_CHAR.test(line.charAt(i))) return -1;
+    i--;
   }
   return -1;
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -225,12 +225,12 @@ export function extractUrls(line: string, cap: number): {
     const effectiveUrlStart = !hasScheme && scan.authorityLeft < hostStart && line.substring(scan.authorityLeft, hostStart).includes("@")
       ? scan.authorityLeft
       : urlStart;
-    // Scheme-less recognized host after a query-assignment delimiter (`=` or
-    // `&`) is ambiguous: standalone URL or a value nested in a parent URL's
-    // query. Without a scheme the detector cannot tell, so fail closed by
-    // emitting malformed rather than skipping (blocker #2). The `!hasScheme`
-    // guard keeps scheme URLs accepted (`url=https://github.com/...` stays valid).
-    if (!hasScheme && effectiveUrlStart > 0 && (line.charAt(effectiveUrlStart - 1) === "=" || line.charAt(effectiveUrlStart - 1) === "&")) {
+    // Scheme-less recognized host after a delimiter (`=`, `&`, `:`, `?`, `#`)
+    // is ambiguous: standalone URL or a value nested in a parent URL's
+    // query/fragment. Without a scheme the detector cannot tell, so fail closed
+    // by emitting malformed rather than skipping. The `!hasScheme` guard keeps
+    // scheme URLs accepted (`url=https://github.com/...` stays valid).
+    if (!hasScheme && effectiveUrlStart > 0 && isDelimiterChar(line.charAt(effectiveUrlStart - 1))) {
       if (out.length >= cap) return { urls: out, overflow: true, steps };
       out.push({ value: line.substring(effectiveUrlStart, authorityEnd), span: { start: effectiveUrlStart, end: authorityEnd }, malformed: true, ownershipSpan: null });
       continue;
@@ -300,10 +300,15 @@ function ownershipSpanFor(authorityEnd: number, end: number, firstQueryOrFrag: n
 function isValidLeftBoundary(line: string, pos: number, hasScheme: boolean): boolean {
   if (pos === 0) return true;
   const prev = line.charAt(pos - 1);
-  // Scheme URLs are unambiguous; accept `=` (query-param value) and `&`
-  // (param separator) so a URL nested in a parent URL's query is detected.
-  if (hasScheme && (prev === "=" || prev === "&")) return true;
+  // Scheme URLs are unambiguous; accept delimiter chars (`=`, `&`, `:`, `?`,
+  // `#`) so a URL nested in a parent URL's query, a YAML value, or a fragment
+  // is detected rather than silently skipped.
+  if (hasScheme && isDelimiterChar(prev)) return true;
   return !LEFT_REJECT_CHAR.test(prev);
+}
+
+function isDelimiterChar(ch: string): boolean {
+  return ch === "=" || ch === "&" || ch === ":" || ch === "?" || ch === "#";
 }
 
 /** True when the URL path contains a dot-segment in the owner/repo/tail

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -1,0 +1,188 @@
+// Authority-aware URL extractor for the distribution boundary detector.
+//
+// Extracted from boundary-candidate-model.ts to keep that module under the
+// 250 pure LOC ceiling and to make the URL lexer independently testable.
+// One responsibility: turn a line into URL candidate spans whose host is
+// exactly `github.com` or `raw.githubusercontent.com`.
+//
+// Authority model (no URL dependency):
+//   - Scheme form: `https?://[userinfo@]host[:port][/path][?query][#frag]`.
+//     Port is NOT supported: `host:port` is rejected (host with `:` is not
+//     a valid hostname for the GitHub authority).
+//   - Userinfo is stripped via the LAST `@` so `https://github.com@evil.com`
+//     is parsed as userinfo=`github.com`, host=`evil.com` — not a GitHub
+//     authority.
+//   - Host comparison is case-insensitive (host lowercased). Owner/repo
+//     comparison is case-insensitive (GitHub legacy). Directory family
+//     names elsewhere remain case-sensitive (NOT this module's concern).
+//   - Host suffix / subdomain / path lookalikes are rejected: host must
+//     equal `github.com` or `raw.githubusercontent.com` exactly. So
+//     `notgithub.com`, `github.com.evil.com`, `evil.github.com`, and
+//     `example.com/github.com/...` are NOT GitHub authorities.
+//   - Scheme-less `github.com/...` and `raw.githubusercontent.com/...`
+//     are supported only at a valid left boundary: the char before the
+//     host must NOT be a host/path/query/fragment continuation char
+//     (`[A-Za-z0-9._@:?#&=\\/-]`), except the `://` scheme separator is
+//     accepted (so the host of a scheme URL is matched).
+//
+// Side-effect-free: pure over inputs.
+
+import type { Span } from "./boundary-candidate-ownership.ts";
+
+/** URL authority hosts the detector recognizes. */
+const GITHUB_HOST = "github.com";
+const RAW_HOST = "raw.githubusercontent.com";
+const RECOGNIZED_HOSTS: ReadonlySet<string> = new Set([GITHUB_HOST, RAW_HOST]);
+
+const OWNER_PATTERN = /^[A-Za-z0-9_-]+$/;
+const REPO_PATTERN = /^[A-Za-z0-9_.-]+$/;
+
+/** Scan pattern: case-insensitive `github.com/` or `raw.githubusercontent.com/`. */
+const HOST_SCAN = /(?:github\.com|raw\.githubusercontent\.com)\//gi;
+
+/** URL end exclusion set (matches the legacy URL_CANDIDATE_PATTERN). */
+const URL_STOP_CHAR = /[\s)\]|\\"'`<>{}]/;
+
+/** Scheme prefix lookbehind: accept when the 3 chars before the host are `://`. */
+function precededBySchemeSeparator(line: string, hostStart: number): boolean {
+  return hostStart >= 3 && line.substring(hostStart - 3, hostStart) === "://";
+}
+
+/** Preceding char rejects the left boundary (host/path/query continuation). */
+const LEFT_REJECT_CHAR = /[A-Za-z0-9._@:?#&=\\/-]/;
+
+/**
+ * Decide whether `hostStart` is a valid left boundary for a scheme-less
+ * authority. Returns true when the host begins the URL (start of line,
+ * whitespace, opening punctuation, etc.) or is preceded by `://`.
+ */
+function isValidLeftBoundary(line: string, hostStart: number): boolean {
+  if (hostStart === 0) return true;
+  if (precededBySchemeSeparator(line, hostStart)) return true;
+  const prev = line.charAt(hostStart - 1);
+  return !LEFT_REJECT_CHAR.test(prev);
+}
+
+/**
+ * Parse the authority of a URL value and return the lowercased host, or
+ * null when the URL has a port (unsupported) or no parseable authority.
+ *
+ * Precondition: caller ensures the URL value starts at a valid boundary
+ * (scheme form OR scheme-less host). The host is the part of the authority
+ * after the last `@` (userinfo stripped) and before any `:port`.
+ */
+export function parseUrlHost(url: string): string | null {
+  const schemeMatch = /^https?:\/\//i.exec(url);
+  const afterScheme = schemeMatch ? url.substring(schemeMatch[0].length) : url;
+  let authorityEnd = afterScheme.length;
+  for (let i = 0; i < afterScheme.length; i++) {
+    const c = afterScheme.charAt(i);
+    if (c === "/" || c === "?" || c === "#") { authorityEnd = i; break; }
+  }
+  const authority = afterScheme.substring(0, authorityEnd);
+  const atIdx = authority.lastIndexOf("@");
+  const hostPort = atIdx === -1 ? authority : authority.substring(atIdx + 1);
+  // Reject port form: a `:` in the host segment is not a valid hostname.
+  if (hostPort.includes(":")) return null;
+  return hostPort.toLowerCase();
+}
+
+/**
+ * Extract `owner/repo` from a URL value whose host is a recognized GitHub
+ * authority, or null when the URL does not point at GitHub. Authority-aware:
+ * the URL must host-match exactly (case-insensitive). Path-lookalike and
+ * userinfo-deception URLs return null because their host is not GitHub.
+ */
+export function extractOwnerRepo(url: string): string | null {
+  const host = parseUrlHost(url);
+  if (host === null || !RECOGNIZED_HOSTS.has(host)) return null;
+  const schemeMatch = /^https?:\/\//i.exec(url);
+  const afterScheme = schemeMatch ? url.substring(schemeMatch[0].length) : url;
+  const slashIdx = afterScheme.indexOf("/");
+  if (slashIdx === -1) return null;
+  const segments = afterScheme.substring(slashIdx + 1).split("/");
+  const owner = segments[0];
+  const repo = segments[1];
+  if (owner === undefined || repo === undefined) return null;
+  if (!OWNER_PATTERN.test(owner) || !REPO_PATTERN.test(repo)) return null;
+  if (host === GITHUB_HOST) {
+    const action = segments[2];
+    const tail = segments[3];
+    if ((action !== "blob" && action !== "raw") || tail === undefined || tail.length === 0) return null;
+  } else {
+    const tail = segments[2];
+    if (tail === undefined || tail.length === 0) return null;
+  }
+  return `${owner}/${repo}`;
+}
+
+/** True when the URL points into the producer's own repo (case-insensitive). */
+export function isProducerOwnedUrl(url: string, identity: { readonly owner_slash_name: string }): boolean {
+  if (identity.owner_slash_name.length === 0) return false;
+  const ownerRepo = extractOwnerRepo(url);
+  if (ownerRepo === null) return false;
+  return ownerRepo.toLowerCase() === identity.owner_slash_name.toLowerCase();
+}
+
+export interface ExtractedUrl {
+  readonly value: string;
+  readonly span: Span;
+}
+
+/**
+ * Scan a line for URL candidates whose host is a recognized GitHub
+ * authority. Returns at most `cap` entries; the boolean `overflow` flag
+ * is set when the cap is reached mid-scan (the caller MUST surface a
+ * typed overflow in that case — ownership never suppresses overflow).
+ *
+ * For each scan hit, the left boundary is checked. The URL value extends
+ * backward to include the scheme prefix when the host is immediately
+ * preceded by `://`, and forward until the first URL stop char.
+ */
+export function extractUrls(line: string, cap: number): {
+  readonly urls: readonly ExtractedUrl[];
+  readonly overflow: boolean;
+} {
+  const out: ExtractedUrl[] = [];
+  HOST_SCAN.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = HOST_SCAN.exec(line)) !== null) {
+    const matchEnd = m.index + m[0].length; // index right after the trailing `/`
+    // The host starts at m.index. But the regex may have matched a host
+    // continuation like the `github.com/` inside `notgithub.com/`: the
+    // preceding char rejects the boundary in that case.
+    const hostStart = m.index;
+    if (!isValidLeftBoundary(line, hostStart)) continue;
+    // Extend URL start back to include the scheme prefix when present.
+    let start = hostStart;
+    if (precededBySchemeSeparator(line, hostStart)) {
+      // Find the scheme start: `http://` or `https://` ending at hostStart.
+      const schemeStart = findSchemeStart(line, hostStart);
+      if (schemeStart !== -1) start = schemeStart;
+    }
+    // Extend URL end forward until the first URL stop char.
+    let end = matchEnd;
+    while (end < line.length && !URL_STOP_CHAR.test(line.charAt(end))) end++;
+    const value = line.substring(start, end);
+    if (extractOwnerRepo(value) === null) continue;
+    if (out.length >= cap) return { urls: out, overflow: true };
+    out.push({ value, span: { start, end } });
+  }
+  return { urls: out, overflow: false };
+}
+
+/** Find the start index of an `http(s)://` scheme ending exactly at `end`. */
+function findSchemeStart(line: string, end: number): number {
+  // `end` points at the `g` of `github.com` (or `r` of `raw.`), so
+  // line.substring(end-3, end) === "://". The scheme name precedes `://`.
+  const schemeSearchEnd = end - 3; // position of `:`
+  // Walk back from schemeSearchEnd-1 over scheme-name chars `[A-Za-z]`.
+  let i = schemeSearchEnd - 1;
+  while (i >= 0 && /[A-Za-z]/.test(line.charAt(i))) i--;
+  // i is now one position before the first scheme char. The scheme is
+  // line.substring(i+1, schemeSearchEnd). Accept only http/https (no
+  // credential-bearing schemes like password://).
+  const scheme = line.substring(i + 1, schemeSearchEnd).toLowerCase();
+  if (scheme === "http" || scheme === "https") return i + 1;
+  return -1;
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -34,22 +34,28 @@ import {
   classifyAuthority,
   findAuthorityEnd,
   INITIAL_AUTHORITY_SCAN_CURSOR,
-  parseUrlHost,
   scanAuthorityForward,
   type AuthorityScanCursor,
+  type RecognizedHost,
 } from "./boundary-url-authority.ts";
 
 const OWNER_PATTERN = /^[A-Za-z0-9_-]+$/;
 const REPO_PATTERN = /^[A-Za-z0-9_.-]+$/;
 
-/** Scan pattern: case-insensitive recognized host followed by `/` or `:`. */
-const HOST_SCAN = /(?:github\.com|raw\.githubusercontent\.com)(?=[/:])/gi;
+/** Scan pattern: case-insensitive recognized host followed by `/`, `:`,
+ *  or `\`. The backslash terminator catches `github.com\@evil.com/...`
+ *  and `github.com\evil.com/...` — both make the host position ambiguous
+ *  (a backslash is path-like in Win32 but illegal in a URL host) and are
+ *  emitted as malformed rather than skipped (blocker #1, P0). */
+const HOST_SCAN = /(?:github\.com|raw\.githubusercontent\.com)(?=[/:\\])/gi;
 
 /** Evasion host scan: bounded run of host-like chars (including percent-encoded
- * and Unicode dots) followed by `/` or `:`. Bounded to 80 to prevent O(n²)
- * backtracking on adversarial long runs; longest recognized host fully
- * percent-encoded is 72 chars. Post-filtered by canonicalization. */
-const EVASION_HOST_TOKEN = /(?:%[0-9A-Fa-f]{2}|[A-Za-z0-9.\u3002\uFF0E-]){1,80}(?=[/:])/g;
+ *  and Unicode dots) followed by `/`, `:`, or `\`. Bounded to 80 to prevent
+ *  O(n²) backtracking on adversarial long runs; longest recognized host fully
+ *  percent-encoded is 72 chars. Post-filtered by canonicalization. The
+ *  backslash terminator mirrors HOST_SCAN so percent-encoded / Unicode-dot
+ *  hosts followed by a backslash are also caught. */
+const EVASION_HOST_TOKEN = /(?:%[0-9A-Fa-f]{2}|[A-Za-z0-9.\u3002\uFF0E-]){1,80}(?=[/:\\])/g;
 
 /** URL end exclusion set: terminates URL ownership at boundary markers.
  * Backslash is NOT here (it sets pathHasBackslash and extends the URL, marking
@@ -67,10 +73,16 @@ const LEFT_REJECT_CHAR = /[A-Za-z0-9._@:?#&=\\/-]/;
  * GitHub authority (default port accepted; malformed port or backslash
  * authority returns null). Path-lookalike and userinfo-deception URLs return
  * null because their host is not a recognized GitHub authority.
+ *
+ * Calls `classifyAuthority` directly (not `parseUrlHost`) so the host is
+ * typed as `RecognizedHost` and the host branch below is exhaustive:
+ * adding a new recognized host without updating this function is a
+ * compile error via `assertNeverRecognizedHost` (blocker #10).
  */
 export function extractOwnerRepo(url: string): string | null {
-  const host = parseUrlHost(url);
-  if (host === null) return null;
+  const cls = classifyAuthority(url);
+  if (cls.kind !== "valid") return null;
+  const host: RecognizedHost = cls.host;
   const schemeMatch = /^https?:\/\//i.exec(url);
   const afterScheme = schemeMatch ? url.substring(schemeMatch[0].length) : url;
   const slashIdx = afterScheme.indexOf("/");
@@ -84,11 +96,21 @@ export function extractOwnerRepo(url: string): string | null {
     const action = segments[2];
     const tail = segments[3];
     if ((action !== "blob" && action !== "raw") || tail === undefined || tail.length === 0) return null;
-  } else {
+  } else if (host === "raw.githubusercontent.com") {
     const tail = segments[2];
     if (tail === undefined || tail.length === 0) return null;
+  } else {
+    assertNeverRecognizedHost(host);
   }
   return `${owner}/${repo}`;
+}
+
+/** Exhaustiveness guard for the RecognizedHost discriminated branch in
+ *  extractOwnerRepo. If a new host is added to RecognizedHost without
+ *  updating the branch above, the call here fails to typecheck because
+ *  `host` is no longer narrowed to `never` at the call site. */
+function assertNeverRecognizedHost(host: never): never {
+  throw new Error(`unreachable: unrecognized host ${host}`);
 }
 
 /** True when the URL points into the producer's own repo (case-insensitive). */
@@ -178,19 +200,36 @@ export function extractUrls(line: string, cap: number): {
     }
     const urlStart = scan.schemeStart !== -1 ? scan.schemeStart : hostStart;
     const hasScheme = scan.schemeStart !== -1;
-    if (!isValidLeftBoundary(line, urlStart, hasScheme)) continue;
-    const value = line.substring(urlStart, urlEnd);
+    // Scheme-less URL with userinfo before the host (e.g. `user@github.com:443/...`):
+    // extend urlStart back to authorityLeft so the URL value carries the
+    // userinfo+port into classifyAuthority, where the scheme-less port fires
+    // the malformed branch (blocker #9). Without this, `@` in LEFT_REJECT_CHAR
+    // silently rejected the host at the left boundary and the URL vanished.
+    // The deception form `github.com@evil.com/...` is unaffected: HOST_SCAN's
+    // lookahead requires `/`, `:`, or `\` after the host, so `github.com@`
+    // never matches and no candidate is emitted for it.
+    const effectiveUrlStart = !hasScheme && scan.authorityLeft < hostStart && line.substring(scan.authorityLeft, hostStart).includes("@")
+      ? scan.authorityLeft
+      : urlStart;
+    if (!isValidLeftBoundary(line, effectiveUrlStart, hasScheme)) continue;
+    const value = line.substring(effectiveUrlStart, urlEnd);
     const cls = classifyAuthority(value);
-    if (cls.kind === "rejected") continue;
-    if (cls.kind === "malformed" || pathHasBackslash || hasDotSegment(value)) {
+    // Malformed check fires BEFORE the rejected short-circuit: a backslash
+    // in the path makes the host position ambiguous even when classifyAuthority
+    // returns rejected (e.g. `https://github.com\@evil.com/...` classifies as
+    // rejected because the post-`@` host is evil.com, but the backslash still
+    // makes the URL malformed and the gate must fail). Reordering closes the
+    // P0 fail-open hole where the rejected branch hid the path backslash.
+    if (pathHasBackslash || cls.kind === "malformed" || hasDotSegment(value)) {
       const mEnd = cls.kind === "malformed" ? authorityEnd : urlEnd;
       if (out.length >= cap) return { urls: out, overflow: true, steps };
-      out.push({ value: line.substring(urlStart, mEnd), span: { start: urlStart, end: mEnd }, malformed: true, ownershipSpan: null });
+      out.push({ value: line.substring(effectiveUrlStart, mEnd), span: { start: effectiveUrlStart, end: mEnd }, malformed: true, ownershipSpan: null });
       continue;
     }
+    if (cls.kind === "rejected") continue;
     if (extractOwnerRepo(value) === null) continue;
     if (out.length >= cap) return { urls: out, overflow: true, steps };
-    out.push({ value, span: { start: urlStart, end: urlEnd }, malformed: false, ownershipSpan: ownershipSpanFor(urlStart, urlEnd, firstQueryOrFrag) });
+    out.push({ value, span: { start: effectiveUrlStart, end: urlEnd }, malformed: false, ownershipSpan: ownershipSpanFor(effectiveUrlStart, urlEnd, firstQueryOrFrag) });
   }
   EVASION_HOST_TOKEN.lastIndex = 0;
   for (let em: RegExpExecArray | null; (em = EVASION_HOST_TOKEN.exec(line)) !== null;) {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -40,8 +40,11 @@ const REPO_PATTERN = /^[A-Za-z0-9_.-]+$/;
 /** Scan pattern: case-insensitive `github.com/` or `raw.githubusercontent.com/`. */
 const HOST_SCAN = /(?:github\.com|raw\.githubusercontent\.com)\//gi;
 
-/** URL end exclusion set (matches the legacy URL_CANDIDATE_PATTERN). */
-const URL_STOP_CHAR = /[\s)\]|\\"'`<>{}]/;
+/** URL end exclusion set (matches the legacy URL_CANDIDATE_PATTERN).
+ * Includes comma, semicolon, Japanese punctuation, and full-width punctuation
+ * to terminate URL ownership at these boundary markers.
+ */
+const URL_STOP_CHAR = /[\s)\]|\\"'`<>{},;\u3001\u3002\uFF1B\uFF0C\uFF01\uFF1F]/;
 
 /** Scheme prefix lookbehind: accept when the 3 chars before the host are `://`. */
 function precededBySchemeSeparator(line: string, hostStart: number): boolean {
@@ -55,10 +58,22 @@ const LEFT_REJECT_CHAR = /[A-Za-z0-9._@:?#&=\\/-]/;
  * Decide whether `hostStart` is a valid left boundary for a scheme-less
  * authority. Returns true when the host begins the URL (start of line,
  * whitespace, opening punctuation, etc.) or is preceded by `://`.
+ *
+ * When the host is preceded by `://`, the scheme must be http or https.
+ * Unsupported schemes (evil://, ftp://, etc.) cause rejection.
+ *
+ * For scheme URLs, we validate the boundary at the scheme start, not at
+ * the host start, to correctly handle userinfo.
  */
 function isValidLeftBoundary(line: string, hostStart: number): boolean {
   if (hostStart === 0) return true;
-  if (precededBySchemeSeparator(line, hostStart)) return true;
+  const schemeStart = findSchemeStartBeforeHost(line, hostStart);
+  if (schemeStart !== -1) {
+    // Validate the boundary at the scheme start, not at the host start.
+    if (schemeStart === 0) return true;
+    const prev = line.charAt(schemeStart - 1);
+    return !LEFT_REJECT_CHAR.test(prev);
+  }
   const prev = line.charAt(hostStart - 1);
   return !LEFT_REJECT_CHAR.test(prev);
 }
@@ -146,7 +161,7 @@ export function extractUrls(line: string, cap: number): {
   const out: ExtractedUrl[] = [];
   HOST_SCAN.lastIndex = 0;
   let m: RegExpExecArray | null;
-  while ((m = HOST_SCAN.exec(line)) !== null) {
+  for (let m: RegExpExecArray | null; (m = HOST_SCAN.exec(line)) !== null;) {
     const matchEnd = m.index + m[0].length; // index right after the trailing `/`
     // The host starts at m.index. But the regex may have matched a host
     // continuation like the `github.com/` inside `notgithub.com/`: the
@@ -155,11 +170,8 @@ export function extractUrls(line: string, cap: number): {
     if (!isValidLeftBoundary(line, hostStart)) continue;
     // Extend URL start back to include the scheme prefix when present.
     let start = hostStart;
-    if (precededBySchemeSeparator(line, hostStart)) {
-      // Find the scheme start: `http://` or `https://` ending at hostStart.
-      const schemeStart = findSchemeStart(line, hostStart);
-      if (schemeStart !== -1) start = schemeStart;
-    }
+    const schemeStart = findSchemeStartBeforeHost(line, hostStart);
+    if (schemeStart !== -1) start = schemeStart;
     // Extend URL end forward until the first URL stop char.
     let end = matchEnd;
     while (end < line.length && !URL_STOP_CHAR.test(line.charAt(end))) end++;
@@ -184,5 +196,23 @@ function findSchemeStart(line: string, end: number): number {
   // credential-bearing schemes like password://).
   const scheme = line.substring(i + 1, schemeSearchEnd).toLowerCase();
   if (scheme === "http" || scheme === "https") return i + 1;
+  return -1;
+}
+
+/** Find the start index of an `http(s)://` scheme before the host position.
+ * Returns -1 if the scheme is not http/https.
+ */
+function findSchemeStartBeforeHost(line: string, hostStart: number): number {
+  // Look for `://` pattern before the host. The scheme is immediately before `://`.
+  for (let i = hostStart - 1; i >= 3; i--) {
+    if (line.substring(i - 2, i + 1) === "://") {
+      // Found `://` at positions i-2, i-1, i. Check if the preceding chars form http or https.
+      const schemeEnd = i - 2;
+      let j = schemeEnd - 1;
+      while (j >= 0 && /[A-Za-z]/.test(line.charAt(j))) j--;
+      const scheme = line.substring(j + 1, schemeEnd).toLowerCase();
+      if (scheme === "http" || scheme === "https") return j + 1;
+    }
+  }
   return -1;
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -98,6 +98,13 @@ export interface ExtractedUrl {
    * covers ONLY the authority region so contained path references stay
    * independently visible; resolveCandidate classifies it evasion-attempt. */
   readonly malformed: boolean;
+  /** Suppression scope. For a valid URL: from URL start to the position of
+   * the first `?` or `#` in the URL value (path-only). When the URL has no
+   * `?`/`#`, this equals `span`. For a malformed URL: `null` (malformed
+   * URLs never own/suppress contained references). The full `span` remains
+   * the classification evidence; `ownershipSpan` is the only range that
+   * suppresses lower-precedence candidates. */
+  readonly ownershipSpan: Span | null;
 }
 
 /**
@@ -135,12 +142,15 @@ export function extractUrls(line: string, cap: number): {
     let urlEnd = hostEnd;
     let inPath = false;
     let inQueryOrFrag = false;
+    let firstQueryOrFrag = -1;
     while (urlEnd < line.length) {
       steps++;
       const c = line.charAt(urlEnd);
       if (URL_STOP_CHAR.test(c)) break;
-      if (c === "?" || c === "#") inQueryOrFrag = true;
-      else if (c === "/") { if (!inQueryOrFrag) inPath = true; }
+      if (c === "?" || c === "#") {
+        if (firstQueryOrFrag === -1) firstQueryOrFrag = urlEnd;
+        inQueryOrFrag = true;
+      } else if (c === "/") { if (!inQueryOrFrag) inPath = true; }
       else if (c === ":" && inPath && !inQueryOrFrag) break;
       urlEnd++;
     }
@@ -148,42 +158,52 @@ export function extractUrls(line: string, cap: number): {
     if (scan.hasBackslash) {
       const aStart = scan.schemeStart !== -1 ? scan.schemeStart : scan.authorityLeft;
       if (out.length >= cap) return { urls: out, overflow: true, steps };
-      out.push({ value: line.substring(aStart, authorityEnd), span: { start: aStart, end: authorityEnd }, malformed: true });
+      out.push({ value: line.substring(aStart, authorityEnd), span: { start: aStart, end: authorityEnd }, malformed: true, ownershipSpan: null });
       continue;
     }
     if (scan.schemeStart !== -1) {
-      if (!isValidLeftBoundary(line, scan.schemeStart)) continue;
+      if (!isValidLeftBoundary(line, scan.schemeStart, true)) continue;
       const value = line.substring(scan.schemeStart, urlEnd);
       const cls = classifyAuthority(value);
       if (cls.kind === "rejected") continue;
       if (cls.kind === "malformed") {
         if (out.length >= cap) return { urls: out, overflow: true, steps };
-        out.push({ value: line.substring(scan.schemeStart, authorityEnd), span: { start: scan.schemeStart, end: authorityEnd }, malformed: true });
+        out.push({ value: line.substring(scan.schemeStart, authorityEnd), span: { start: scan.schemeStart, end: authorityEnd }, malformed: true, ownershipSpan: null });
         continue;
       }
       if (extractOwnerRepo(value) === null) continue;
       if (out.length >= cap) return { urls: out, overflow: true, steps };
-      out.push({ value, span: { start: scan.schemeStart, end: urlEnd }, malformed: false });
+      out.push({ value, span: { start: scan.schemeStart, end: urlEnd }, malformed: false, ownershipSpan: ownershipSpanFor(scan.schemeStart, urlEnd, firstQueryOrFrag) });
       continue;
     }
     // Scheme-less host.
-    if (!isValidLeftBoundary(line, hostStart)) continue;
+    if (!isValidLeftBoundary(line, hostStart, false)) continue;
     const value = line.substring(hostStart, urlEnd);
     const cls = classifyAuthority(value);
     if (cls.kind === "rejected") continue;
     if (cls.kind === "malformed") {
       if (out.length >= cap) return { urls: out, overflow: true, steps };
-      out.push({ value: line.substring(hostStart, authorityEnd), span: { start: hostStart, end: authorityEnd }, malformed: true });
+      out.push({ value: line.substring(hostStart, authorityEnd), span: { start: hostStart, end: authorityEnd }, malformed: true, ownershipSpan: null });
       continue;
     }
     if (extractOwnerRepo(value) === null) continue;
     if (out.length >= cap) return { urls: out, overflow: true, steps };
-    out.push({ value, span: { start: hostStart, end: urlEnd }, malformed: false });
+    out.push({ value, span: { start: hostStart, end: urlEnd }, malformed: false, ownershipSpan: ownershipSpanFor(hostStart, urlEnd, firstQueryOrFrag) });
   }
   return { urls: out, overflow: false, steps };
 }
 
-function isValidLeftBoundary(line: string, pos: number): boolean {
+/** Ownership span ends at the first `?` or `#` within `[start, end)`. */
+function ownershipSpanFor(start: number, end: number, firstQueryOrFrag: number): Span {
+  if (firstQueryOrFrag === -1) return { start, end };
+  return { start, end: firstQueryOrFrag };
+}
+
+function isValidLeftBoundary(line: string, pos: number, hasScheme: boolean): boolean {
   if (pos === 0) return true;
-  return !LEFT_REJECT_CHAR.test(line.charAt(pos - 1));
+  const prev = line.charAt(pos - 1);
+  // Scheme URLs are unambiguous; accept `=` (query-param value) and `&`
+  // (param separator) so a URL nested in a parent URL's query is detected.
+  if (hasScheme && (prev === "=" || prev === "&")) return true;
+  return !LEFT_REJECT_CHAR.test(prev);
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -130,13 +130,17 @@ export interface ExtractedUrl {
    * covers ONLY the authority region so contained path references stay
    * independently visible; resolveCandidate classifies it evasion-attempt. */
   readonly malformed: boolean;
-  /** Suppression scope. For a valid URL: from URL start to the position of
-   * the first `?` or `#` in the URL value (path-only). When the URL has no
-   * `?`/`#`, this equals `span`. For a malformed URL: `null` (malformed
-   * URLs never own/suppress contained references). The full `span` remains
-   * the classification evidence; `ownershipSpan` is the only range that
-   * suppresses lower-precedence candidates. */
-  readonly ownershipSpan: Span | null;
+/** Suppression scope. For a valid URL: from the first path slash after the
+ * authority (authorityEnd) to the first `?` or `#` (path-only). The start
+ * is the path slash, not the URL start, so producer-internal IDs in the
+ * scheme/userinfo (`https://ADR-0001@github.com/...`) are NOT inside the
+ * ownership span and stay independently visible (blocker #8). When the URL
+ * has no path (no slash after the authority), this is `null` (no path to
+ * own). For a malformed URL: `null` (malformed URLs never own/suppress
+ * contained references). The full `span` remains the classification
+ * evidence; `ownershipSpan` is the only range that suppresses
+ * lower-precedence candidates. */
+readonly ownershipSpan: Span | null;
 }
 
 /**
@@ -189,6 +193,14 @@ export function extractUrls(line: string, cap: number): {
       urlEnd++;
     }
     const authorityEnd = findAuthorityEnd(line, hostEnd, urlEnd);
+    // Linear-scan guarantee (blocker #7): advance HOST_SCAN past the URL
+    // value just scanned, so subsequent `github.com/` hits inside the SAME
+    // URL value do not each trigger a fresh urlEnd walk (quadratic on
+    // `"github.com/".repeat(1000)`). When the URL has a `?` or `#`, resume
+    // just after it so nested URLs in the query/fragment are still found.
+    // Placed before any branch so every continue inherits the advancement.
+    const scanResume = firstQueryOrFrag !== -1 ? firstQueryOrFrag + 1 : urlEnd;
+    if (scanResume > HOST_SCAN.lastIndex) HOST_SCAN.lastIndex = scanResume;
     if (scan.hasBackslash) {
       const aStart = scan.schemeStart !== -1 ? scan.schemeStart : scan.authorityLeft;
       if (out.length >= cap) return { urls: out, overflow: true, steps };
@@ -231,7 +243,7 @@ export function extractUrls(line: string, cap: number): {
     if (cls.kind === "rejected") continue;
     if (extractOwnerRepo(value) === null) continue;
     if (out.length >= cap) return { urls: out, overflow: true, steps };
-    out.push({ value, span: { start: effectiveUrlStart, end: urlEnd }, malformed: false, ownershipSpan: ownershipSpanFor(effectiveUrlStart, urlEnd, firstQueryOrFrag) });
+    out.push({ value, span: { start: effectiveUrlStart, end: urlEnd }, malformed: false, ownershipSpan: ownershipSpanFor(authorityEnd, urlEnd, firstQueryOrFrag) });
   }
   EVASION_HOST_TOKEN.lastIndex = 0;
   for (let em: RegExpExecArray | null; (em = EVASION_HOST_TOKEN.exec(line)) !== null;) {
@@ -241,24 +253,38 @@ export function extractUrls(line: string, cap: number): {
     const canonical = canonicalizeHostEvasion(raw);
     if (canonical !== "github.com" && canonical !== "raw.githubusercontent.com") continue;
     const ts = em.index;
-    if (out.some((u) => u.span.start <= ts && ts < u.span.end)) continue;
+    // Blocker #6: dedup against ownershipSpan (path-only), not the full URL
+    // span. An evasion host placed in an external URL's query sits inside
+    // the outer URL's full `span` but OUTSIDE its `ownershipSpan` (which
+    // ends at the first `?`/`#`), so it must be emitted independently.
+    if (out.some((u) => u.ownershipSpan !== null && u.ownershipSpan.start <= ts && ts < u.ownershipSpan.end)) continue;
     if (out.length >= cap) return { urls: out, overflow: true, steps };
     let ue = ts + raw.length;
+    let evasionFirstQueryOrFrag = -1;
     while (ue < line.length) {
       steps++;
       const ch = line.charAt(ue);
       if (URL_STOP_CHAR.test(ch) || ch === "\\") break;
+      if ((ch === "?" || ch === "#") && evasionFirstQueryOrFrag === -1) evasionFirstQueryOrFrag = ue;
       ue++;
     }
     out.push({ value: line.substring(ts, ue), span: { start: ts, end: ue }, malformed: true, ownershipSpan: null });
+    // Same linear-scan guarantee as HOST_SCAN (blocker #7).
+    const evasionResume = evasionFirstQueryOrFrag !== -1 ? evasionFirstQueryOrFrag + 1 : ue;
+    if (evasionResume > EVASION_HOST_TOKEN.lastIndex) EVASION_HOST_TOKEN.lastIndex = evasionResume;
   }
   return { urls: out, overflow: false, steps };
 }
 
-/** Ownership span ends at the first `?` or `#` within `[start, end)`. */
-function ownershipSpanFor(start: number, end: number, firstQueryOrFrag: number): Span {
-  if (firstQueryOrFrag === -1) return { start, end };
-  return { start, end: firstQueryOrFrag };
+/** Ownership span starts at `authorityEnd` (the first path slash after the
+ *  host) and ends at the first `?` or `#` within `[authorityEnd, end)`.
+ *  Returns null when there is no path region to own (authorityEnd >= end,
+ *  or a `?`/`#` precedes the path slash). */
+function ownershipSpanFor(authorityEnd: number, end: number, firstQueryOrFrag: number): Span | null {
+  if (authorityEnd >= end) return null;
+  if (firstQueryOrFrag === -1) return { start: authorityEnd, end };
+  if (firstQueryOrFrag <= authorityEnd) return null;
+  return { start: authorityEnd, end: firstQueryOrFrag };
 }
 
 function isValidLeftBoundary(line: string, pos: number, hasScheme: boolean): boolean {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -9,10 +9,12 @@
 // emission:
 //   - HOST_SCAN finds a recognized host followed by `/` (path) or `:`
 //     (port), so default-port URLs (`https://github.com:443/...`) are seen.
-//   - For each hit, scanAuthorityBackward locates the scheme and detects
-//     backslash malformedness. A backslash in the authority is always
-//     malformed: it makes the host position ambiguous and the URL cannot
-//     own/hide contained producer references.
+//   - For each hit, scanAuthorityForward advances a single forward cursor
+//     from the previous hit up to `hostStart`, carrying scheme and
+//     backslash evidence. Total scan cost is O(line.length) regardless of
+//     how many host hits land on the line. A backslash in the authority
+//     is always malformed: it makes the host position ambiguous and the
+//     URL cannot own/hide contained producer references.
 //   - Port validation: only the scheme default port is accepted (443 for
 //     https, 80 for http). Any other port, or any port on a scheme-less
 //     URL, is malformed. A malformed authority NEVER silently passes: it
@@ -20,14 +22,20 @@
 //     the authority region, so contained path references stay independently
 //     visible, and resolveCandidate classifies it as evasion-attempt.
 //
+// `steps` counts the per-character work performed by the scanner (forward
+// authority scan + URL-end walk), exposing a linear-complexity contract:
+// callers can assert `steps <= K * line.length + C`.
+//
 // Side-effect-free: pure over inputs.
 
 import type { Span } from "./boundary-candidate-ownership.ts";
 import {
   classifyAuthority,
   findAuthorityEnd,
+  INITIAL_AUTHORITY_SCAN_CURSOR,
   parseUrlHost,
-  scanAuthorityBackward,
+  scanAuthorityForward,
+  type AuthorityScanCursor,
 } from "./boundary-url-authority.ts";
 
 const OWNER_PATTERN = /^[A-Za-z0-9_-]+$/;
@@ -97,27 +105,38 @@ export interface ExtractedUrl {
  * authority. Returns at most `cap` entries; `overflow` is set when the cap
  * is reached mid-scan (ownership never suppresses overflow).
  *
- * For each host hit, scanAuthorityBackward locates the scheme and detects
- * backslash malformedness. A backslash in the authority => malformed. A
- * valid scheme URL with a non-default port => malformed. A scheme-less URL
- * with any port => malformed. Malformed candidates' spans cover ONLY the
- * authority region so path references stay independently visible; valid
- * URLs span the full URL (scheme through stop char) and own their path.
+ * For each host hit, scanAuthorityForward advances a single forward cursor
+ * from the previous hit up to `hostStart`, carrying scheme and backslash
+ * evidence. A backslash in the authority => malformed. A valid scheme URL
+ * with a non-default port => malformed. A scheme-less URL with any port
+ * => malformed. Malformed candidates' spans cover ONLY the authority
+ * region so path references stay independently visible; valid URLs span
+ * the full URL (scheme through stop char) and own their path.
+ *
+ * `steps` counts per-character scanner operations (forward authority scan
+ * + URL-end walk). It is bounded by a linear function of `line.length`.
  */
 export function extractUrls(line: string, cap: number): {
   readonly urls: readonly ExtractedUrl[];
   readonly overflow: boolean;
+  readonly steps: number;
 } {
   const out: ExtractedUrl[] = [];
+  let cursor: AuthorityScanCursor = INITIAL_AUTHORITY_SCAN_CURSOR;
+  let steps = 0;
   HOST_SCAN.lastIndex = 0;
   for (let m: RegExpExecArray | null; (m = HOST_SCAN.exec(line)) !== null;) {
     const hostStart = m.index;
     const hostEnd = hostStart + m[0].length;
-    const scan = scanAuthorityBackward(line, hostStart);
+    const fwd = scanAuthorityForward(line, hostStart, cursor);
+    cursor = fwd.cursor;
+    steps += fwd.steps;
+    const scan = fwd.scan;
     let urlEnd = hostEnd;
     let inPath = false;
     let inQueryOrFrag = false;
     while (urlEnd < line.length) {
+      steps++;
       const c = line.charAt(urlEnd);
       if (URL_STOP_CHAR.test(c)) break;
       if (c === "?" || c === "#") inQueryOrFrag = true;
@@ -128,7 +147,7 @@ export function extractUrls(line: string, cap: number): {
     const authorityEnd = findAuthorityEnd(line, hostEnd, urlEnd);
     if (scan.hasBackslash) {
       const aStart = scan.schemeStart !== -1 ? scan.schemeStart : scan.authorityLeft;
-      if (out.length >= cap) return { urls: out, overflow: true };
+      if (out.length >= cap) return { urls: out, overflow: true, steps };
       out.push({ value: line.substring(aStart, authorityEnd), span: { start: aStart, end: authorityEnd }, malformed: true });
       continue;
     }
@@ -138,12 +157,12 @@ export function extractUrls(line: string, cap: number): {
       const cls = classifyAuthority(value);
       if (cls.kind === "rejected") continue;
       if (cls.kind === "malformed") {
-        if (out.length >= cap) return { urls: out, overflow: true };
+        if (out.length >= cap) return { urls: out, overflow: true, steps };
         out.push({ value: line.substring(scan.schemeStart, authorityEnd), span: { start: scan.schemeStart, end: authorityEnd }, malformed: true });
         continue;
       }
       if (extractOwnerRepo(value) === null) continue;
-      if (out.length >= cap) return { urls: out, overflow: true };
+      if (out.length >= cap) return { urls: out, overflow: true, steps };
       out.push({ value, span: { start: scan.schemeStart, end: urlEnd }, malformed: false });
       continue;
     }
@@ -153,15 +172,15 @@ export function extractUrls(line: string, cap: number): {
     const cls = classifyAuthority(value);
     if (cls.kind === "rejected") continue;
     if (cls.kind === "malformed") {
-      if (out.length >= cap) return { urls: out, overflow: true };
+      if (out.length >= cap) return { urls: out, overflow: true, steps };
       out.push({ value: line.substring(hostStart, authorityEnd), span: { start: hostStart, end: authorityEnd }, malformed: true });
       continue;
     }
     if (extractOwnerRepo(value) === null) continue;
-    if (out.length >= cap) return { urls: out, overflow: true };
+    if (out.length >= cap) return { urls: out, overflow: true, steps };
     out.push({ value, span: { start: hostStart, end: urlEnd }, malformed: false });
   }
-  return { urls: out, overflow: false };
+  return { urls: out, overflow: false, steps };
 }
 
 function isValidLeftBoundary(line: string, pos: number): boolean {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -54,8 +54,10 @@ const HOST_SCAN = /(?:github\.com|raw\.githubusercontent\.com)(?=[/:\\])/gi;
  *  O(n²) backtracking on adversarial long runs; longest recognized host fully
  *  percent-encoded is 72 chars. Post-filtered by canonicalization. The
  *  backslash terminator mirrors HOST_SCAN so percent-encoded / Unicode-dot
- *  hosts followed by a backslash are also caught. */
-const EVASION_HOST_TOKEN = /(?:%[0-9A-Fa-f]{2}|[A-Za-z0-9.\u3002\uFF0E-]){1,80}(?=[/:\\])/g;
+ *  hosts followed by a backslash are also caught. The Unicode-dot class
+ *  covers U+3002, U+FF0E, and U+FF61; canonicalizeHostEvasion collapses all
+ *  three to ASCII `.`. */
+const EVASION_HOST_TOKEN = /(?:%[0-9A-Fa-f]{2}|[A-Za-z0-9.\u3002\uFF0E\uFF61-]){1,80}(?=[/:\\])/g;
 
 /** URL end exclusion set: terminates URL ownership at boundary markers.
  * Backslash is NOT here (it sets pathHasBackslash and extends the URL, marking
@@ -268,15 +270,18 @@ function isValidLeftBoundary(line: string, pos: number, hasScheme: boolean): boo
   return !LEFT_REJECT_CHAR.test(prev);
 }
 
-/** True when the URL path contains a dot-segment (`.`, `..`, `%2e`, `%2E`,
- * `%2e%2e`, `%2E%2E`) in the owner/repo/tail position. RFC 3986 reserves these
- * for relative-path resolution; they never appear in a concrete GitHub URL. */
+/** True when the URL path contains a dot-segment in the owner/repo/tail
+ *  position. RFC 3986 reserves `.` and `..` for relative-path resolution;
+ *  they never appear in a concrete GitHub URL. Each segment is normalized
+ *  by case-insensitively replacing `%2e` with `.` first, so mixed
+ *  literal+encoded forms (`.%2e`, `%2e.`) collapse to `..` and are caught
+ *  alongside the pure literal (`..`) and pure-encoded (`%2e%2e`) forms. */
 function hasDotSegment(url: string): boolean {
   const m = /^([A-Za-z][A-Za-z0-9.+-]*:\/\/)?[^/]+\//.exec(url);
   if (!m) return false;
   for (const seg of url.substring(m[0].length).split("/")) {
-    const lower = seg.toLowerCase();
-    if (seg === "." || seg === ".." || lower === "%2e" || lower === "%2e%2e") return true;
+    const norm = seg.replace(/%2e/gi, ".");
+    if (norm === "." || norm === "..") return true;
   }
   return false;
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -225,6 +225,16 @@ export function extractUrls(line: string, cap: number): {
     const effectiveUrlStart = !hasScheme && scan.authorityLeft < hostStart && line.substring(scan.authorityLeft, hostStart).includes("@")
       ? scan.authorityLeft
       : urlStart;
+    // Scheme-less recognized host after a query-assignment delimiter (`=` or
+    // `&`) is ambiguous: standalone URL or a value nested in a parent URL's
+    // query. Without a scheme the detector cannot tell, so fail closed by
+    // emitting malformed rather than skipping (blocker #2). The `!hasScheme`
+    // guard keeps scheme URLs accepted (`url=https://github.com/...` stays valid).
+    if (!hasScheme && effectiveUrlStart > 0 && (line.charAt(effectiveUrlStart - 1) === "=" || line.charAt(effectiveUrlStart - 1) === "&")) {
+      if (out.length >= cap) return { urls: out, overflow: true, steps };
+      out.push({ value: line.substring(effectiveUrlStart, authorityEnd), span: { start: effectiveUrlStart, end: authorityEnd }, malformed: true, ownershipSpan: null });
+      continue;
+    }
     if (!isValidLeftBoundary(line, effectiveUrlStart, hasScheme)) continue;
     const value = line.substring(effectiveUrlStart, urlEnd);
     const cls = classifyAuthority(value);

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/boundary-url-parser.ts
@@ -1,124 +1,56 @@
 // Authority-aware URL extractor for the distribution boundary detector.
 //
 // Extracted from boundary-candidate-model.ts to keep that module under the
-// 250 pure LOC ceiling and to make the URL lexer independently testable.
-// One responsibility: turn a line into URL candidate spans whose host is
-// exactly `github.com` or `raw.githubusercontent.com`.
+// 250 pure LOC ceiling. One responsibility: turn a line into URL candidate
+// spans whose host is exactly `github.com` or `raw.githubusercontent.com`.
 //
-// Authority model (no URL dependency):
-//   - Scheme form: `https?://[userinfo@]host[:port][/path][?query][#frag]`.
-//     Port is NOT supported: `host:port` is rejected (host with `:` is not
-//     a valid hostname for the GitHub authority).
-//   - Scheme discovery walks only the lexical authority/userinfo region
-//     immediately preceding the host and parses the full RFC 3986 scheme
-//     token. Only exactly `http`/`https` is accepted, so composite schemes
-//     such as `git+https://` are unsupported and cannot own/hide contained
-//     producer references. The walk never crosses whitespace, a path
-//     separator, or another token, so a later bare host never grabs an
-//     earlier URL's scheme.
-//   - Userinfo is stripped via the LAST `@` so `https://github.com@evil.com`
-//     is parsed as userinfo=`github.com`, host=`evil.com` — not a GitHub
-//     authority.
-//   - Host comparison is case-insensitive (host lowercased). Owner/repo
-//     comparison is case-insensitive (GitHub legacy). Directory family
-//     names elsewhere remain case-sensitive (NOT this module's concern).
-//   - Host suffix / subdomain / path lookalikes are rejected: host must
-//     equal `github.com` or `raw.githubusercontent.com` exactly. So
-//     `notgithub.com`, `github.com.evil.com`, `evil.github.com`, and
-//     `example.com/github.com/...` are NOT GitHub authorities.
-//   - Scheme-less `github.com/...` and `raw.githubusercontent.com/...`
-//     are supported only at a valid left boundary: the char before the
-//     host must NOT be a host/path/query/fragment continuation char
-//     (`[A-Za-z0-9._@:?#&=\\/-]`), except the `://` scheme separator is
-//     accepted (so the host of a scheme URL is matched).
+// Authority classification (host/port/backslash malformedness) lives in
+// boundary-url-authority.ts. This module owns the line scan and candidate
+// emission:
+//   - HOST_SCAN finds a recognized host followed by `/` (path) or `:`
+//     (port), so default-port URLs (`https://github.com:443/...`) are seen.
+//   - For each hit, scanAuthorityBackward locates the scheme and detects
+//     backslash malformedness. A backslash in the authority is always
+//     malformed: it makes the host position ambiguous and the URL cannot
+//     own/hide contained producer references.
+//   - Port validation: only the scheme default port is accepted (443 for
+//     https, 80 for http). Any other port, or any port on a scheme-less
+//     URL, is malformed. A malformed authority NEVER silently passes: it
+//     is emitted as a separate candidate whose ownership span covers only
+//     the authority region, so contained path references stay independently
+//     visible, and resolveCandidate classifies it as evasion-attempt.
 //
 // Side-effect-free: pure over inputs.
 
 import type { Span } from "./boundary-candidate-ownership.ts";
-
-/** URL authority hosts the detector recognizes. */
-const GITHUB_HOST = "github.com";
-const RAW_HOST = "raw.githubusercontent.com";
-const RECOGNIZED_HOSTS: ReadonlySet<string> = new Set([GITHUB_HOST, RAW_HOST]);
+import {
+  classifyAuthority,
+  findAuthorityEnd,
+  parseUrlHost,
+  scanAuthorityBackward,
+} from "./boundary-url-authority.ts";
 
 const OWNER_PATTERN = /^[A-Za-z0-9_-]+$/;
 const REPO_PATTERN = /^[A-Za-z0-9_.-]+$/;
 
-/** Scan pattern: case-insensitive `github.com/` or `raw.githubusercontent.com/`. */
-const HOST_SCAN = /(?:github\.com|raw\.githubusercontent\.com)\//gi;
+/** Scan pattern: case-insensitive recognized host followed by `/` or `:`. */
+const HOST_SCAN = /(?:github\.com|raw\.githubusercontent\.com)(?=[/:])/gi;
 
-/** URL end exclusion set (matches the legacy URL_CANDIDATE_PATTERN).
- * Includes comma, semicolon, Japanese punctuation, and full-width punctuation
- * to terminate URL ownership at these boundary markers.
- */
+/** URL end exclusion set: terminates URL ownership at boundary markers. */
 const URL_STOP_CHAR = /[\s)\]|\\"'`<>{},;\u3001\u3002\uFF1B\uFF0C\uFF01\uFF1F]/;
 
 /** Preceding char rejects the left boundary (host/path/query continuation). */
 const LEFT_REJECT_CHAR = /[A-Za-z0-9._@:?#&=\\/-]/;
 
-/** Characters allowed inside a URL authority (userinfo) region (RFC 3986). */
-const AUTHORITY_CHAR = /[A-Za-z0-9._~!$&'()*+,;=:@%]/;
-
-/** One character of an RFC 3986 scheme token: ALPHA / DIGIT / "+" / "-" / ".". */
-const SCHEME_CHAR = /[A-Za-z0-9+\-.]/;
-
 /**
- * Decide whether `hostStart` is a valid left boundary for a scheme-less
- * authority. Returns true when the host begins the URL (start of line,
- * whitespace, opening punctuation, etc.) or is preceded by `://`.
- *
- * When the host is preceded by `://`, the scheme must be http or https.
- * Unsupported schemes (evil://, ftp://, git+https://, etc.) cause rejection.
- *
- * For scheme URLs, we validate the boundary at the scheme start, not at
- * the host start, to correctly handle userinfo.
- */
-function isValidLeftBoundary(line: string, hostStart: number): boolean {
-  if (hostStart === 0) return true;
-  const schemeStart = findSchemeStartBeforeHost(line, hostStart);
-  if (schemeStart !== -1) {
-    // Validate the boundary at the scheme start, not at the host start.
-    if (schemeStart === 0) return true;
-    const prev = line.charAt(schemeStart - 1);
-    return !LEFT_REJECT_CHAR.test(prev);
-  }
-  const prev = line.charAt(hostStart - 1);
-  return !LEFT_REJECT_CHAR.test(prev);
-}
-
-/**
- * Parse the authority of a URL value and return the lowercased host, or
- * null when the URL has a port (unsupported) or no parseable authority.
- *
- * Precondition: caller ensures the URL value starts at a valid boundary
- * (scheme form OR scheme-less host). The host is the part of the authority
- * after the last `@` (userinfo stripped) and before any `:port`.
- */
-export function parseUrlHost(url: string): string | null {
-  const schemeMatch = /^https?:\/\//i.exec(url);
-  const afterScheme = schemeMatch ? url.substring(schemeMatch[0].length) : url;
-  let authorityEnd = afterScheme.length;
-  for (let i = 0; i < afterScheme.length; i++) {
-    const c = afterScheme.charAt(i);
-    if (c === "/" || c === "?" || c === "#") { authorityEnd = i; break; }
-  }
-  const authority = afterScheme.substring(0, authorityEnd);
-  const atIdx = authority.lastIndexOf("@");
-  const hostPort = atIdx === -1 ? authority : authority.substring(atIdx + 1);
-  // Reject port form: a `:` in the host segment is not a valid hostname.
-  if (hostPort.includes(":")) return null;
-  return hostPort.toLowerCase();
-}
-
-/**
- * Extract `owner/repo` from a URL value whose host is a recognized GitHub
- * authority, or null when the URL does not point at GitHub. Authority-aware:
- * the URL must host-match exactly (case-insensitive). Path-lookalike and
- * userinfo-deception URLs return null because their host is not GitHub.
+ * Extract `owner/repo` from a URL value whose authority is a VALID recognized
+ * GitHub authority (default port accepted; malformed port or backslash
+ * authority returns null). Path-lookalike and userinfo-deception URLs return
+ * null because their host is not a recognized GitHub authority.
  */
 export function extractOwnerRepo(url: string): string | null {
   const host = parseUrlHost(url);
-  if (host === null || !RECOGNIZED_HOSTS.has(host)) return null;
+  if (host === null) return null;
   const schemeMatch = /^https?:\/\//i.exec(url);
   const afterScheme = schemeMatch ? url.substring(schemeMatch[0].length) : url;
   const slashIdx = afterScheme.indexOf("/");
@@ -128,7 +60,7 @@ export function extractOwnerRepo(url: string): string | null {
   const repo = segments[1];
   if (owner === undefined || repo === undefined) return null;
   if (!OWNER_PATTERN.test(owner) || !REPO_PATTERN.test(repo)) return null;
-  if (host === GITHUB_HOST) {
+  if (host === "github.com") {
     const action = segments[2];
     const tail = segments[3];
     if ((action !== "blob" && action !== "raw") || tail === undefined || tail.length === 0) return null;
@@ -150,17 +82,23 @@ export function isProducerOwnedUrl(url: string, identity: { readonly owner_slash
 export interface ExtractedUrl {
   readonly value: string;
   readonly span: Span;
+  /** True when the authority is malformed (backslash / bad port). The span
+   * covers ONLY the authority region so contained path references stay
+   * independently visible; resolveCandidate classifies it evasion-attempt. */
+  readonly malformed: boolean;
 }
 
 /**
  * Scan a line for URL candidates whose host is a recognized GitHub
- * authority. Returns at most `cap` entries; the boolean `overflow` flag
- * is set when the cap is reached mid-scan (the caller MUST surface a
- * typed overflow in that case — ownership never suppresses overflow).
+ * authority. Returns at most `cap` entries; `overflow` is set when the cap
+ * is reached mid-scan (ownership never suppresses overflow).
  *
- * For each scan hit, the left boundary is checked. The URL value extends
- * backward to include the scheme prefix when the host is immediately
- * preceded by `://`, and forward until the first URL stop char.
+ * For each host hit, scanAuthorityBackward locates the scheme and detects
+ * backslash malformedness. A backslash in the authority => malformed. A
+ * valid scheme URL with a non-default port => malformed. A scheme-less URL
+ * with any port => malformed. Malformed candidates' spans cover ONLY the
+ * authority region so path references stay independently visible; valid
+ * URLs span the full URL (scheme through stop char) and own their path.
  */
 export function extractUrls(line: string, cap: number): {
   readonly urls: readonly ExtractedUrl[];
@@ -169,50 +107,51 @@ export function extractUrls(line: string, cap: number): {
   const out: ExtractedUrl[] = [];
   HOST_SCAN.lastIndex = 0;
   for (let m: RegExpExecArray | null; (m = HOST_SCAN.exec(line)) !== null;) {
-    const matchEnd = m.index + m[0].length; // index right after the trailing `/`
-    // The host starts at m.index. But the regex may have matched a host
-    // continuation like the `github.com/` inside `notgithub.com/`: the
-    // preceding char rejects the boundary in that case.
     const hostStart = m.index;
+    const hostEnd = hostStart + m[0].length;
+    const scan = scanAuthorityBackward(line, hostStart);
+    let urlEnd = hostEnd;
+    while (urlEnd < line.length && !URL_STOP_CHAR.test(line.charAt(urlEnd))) urlEnd++;
+    const authorityEnd = findAuthorityEnd(line, hostEnd, urlEnd);
+    if (scan.hasBackslash) {
+      const aStart = scan.schemeStart !== -1 ? scan.schemeStart : scan.authorityLeft;
+      if (out.length >= cap) return { urls: out, overflow: true };
+      out.push({ value: line.substring(aStart, authorityEnd), span: { start: aStart, end: authorityEnd }, malformed: true });
+      continue;
+    }
+    if (scan.schemeStart !== -1) {
+      if (!isValidLeftBoundary(line, scan.schemeStart)) continue;
+      const value = line.substring(scan.schemeStart, urlEnd);
+      const cls = classifyAuthority(value);
+      if (cls.kind === "rejected") continue;
+      if (cls.kind === "malformed") {
+        if (out.length >= cap) return { urls: out, overflow: true };
+        out.push({ value: line.substring(scan.schemeStart, authorityEnd), span: { start: scan.schemeStart, end: authorityEnd }, malformed: true });
+        continue;
+      }
+      if (extractOwnerRepo(value) === null) continue;
+      if (out.length >= cap) return { urls: out, overflow: true };
+      out.push({ value, span: { start: scan.schemeStart, end: urlEnd }, malformed: false });
+      continue;
+    }
+    // Scheme-less host.
     if (!isValidLeftBoundary(line, hostStart)) continue;
-    // Extend URL start back to include the scheme prefix when present.
-    let start = hostStart;
-    const schemeStart = findSchemeStartBeforeHost(line, hostStart);
-    if (schemeStart !== -1) start = schemeStart;
-    // Extend URL end forward until the first URL stop char.
-    let end = matchEnd;
-    while (end < line.length && !URL_STOP_CHAR.test(line.charAt(end))) end++;
-    const value = line.substring(start, end);
+    const value = line.substring(hostStart, urlEnd);
+    const cls = classifyAuthority(value);
+    if (cls.kind === "rejected") continue;
+    if (cls.kind === "malformed") {
+      if (out.length >= cap) return { urls: out, overflow: true };
+      out.push({ value: line.substring(hostStart, authorityEnd), span: { start: hostStart, end: authorityEnd }, malformed: true });
+      continue;
+    }
     if (extractOwnerRepo(value) === null) continue;
     if (out.length >= cap) return { urls: out, overflow: true };
-    out.push({ value, span: { start, end } });
+    out.push({ value, span: { start: hostStart, end: urlEnd }, malformed: false });
   }
   return { urls: out, overflow: false };
 }
 
-/**
- * Find the start index of an `http(s)://` scheme whose authority ends at
- * `hostStart`. Walks backward ONLY through the lexical authority/userinfo
- * region, so whitespace, a path separator, or another token halts the walk
- * and yields -1 — a later bare host can never grab an earlier URL's scheme.
- * When `://` is reached, the full RFC-style scheme token is parsed and
- * accepted only when it is exactly `http` or `https`; composite schemes
- * such as `git+https` are unsupported and return -1.
- */
-function findSchemeStartBeforeHost(line: string, hostStart: number): number {
-  let i = hostStart - 1;
-  while (i >= 3) {
-    if (line.substring(i - 2, i + 1) === "://") {
-      const schemeEnd = i - 2;
-      let j = schemeEnd - 1;
-      if (j < 0 || !/[A-Za-z]/.test(line.charAt(j))) return -1;
-      while (j > 0 && SCHEME_CHAR.test(line.charAt(j - 1))) j--;
-      const scheme = line.substring(j, schemeEnd).toLowerCase();
-      if (scheme === "http" || scheme === "https") return j;
-      return -1;
-    }
-    if (!AUTHORITY_CHAR.test(line.charAt(i))) return -1;
-    i--;
-  }
-  return -1;
+function isValidLeftBoundary(line: string, pos: number): boolean {
+  if (pos === 0) return true;
+  return !LEFT_REJECT_CHAR.test(line.charAt(pos - 1));
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/index.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/index.ts
@@ -49,7 +49,6 @@ export type { ProtectedPathSet } from "./protected-paths.ts";
 
 export {
   classifyLine,
-  decideProjection,
   detectCandidates,
   resolveCandidate,
   isConcreteDocsPath,
@@ -60,10 +59,17 @@ export type {
   RepositoryIdentity as DetectorRepositoryIdentity,
   Candidate,
   CandidateType,
-  ClassifyFileInput,
+  OverflowReason,
   LineClassification,
-  DecideResult,
 } from "./boundary-pipeline.ts";
+
+export {
+  decideProjection,
+} from "./boundary-gate.ts";
+export type {
+  ClassifyFileInput,
+  DecideResult,
+} from "./boundary-gate.ts";
 
 export {
   buildSourceManifest,

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/launcher.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/launcher.ts
@@ -188,6 +188,7 @@ function runLauncherInner(opts: LauncherOptions, deps: LauncherDependencies): La
   const detectorConfig: DetectorConfig = {
     repository_identity: opts.repository_identity,
     producer_internal_id_prefixes: DEFAULT_PRODUCER_PREFIXES,
+    distributed_workflow_control_prefixes: ["STEP", "QG"],
   };
   const boundaryResults = runBoundaryDetector({ blobs }, detectorConfig);
   const failureCount = boundaryResults.reduce((n, r) => n + r.failures.length, 0);

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/types.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/types.ts
@@ -133,7 +133,9 @@ export type DetectionCategory =
   | "concrete-path"
   | "fixed-url"
   | "unclassified-entry"
-  | "adapter-failure";
+  | "adapter-failure"
+  | "distributed-control"
+  | "evasion-attempt";
 
 export interface LineInput {
   readonly text: string;


### PR DESCRIPTION
## Summary

Trusted distribution-boundary detector の全面 hardening。10ラウンドの fresh 5-lane review (goal/code/security/QA/context) を経て **review-v10: 5/5 PASS** を達成。

Refs: #2092

## Changes (36 additive commits from `d218048c`)

### 新規 runtime module
- `boundary-url-authority.ts` — authority classification (valid/malformed/rejected), `scanAuthorityForward` (単調前進), `canonicalizeHostEvasion` (3-round percent-decode + Unicode dot + case-fold), `parseUrlHost` (default-port validation, backslash rejection)

### 既存 module の拡張
- `boundary-url-parser.ts` — HOST_SCAN (`[/:\]` lookahead), EVASION_HOST_TOKEN (canonicalizable host detection), URL termination (CJK punctuation, em dash, open delimiters, path-only colon), ownershipSpan (path-only, null for malformed), `isDelimiterChar` (`=`/`&`/`:`/`?`/`#`), `hasDotSegment` (mixed-encoding aware), linear scan (lastIndex advancement)
- `boundary-docs-path-parser.ts` — arbitrary-depth relative prefix (`precomputePrefixValid` O(n) forward scan), dot-segment normalization, `%2F`/`%5C` separators, CJK punctuation left-boundary + PATH_STOP_CHAR, URL-owned path cap exclusion
- `boundary-candidate-ownership.ts` — `ownershipSpan` separation (keeper containment uses ownershipSpan, not span)
- `boundary-candidate-model.ts` — `RecognizedHost` discriminated union + `assertNeverRecognizedHost`, malformed URL → `unclassified/evasion-attempt`
- `boundary-pipeline.ts` — per-call stateless `GENERIC_ID_PATTERN`, `ownershipSpan`-based urlSpans/ownedSpans
- `boundary-reconstruction.ts` — owned-span skip before token overflow

### Test coverage (645 tests, 50 files)
- 11 review-v7 blockers resolved, 4 review-v8 blockers resolved, 1 review-v9 blocker resolved
- Adversarial probes: scheme/host/path/delimiter/encoding の全次元で fail-open なし

## Verification

- `bun test`: 645 pass / 0 fail (50 files, 1535 expect calls)
- `bun run typecheck` (`tsc --noEmit`): clean
- `archive-builder.test.ts` isolated: 19/19
- Pure LOC: 全ファイル ≤250 (max: url-parser 176)
- `git diff --check`: clean

## Review history

| Round | OID | Result |
|-------|-----|--------|
| v4 | `8f42960e` | 2 FAIL (goal, code) |
| v5 | `f2f99071` | 2 FAIL (goal, code) |
| v6 | `0df14c5e` | 3 FAIL (goal, code, security) |
| v7 | `c7cfb485` | 4 FAIL (goal, code, security, QA) |
| v8 | `b19dbd23` | 1 FAIL (goal) |
| v9 | `6a21dcf3` | 1 FAIL (security) |
| **v10** | **`13e5594a`** | **5 PASS** |
