### PR TITLE
feat(agentdev): inspect 3 Command を Workflow Skill へ移管（thin Command 化 + soft guard、OU-004）

### DIFF
--- a/src/opencode/commands/agentdev/inspect-docs.md
+++ b/src/opencode/commands/agentdev/inspect-docs.md
@@ -28,7 +28,7 @@ docs全体（REQ/Decision/SPEC/guides）の意味整合性を診断し、検出�
 ## inspect-* コマンド選択 routing
 
 変更ファイル種別に基づき、実行する inspect-* コマンドを選ぶ。
-本コマンド（inspect-docs）と inspect-skills は配布物（`.opencode/commands/agentdev/`、`.opencode/skills/agentdev-*/`）の検出対象が一部重複する（inspect-docs Step 11 配布物整合性検査、inspect-skills Step 3 配布物構文健全性・責務整合診断）。変更範囲に応じて routing することで重複検出を防ぐ。
+本コマンド（inspect-docs）と inspect-skills は配布物（`.opencode/commands/agentdev/`、`.opencode/skills/agentdev-*/`）の検出対象が一部重複する（inspect-docs の配布物整合性検査、inspect-skills の配布物構文健全性・責務整合診断）。変更範囲に応じて routing することで重複検出を防ぐ。
 
 | 変更ファイル種別 | 実行コマンド |
 |------|------|
@@ -51,66 +51,18 @@ routing は実行コマンド選択の目安であり、各コマンドの検出
 - extension が破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する
 - 詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
-## 手順
+## workflow
 
-### Step 1: スキャン対象の収集
+本コマンドは workflow 実装本体を `agentdev-workflow-inspect-docs` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}）。同スキルは read-only-diagnostic型（STEP model 対象外、resume point なし）として4工程の control plane を所有する。
 
-`docs/requirements/`、`docs/decisions/`、`docs/specs/`、`docs/guides/`、`README.md`、`.opencode/` を収集
-### Step 2: REQ参照ID整合性確認
+- **STEP-1** スキャン対象の収集 — `docs/requirements/`、`docs/decisions/`、`docs/specs/`、`docs/guides/`、`README.md`、`.opencode/`
+- **STEP-2** REQ 体系・文書種別別意味診断 — REQ 参照ID整合性、第一参照導線、現行/廃止/世代境界、6観点 structure review（SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）、文書分類一貫性、SPEC/Decision/guides/README 意味診断
+- **STEP-3** 配布物整合性検査・route 判定 — 構文健全性・文意保持・責務整合診断、docs-check route 候補提示、未処理 artifact 確認
+- **STEP-4** 検出事項出力・永続化・完了報告 — inbox 出力（source-of-truth priority、NG 分類）、実行前同期、`.agentdev/inspect/` commit/push、完了報告
 
-`agentdev-req-structure-diagnostics` 参照
-### Step 3: 第一参照導線確認
+各工程の詳細は `agentdev-workflow-inspect-docs` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。同スキルは本コマンドの工程経由でのみ利用し、単独の skill 起動は soft guard（REQ-{NNNN}-{NNN}）で抑制する。
 
-`agentdev-req-structure-diagnostics` 参照
-### Step 4: 現行/廃止/世代境界確認
-
-`agentdev-req-structure-diagnostics` 参照
-### Step 5: SPEC意味診断
-
-SPEC が REQ/Decision/guides の代替、将来計画の混入、実行時依存先としての不適切扱いを確認
-### Step 6: Decision意味診断
-
-承認済み ADR のみを現行判断の根拠として扱っているか確認
-### Step 7: guides意味診断
-
-guides が navigation layer の範囲を超えていないか確認。履歴混入を検出した場合 route を追加
-### Step 8: README 索引診断
-
-README 索引が導線の範囲を超えていないか確認。内容過多を検出した場合分割を誘導
-### Step 9: REQ structure review（6観点）
-
-SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT。`agentdev-req-structure-diagnostics` 参照
-### Step 10: 文書分類一貫性検査
-
-document-model SPEC（extension 経由）の classification policy への適合確認。REQ 要件行に schema field、enum 値一覧、route/category/status 判定表、file pattern、テンプレート種別、report format、内部アルゴリズム、作業履歴、実装パラメータ等の SPEC分離基準違反が残留していないかを `agentdev-req-structure-diagnostics` に従って自動検出する
-### Step 11: 配布物整合性検査
-
-配布物（`.opencode/commands/agentdev/`、`.opencode/skills/agentdev-*/`）について、docs-spec-rebuild-integrity SPEC（extension 経由）が定義する検査パターンに従い、構文健全性（frontmatter 重複、見出し重複、Markdown 構文破損、存在しない command 参照、エンコーディング不整合）、文意保持（壊れた括弧、壊れた参照表現、主語/目的語欠落文）、責務整合（command 本体と SPEC 間の責務説明照合、case-open/run/close/auto の責務境界一致）を診断する。`agentdev-req-structure-diagnostics` 参照
-
-存在しない command 参照の検出は、README listing と command 本文の相互参照について存在しない command を指す参照を検出事項とし、実在する command 参照は検出対象外とする（docs-spec-rebuild-integrity SPEC 構文健全性検査準拠）。
-
-エンコーディング不整合の検出は、配布物 Markdown の UTF-{N} BOM 付きファイルと単一ファイル内の CRLF/LF 混在を検出事項とし、BOM なし UTF-{N} かつ単一改行コードで構成されたファイルは検出対象外とする（同上）。
-### Step 12: docs-check route判定
-
-意味的疑いのうち機械的検査に落とせるものを docs-check ルール／検査データ候補として提示
-### Step 13: 未処理artifact確認
-
-`agentdev-req-structure-diagnostics` 参照
-### Step 14: 検出事項出力
-
-検出事項を `.agentdev/inspect/inbox/inspect-docs-finding-{timestamp}.md` へ出力。
-source-of-truth priority: 現行 REQ > 承認済み ADR > SPEC > guides。
-NG 分類（false positive/ pre-existing/ 今回修正対象）は docs-spec-rebuild-integrity SPEC（extension 経由）の NG 分類表に従い、各検出事項に分類、理由、後続対象を付ける
-### Step 15: 実行前同期（git pull --ff-only）
-
- - `git pull --ff-only` を実行
- - **失敗時**: 共通 template (`.opencode/commands/agentdev/templates/common/git-error-messages.md`) の該当形式で表示して停止する（自動解消しない）
-### Step 16: .agentdev/inspect/ 変更の commit と push
-
-`agentdev-git-worktree` の「ドメイン状態永続化プロシージャ」（並列実行安全ステージングプロシージャ含む）に従い、`.agentdev/inspect/` 配下の変更を commit/ push する。commit message は `chore(agentdev): capture inspect-docs finding`（Conventional Commits 形式）。変更なし時は commit/push せず完了報告で「変更なし」と報告する。push 失敗時は同プロシージャの構造化エラー形式で停止する（完了扱いにしない）
-### Step 17: 完了報告
-
-完了報告 template に従って出力
+**共通ルール**（全工程適用、詳細は workflow skill 参照）: エラー処理（スキャン対象ディレクトリ不存在時は該当カテゴリを空扱い警告、ファイル読込失敗時はスキップ警告）
 
 ## ガードレール
 
@@ -119,12 +71,5 @@ NG 分類（false positive/ pre-existing/ 今回修正対象）は docs-spec-reb
 - G03: worktree/ブランチを作成しない
 - G04: intake/learning/RU の処理を行わない
 - G05: source-of-truth priority（現行 REQ > 承認済み ADR > SPEC > guides）に従って矛盾を判定する
-
-## エラー処理
-
-| エラー | 対処 |
-|--------|------|
-| スキャン対象ディレクトリが存在しない | 該当カテゴリを空として扱い、警告を出力 |
-| ファイル読込失敗 | 該当ファイルをスキップし、警告を出力 |
 
 

--- a/src/opencode/commands/agentdev/inspect-promote.md
+++ b/src/opencode/commands/agentdev/inspect-promote.md
@@ -34,71 +34,22 @@ description: 検出事項を分類、採用し、採用済み成果物として 
 - extension が破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する
 - 詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
-## 手順
+## workflow
 
-### Step 1: 実行前同期（git pull --ff-only）
+本コマンドは workflow 実装本体を `agentdev-workflow-inspect-promote` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}）。同スキルは finding disposition（分類・採用・保留・却下）を独立 resume point とする8 STEP の control plane を所有する。durable state（`.agentdev/inspect/inbox/`、`.agentdev/inspect/promoted/`、`.agentdev/intake/promoted/`、auto-promote-log）から会話記憶に依存せず再開できる。
 
- - `git pull --ff-only` を実行
- - **失敗時**: 共通 template (`.opencode/commands/agentdev/templates/common/git-error-messages.md`) の該当形式で表示して停止する（自動解消しない）
-### Step 2: inbox スキャン
+- **STEP-1** 実行前同期 — `git pull --ff-only`（失敗時は git-error-messages template で停止）
+- **STEP-2** inbox スキャン — `.agentdev/inspect/inbox/*.md` 読込（空時は「対象なし」で終了）
+- **STEP-3** 検出事項分類（暫定分類） — promote/ defer/ reject 判定と根拠の確定（finding disposition 入口 resume point）
+- **STEP-4** 自動 promote（`--auto` opt-in 時のみ、fast path） — 高確信度検出事項を `.agentdev/intake/promoted/` へ投入、auto-promote-log 記録
+- **STEP-5** adversarial-review（経路B） — 挿入境界（暫定分類後・HITL 前）での発動条件判定と review 呼出、結果反映、unresolved 停止
+- **STEP-6** HITL 確定（手動分類対象） — 分類結果を提示し、ユーザー承認を得る
+- **STEP-7** 処理実行（promote / reject / defer） — promoted/ 保存 + inbox 削除、即時削除（却下理由を commit message に含める）、inbox 残置（出口 resume point）
+- **STEP-8** 完了報告・永続化 — 判定結果と後続 route の報告、`.agentdev/` 変更の commit/push
 
-`.agentdev/inspect/inbox/*.md` を読み込む。空の場合は「対象なし」と報告して終了
-### Step 3: 検出事項分類
+各 STEP の詳細（開始条件・結果・手順・resume point・関連 Capability Skill 連携）は `agentdev-workflow-inspect-promote` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。同スキルは本コマンドの工程経由でのみ利用し、単独の skill 起動は soft guard（REQ-{NNNN}-{NNN}）で抑制する。
 
-各検出事項について以下を評価し、promote/ defer/ reject を判定する:
- - 明確な不整合 → promote（RU 化対象）
- - 不整合かどうか、採否、範囲、優先度、正とする情報源が未確定 → defer（intake 送付候補）
- - 誤検知、対応不要 → reject
- - 具体的修正対象を持たない再発防止知見 → defer（learning 送付候補）
-### Step 4: 自動 promote（`--auto` opt-in 時のみ）
-
-`--auto` が指定された場合、分類結果のうち workflow-contracts SPEC（extension 経由）の自動 promote 対象カテゴリに合致し、かつ安定契約例外および否定文脈を満たさない高確信度検出事項を HITL 承認なしで `.agentdev/intake/promoted/inspect-auto-{timestamp}-{slug}.md` へ投入する。
-各投入を `.agentdev/inspect/promoted/auto-promote-log.md` に追記する（対象検出事項、カテゴリ、投入先ファイル、根拠）。
-`--auto` 未指定時は本 step をスキップし、自動投入を行わない
-
-### Step 4-1: adversarial-review 発動条件判定（経路B）
-
-review 挿入境界（暫定分類後・HITL 前）で発動条件を判定する（REQ-{NNNN}-{NNN}、REQ-{NNNN}-{NNN}、詳細は inspect-promote SPEC「adversarial-review 挿入境界（経路B）」節参照）。inspect-promote は adversarial-review を原則実行する（default-on、REQ-{NNNN}-{NNN}）。手動分類対象の検出事項（review 対象）が1件以上存在する場合に発動する。ユーザー明示指定は通常発動の必須条件ではない。
-
-- **skip 条件**: `--auto` 経路（fast path、REQ-{NNNN}-{NNN}）、または手動分類対象の検出事項が0件（inbox 空、全件 fast path 完了）の場合、省略して従来フロー（Step 5 HITL 確定）を継続できる（REQ-{NNNN}-{NNN}）。skip 判断のためだけの新規 HITL、承認点は追加しない。
-- **ユーザー明示指定時の必須実行**: ユーザーが本コマンド起動時に adversarial-review を明示的に要求した場合、skip 条件の該当にかかわらず必ず発動する（REQ-{NNNN}-{NNN}）。ただし review 対象（手動分類対象）が存在しない場合は発動しない。
-
-`--auto` により Step 4 で自動 promote された検出事項は HITL を経由しない fast path であり、本判定、Step 4-2 の対象外とする（REQ-{NNNN}-{NNN}、review 挿入迂回）。skip 条件該当時、呼出失敗時（REQ-{NNNN}-{NNN}）は Step 4-2 を実行せず Step 5（HITL 確定）へ従来フローを維持する（REQ-{NNNN}-{NNN}）。
-
-### Step 4-2: adversarial-review 呼出（経路B）
-
-Step 4-1 の発動条件を満たした場合、手動分類対象の検出事項とその暫定分類結果（promote/ defer/ reject 判定と根拠）を入力コンテキストとして adversarial-review を呼び出す（REQ-{NNNN}-{NNN}、REQ-{NNNN}-{NNN}）。adversarial-review は任意助言手段であり、必須工程、QG、承認ゲート、統制ゲートとして導入しない（REQ-{NNNN}-{NNN}）。共通契約（入力コンテキスト、返却契約、呼出失敗時取扱い、再 review 条件、停止条件4点）は adversarial-review SPEC を正とし、本 step は再定義しない
-
-呼出結果の取扱い:
-
-- accepted finding を暫定分類結果へ反映する（REQ-{NNNN}-{NNN}、本コマンドの責務）。反映で暫定分類の意味内容が変更された場合、Step 3（検出事項分類）へ戻し再分類する
-- unresolved な本質的争点が残る場合、Step 5（HITL 確定）へ進まず、ユーザー判断事項として停止する（REQ-{NNNN}-{NNN}）。adversarial-review 自体を恒久的な統制ゲートとしない
-- 呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し、利用不能を報告した上で Step 5（HITL 確定）の従来フローを維持する（REQ-{NNNN}-{NNN}、REQ-{NNNN}-{NNN}）
-
-### Step 5: HITL 確定（手動分類対象）
-
-自動 promote 対象外の検出事項はユーザーの明示的な承認なしに採用済み成果物を生成しない。分類結果を提示し、承認を得る
-### Step 6: promote 処理
-
-承認された promote 対象検出事項を `.agentdev/inspect/promoted/` へ保存。元の inbox file は削除
-### Step 7: reject 処理
-
-承認された reject 対象検出事項は即時削除する。reject 時の commit message に却下理由を含める（AG-{NNN}、監査証跠の補強）
-### Step 8: defer 処理
-
-defer となった検出事項は `.agentdev/inspect/inbox/` に残置。intake/ learning 送付の推奨を報告
-### Step 9: 完了報告
-
-promote/ defer/ reject/ auto-promote の判定結果と後続 route を提示。`--auto` 実行時は投入件数、投入先一覧、ログパスを含める
-### Step 10: .agentdev/ 変更の commit と push
-
- - `git diff --name-only` で `.agentdev/inspect/` および `.agentdev/intake/` 配下の変更を確認（auto-promote の intake/promoted/ 投入、promoted/ への保存、reject に伴う inbox 削除、auto-promote-log 更新を含む）
- - **変更なし時**: commit/push せず「変更なし」と報告
- - **変更あり時**:
- 1. `git add` は `.agentdev/inspect/` と `.agentdev/intake/` のみ対象
- 2. commit message: `chore(agentdev): promote inspect findings`
- 3. `git push` 実行
- 4. **push 失敗時**: 共通 template (`.opencode/commands/agentdev/templates/common/git-error-messages.md`) の該当形式で表示して停止する（完了扱いにしない）
+**共通ルール**（全 STEP 適用、詳細は workflow skill 参照）: エラー処理（inbox 空時は「対象なし」終了、読込失敗時はスキップ警告、全件 defer 時は残置報告、push 失敗時は停止）
 
 ## ガードレール
 
@@ -110,13 +61,5 @@ promote/ defer/ reject/ auto-promote の判定結果と後続 route を提示。
 - G06: `--auto` は明示 opt-in の場合のみ有効。省略時は自動 promote を一切行わない
 - G07: `--auto` は自動 promote 対象カテゴリ（workflow-contracts SPEC 参照、extension 経由）に合致する高確信度検出事項のみを投入し、意味判断、曖昧な分類、ADR 要否判断を含む検出事項は手動分類へ回す
 - G08: `--auto` 実行の都度、投入対象、根拠を `.agentdev/inspect/promoted/auto-promote-log.md` に記録する。誤検知 revoke 手順は同 SPEC 参照
-
-## エラー処理
-
-| エラー | 対処 |
-|--------|------|
-| inbox が空 | 「対象なし」と報告して終了 |
-| 検出事項ファイル読込失敗 | 該当ファイルをスキップし、警告を出力 |
-| ユーザーが全件 defer | inbox に全件残置し、報告 |
 
 

--- a/src/opencode/commands/agentdev/inspect-skills.md
+++ b/src/opencode/commands/agentdev/inspect-skills.md
@@ -30,7 +30,7 @@ Command→Skill 参照妥当性と Skill 構造を検査対象を直接修正せ
 ## inspect-* コマンド選択 routing
 
 変更ファイル種別に基づき、実行する inspect-* コマンドを選ぶ。
-本コマンド（inspect-skills）と inspect-docs は配布物（`.opencode/commands/agentdev/`、`.opencode/skills/agentdev-*/`）の検出対象が一部重複する（inspect-skills Step 3 配布物構文健全性・責務整合診断、inspect-docs Step 11 配布物整合性検査）。変更範囲に応じて routing することで重複検出を防ぐ。
+本コマンド（inspect-skills）と inspect-docs は配布物（`.opencode/commands/agentdev/`、`.opencode/skills/agentdev-*/`）の検出対象が一部重複する（inspect-skills の配布物構文健全性・責務整合診断、inspect-docs の配布物整合性検査）。変更範囲に応じて routing することで重複検出を防ぐ。
 
 | 変更ファイル種別 | 実行コマンド |
 |------|------|
@@ -53,40 +53,17 @@ routing は実行コマンド選択の目安であり、各コマンドの検出
 - extension が破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する
 - 詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
-## 手順
+## workflow
 
-### Step 1: 診断対象の読込
+本コマンドは workflow 実装本体を `agentdev-workflow-inspect-skills` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}）。同スキルは read-only-diagnostic型（STEP model 対象外、resume point なし）として3工程の control plane を所有する。
 
-Command/ Skill 定義を読み込み、Command→Skill 参照、Skill frontmatter、本文構造、references 利用、template/ script 参照を把握する
-### Step 2: 各診断観点の評価
+- **STEP-1** 診断対象の読込 — Command/ Skill 定義の把握（Command→Skill 参照、Skill frontmatter、本文構造、references 利用、template/ script 参照）
+- **STEP-2** 診断観点の評価・分類・route 提示 — 参照妥当性、粒度、段階的開示、責務境界、canonical name、内部構造依存の評価、配布物構文健全性・責務整合診断、診断分類ラベル付与、推奨 route 提示（修正は実行しない）
+- **STEP-3** 検出事項出力・永続化・完了報告 — inbox 出力、実行前同期、`.agentdev/inspect/` commit/push、完了報告
 
-`agentdev-inspect-skills` に従い、参照妥当性、粒度、段階的開示、責務境界、canonical name、内部構造依存を評価する
-### Step 3: 配布物構文健全性、責務整合診断
+各工程の詳細は `agentdev-workflow-inspect-skills` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。同スキルは本コマンドの工程経由でのみ利用し、単独の skill 起動は soft guard（REQ-{NNNN}-{NNN}）で抑制する。
 
-配布物（`.opencode/commands/agentdev/`、`.opencode/skills/agentdev-*/`）について、docs-spec-rebuild-integrity SPEC（extension 経由）が定義する検査パターンのうち Command/Skill 構造に関わる観点（frontmatter 重複、見出し重複、Markdown 構文破損、存在しない command 参照、エンコーディング不整合、壊れた括弧、command と関連 skill 間の責務説明矛盾）を `agentdev-inspect-skills` に従って診断する
-
-存在しない command 参照の検出は、README listing と command 本文の相互参照について存在しない command を指す参照を検出事項とし、実在する command 参照は検出対象外とする（docs-spec-rebuild-integrity SPEC 構文健全性検査準拠）。
-
-エンコーディング不整合の検出は、配布物 Markdown の UTF-{N} BOM 付きファイルと単一ファイル内の CRLF/LF 混在を検出事項とし、BOM なし UTF-{N} かつ単一改行コードで構成されたファイルは検出対象外とする（同上）。
-### Step 4: 分類
-
-検出事項ごとに診断分類ラベルを付与する。NG 分類（false positive/ pre-existing/ 今回修正対象）は docs-spec-rebuild-integrity SPEC（extension 経由）の NG 分類表に従い、各検出事項に分類、理由、後続対象を付ける
-### Step 5: route 提示
-
-修正は実行せず、推奨 route を提示する
-### Step 6: 検出事項出力
-
-検出事項を `.agentdev/inspect/inbox/inspect-skills-finding-{topic}.md` へ出力
-### Step 7: 実行前同期（git pull --ff-only）
-
- - `git pull --ff-only` を実行
- - **失敗時**: 共通 template (`.opencode/commands/agentdev/templates/common/git-error-messages.md`) の該当形式で表示して停止する（自動解消しない）
-### Step 8: .agentdev/inspect/ 変更の commit と push
-
-`agentdev-git-worktree` の「ドメイン状態永続化プロシージャ」（並列実行安全ステージングプロシージャ含む）に従い、`.agentdev/inspect/` 配下の変更を commit/ push する。commit message は `chore(agentdev): capture inspect-skills finding`（Conventional Commits 形式）。変更なし時は commit/push せず完了報告で「変更なし」と報告する。push 失敗時は同プロシージャの構造化エラー形式で停止する（完了扱いにしない）
-### Step 9: 完了報告
-
-完了報告 template に従って出力
+**共通ルール**（全工程適用、詳細は workflow skill 参照）: エラー処理（対象ファイル不存在時は空扱い警告、読込失敗時はスキップ警告、参照先 Skill 不存在時は検出事項として報告）
 
 ## ガードレール
 
@@ -95,13 +72,5 @@ Command/ Skill 定義を読み込み、Command→Skill 参照、Skill frontmatte
 - G03: RU、intake、learning、backlog 成果物を保存しない
 - G04: commit/ push は `.agentdev/inspect/` 配下の永続化のみ許可。branch/ worktree 操作は禁止
 - G05: 自動修正せず、推奨 route の提示に留める
-
-## エラー処理
-
-| エラー | 対処 |
-|--------|------|
-| 対象ファイルが存在しない | 該当カテゴリを空として扱い、警告を出力 |
-| ファイル読込失敗 | 該当ファイルをスキップし、警告を出力 |
-| 参照先 Skill が存在しない | 検出事項として報告し、canonical name の確認を推奨 |
 
 

--- a/src/opencode/skills/agentdev-workflow-inspect-docs/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-docs/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: agentdev-workflow-inspect-docs
+description: "inspect-docs command の workflow 実装本体。docs 全体（REQ/Decision/SPEC/guides/README）の意味整合性診断（REQ 参照ID整合性、第一参照導線、現行/廃止/世代境界、SPEC/Decision/guides/README 意味診断、REQ structure review 6観点、文書分類一貫性）、配布物整合性検査、検出事項の inbox 出力と git 永続化を所有する。read-only-diagnostic型（STEP model 対象外、resume point なし）。USE FOR: inspect-docs command 実行時の workflow 制御（スキャン対象収集・REQ 体系・文書種別別意味診断・配布物整合性検査・docs-check route 判定・検出事項出力・永続化・完了報告）。DO NOT USE FOR: 検出事項の分類・採用・処分（inspect-promote）、Command/Skill 参照妥当性診断（inspect-skills）、決定的検査・機械的検査の実行と検査ルール定義（docs-check 等の機械検査レイヤ）、診断対象ファイルの直接修正、REQ/Decision/SPEC 保存（req-save、spec-save）、Issue/PR 操作（agentdev-gh-cli）、worktree/branch 操作（agentdev-git-worktree）、intake/learning/RU 処理、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# inspect-docs workflow スキル
+
+inspect-docs command の workflow 実装本体。docs 全体（REQ/Decision/SPEC/guides/README）と配布物の意味整合性診断から、検出事項の `.agentdev/inspect/inbox/` 出力、`.agentdev/inspect/` 配下の git 永続化、完了報告までの制御構造を所有する。
+
+inspect-docs command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 型判定: read-only-diagnostic型（STEP model 対象外）
+
+本スキルは read-only-diagnostic型（検査対象を直接修正しない診断専用の型）であり、STEP model の対象外である（REQ-{NNNN}-{NNN}）。**STEP resume point / export / import を持たない**。
+
+- 工程は先頭から通しで実行する。中断が発生した場合は workflow を最初から再実行する（診断は対象の読み取りと検出事項ファイルの生成のみの冪等な処理であり、再実行で同等の結果を得る）
+- 会話コンテキストを権威情報源とする再開点の再構成、状態の export / import を本スキルは定義しない
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md（control plane）と `references/` 配下（各工程詳細）が担う。
+Workflow Skill 固有契約（Command / Workflow Skill / Capability Skill 責務、1:N 分割基準、依存方向、配置契約）は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-inspect-docs.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と inspect-docs command の公開契約のみを前提とする。SPEC ディレクトリの内部構成（`foundations`, `responsibilities` 等）は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- inspect-docs command の実行時 workflow 制御（全工程）
+- スキャン対象の収集（docs/ 配下、README.md、`.opencode/`）
+- REQ 体系意味診断（参照ID整合性、第一参照導線、現行/廃止/世代境界、6観点 structure review、文書分類一貫性）
+- 文書種別別意味診断（SPEC、Decision、guides、README 索引）
+- 配布物整合性検査（構文健全性、文意保持、責務整合）
+- docs-check route 判定、未処理 artifact 確認
+- 検出事項の inbox 出力、`.agentdev/inspect/` 配下の git 永続化、完了報告
+
+## DO NOT USE FOR
+
+- 検出事項の分類・採用・処分（promote/defer/reject）（`/agentdev/inspect-promote`）
+- Command/Skill 参照妥当性診断、Skill 構造診断（`/agentdev/inspect-skills`、`agentdev-inspect-skills`）
+- 決定的検査・機械的検査の実行、検査ルールの定義（docs-check 等の機械検査レイヤ、決定的検証スクリプト）
+- 診断対象（docs/、`.opencode/`）のファイル直接修正
+- REQ/Decision/SPEC ファイル保存（`/agentdev/req-save`、`/agentdev/spec-save`）
+- Issue/PR 作成・更新（`agentdev-gh-cli`）
+- worktree/branch 作成（`agentdev-git-worktree`）
+- intake/learning/RU 処理（`/agentdev/intake-promote` 等）
+
+## 入力
+
+- なし（実行時に全対象成果物を自動スキャン）
+
+## 出力
+
+- 診断結果（セッション内テキスト出力 + `.agentdev/inspect/inbox/inspect-docs-finding-{timestamp}.md`）
+- 検出事項リスト（観点、対象、根拠、source-of-truth 判定、推奨 route）
+
+## 副作用
+
+- `.agentdev/inspect/inbox/inspect-docs-finding-*.md` の生成
+- `.agentdev/inspect/` 配下の変更に限る git commit/push（commit message: `chore(agentdev): capture inspect-docs finding`）
+- 検査対象（docs/、`.opencode/`）のファイル変更は行わない
+
+## 3層責務（deterministic check / semantic diagnosis / finding disposition）
+
+| 層 | 担当 | 本スキルの位置づけ |
+|---|---|---|
+| deterministic check（機械的検査） | docs-check 等の機械検査レイヤ、決定的検証スクリプト | 対象外。機械的パターンマッチングで判定可能な検査を重複して保持しない |
+| semantic diagnosis（意味診断） | inspect-docs workflow（本スキル）、inspect-skills workflow | **本スキルの担当**。docs 体系の意味整合性を診断し検出事項として出力する |
+| finding disposition（検出事項の分類・採用） | inspect-promote workflow | 対象外。本スキルは検出事項の分類・採用を行わない |
+
+## Control Plane（工程一覧）
+
+本スキルの工程一覧を次に示す。STEP ラベルは工程順序の整理ラベルであり、**resume point ではない**（read-only-diagnostic型、REQ-{NNNN}-{NNN}）。
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-1 | スキャン対象の収集 | command 実行開始 | 収集済み対象一覧 | [references/scan-and-doc-diagnostics.md](references/scan-and-doc-diagnostics.md) |
+| STEP-2 | REQ 体系・文書種別別意味診断 | 対象一覧確定 | REQ/Decision/SPEC/guides/README の診断結果 | [references/scan-and-doc-diagnostics.md](references/scan-and-doc-diagnostics.md) |
+| STEP-3 | 配布物整合性検査・route 判定 | STEP-2 完了 | 配布物診断結果、docs-check route 候補、未処理 artifact 確認結果 | [references/distribution-check-and-output.md](references/distribution-check-and-output.md) |
+| STEP-4 | 検出事項出力・永続化・完了報告 | STEP-1〜3 の診断結果確定 | 検出事項ファイル、`.agentdev/inspect/` commit/push、完了報告 | [references/distribution-check-and-output.md](references/distribution-check-and-output.md) |
+
+### 工程間の依存と分岐
+
+- STEP-1 → STEP-2 → STEP-3 → STEP-4（分岐なし、常に同一順序で実行）
+- スキャン対象ディレクトリが存在しない場合は該当カテゴリを空として扱い警告を出力する（エラー処理は各工程 reference 参照）
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-req-structure-diagnostics`: REQ 参照ID整合性、第一参照導線、現行/廃止/世代境界、6観点 structure review、文書分類一貫性、配布物整合性の判定ロジック
+- `agentdev-doc-diagnostics`: 診断カテゴリ、共通証拠構造、finding 出力契約、文書種別別診断へのルーティング
+- `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング含む）
+- `agentdev-conventional-commits`: commit message 規約
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+
+## Workflow Extension 読込契約
+
+本スキルは workflow-extension（`.agentdev/extensions/skills/agentdev-workflow-inspect-docs.yaml`、kind: workflow-extension）を読み込む場合がある。Workflow Skill のみが読み、inspect-docs command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する（fail-open）。破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する。
+
+## 共通制約
+
+- **診断専用**: 許可される副作用は `.agentdev/inspect/inbox/inspect-docs-finding-*.md` の生成と `.agentdev/inspect/` 配下の git 永続化のみ（G01〜G04）
+- **source-of-truth priority**: 現行 REQ > 承認済み Decision > SPEC > guides の順で矛盾を判定する（G05）
+- **SPEC 参照は extension 経由**: document-model SPEC、docs-spec-rebuild-integrity SPEC 等の分類ポリシー・検査パターンは extension 経由で解決し、SPEC 内部パスを固定知識として参照しない
+
+## 終了条件（termination）
+
+- 検出事項ファイル（`.agentdev/inspect/inbox/inspect-docs-finding-{timestamp}.md`）の出力が完了している
+- `.agentdev/inspect/` 配下の変更が commit/push 済みである（変更なし時は「変更なし」報告済み）
+- 完了報告 template（`.opencode/commands/agentdev/templates/inspect-docs/standard.md`）に従った報告を出力した
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **inspect-docs command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）
+- **`agentdev-workflow-inspect-promote`**: 検出事項の後段（分類・採用）を担当する workflow skill

--- a/src/opencode/skills/agentdev-workflow-inspect-docs/references/distribution-check-and-output.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-docs/references/distribution-check-and-output.md
@@ -1,0 +1,79 @@
+# STEP-3 / STEP-4: 配布物整合性検査・検出事項出力・永続化（distribution-check-and-output）
+
+> 本 reference は `agentdev-workflow-inspect-docs` SKILL.md の Control Plane STEP-3、STEP-4 詳細である。read-only-diagnostic型のため resume point を持たない（REQ-{NNNN}-{NNN}）。
+
+## 開始条件
+
+- STEP-3: STEP-2 の文書種別別意味診断の完了
+- STEP-4: STEP-1〜3 の診断結果の確定
+
+## 結果
+
+- 配布物整合性診断結果、docs-check route 候補、未処理 artifact 確認結果
+- 検出事項ファイル（`.agentdev/inspect/inbox/inspect-docs-finding-{timestamp}.md`）
+- `.agentdev/inspect/` 配下の commit/push、完了報告
+
+## 手順
+
+### Step 11: 配布物整合性検査
+
+配布物（`.opencode/commands/agentdev/`、`.opencode/skills/agentdev-*/`）について、docs-spec-rebuild-integrity SPEC（extension 経由）が定義する検査パターンに従い、構文健全性（frontmatter 重複、見出し重複、Markdown 構文破損、存在しない command 参照、エンコーディング不整合）、文意保持（壊れた括弧、壊れた参照表現、主語/目的語欠落文）、責務整合（command 本体と SPEC 間の責務説明照合、case-open/run/close/auto の責務境界一致）を診断する。`agentdev-req-structure-diagnostics` 参照。
+
+存在しない command 参照の検出は、README listing と command 本文の相互参照について存在しない command を指す参照を検出事項とし、実在する command 参照は検出対象外とする（docs-spec-rebuild-integrity SPEC 構文健全性検査準拠）。
+
+エンコーディング不整合の検出は、配布物 Markdown の UTF-8 BOM 付きファイルと単一ファイル内の CRLF/LF 混在を検出事項とし、BOM なし UTF-8 かつ単一改行コードで構成されたファイルは検出対象外とする（同上）。
+
+### Step 12: docs-check route 判定
+
+意味的疑いのうち機械的検査に落とせるものを docs-check ルール／検査データ候補として提示する。
+
+### Step 13: 未処理 artifact 確認
+
+`agentdev-req-structure-diagnostics` 参照。
+
+### Step 14: 検出事項出力
+
+検出事項を `.agentdev/inspect/inbox/inspect-docs-finding-{timestamp}.md` へ出力する。
+source-of-truth priority: 現行 REQ > 承認済み ADR > SPEC > guides。
+NG 分類（false positive/ pre-existing/ 今回修正対象）は docs-spec-rebuild-integrity SPEC（extension 経由）の NG 分類表に従い、各検出事項に分類、理由、後続対象を付ける。
+
+### Step 15: 実行前同期（git pull --ff-only）
+
+- `git pull --ff-only` を実行する
+- **失敗時**: 共通 template（`.opencode/commands/agentdev/templates/common/git-error-messages.md`）の該当形式で表示して停止する（自動解消しない）
+
+### Step 16: .agentdev/inspect/ 変更の commit と push
+
+`agentdev-git-worktree` の「ドメイン状態永続化プロシージャ」（並列実行安全ステージングプロシージャ含む）に従い、`.agentdev/inspect/` 配下の変更を commit/ push する。commit message は `chore(agentdev): capture inspect-docs finding`（Conventional Commits 形式）。変更なし時は commit/push せず完了報告で「変更なし」と報告する。push 失敗時は同プロシージャの構造化エラー形式で停止する（完了扱いにしない）。
+
+### Step 17: 完了報告
+
+完了報告 template（`.opencode/commands/agentdev/templates/inspect-docs/standard.md`）に従って出力する。
+
+## エラー処理
+
+| エラー | 対処 |
+|--------|------|
+| ファイル読込失敗 | 該当ファイルをスキップし、警告を出力 |
+| `git pull --ff-only` 失敗 | git-error-messages 共通 template の該当形式で表示して停止 |
+| push 失敗 | ドメイン状態永続化プロシージャの構造化エラー形式で停止（完了扱いにしない） |
+
+## 関連 STEP
+
+- 前: STEP-2（scan-and-doc-diagnostics）
+- 次: なし（workflow 終了）
+
+## 関連 Capability Skill
+
+- `agentdev-req-structure-diagnostics`: 配布物整合性検査、未処理 artifact 確認の判定ロジック
+- `agentdev-doc-diagnostics`: finding 出力契約、NG 分類
+- `agentdev-git-worktree`: ドメイン状態永続化プロシージャ
+- `agentdev-conventional-commits`: commit message 規約
+- `agentdev-project-extensions`: docs-spec-rebuild-integrity SPEC の extension 経由解決
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G01（`.agentdev/inspect/inbox/inspect-docs-finding-*.md` の生成のみ例外許可、他のファイル変更禁止）
+- G02（GitHub Issue/PR を作成、更新しない）
+- G03（worktree/ブランチを作成しない）
+- G04（intake/learning/RU の処理を行わない）

--- a/src/opencode/skills/agentdev-workflow-inspect-docs/references/scan-and-doc-diagnostics.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-docs/references/scan-and-doc-diagnostics.md
@@ -1,0 +1,77 @@
+# STEP-1 / STEP-2: スキャン対象収集・REQ 体系・文書種別別意味診断（scan-and-doc-diagnostics）
+
+> 本 reference は `agentdev-workflow-inspect-docs` SKILL.md の Control Plane STEP-1、STEP-2 詳細である。read-only-diagnostic型のため resume point を持たない（REQ-{NNNN}-{NNN}）。
+
+## 開始条件
+
+- STEP-1: inspect-docs command の実行開始
+- STEP-2: スキャン対象一覧の確定
+
+## 結果
+
+- REQ/Decision/SPEC/guides/README の意味診断結果（検出事項候補、根拠、source-of-truth 判定、推奨 route）
+
+## 手順
+
+### Step 1: スキャン対象の収集
+
+`docs/requirements/`、`docs/decisions/`、`docs/specs/`、`docs/guides/`、`README.md`、`.opencode/` を収集する。
+
+### Step 2: REQ 参照ID整合性確認
+
+`agentdev-req-structure-diagnostics` 参照。
+
+### Step 3: 第一参照導線確認
+
+`agentdev-req-structure-diagnostics` 参照。
+
+### Step 4: 現行/廃止/世代境界確認
+
+`agentdev-req-structure-diagnostics` 参照。
+
+### Step 5: SPEC 意味診断
+
+SPEC が REQ/Decision/guides の代替、将来計画の混入、実行時依存先としての不適切扱いを確認する。
+
+### Step 6: Decision 意味診断
+
+承認済み ADR のみを現行判断の根拠として扱っているか確認する。
+
+### Step 7: guides 意味診断
+
+guides が navigation layer の範囲を超えていないか確認する。履歴混入を検出した場合 route を追加する。
+
+### Step 8: README 索引診断
+
+README 索引が導線の範囲を超えていないか確認する。内容過多を検出した場合分割を誘導する。
+
+### Step 9: REQ structure review（6観点）
+
+SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT。`agentdev-req-structure-diagnostics` 参照。
+
+### Step 10: 文書分類一貫性検査
+
+document-model SPEC（extension 経由）の classification policy への適合確認。REQ 要件行に schema field、enum 値一覧、route/category/status 判定表、file pattern、テンプレート種別、report format、内部アルゴリズム、作業履歴、実装パラメータ等の SPEC分離基準違反が残留していないかを `agentdev-req-structure-diagnostics` に従って自動検出する。
+
+## エラー処理
+
+| エラー | 対処 |
+|--------|------|
+| スキャン対象ディレクトリが存在しない | 該当カテゴリを空として扱い、警告を出力 |
+| ファイル読込失敗 | 該当ファイルをスキップし、警告を出力 |
+
+## 関連 STEP
+
+- 前: なし（workflow 先頭）
+- 次: STEP-3（distribution-check-and-output）
+
+## 関連 Capability Skill
+
+- `agentdev-req-structure-diagnostics`: Step 2〜4、9、10 の判定ロジック
+- `agentdev-doc-diagnostics`: 診断カテゴリ、証拠構造、文書種別別ルーティング
+- `agentdev-project-extensions`: document-model SPEC の extension 経由解決
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G01（ファイルを変更、作成、削除しない。ただし `.agentdev/inspect/inbox/inspect-docs-finding-*.md` の生成は例外として許可）
+- G05（source-of-truth priority（現行 REQ > 承認済み ADR > SPEC > guides）に従って矛盾を判定）

--- a/src/opencode/skills/agentdev-workflow-inspect-promote/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-promote/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: agentdev-workflow-inspect-promote
+description: "inspect-promote command の workflow 実装本体。検出事項（finding）の分類（promote/defer/reject）、自動 promote（--auto opt-in、fast path）、adversarial-review 経路B、HITL 確定、promote/reject/defer 処理実行、完了報告と .agentdev/ 永続化を所有する。finding disposition（分類・採用・保留・却下）が独立 resume point を持つ STEP model であり、durable state（.agentdev/inspect/inbox/、promoted/、auto-promote-log、intake/promoted/）から会話記憶に依存せず再開できる。USE FOR: inspect-promote command 実行時の workflow 制御（inbox スキャン・検出事項分類・自動 promote・adversarial-review 経路B・HITL 確定・処理実行・永続化・完了報告）。DO NOT USE FOR: 検出事項の生成（inspect-docs、inspect-skills）、docs 体系や Command/Skill の意味診断、採用済み成果物の RU 化・統合（backlog-review）、REQ/Decision/SPEC 変更、Issue/PR 操作（agentdev-gh-cli）、worktree/branch 操作（agentdev-git-worktree）、adversarial-review の共通契約定義（agentdev-adversarial-review）、自動 promote 対象カテゴリの定義（workflow-contracts SPEC、extension 経由）、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# inspect-promote workflow スキル
+
+inspect-promote command の workflow 実装本体。`.agentdev/inspect/inbox/` の検出事項を分類（promote/defer/reject）し、採用した検出事項を `.agentdev/inspect/promoted/` へ保存、却下した検出事項を即時削除、見送りを inbox に残置する。`--auto` 明示 opt-in 時は高確信度検出事項を `.agentdev/intake/promoted/` へ自動投入する。finding disposition を STEP resume point として所有する。
+
+inspect-promote command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md（control plane）と `references/` 配下（各 STEP 詳細）が担う。
+Workflow Skill 固有契約（Command / Workflow Skill / Capability Skill 責務、1:N 分割基準、依存方向、配置契約）は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-inspect-promote.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と inspect-promote command の公開契約のみを前提とする。SPEC ディレクトリの内部構成（`foundations`, `responsibilities` 等）は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- inspect-promote command の実行時 workflow 制御（全 STEP）
+- 検出事項の分類（promote/defer/reject）と HITL 確定
+- 自動 promote（`--auto` 明示 opt-in 時のみ、fast path）
+- adversarial-review 経路B（暫定分類後・HITL 前の review 挿入）
+- promote/ reject/ defer 処理の実行（promoted/ 保存、即時削除、inbox 残置）
+- `.agentdev/inspect/`・`.agentdev/intake/` 配下の変更の commit/push、完了報告
+
+## DO NOT USE FOR
+
+- 検出事項の生成（`/agentdev/inspect-docs`、`/agentdev/inspect-skills`）
+- docs 体系や Command/Skill の意味診断（各 inspect workflow）
+- 採用済み成果物の RU 化・統合・矛盾検出（`/agentdev/backlog-review`）
+- REQ/Decision/SPEC 変更、正規文書変更
+- Issue/PR 操作（`agentdev-gh-cli`）
+- worktree/branch 操作（`agentdev-git-worktree`）
+- adversarial-review の共通契約（入力コンテキスト、返却契約、呼出失敗時取扱い、再 review 条件、停止条件）の定義（`agentdev-adversarial-review`）
+- 自動 promote 対象カテゴリ、投入先、誤検知 revoke 手順の定義（workflow-contracts SPEC、extension 経由で解決）
+
+## 入力
+
+- `.agentdev/inspect/inbox/*.md`（検出事項ファイル群）
+- `--auto`（省略可能）: 高確信度検出事項の自動 promote を有効化する明示 opt-in。省略時は従来の手動分類フローのみ
+
+## 出力
+
+- `.agentdev/inspect/promoted/*.md`（手動 promote 採用済み、RU 化対象）
+- reject 検出事項は即時削除（reject 時の commit message に却下理由を含める、監査証跡の補強）
+- `.agentdev/intake/promoted/inspect-auto-*.md`（`--auto` 時の自動 promote 成果物。backlog-review へ流入）
+- `.agentdev/inspect/promoted/auto-promote-log.md`（`--auto` 実行ログ。append-only）
+- セッション内完了報告
+
+## 副作用
+
+- `.agentdev/inspect/`（inbox 削除・残置、promoted/ 保存、auto-promote-log 更新）と `.agentdev/intake/`（promoted/ 投入）配下のファイル作成・削除
+- 上記配下に限る git commit/push（commit message: `chore(agentdev): promote inspect findings`）
+- 検出事項の分類確定状態とユーザー承認状態は durable state（ファイル配置）として保持する
+
+## 3層責務（deterministic check / semantic diagnosis / finding disposition）
+
+| 層 | 担当 | 本スキルの位置づけ |
+|---|---|---|
+| deterministic check（機械的検査） | docs-check 等の機械検査レイヤ、決定的検証スクリプト | 対象外。機械的検査は前段レイヤが担当する |
+| semantic diagnosis（意味診断） | inspect-docs workflow、inspect-skills workflow | 対象外。本スキルは診断を生成しない（前段が生成した検出事項を消費するのみ） |
+| finding disposition（検出事項の分類・採用） | inspect-promote workflow（本スキル） | **本スキルの担当**。検出事項の分類・採用・保留・却下とユーザー承認を処理する |
+
+## Control Plane（STEP 一覧）
+
+inspect-promote workflow は次の8 STEP で構成する。各 STEP は resume point を持つ（DEC-{N}、`docs/specs/<workflows/step-reference-contract>.md`）。会話コンテキストに依存せず、durable state（`.agentdev/inspect/inbox/`、`.agentdev/inspect/promoted/`、`.agentdev/intake/promoted/`、auto-promote-log）から再開点を再構成する。**finding disposition（STEP-3〜STEP-7 の分類・採用・保留・却下）は独立した resume point 群を構成する。**
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-1 | 実行前同期 | command 実行開始 | `git pull --ff-only` 完了 | [references/inbox-scan-and-classification.md](references/inbox-scan-and-classification.md) |
+| STEP-2 | inbox スキャン | 同期完了 | 検出事項一覧（空時は「対象なし」で終了） | [references/inbox-scan-and-classification.md](references/inbox-scan-and-classification.md) |
+| STEP-3 | 検出事項分類（暫定分類） | 検出事項一覧確定 | 暫定分類結果（promote/defer/reject と根拠） | [references/inbox-scan-and-classification.md](references/inbox-scan-and-classification.md) |
+| STEP-4 | 自動 promote（`--auto` fast path） | `--auto` 指定かつ暫定分類確定 | `.agentdev/intake/promoted/inspect-auto-*.md` 投入、auto-promote-log 記録 | [references/auto-promote-and-review.md](references/auto-promote-and-review.md) |
+| STEP-5 | adversarial-review（経路B） | 挿入境界（暫定分類後・HITL 前）到達、発動条件成立 | review 結果の暫定分類反映、または unresolved 停止、または従来フロー継続 | [references/auto-promote-and-review.md](references/auto-promote-and-review.md) |
+| STEP-6 | HITL 確定（手動分類対象） | review 完了または skip | ユーザー承認済み分類結果 | [references/hitl-and-disposition.md](references/hitl-and-disposition.md) |
+| STEP-7 | 処理実行（promote / reject / defer） | HITL 承認完了 | promoted/ 保存、inbox 削除（promote）、即時削除（reject）、inbox 残置（defer） | [references/hitl-and-disposition.md](references/hitl-and-disposition.md) |
+| STEP-8 | 完了報告・永続化 | 処理実行完了 | 完了報告、`.agentdev/` 変更の commit/push | [references/hitl-and-disposition.md](references/hitl-and-disposition.md) |
+
+### STEP 間の依存と分岐
+
+- **通常（手動分類）**: STEP-1 → STEP-2 → STEP-3 → （`--auto` 未指定時は STEP-4 を skip） → STEP-5（skip 条件該当時は省略） → STEP-6 → STEP-7 → STEP-8
+- **`--auto` 指定時**: STEP-4 で自動 promote 対象を fast path として投入し、手動分類対象のみ STEP-5 以降へ進む
+- **inbox 空**: STEP-2 で「対象なし」と報告して終了
+- **unresolved な本質的争点**: STEP-5 でユーザー判断事項として停止（STEP-6 へ進まない）
+
+## resume protocol（DEC-{N}、会話記憶非依存）
+
+- 各 STEP の再開点は durable state から再構成する（`<workflows/input-resolution-and-durable-state>` SPEC の優先順位に従う）
+- **検出事項ごとの分類確定状態の再構成**: inbox に残存する検出事項は未確定（STEP-3 分類から再開）、`.agentdev/inspect/promoted/` に保存済みの検出事項は promote 確定（再保存しない）、auto-promote-log 記載済みかつ `.agentdev/intake/promoted/inspect-auto-*.md` 投入済みは自動 promote 確定（再投入しない）、inbox から削除済みは reject 確定（復元しない）、inbox 残置かつ処理実行済み報告があるものは defer 確定
+- **HITL 承認状態**: 承認は処理実行（STEP-7）の完了状態から逆算して再構成する。処理実行が済んでいない検出事項は承認未了と扱い、HITL 確定（STEP-6）から再開する
+- 自然言語の前 STEP result のみに依存した再開を行わない
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-adversarial-review`: 経路B review 呼出（共通契約は同 skill が正規所有）
+- `agentdev-git-worktree`: 並列実行安全ステージングプロシージャ（明示パス stage、`git commit -- <paths>`）
+- `agentdev-conventional-commits`: commit message 規約（reject 時の却下理由記載含む）
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+
+## Workflow Extension 読込契約
+
+本スキルは workflow-extension（`.agentdev/extensions/skills/agentdev-workflow-inspect-promote.yaml`、kind: workflow-extension）を読み込む場合がある。Workflow Skill のみが読み、inspect-promote command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する（fail-open）。破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する。自動 promote 対象カテゴリ、投入先、実行ログ、誤検知 revoke 手順は workflow-contracts SPEC（extension 経由で解決）を正とし、本スキルはカテゴリ定義を重複保持しない。
+
+## 共通制約
+
+- **HITL 承認必須**: 自動 promote 対象（`--auto`）を除き、ユーザーの明示的な承認なしに採用済み成果物を生成しない（G01）
+- **reject は即時削除**: `archive/rejected/` への移動は廃止。即時削除以外の取扱を禁止し、reject 時の commit message に却下理由を含める（G03）
+- **defer は inbox 残置**: defer となった検出事項を `.agentdev/inspect/inbox/` から移動しない（G04）
+- **`--auto` は明示 opt-in の場合のみ有効**: 省略時は自動 promote を一切行わない（G06）。自動 promote 対象は workflow-contracts SPEC（extension 経由）が定義する高確信度カテゴリのみとし、意味判断、曖昧な分類、ADR 要否判断を含む検出事項は手動分類へ回す（G07）
+- **実行ログ**: `--auto` 実行の都度、投入対象、根拠を `.agentdev/inspect/promoted/auto-promote-log.md` に記録する（G08）
+- **adversarial-review は任意助言手段**: 必須工程、QG、承認ゲート、統制ゲートとして導入しない。呼出失敗時は silent skip を禁止し、従来フロー（HITL 確定）を維持する
+
+## 終了条件（termination）
+
+- 全検出事項が promote（promoted/ 保存 + inbox 削除）/ reject（即時削除）/ defer（inbox 残置）/ 自動 promote（intake/promoted/ 投入 + ログ記録）のいずれかに確定している
+- `.agentdev/inspect/` と `.agentdev/intake/` 配下の変更が commit/push 済みである（変更なし時は「変更なし」報告済み）
+- 完了報告 template（`.opencode/commands/agentdev/templates/inspect-promote/standard.md`）に従い、promote/defer/reject/auto-promote の判定結果と後続 route（`--auto` 実行時は投入件数、投入先一覧、ログパスを含む）を報告した
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **`<workflows/step-reference-contract>` SPEC**: STEP reference 構造、resume point
+- **`<workflows/input-resolution-and-durable-state>` SPEC**: 入力解決優先順位、durable state
+- **inspect-promote command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）
+- **`agentdev-workflow-inspect-docs` / `agentdev-workflow-inspect-skills`**: 検出事項の生成を担当する前段 workflow skill

--- a/src/opencode/skills/agentdev-workflow-inspect-promote/references/auto-promote-and-review.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-promote/references/auto-promote-and-review.md
@@ -1,0 +1,46 @@
+# STEP-4 / STEP-5: 自動 promote・adversarial-review 経路B（auto-promote-and-review）
+
+> 本 reference は `agentdev-workflow-inspect-promote` SKILL.md の Control Plane STEP-4、STEP-5 詳細である。各 STEP は resume point を持つ（DEC-{N}、`<workflows/step-reference-contract>` SPEC）。
+
+## STEP-4: 自動 promote（`--auto` opt-in 時のみ）
+
+- **Purpose**: 機械的に特定可能で移行先が一意に定まる高確信度検出事項を、HITL を経ずに intake/promoted/ へ自動投入する（fast path）
+- **Input Resolution**: STEP-3 の暫定分類結果。自動 promote 対象カテゴリ、安定契約例外、否定文脈の判定基準は workflow-contracts SPEC（extension 経由で解決）を正とする
+- **Preconditions**: `--auto` が明示指定されていること、STEP-3 完了
+- **Procedure**: 分類結果のうち workflow-contracts SPEC（extension 経由）の自動 promote 対象カテゴリに合致し、かつ安定契約例外および否定文脈を満たさない高確信度検出事項を `.agentdev/intake/promoted/inspect-auto-{timestamp}-{slug}.md` へ投入する。各投入を `.agentdev/inspect/promoted/auto-promote-log.md` に追記する（対象検出事項、カテゴリ、投入先ファイル、根拠）。`--auto` 未指定時は本 STEP をスキップし、自動投入を行わない
+- **Result**: 自動投入済み検出事項、auto-promote-log 記録
+- **Evidence**: `.agentdev/intake/promoted/inspect-auto-*.md` ファイルと auto-promote-log の追記エントリ
+- **Completion Verification**: 自動投入対象が全て投入済みで、各投入がログに記録済みであること
+- **Resume-Idempotency**: auto-promote-log 記載済みかつ投入先ファイルが存在する検出事項は自動 promote 確定として再投入しない。再開時はログと投入先ファイルの突合により未投入分のみを処理する
+
+## STEP-5: adversarial-review（経路B）
+
+- **Purpose**: 暫定分類結果を adversarial-review による対論的審議へかけ、分類の妥当性を高める
+- **Input Resolution**: 手動分類対象の検出事項とその暫定分類結果（promote/defer/reject 判定と根拠）を入力コンテキストとする
+- **Preconditions**: review 挿入境界（暫定分類後・HITL 前）への到達。発動条件は後述の判定に従う
+- **Procedure**:
+  1. **発動条件判定**: inspect-promote は adversarial-review を原則実行する（default-on）。手動分類対象の検出事項（review 対象）が1件以上存在する場合に発動する。ユーザー明示指定は通常発動の必須条件ではない
+  2. **skip 条件**: `--auto` 経路（fast path）、または手動分類対象の検出事項が0件（inbox 空、全件 fast path 完了）の場合、省略して従来フロー（STEP-6 HITL 確定）を継続できる。skip 判断のためだけの新規 HITL、承認点は追加しない
+  3. **ユーザー明示指定時の必須実行**: ユーザーが本コマンド起動時に adversarial-review を明示的に要求した場合、skip 条件の該当にかかわらず必ず発動する。ただし review 対象（手動分類対象）が存在しない場合は発動しない
+  4. **review 呼出**: 手動分類対象の検出事項と暫定分類結果を入力コンテキストとして adversarial-review を呼び出す。adversarial-review は任意助言手段であり、必須工程、QG、承認ゲート、統制ゲートとして導入しない。共通契約（入力コンテキスト、返却契約、呼出失敗時取扱い、再 review 条件、停止条件4点）は adversarial-review SPEC を正とし、本 STEP は再定義しない
+  5. **結果反映**: accepted finding を暫定分類結果へ反映する。反映で暫定分類の意味内容が変更された場合、STEP-3（検出事項分類）へ戻し再分類する
+- **Result**: review 結果反映済みの暫定分類、または unresolved 停止、または従来フロー継続
+- **Evidence**: review 呼出の実行記録、accepted finding の反映記録
+- **Completion Verification**: accepted finding の反映が完了していること、または unresolved 判定時に停止していること、または skip 条件該当時に従来フローへ遷移していること
+- **Resume-Idempotency**: `--auto` により STEP-4 で自動 promote された検出事項は HITL を経由しない fast path であり、本判定、本 review の対象外とする（review 挿入迂回）。skip 条件該当時、呼出失敗時は STEP-6 を実行せず従来フロー（HITL 確定）を維持する。unresolved な本質的争点が残る場合、STEP-6 へ進まずユーザー判断事項として停止する（adversarial-review 自体を恒久的な統制ゲートとしない）。呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し、利用不能を報告した上で従来フローを維持する
+
+## 関連 STEP
+
+- 前: STEP-3（inbox-scan-and-classification）
+- 次: STEP-6（hitl-and-disposition）
+
+## 関連 Capability Skill
+
+- `agentdev-adversarial-review`: 経路B review 呼出（共通契約の正規所有者）
+- `agentdev-project-extensions`: workflow-contracts SPEC の extension 経由解決
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G01（ユーザーの明示的な承認なしに採用済み成果物を生成しない。`--auto` による自動 promote 対象を除く）
+- G06（`--auto` は明示 opt-in の場合のみ有効。省略時は自動 promote を一切行わない）
+- G08（`--auto` 実行の都度、投入対象、根拠を `.agentdev/inspect/promoted/auto-promote-log.md` に記録する。誤検知 revoke 手順は同 SPEC 参照）

--- a/src/opencode/skills/agentdev-workflow-inspect-promote/references/hitl-and-disposition.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-promote/references/hitl-and-disposition.md
@@ -1,0 +1,68 @@
+# STEP-6 / STEP-7 / STEP-8: HITL 確定・処理実行・完了報告と永続化（hitl-and-disposition）
+
+> 本 reference は `agentdev-workflow-inspect-promote` SKILL.md の Control Plane STEP-6〜STEP-8 詳細である。各 STEP は resume point を持つ（DEC-{N}、`<workflows/step-reference-contract>` SPEC）。
+
+## STEP-6: HITL 確定（手動分類対象）
+
+- **Purpose**: 自動 promote 対象外の検出事項について、ユーザーの明示的な承認を得て分類を確定する
+- **Input Resolution**: STEP-5 の反映済み暫定分類結果（skip 時は STEP-3 の暫定分類結果）。検出事項本文は inbox ファイル（durable state）から読み取る
+- **Preconditions**: STEP-5 完了または skip 条件該当、手動分類対象が1件以上存在
+- **Procedure**: 自動 promote 対象外の検出事項はユーザーの明示的な承認なしに採用済み成果物を生成しない。分類結果を提示し、承認を得る
+- **Result**: ユーザー承認済み分類結果（promote/defer/reject の確定）
+- **Evidence**: 分類提示内容とユーザー承認の応答
+- **Completion Verification**: 手動分類対象の全検出事項について承認応答を得たこと
+- **Resume-Idempotency**: 承認状態は処理実行（STEP-7）の完了状態から逆算して再構成する。処理実行が済んでいない検出事項は承認未了と扱い、本 STEP から再開する（未承認の推定で処理を実行しない）
+
+## STEP-7: 処理実行（promote / reject / defer）
+
+- **Purpose**: 承認済み分類に従い、検出事項の配置変更（promote 保存、reject 削除、defer 残置）を実行する（finding disposition の出口 resume point）
+- **Input Resolution**: STEP-6 の承認済み分類結果、`--auto` 時は STEP-4 の自動 promote 確定状態（auto-promote-log との突合）
+- **Preconditions**: STEP-6 完了（手動分類対象）、STEP-4 完了（自動 promote 対象）
+- **Procedure**:
+  - **promote 処理**: 承認された promote 対象検出事項を `.agentdev/inspect/promoted/` へ保存する。元の inbox file は削除する
+  - **reject 処理**: 承認された reject 対象検出事項は即時削除する。reject 時の commit message に却下理由を含める（監査証跡の補強）
+  - **defer 処理**: defer となった検出事項は `.agentdev/inspect/inbox/` に残置する。intake/ learning 送付の推奨を報告する
+- **Result**: 全検出事項の配置確定（promoted/ 保存済み、削除済み、inbox 残置）
+- **Evidence**: 配置後のファイル構成（promoted/、inbox/）、reject を含む commit message
+- **Completion Verification**: 全検出事項が promote（promoted/ 保存 + inbox 削除）/ reject（削除）/ defer（残置）/ 自動 promote（投入済み）のいずれかに確定していること
+- **Resume-Idempotency**: promoted/ に保存済みの検出事項は promote 確定として再保存しない。inbox から削除済みは reject 確定として復元しない。inbox 残置は未確定または defer のため、auto-promote-log との突合で defer 確定か未処理かを判別する
+
+## STEP-8: 完了報告・永続化
+
+- **Purpose**: 分類結果と後続 route を報告し、`.agentdev/` 配下の変更を永続化する
+- **Input Resolution**: STEP-7 の配置確定状態（`git diff --name-only` で `.agentdev/inspect/` および `.agentdev/intake/` 配下の変更を確認）
+- **Preconditions**: STEP-7 完了
+- **Procedure**:
+  1. `git diff --name-only` で `.agentdev/inspect/` および `.agentdev/intake/` 配下の変更を確認する（auto-promote の intake/promoted/ 投入、promoted/ への保存、reject に伴う inbox 削除、auto-promote-log 更新を含む）
+  2. **変更なし時**: commit/push せず「変更なし」と報告する
+  3. **変更あり時**: `git add` は `.agentdev/inspect/` と `.agentdev/intake/` のみ対象とする。commit message は `chore(agentdev): promote inspect findings`（reject を含む場合は却下理由を含める）。`git push` を実行する。push 失敗時は共通 template（`.opencode/commands/agentdev/templates/common/git-error-messages.md`）の該当形式で表示して停止する（完了扱いにしない）
+  4. 完了報告 template（`.opencode/commands/agentdev/templates/inspect-promote/standard.md`）に従い、promote/ defer/ reject/ auto-promote の判定結果と後続 route を提示する。`--auto` 実行時は投入件数、投入先一覧、ログパスを含める
+- **Result**: 完了報告出力、`.agentdev/` 変更の commit/push
+- **Evidence**: commit hash、push 実行結果、完了報告
+- **Completion Verification**: 変更が commit/push 済みであること（または変更なし報告済み）、完了報告を出力したこと
+- **Resume-Idempotency**: commit/push の対象は明示パスに限定され、再実行で未 commit 変更が残っていないかを `git diff --name-only` で再確認できる。push 済み commit の重複実行は発生しない（変更なし時は commit/push を行わない）
+
+## エラー処理
+
+| エラー | 対処 |
+|--------|------|
+| inbox が空 | 「対象なし」と報告して終了 |
+| 検出事項ファイル読込失敗 | 該当ファイルをスキップし、警告を出力 |
+| ユーザーが全件 defer | inbox に全件残置し、報告 |
+| push 失敗 | git-error-messages 共通 template の該当形式で表示して停止（完了扱いにしない） |
+
+## 関連 STEP
+
+- 前: STEP-5（auto-promote-and-review）
+- 次: なし（workflow 終了）
+
+## 関連 Capability Skill
+
+- `agentdev-git-worktree`: 並列実行安全ステージングプロシージャ（明示パス stage）
+- `agentdev-conventional-commits`: commit message 規約
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G03（reject された検出事項は即時削除される。即時削除以外の取扱を禁止する）
+- G04（defer された検出事項は `.agentdev/inspect/inbox/` に残す）
+- G05（docs-check ルール／検査データ追加候補は独立 route とせず、採用済み成果物の要件化方向または受け入れ条件に含める）

--- a/src/opencode/skills/agentdev-workflow-inspect-promote/references/inbox-scan-and-classification.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-promote/references/inbox-scan-and-classification.md
@@ -1,0 +1,54 @@
+# STEP-1 / STEP-2 / STEP-3: 実行前同期・inbox スキャン・検出事項分類（inbox-scan-and-classification）
+
+> 本 reference は `agentdev-workflow-inspect-promote` SKILL.md の Control Plane STEP-1〜STEP-3 詳細である。各 STEP は resume point を持つ（DEC-{N}、`<workflows/step-reference-contract>` SPEC）。
+
+## STEP-1: 実行前同期
+
+- **Purpose**: リモートの最新状態を取り込み、検出事項の分類処理を最新の inbox 状態に対して実行する
+- **Input Resolution**: durable state 優先順位に従い `.agentdev/inspect/inbox/` の現状を読み込む前にリポジトリ状態を同期する
+- **Preconditions**: inspect-promote command の実行開始
+- **Procedure**: `git pull --ff-only` を実行する。失敗時は共通 template（`.opencode/commands/agentdev/templates/common/git-error-messages.md`）の該当形式で表示して停止する（自動解消しない）
+- **Result**: fast-forward 済みの最新リポジトリ状態
+- **Evidence**: pull 実行結果（hash、または構造化エラー出力）
+- **Completion Verification**: pull が成功していること（エラー出力なし）
+- **Resume-Idempotency**: 同期は読み取り側の前処理であり冪等。再実行時は再度 `git pull --ff-only` を実行してよい
+
+## STEP-2: inbox スキャン
+
+- **Purpose**: 処理対象となる検出事項の一覧を確定する
+- **Input Resolution**: `.agentdev/inspect/inbox/*.md`（durable state）を読み込む。自然言語の前 STEP result に依存しない
+- **Preconditions**: STEP-1 完了
+- **Procedure**: `.agentdev/inspect/inbox/*.md` を読み込む。空の場合は「対象なし」と報告して終了する
+- **Result**: 検出事項一覧（ファイルパス、内容）
+- **Evidence**: 読み込んだ検出事項ファイルの一覧
+- **Completion Verification**: inbox 配下の全 `.md` ファイルを読み込んだこと
+- **Resume-Idempotency**: inbox のファイル構成は durable state そのもの。再開時は常に再スキャンして最新構成を採用する
+
+## STEP-3: 検出事項分類（暫定分類）
+
+- **Purpose**: 各検出事項について promote/defer/reject の暫定分類と根拠を確定する（finding disposition の入口 resume point）
+- **Input Resolution**: STEP-2 の検出事項一覧。各検出事項の観点、対象、根拠、source-of-truth 判定、推奨 route は検出事項ファイル本文（durable state）から読み取る
+- **Preconditions**: STEP-2 完了、検出事項が1件以上存在
+- **Procedure**: 各検出事項について以下を評価し、promote/defer/reject を判定する
+  - 明確な不整合 → promote（RU 化対象）
+  - 不整合かどうか、採否、範囲、優先度、正とする情報源が未確定 → defer（intake 送付候補）
+  - 誤検知、対応不要 → reject
+  - 具体的修正対象を持たない再発防止知見 → defer（learning 送付候補）
+- **Result**: 暫定分類結果（検出事項ごとの promote/defer/reject 判定と根拠）
+- **Evidence**: 検出事項ごとの判定と根拠の記録
+- **Completion Verification**: 全検出事項に暫定分類ラベルと根拠が付与されていること
+- **Resume-Idempotency**: 暫定分類は会話状態にのみ存在する中間状態である。再開時は STEP-2 の再スキャン結果に対して暫定分類を再構成する。inbox に残存する検出事項は未確定として扱う
+
+## 関連 STEP
+
+- 前: なし（workflow 先頭）
+- 次: STEP-4（auto-promote-and-review）、`--auto` 未指定時は STEP-5
+
+## 関連 Capability Skill
+
+- `agentdev-git-worktree`: 実行前同期、並列実行安全ステージングプロシージャ
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G02（promote された検出事項のみを `.agentdev/inspect/promoted/` へ保存する）
+- G07（`--auto` は自動 promote 対象カテゴリ（workflow-contracts SPEC 参照、extension 経由）に合致する高確信度検出事項のみを投入し、意味判断、曖昧な分類、ADR 要否判断を含む検出事項は手動分類へ回す）

--- a/src/opencode/skills/agentdev-workflow-inspect-skills/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-skills/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: agentdev-workflow-inspect-skills
+description: "inspect-skills command の workflow 実装本体。Command→Skill 参照妥当性、Skill frontmatter・本文構造・references 利用・template/ script 参照・粒度・段階的開示・責務境界・実行主体分類の診断、配布物構文健全性・責務整合診断、検出事項の分類と route 提示、inbox 出力と git 永続化を所有する。read-only-diagnostic型（STEP model 対象外、resume point なし）。project 非依存で単体動作する。USE FOR: inspect-skills command 実行時の workflow 制御（診断対象読込・診断観点評価・配布物構文健全性診断・分類・route 提示・検出事項出力・永続化・完了報告）。DO NOT USE FOR: 検出事項の分類・採用・処分（inspect-promote）、docs 体系の意味整合性診断（inspect-docs）、決定的検査・機械的検査の実行と検査ルール定義（docs-check 等の機械検査レイヤ）、診断対象ファイルの直接修正、正規文書や REQ/Decision/SPEC の変更、Issue/PR 作成（agentdev-gh-cli）、worktree/branch 操作（agentdev-git-worktree）、RU/intake/learning/backlog 成果物保存、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# inspect-skills workflow スキル
+
+inspect-skills command の workflow 実装本体。Command/Skill 参照妥当性と Skill 構造の診断から、検出事項の分類、推奨 route の提示、`.agentdev/inspect/inbox/` 出力、`.agentdev/inspect/` 配下の git 永続化、完了報告までの制御構造を所有する。
+
+inspect-skills command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 型判定: read-only-diagnostic型（STEP model 対象外）
+
+本スキルは read-only-diagnostic型（検査対象を直接修正しない診断専用の型）であり、STEP model の対象外である（REQ-{NNNN}-{NNN}）。**STEP resume point / export / import を持たない**。
+
+- 工程は先頭から通しで実行する。中断が発生した場合は workflow を最初から再実行する（診断は対象の読み取りと検出事項ファイルの生成のみの冪等な処理であり、再実行で同等の結果を得る）
+- 会話コンテキストを権威情報源とする再開点の再構成、状態の export / import を本スキルは定義しない
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md（control plane）と `references/` 配下（各工程詳細）が担う。
+Workflow Skill 固有契約（Command / Workflow Skill / Capability Skill 責務、1:N 分割基準、依存方向、配置契約）は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-inspect-skills.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と inspect-skills command の公開契約のみを前提とする。SPEC ディレクトリの内部構成（`foundations`, `responsibilities` 等）は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- inspect-skills command の実行時 workflow 制御（全工程）
+- 診断対象の読込（Command/ Skill 定義、関連 template/ reference/ script）
+- 診断観点の評価（参照妥当性、粒度、段階的開示、責務境界、canonical name、内部構造依存）
+- 配布物構文健全性・責務整合診断
+- 検出事項の分類と推奨 route の提示（修正は実行しない）
+- 検出事項の inbox 出力、`.agentdev/inspect/` 配下の git 永続化、完了報告
+
+## DO NOT USE FOR
+
+- 検出事項の分類・採用・処分（promote/defer/reject）（`/agentdev/inspect-promote`）
+- docs 体系（REQ/Decision/SPEC/guides/README）の意味整合性診断（`/agentdev/inspect-docs`）
+- 決定的検査・機械的検査の実行、検査ルールの定義（docs-check 等の機械検査レイヤ）
+- 診断対象ファイルの直接修正、自動修正
+- 正規文書変更、REQ/Decision/SPEC 変更、Command/Skill/Template/Script 変更
+- Issue/PR 作成・更新（`agentdev-gh-cli`）
+- worktree/branch 操作（`agentdev-git-worktree`）
+- RU/intake/learning/backlog 成果物の保存
+
+## 入力
+
+- Command 定義ファイル群
+- Skill 定義ファイル群
+- 必要に応じて関連する template/ reference/ script ファイル群
+
+## 出力
+
+- 診断レポート（セッション内テキスト出力）
+- 検出事項リスト（対象、観点、分類、根拠、推奨 route）
+- `.agentdev/inspect/inbox/inspect-skills-finding-{topic}.md`
+
+## 副作用
+
+- `.agentdev/inspect/inbox/inspect-skills-finding-*.md` の生成
+- `.agentdev/inspect/` 配下の変更に限る git commit/push（commit message: `chore(agentdev): capture inspect-skills finding`）
+- 診断対象（Command/ Skill/ Template/ Script 定義）のファイル変更は行わない
+
+## 3層責務（deterministic check / semantic diagnosis / finding disposition）
+
+| 層 | 担当 | 本スキルの位置づけ |
+|---|---|---|
+| deterministic check（機械的検査） | docs-check 等の機械検査レイヤ、決定的検証スクリプト | 対象外。機械的パターンマッチングで判定可能な検査を重複して保持しない |
+| semantic diagnosis（意味診断） | inspect-skills workflow（本スキル）、inspect-docs workflow | **本スキルの担当**。Command/Skill 参照妥当性と Skill 構造を診断し検出事項として出力する |
+| finding disposition（検出事項の分類・採用） | inspect-promote workflow | 対象外。本スキルは検出事項の分類・採用を行わない |
+
+## Control Plane（工程一覧）
+
+本スキルの工程一覧を次に示す。STEP ラベルは工程順序の整理ラベルであり、**resume point ではない**（read-only-diagnostic型、REQ-{NNNN}-{NNN}）。
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-1 | 診断対象の読込 | command 実行開始 | Command/ Skill 定義の把握（参照、frontmatter、本文構造、references、template/ script 参照） | [references/skill-structure-diagnostics.md](references/skill-structure-diagnostics.md) |
+| STEP-2 | 診断観点の評価・分類・route 提示 | 診断対象把握完了 | 検出事項（分類、根拠、推奨 route 付き） | [references/skill-structure-diagnostics.md](references/skill-structure-diagnostics.md) |
+| STEP-3 | 検出事項出力・永続化・完了報告 | STEP-2 の検出事項確定 | 検出事項ファイル、`.agentdev/inspect/` commit/push、完了報告 | [references/finding-output-and-persist.md](references/finding-output-and-persist.md) |
+
+### 工程間の依存と分岐
+
+- STEP-1 → STEP-2 → STEP-3（分岐なし、常に同一順序で実行）
+- 対象ファイルが存在しない場合は該当カテゴリを空として扱い警告を出力する（エラー処理は各工程 reference 参照）
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-inspect-skills`: 診断観点と判定基準（参照妥当性、粒度、段階的開示、責務境界、canonical name、内部構造依存、配布物構文健全性）
+- `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング含む）
+- `agentdev-conventional-commits`: commit message 規約
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+
+## Workflow Extension 読込契約
+
+本スキルは workflow-extension（`.agentdev/extensions/skills/agentdev-workflow-inspect-skills.yaml`、kind: workflow-extension）を読み込む場合がある。Workflow Skill のみが読み、inspect-skills command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する（fail-open）。破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する。
+
+本スキルは project 非依存で単体動作する正当な状態であり、extension が存在しなくても診断の全工程が動作する（対応 extension が存在しない command/skill は正常動作である）。docs-spec-rebuild-integrity SPEC の検査パターンは extension 経由で解決する。
+
+## 共通制約
+
+- **診断専用**: 許可される副作用は `.agentdev/inspect/inbox/inspect-skills-finding-*.md` の生成と `.agentdev/inspect/` 配下の git 永続化のみ（G01〜G04）
+- **修正せず route 提示のみ**: 自動修正せず、推奨 route の提示に留める（G05）
+- **SPEC 参照は extension 経由**: docs-spec-rebuild-integrity SPEC 等の検査パターンは extension 経由で解決し、SPEC 内部パスを固定知識として参照しない
+
+## 終了条件（termination）
+
+- 検出事項ファイル（`.agentdev/inspect/inbox/inspect-skills-finding-{topic}.md`）の出力が完了している
+- `.agentdev/inspect/` 配下の変更が commit/push 済みである（変更なし時は「変更なし」報告済み）
+- 完了報告 template（`.opencode/commands/agentdev/templates/inspect-skills/standard.md`）に従った報告を出力した
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **inspect-skills command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）
+- **`agentdev-workflow-inspect-promote`**: 検出事項の後段（分類・採用）を担当する workflow skill

--- a/src/opencode/skills/agentdev-workflow-inspect-skills/references/finding-output-and-persist.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-skills/references/finding-output-and-persist.md
@@ -1,0 +1,54 @@
+# STEP-3: 検出事項出力・永続化・完了報告（finding-output-and-persist）
+
+> 本 reference は `agentdev-workflow-inspect-skills` SKILL.md の Control Plane STEP-3 詳細である。read-only-diagnostic型のため resume point を持たない（REQ-{NNNN}-{NNN}）。
+
+## 開始条件
+
+- STEP-2 の検出事項（分類、根拠、推奨 route 付き）の確定
+
+## 結果
+
+- 検出事項ファイル（`.agentdev/inspect/inbox/inspect-skills-finding-{topic}.md`）
+- `.agentdev/inspect/` 配下の commit/push、完了報告
+
+## 手順
+
+### Step 6: 検出事項出力
+
+検出事項を `.agentdev/inspect/inbox/inspect-skills-finding-{topic}.md` へ出力する。
+
+### Step 7: 実行前同期（git pull --ff-only）
+
+- `git pull --ff-only` を実行する
+- **失敗時**: 共通 template（`.opencode/commands/agentdev/templates/common/git-error-messages.md`）の該当形式で表示して停止する（自動解消しない）
+
+### Step 8: .agentdev/inspect/ 変更の commit と push
+
+`agentdev-git-worktree` の「ドメイン状態永続化プロシージャ」（並列実行安全ステージングプロシージャ含む）に従い、`.agentdev/inspect/` 配下の変更を commit/ push する。commit message は `chore(agentdev): capture inspect-skills finding`（Conventional Commits 形式）。変更なし時は commit/push せず完了報告で「変更なし」と報告する。push 失敗時は同プロシージャの構造化エラー形式で停止する（完了扱いにしない）。
+
+### Step 9: 完了報告
+
+完了報告 template（`.opencode/commands/agentdev/templates/inspect-skills/standard.md`）に従って出力する。
+
+## エラー処理
+
+| エラー | 対処 |
+|--------|------|
+| `git pull --ff-only` 失敗 | git-error-messages 共通 template の該当形式で表示して停止 |
+| push 失敗 | ドメイン状態永続化プロシージャの構造化エラー形式で停止（完了扱いにしない） |
+
+## 関連 STEP
+
+- 前: STEP-2（skill-structure-diagnostics）
+- 次: なし（workflow 終了）
+
+## 関連 Capability Skill
+
+- `agentdev-git-worktree`: ドメイン状態永続化プロシージャ
+- `agentdev-conventional-commits`: commit message 規約
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G02（GitHub Issue/PR を作成、更新しない）
+- G03（RU、intake、learning、backlog 成果物を保存しない）
+- G04（commit/ push は `.agentdev/inspect/` 配下の永続化のみ許可。branch/ worktree 操作は禁止）

--- a/src/opencode/skills/agentdev-workflow-inspect-skills/references/skill-structure-diagnostics.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-skills/references/skill-structure-diagnostics.md
@@ -1,0 +1,61 @@
+# STEP-1 / STEP-2: 診断対象読込・診断観点評価・分類・route 提示（skill-structure-diagnostics）
+
+> 本 reference は `agentdev-workflow-inspect-skills` SKILL.md の Control Plane STEP-1、STEP-2 詳細である。read-only-diagnostic型のため resume point を持たない（REQ-{NNNN}-{NNN}）。
+
+## 開始条件
+
+- STEP-1: inspect-skills command の実行開始
+- STEP-2: 診断対象（Command/ Skill 定義）の把握完了
+
+## 結果
+
+- 検出事項リスト（対象、観点、分類、根拠、推奨 route 付き）
+
+## 手順
+
+### Step 1: 診断対象の読込
+
+Command/ Skill 定義を読み込み、Command→Skill 参照、Skill frontmatter、本文構造、references 利用、template/ script 参照を把握する。
+
+### Step 2: 各診断観点の評価
+
+`agentdev-inspect-skills` に従い、参照妥当性、粒度、段階的開示、責務境界、canonical name、内部構造依存を評価する。
+
+### Step 3: 配布物構文健全性、責務整合診断
+
+配布物（`.opencode/commands/agentdev/`、`.opencode/skills/agentdev-*/`）について、docs-spec-rebuild-integrity SPEC（extension 経由）が定義する検査パターンのうち Command/Skill 構造に関わる観点（frontmatter 重複、見出し重複、Markdown 構文破損、存在しない command 参照、エンコーディング不整合、壊れた括弧、command と関連 skill 間の責務説明矛盾）を `agentdev-inspect-skills` に従って診断する。
+
+存在しない command 参照の検出は、README listing と command 本文の相互参照について存在しない command を指す参照を検出事項とし、実在する command 参照は検出対象外とする（docs-spec-rebuild-integrity SPEC 構文健全性検査準拠）。
+
+エンコーディング不整合の検出は、配布物 Markdown の UTF-8 BOM 付きファイルと単一ファイル内の CRLF/LF 混在を検出事項とし、BOM なし UTF-8 かつ単一改行コードで構成されたファイルは検出対象外とする（同上）。
+
+### Step 4: 分類
+
+検出事項ごとに診断分類ラベルを付与する。NG 分類（false positive/ pre-existing/ 今回修正対象）は docs-spec-rebuild-integrity SPEC（extension 経由）の NG 分類表に従い、各検出事項に分類、理由、後続対象を付ける。
+
+### Step 5: route 提示
+
+修正は実行せず、推奨 route を提示する。
+
+## エラー処理
+
+| エラー | 対処 |
+|--------|------|
+| 対象ファイルが存在しない | 該当カテゴリを空として扱い、警告を出力 |
+| ファイル読込失敗 | 該当ファイルをスキップし、警告を出力 |
+| 参照先 Skill が存在しない | 検出事項として報告し、canonical name の確認を推奨 |
+
+## 関連 STEP
+
+- 前: なし（workflow 先頭）
+- 次: STEP-3（finding-output-and-persist）
+
+## 関連 Capability Skill
+
+- `agentdev-inspect-skills`: 診断観点と判定基準（Step 2、3）
+- `agentdev-project-extensions`: docs-spec-rebuild-integrity SPEC の extension 経由解決
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G01（ファイルを変更、作成、削除しない。ただし `.agentdev/inspect/inbox/inspect-skills-finding-*.md` の生成は例外として許可）
+- G05（自動修正せず、推奨 route の提示に留める）


### PR DESCRIPTION
Refs: #2104

## 概要

Epic #2099 Wave 2 / Issue #2104（OU-004: inspect 3 Command Workflow Skill migration）。inspect-docs / inspect-skills / inspect-promote の3 Command を Workflow Skill へ移管した。inspect-docs / inspect-skills は read-only-diagnostic型（STEP model 対象外、resume point / export / import なし）、inspect-promote は finding disposition（分類・採用・保留・却下）を独立 resume point とする STEP model として設計した。3層責務（deterministic check / semantic diagnosis / finding disposition）は各 Workflow Skill に担当分離表として明記し維持した。

## 実装内容

1. **Workflow Skill 3件を新設**（`src/opencode/skills/agentdev-workflow-inspect-{docs,skills,promote}/`、SKILL.md + references 計10ファイル）
   - `agentdev-workflow-inspect-docs`: 4工程（スキャン対象収集 / REQ 体系・文書種別別意味診断 / 配布物整合性検査・route 判定 / 検出事項出力・永続化・完了報告）。read-only-diagnostic型として STEP model 対象外を明記
   - `agentdev-workflow-inspect-skills`: 3工程（診断対象読込 / 診断観点評価・分類・route 提示 / 検出事項出力・永続化・完了報告）。同型。project 非依存で単体動作する正当な状態（extension 不要）を Workflow Extension 読込契約に明記
   - `agentdev-workflow-inspect-promote`: 8 STEP（実行前同期 / inbox スキャン / 検出事項分類（暫定分類）/ 自動 promote（--auto fast path）/ adversarial-review 経路B / HITL 確定 / 処理実行（promote・reject・defer）/ 完了報告・永続化）。全 STEP に Purpose / Input Resolution / Preconditions / Procedure / Result / Evidence / Completion Verification / Resume-Idempotency の8要素を定義
2. **3 Command を thin Command 化**（public interface / guardrails / Workflow Skill dispatch のみ。手順本文とエラー処理表を Workflow Skill の references/ へ移管）
3. **soft guard 付与**: 各 Workflow Skill の frontmatter description に DO NOT USE FOR トリガー（直接起動の抑制）を、各 Command の workflow 節に工程経由のみの利用と soft guard による単独起動抑制を記載
4. **Capability Skill 内部 reference 直接依存の除去**: Command は Workflow Skill 名のみ参照し、Capability Skill は `agentdev-req-structure-diagnostics`、`agentdev-doc-diagnostics`、`agentdev-inspect-skills`、`agentdev-adversarial-review` 等を名レベルで参照
5. **3層責務の維持**: 各 Workflow Skill に deterministic check（docs-check 等の機械検査レイヤ）/ semantic diagnosis（inspect-docs・inspect-skills）/ finding disposition（inspect-promote）の担当分離表を配置。検出と処分の責務混在なし
6. **Public IF 維持**: 3 Command の description（frontmatter）、入出力契約、ガードレール ID（G01〜G08）、inspect-* routing 表、project extensions 節、完了報告 template 経路は変更なし。routing 表の工程番号参照（旧 Step 11 / Step 3）のみ機能名参照へ decoupling

## 完了条件

- [x] 3 Command 本文が public interface / guardrails / Workflow Skill dispatch のみを所有し、workflow 実装本体を複製していないこと（検証済み: `## 手順` セクション除去、行数 76 / 77 / 66 行、手順詳細は Skill references 配下にのみ存在）
- [x] 3 Workflow Skill が存在し、独立実行可能であること（検証済み: SKILL.md + references に全手順を移管、frontmatter name とディレクトリ名一致、USE FOR / DO NOT USE FOR 宣言済み）
- [x] read-only-diagnostic型（inspect-docs / inspect-skills）の Workflow Skill が STEP model 対象外（resume point / export / import なし）として設計されていること（検証済み: 型判定節で対象外を明記、resume point を要求する記述なし、中断時は先頭から再実行と宣言）
- [x] inspect-promote Workflow Skill の finding disposition が独立 resume point を持ち、durable state で resume 可能であること（検証済み: resume protocol 節で分類確定状態の再構成規則を定義、全8 STEP が8要素を保有、会話記憶非依存）
- [x] deterministic check / semantic diagnosis / finding disposition の3層責務が維持されていること（検証済み: 各 Skill に担当分離表、診断 Skill は分類・採用を行わず、inspect-promote は診断を生成しない）
- [x] 3 Command に soft guard が付与されていること（検証済み: Command workflow 節 + Skill description DO NOT USE FOR トリガーの双方）
- [x] 3 Command 本文から Capability Skill 内部 reference への直接依存が存在しないこと（検証済み: `agentdev-*/references/` 形式のパス参照 0 件、Capability Skill は名レベル参照のみ）
- [x] Public IF に意図しない変更がないこと（検証済み: description・入出力・ガードレール・テンプレート経路は原文維持、変更ファイルは対象成果物の範囲内のみ）

チェックボックスは PR 作成時点での検証記録である。最終完了判定は case-close QG-4 の責務とする。

## テスト結果

- TS-001: 合格。3 Command（inspect-docs / inspect-skills / inspect-promote）について、Command が public interface / dispatch のみを所有、対応する Workflow Skill が存在し独立実行可能、soft guard 付与済み、Capability 境界が名レベル参照であることを機械検証した（`## 手順` 除去、dispatch 参照、soft guard 記述、内部 reference パス参照の検査）。
- TS-002: 合格。inspect-promote Workflow Skill について STEP reference / resume model / durable state / Input Resolution 契約が成立していることを確認した（8 STEP 全てに8要素あり、resume protocol 節が durable state からの分類確定状態再構成を定義、conversation memory 非依存）。read-only-diagnostic型（inspect-docs / inspect-skills）は STEP model 対象外のため検証対象から除外した。
- TS-104: 合格。agentdev-skill-authoring の品質基準（frontmatter name 一致、USE FOR / DO NOT USE FOR トリガー、参照深度1階層、100行超 reference なし）と agentdev-command-authoring の品質基準（frontmatter description 単一、行数、実行時パス参照）で全10ファイルを査読し、未解決違反 0 件。
- Step 7-1（配布依存境界 事前 gate）: 合格。`check_distribution_boundary.ts --profile source --json` → ok: true、scanned 275 files、concrete_id_hits 0、concrete_path_hits 0、fixed_url_hits 0。
- check_command_format.ts: OK（Step 見出し規約、ガードレール番号形式、違反 0）。
- check_executor_notation.ts: ok（IR 系違反 0、scanned 392 files）。
- lint_skills.ts 等の `.opencode/` 配下検査は worktree の構造的制約（ジャンクション未伝播のため `.opencode/skills/` に repo-local のみ存在）により src/opencode/ SoT パスから同等の構造検査（frontmatter name 一致、description 存在、トリガー存在、See Also 参照解決）を実施し合格。

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 完了条件達成数 | 8/8 | 8/8 | 合格 |
| TS-001 / TS-002 / TS-104 | 全て合格 | 全項目合格 | 合格 |
| check_distribution_boundary（--profile source） | failures 0 / errors 0（275 files） | 違反 0 件 | 合格 |
| check_command_format / check_executor_notation | 違反 0 件 | 違反 0 件 | 合格 |
| Command 行数 | 76 / 77 / 66 行 | 100 行以内（目標） | 合格 |
| 変更ファイル数 | 13（3 Command + 10 Skill ファイル） | 対象成果物の範囲内のみ | 合格 |

## Findings / Capture候補

### intake

- 発見元: 本 PR の移行作業（grep 検査）
- 内容: `src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-categories.md`（「inspect-docs Step 11、inspect-skills Step 3 でルーティングし」）と `diagnostic-routing.md`（「ルーティング表と inspect-docs Step との対応」節）が inspect-docs / inspect-skills の旧 Command 手順番号を参照している。本移行で手順番号は Workflow Skill 側へ移動したため、この参照は陳腐化する。`agentdev-doc-diagnostics` は本 Issue の対象成果物外のため本 PR では修正せず、横断是正の intake 候補として記録する（OU-005 Command SPEC 同期、OU-007 旧責務残存 cleanup の管轄と重なる）。
- 分類: intake

### learning

- 発見元: 本 PR の Workflow Skill 作成作業
- 内容: 配布物（src/opencode/）に Workflow Skill の STEP 表を記述する際、STEP / QG 接頭辞は具体番号付きで配布可能（distributed-control として境界検査を通過）だが、他の全 ID ファミリー（REQ / DEC / ADR / AG / IR / TS / OU / RU / EC 等）は具体番号を書くと配布依存境界検査で違反または未分類エラーになる。具体番号が必要な場面は STEP / QG に限定し、それ以外はマスク形式で統一する必要がある。OU-002 / OU-003 など並列 Wave での Workflow Skill 作成時に同じ制約に当たるため、作成段階からマスク形式で書くことで手戻りを防げる。
- 分類: learning

## SPEC確定候補

- read-only-diagnostic型 Workflow Skill の標準セクション構成（型判定節、工程一覧（STEP ラベルは順序ラベルであり resume point ではない旨の宣言）、中断時は先頭から再実行する冪等性根拠、終了条件）を Workflow Skill Model SPEC（workflows ドメイン）へ確定する候補。本 PR では inspect-docs / inspect-skills の2 Skill で同一構成を採用しており、Wave 2 移行後の横断整合の判断材料となる。
- inspect-promote の分類確定状態再構成規則（inbox 残存 = 未確定、`.agentdev/inspect/promoted/` 保存済み = promote 確定、auto-promote-log 記載済みかつ投入先ファイル存在 = 自動 promote 確定、削除済み = reject 確定、inbox 残置かつ処理実行済み = defer 確定、HITL 承認は処理実行 STEP の完了状態から逆算）を workflow-contracts SPEC または backlog-artifact-lifecycle SPEC の検出事項プロトコル側へ確定する候補。