### PR TITLE
feat(agentdev): intake/learning/backlog 5 Command を Workflow Skill へ移管（OU-003）

### DIFF
--- a/src/opencode/commands/agentdev/backlog-review.md
+++ b/src/opencode/commands/agentdev/backlog-review.md
@@ -39,109 +39,20 @@ RU-*.md の構造（frontmatter: `source_type`, `generated_by`, `generated_at`, 
 
 `source_type: chat` かつ `generated_by: session` のRU（session由来RU）の生成形式は、一時成果物ライフサイクル要件と artifact-contracts SPEC「RU アーティファクト契約（session由来RU）」セクションを正規原本とする。本コマンドは frontmatter 必須フィールド、二段階承認、`agreement_confirmed_at`、session 論理URI、RU 本文必須8セクション、永続ID 採番、`tentative_classification` の各要件を同 SPEC へ委譲し、再定義しない
 
-## 手順
+## workflow
 
-### Step 1: 実行前同期
+本コマンドは workflow 実装本体を `agentdev-workflow-backlog-review` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}）。同スキルが8 STEP の control plane として制御構造を所有する。各 STEP は resume point を持ち、durable state（promoted/ 残存成果物、`.agentdev/backlog/req-units/` の RU-*.md 実ファイルと frontmatter）から再開点を再構成する（DEC-{N}）。
 
-`git pull --ff-only` を実行する。
-失敗時は構造化エラーメッセージを表示して停止する（`agentdev-git-worktree` と同一のエラー形式）。
+- **STEP-1** 実行前同期・成果物検出 — `git pull --ff-only`、引数有無による対象切り替え（引数なし時は三ディレクトリ検出、引数あり時は指定パスのみ）、0件時は正常終了
+- **STEP-2** 分析・暫定分類付与 — 成果物読込・分析、document-model SPEC（extension 経由）の文書7分類モデルによる `tentative_classification` 付与
+- **STEP-3** 統合・分割判定・depends_on 依存解決 — RU 構成案（統合・分割判定、依存解決結果）の確定
+- **STEP-4** review（経路E） — adversarial-review 発動条件判定・review 呼出・accepted finding 反映（矛盾は矛盾検出へ引継ぎ、skip 条件該当時は省略）
+- **STEP-5** HITL — RU 構成案のユーザー承認（RU 生成承認を兼ねる。矛盾なし時は単一承認）
+- **STEP-6** 矛盾検出・追加判断 — 矛盾検出（検出時のみ追加判断、矛盾しない artifact は通常通り RU 化、partial success）
+- **STEP-7** RU 生成・成功成果物削除 — `.agentdev/backlog/req-units/RU-*.md` 生成、RU 化に成功した成果物のみ削除
+- **STEP-8** Git 永続化・完了報告 — 明示パス staging、`git commit -- <paths>`、push、テンプレート別完了報告（全成功 / partial success / 対象なし）
 
-### Step 2: 成果物検出
-
-引数の有無に応じて対象を切り替える:
-
-**引数なしの場合**: 三ディレクトリから採用済み成果物を検出:
-- `.agentdev/intake/promoted/*.md`
-- `.agentdev/learning/promoted/*.md`
-- `.agentdev/inspect/promoted/*.md`
-
-**引数ありの場合**: 指定されたファイルパスのみを対象。
-存在しないパスはエラー報告してスキップ。
-
-検出結果の判定:
-- **0件**: 正常終了（エラー扱いとしない）。完了報告で「対象なし」と報告
-- **1件以上**: ファイルパス昇順で Step 3 へ
-
-### Step 3: 成果物読み込み、分析 + 暫定分類付与
-
-分析基準、前工程からの引き継ぎメタデータ付与ルールは `agentdev-backlog-integration` を参照
-
-**暫定分類付与（REQ）**: 各 RU 候補について、document-model SPEC（extension 経由）の文書7分類モデル（REQ、挙動SPEC、カタログSPEC、guide、learning維持、作業記録、対象外）を参照して暫定分類を付与する。
-暫定分類は後続 `/agentdev/req-define` の Step 5-2 で最終確定される候補であり、本コマンドが確定しない。
-分析結果と併せて RU frontmatter に `tentative_classification` として記録する。
-
-### Step 4: 統合、分割判定 + depends_on 依存解決 + ユーザー承認
-
-統合、分割判定基準、depends_on 依存解決ルールは `agentdev-backlog-integration` を参照
-
-**構成、review、承認の順序（REQ-{NNNN}-{NNN}）**: Step 4 前半（統合、分割判定、depends_on 依存解決）で RU 構成案を確定し、続く Step 4-1（adversarial-review 呼出、default-on）を経て、Step 4 後半（ユーザー承認）で承認を確定する。構成、review、承認の順序の正規所有者は backlog-review command SPEC「adversarial-review 挿入境界（経路E）」節である。
-
-**矛盾なしの場合の単一承認（REQ）**: 後続の Step 5 で矛盾が検出されない場合、本 Step 4 の統合、分割判定承認を RU 生成承認（Step 5/6）としても扱う。
-単一承認で処理し、追加の HITL は不要。
-
-### Step 4-1: adversarial-review 呼出（経路E、REQ-{NNNN}-{NNN}）
-
-backlog-review 経路E の adversarial-review 挿入境界。Step 4 前半（構成）完了後、Step 4 後半（承認）前に挿入する。挿入境界、発動条件、順序、矛盾取扱いの正規所有者は backlog-review command SPEC「adversarial-review 挿入境界（経路E）」節であり、本 Step は実行時投影先である。候補判断基準、内部手続きの詳細は `agentdev-backlog-integration` を参照。
-
-**発動条件判定（REQ-{NNNN}-{NNN}/002/003）**: backlog-review は adversarial-review を原則実行する（default-on、REQ-{NNNN}-{NNN}）。RU 構成案（統合・分割判定、depends_on 依存解決）に意味的決定が存在する場合に発動する。ユーザー明示指定は通常発動の必須条件ではない。発動条件判定 Step と review 呼出 Step を分離する（REQ-{NNNN}-{NNN}）。
-
-- **skip 条件**: RU 構成要素が1件のみ（統合・分割判定不要、depends_on 解決不要）で矛盾検出対象が存在しない場合、省略して従来フロー（Step 4 後半以降）を継続できる（REQ-{NNNN}-{NNN}）。skip 判断のためだけの新規 HITL、承認点は追加しない
-- **ユーザー明示指定時の必須実行**: ユーザーが明示的に adversarial-review を指定した場合、skip 条件の該当にかかわらず必ず発動する（REQ-{NNNN}-{NNN}）
-
-**review 呼出（REQ-{NNNN}-{NNN}）**: 発動条件該当時、`agentdev-adversarial-review` を起動する。審議対象は Step 4 前半で確定した RU 構成案（統合・分割判定結果、depends_on 解決結果、暫定分類付与結果）。呼出契約、返却契約、副作用境界は `agentdev-adversarial-review` と delegation-contracts SPEC（`semantic_review`、書き込み禁止型）を正とする。
-
-**矛盾の扱い（REQ-{NNNN}-{NNN}）**: review 審議で採用済み成果物間の矛盾が指摘された場合、当該矛盾は Step 5（既存矛盾検出）へ引き渡す。adversarial-review 自身は矛盾を自動解決せず、矛盾の判定、partial success 扱い、ユーザー追加判断への委ねは Step 5 の既存矛盾検出ロジックが正である。
-
-**従来フロー維持（REQ-{NNNN}-{NNN}）**: skip 条件該当時、呼出失敗時（REQ-{NNNN}-{NNN}）のいずれの場合も、従来フロー（Step 4 後半以降）を維持する。review 挿入境界は既存 Step を追加、削除、並べ替えしない。
-
-**accepted finding 反映と再 review（REQ-{NNNN}-{NNN}/007）**: accepted finding の RU 構成案への反映は本コマンド（呼出元）の責務である。反映後に RU 構成案の意味内容が変更された場合、必要な既存検証（depends_on 再解決、矛盾検出再実行）を行い、意味内容変更から新たな本質的争点が生じ得る場合のみ再 review を発動できる。同一 finding を新証拠・新前提・異なる failure condition・未評価範囲なしに再起票しない。
-
-**unresolved 時の取扱い（REQ-{NNNN}-{NNN}）**: unresolved な本質的争点またはユーザー判断事項が残る場合、RU 生成（Step 6）、採用済み成果物削除（Step 7）、Git 永続化（Step 8）等の後続不可逆処理へ進まない。
-
-### Step 5: 矛盾検出 + 必要に応じて追加判断
-
-矛盾検出ロジック、出力形式は `agentdev-backlog-integration` を参照
-
-**矛盾検出時の追加判断（REQ）**: 矛盾が検出された場合のみ、ユーザーに追加判断を求める。
-矛盾する artifact を RU 化せずユーザーに確認する。
-矛盾しない artifact は通常通り RU 化する（partial success）。
-自動解決しない（G05）
-
-### Step 6: RU 生成
-
-RU 生成ルール、frontmatter スキーマ、depends_on 検証は `agentdev-backlog-integration` を参照
-
-**session由来RU の場合**: `source_type: chat`、`generated_by: session` のRU は「session由来RU 生成形式（参照）」セクションに従う。二段階承認、frontmatter 必須フィールド、session 論理URI、RU 本文必須8セクション、採番、保存手続きは正規原本（一時成果物ライフサイクル要件、artifact-contracts SPEC「RU アーティファクト契約（session由来RU）」）へ委譲する
-
-### Step 7: 成功成果物の削除
-
-RU 生成が成功した採用済み成果物のみを削除する:
-
-- **削除条件**: 当該成果物が RU に取り込まれ、RU ファイルの生成が確認できた場合のみ
-- **残置対象**: RU 化に失敗した成果物、矛盾により除外された成果物
-- 削除結果を記録する
-
-### Step 8: Git 永続化
-
-`.agentdev/` 配下の変更を commit/ push する:
-
-- `git diff --name-only` で `.agentdev/` 配下の変更を確認
-- **変更なし時**: commit/push せず完了報告で「変更なし」と報告
-- **変更あり時**:
- 1. 並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い明示パスでステージする。
- 生成した RU は `.agentdev/backlog/req-units/` 配下、削除した採用済み成果物は `.agentdev/{intake,learning,inspect}/promoted/` 配下の各パスを `git add <path>`/ `git rm <path>` で明示的にステージする。
- `.agentdev/` 全体の一括 `git add` は禁止
- 2. commit message: `chore(agentdev): generate requirement units via backlog-review`
- 3. `git commit -- <paths>`（--only pathspec 形式）を実行し、`git push` を行う。失敗時は構造化エラーメッセージを表示して停止
-
-### Step 9: 完了報告
-
-完了報告 → 完了報告templateに従って出力:
-- 全て成功 → `.opencode/commands/agentdev/templates/backlog-review/standard.md`
-- partial success（矛盾あり）→ `.opencode/commands/agentdev/templates/backlog-review/partial.md`
-- 採用済み成果物なし → `.opencode/commands/agentdev/templates/backlog-review/zero-promoted.md`
-
-RU 生成結果、git 永続化結果を含める。次のコマンド: `/agentdev/req-define`
+各 STEP の詳細（開始条件・結果・手順・resume point・関連 Capability Skill 連携）は `agentdev-workflow-backlog-review` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
 ## ガードレール
 

--- a/src/opencode/commands/agentdev/intake-capture.md
+++ b/src/opencode/commands/agentdev/intake-capture.md
@@ -8,7 +8,7 @@ description: 未分類の変更候補を手動入力から intake item として
 
 **このコマンドは保存専用である。
 ** GitHub Issue の作成、採用可否の判断は行わない。
-作業知見だけの内容は対象外である（`agentdev-workflow-orchestration` skill の Split Rule を参照）。
+作業知見だけの内容は対象外である（`agentdev-workflow-orchestration` の capture 振り分け基準を参照）。
 
 ## project extensions
 
@@ -28,80 +28,19 @@ description: 未分類の変更候補を手動入力から intake item として
 
 - `.agentdev/intake/inbox/YYYY-MM-DD-{topic-slug}.md` に保存された intake item
 
-## Intake Item 形式
+## workflow
 
-intake item は以下の推奨標準形に従う Markdown 成果物とする。
-workflow 管理用の frontmatter、状態フィールド、重複排除キーは持たない。
+本コマンドは workflow 実装本体を `agentdev-workflow-intake-capture` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}）。同スキルが保存専用 workflow の実装（入力の受領から intake item 生成、保存、git 永続化、完了報告まで）を所有する。
 
-```markdown
-# {タイトル}
+本 workflow は capture-only型であり、STEP model の対象外である（REQ-{NNNN}-{NNN}）。resume point / export / import を持たない。工程は逐次実行し、中断時は最初から再実行する。
 
-## 観測
-{何が観測されたか}
+- **工程-1** 入力の受領 — ユーザーからの変更候補の内容受領（自然言語をそのまま取り扱う）
+- **工程-2** intake item の生成 — 推奨標準形への整理（推測・補完禁止、対象セクションは省略）
+- **工程-3** ファイル名の生成・実行前同期 — `YYYY-MM-DD-{topic-slug}.md` 形式、`git pull --ff-only`
+- **工程-4** 保存・永続化 — `.agentdev/intake/inbox/` へ保存、`.agentdev/intake/` 変更の commit/push
+- **工程-5** 完了報告 — 完了報告 template 出力、git 永続化結果を含める
 
-## 今回扱わない理由
-{なぜ今すぐ対応しないのか}
-
-## 影響
-{影響の評価}
-
-## レビューで決めること
-{レビューで判断すべき点}
-
-## 根拠（任意）
-{補足情報・証拠}
-```
-
-**セクションに関する制約**:
-- 各セクションの見出し名は固定しない。ユーザーの入力に合わせて整理する
-- 必須セクション、省略不可セクションを設けない
-- 内容がないセクションを形式維持のためだけに作成しない
-- frontmatter、状態値、メタデータフィールドを必須にしない
-
-## 手順
-
-### Step 1: 入力の受領
-
-ユーザーから変更候補の内容を受け取る。
-自然言語で記述された内容をそのまま取り扱う。
-
-### Step 2: intake item の生成
-
-ユーザーの入力を上記推奨標準形に整理する。
-ユーザーが明示的に指定していないセクションは推測、補完せず、そのセクションを省略する（内容がないセクションを作成しない）。
-ユーザーの入力に含まれない情報を自動生成、推論して記載することを禁止する。
-
-### Step 3: ファイル名の生成
-
- - 日付: 実行時のシステム日付（`YYYY-MM-DD`）
- - topic-slug: タイトルから生成（小文字英数字、ハイフン区切り、30文字以内）
- - 形式: `YYYY-MM-DD-{topic-slug}.md`
-
-3-1. **実行前同期**:
- - `git pull --ff-only` を実行する
- - **失敗時**: 共通 template (`.opencode/commands/agentdev/templates/common/git-error-messages.md`) の「Git 同期エラー」形式で表示して停止する（自動解消しない）
-
-### Step 4: 保存
-
- - 保存先: `.agentdev/intake/inbox/`
- - ディレクトリが存在しない場合は作成する
- - 同名ファイルが存在する場合は `{topic-slug}-2`, `{topic-slug}-3` のように連番を付与する
-
-**Step 4-1**: .agentdev/intake/ 変更の commit と push。
-`agentdev-git-worktree` の「ドメイン状態永続化プロシージャ」（並列実行安全ステージングプロシージャ含む）に従い、`.agentdev/intake/` 配下の変更を commit/ push する。commit message は `chore(agentdev): capture intake item`（Conventional Commits 形式）。変更なし時は commit/push せず Step 5 の完了報告で「変更なし」と報告する。push 失敗時は同プロシージャの構造化エラー形式で停止する（完了扱いにしない）
-
-### Step 5: 完了報告
-
-完了報告templateに従って出力。
-template: .opencode/commands/agentdev/templates/intake-capture/standard.md。
-git 永続化結果（変更有無、ファイル一覧、commit hash、push 成否）を含める
-
-## エラー処理
-
-| エラー | 対処 |
-|--------|------|
-| git pull --ff-only 失敗 | 構造化エラーメッセージを表示して停止。自動解消しない |
-| git push 失敗 | 構造化エラーメッセージを表示。完了扱いにしない |
+工程の詳細（intake item 推奨標準形、ファイル名規則、エラー処理、関連 Capability Skill 連携）は `agentdev-workflow-intake-capture` スキルを参照。本コマンドは同スキルを名レベルで参照し、内部構造へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
 ## ガードレール
 

--- a/src/opencode/commands/agentdev/intake-from-github.md
+++ b/src/opencode/commands/agentdev/intake-from-github.md
@@ -30,76 +30,22 @@ description: クローズ済み GitHub Issue/PR から未回収の変更候補�
 - `.agentdev/intake/inbox/YYYY-MM-DD-{topic-slug}.md` に保存された intake item（候補ごとに1ファイル）
 - 抽出サマリーレポート（ユーザー確認用）
 
-## Intake Item 形式
+## workflow
 
-`intake-capture` と同一の推奨標準形を使用する。
-frontmatter、状態フィールド、重複排除キーは持たない。
-各セクションの見出し名は固定せず、抽出内容に合わせて整理する。
-内容がないセクションを作成しない。
+本コマンドは workflow 実装本体を `agentdev-workflow-intake-from-github` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}）。同スキルが保存専用 workflow の実装（期間解釈から抽出、保存、git 永続化、サマリーレポート、完了報告まで）を所有する。
 
-## 手順
+本 workflow は capture-only型であり、STEP model の対象外である（REQ-{NNNN}-{NNN}）。resume point / export / import を持たない。工程は逐次実行し、中断時は最初から再実行する。
 
-### Step 1: 期間解釈
+- **工程-1** 期間解釈 — 期間指定または Issue/PR 番号指定の解釈（`agentdev-intake-pipeline`）
+- **工程-2** データ取得 — クローズ済み Issue/PR のデータ取得（gh CLI、`agentdev-gh-cli` 読取手続き）
+- **工程-3** 構造的検出 — 抽出ルールによる残課題候補の検出（`agentdev-intake-pipeline`）
+- **工程-4** LLM 全文解析 — キーワードリスト、コンテキスト付与ルール（`agentdev-intake-pipeline`）
+- **工程-5** intake item 生成・実行前同期 — item 生成ルール、ファイル名規則（`agentdev-intake-pipeline`）、`git pull --ff-only`
+- **工程-6** 保存・永続化 — `.agentdev/intake/inbox/` へ保存、`.agentdev/intake/` 変更の commit/push
+- **工程-7** サマリーレポート提示 — 抽出結果のサマリーのユーザーへの提示
+- **工程-8** 完了報告 — 完了報告 template 出力、git 永続化結果を含める
 
-抽出アルゴリズムは `agentdev-intake-pipeline` を参照
-
-### Step 2: データ取得
-
-取得方法、CLI コマンドは `agentdev-intake-pipeline` を参照
-
-### Step 3: 構造的検出
-
-抽出ルールは `agentdev-intake-pipeline` を参照
-
-### Step 4: LLM 全文解析
-
-キーワードリスト、コンテキスト付与ルールは `agentdev-intake-pipeline` を参照
-
-### Step 5: intake item 生成
-
-item 生成ルール、ファイル名規則は `agentdev-intake-pipeline` を参照
-
-5-1. **実行前同期（git pull）**:
- - `git pull --ff-only` を実行する
- - **失敗時**: 共通 template (`.opencode/commands/agentdev/templates/common/git-error-messages.md`) の「Git 同期エラー」形式で表示して停止する（自動解消しない）
-
-### Step 6: 保存
-
- - 保存先: `.agentdev/intake/inbox/`
- - ディレクトリが存在しない場合は作成する
- - 同名ファイルが存在する場合は連番を付与する
-
-**Step 6-1**: .agentdev/intake/ 変更の commit と push。
-`agentdev-git-worktree` の「ドメイン状態永続化プロシージャ」（並列実行安全ステージングプロシージャ含む）に従い、`.agentdev/intake/` 配下の変更を commit/ push する。commit message は `chore(agentdev): capture intake items from github`（Conventional Commits 形式）。変更なし時は commit/push せず Step 8 の完了報告で「変更なし」と報告する。push 失敗時は同プロシージャの構造化エラー形式で停止する（完了扱いにしない）
-
-### Step 7: サマリーレポート提示
-
-抽出結果をサマリーとしてユーザーに提示する:
- ```
- ## Intake from GitHub 抽出サマリー
-
- - 対象期間: {since} 〜 {until}
- - 対象 Issue/PR 数: {N}
- - 抽出候補数: {M}
- - 保存先: .agentdev/intake/inbox/
-
- | # | タイトル | 元 Issue/PR | ファイル |
- |---|----------|-------------|----------|
- | 1 | ... | #XX | YYYY-MM-DD-xxx.md |
- ```
-
-### Step 8: 完了報告
-
-完了報告templateに従って出力。
-template: .opencode/commands/agentdev/templates/intake-from-github/standard.md。
-git 永続化結果（変更有無、ファイル一覧、commit hash、push 成否）を含める
-
-## エラー処理
-
-| エラー | 対処 |
-|--------|------|
-| git pull --ff-only 失敗 | 構造化エラーメッセージを表示して停止。自動解消しない |
-| git push 失敗 | 構造化エラーメッセージを表示。完了扱いにしない |
+工程の詳細（intake item 形式、サマリーレポート形式、エラー処理、関連 Capability Skill 連携）は `agentdev-workflow-intake-from-github` スキルを参照。本コマンドは同スキルを名レベルで参照し、内部構造へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
 ## ガードレール
 

--- a/src/opencode/commands/agentdev/intake-promote.md
+++ b/src/opencode/commands/agentdev/intake-promote.md
@@ -48,94 +48,18 @@ intake-promote の内部 review フェーズにおける分類値は以下の 3 
 |------------|------|----------|
 | `backlog-review` | 採用 item 全て | backlog-review が分析しやすい形式に整理（観測内容、影響、課題、既存要件との関連を構造化） |
 
-## 手順
+## workflow
 
-### Step 1: inbox の確認
+本コマンドは workflow 実装本体を `agentdev-workflow-intake-promote` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}）。同スキルが6 STEP の control plane として制御構造を所有する。各 STEP は resume point を持ち、durable state（`.agentdev/intake/inbox/` と `.agentdev/intake/promoted/` の実ファイル状態、分類確定状態）から再開点を再構成する（DEC-{N}）。
 
-`.agentdev/intake/inbox/` 内の intake item を一覧表示する。詳細は `agentdev-intake-pipeline` を参照
+- **STEP-1** classification — inbox 確認、item 読込、レビュー評価、暫定分類提示
+- **STEP-2** review（経路C） — adversarial-review 発動条件判定・review 呼出・accepted finding の暫定分類への反映（skip 条件該当時は省略）
+- **STEP-3** HITL — 分類結果のユーザー提示・承認（判断の確定）。分類承認後の自動実行、破壊的変更の明示承認を含む
+- **STEP-4** persistence — 採用 item の backlog-review 向け整形・`.agentdev/intake/promoted/` への保存
+- **STEP-5** destructive handling — 振り分け（採用 inbox 削除・保留残置・reject 即時削除）、`git pull --ff-only`、commit/push（reject 理由付き commit message を含む）
+- **STEP-6** 完了報告 — 分類結果と git 永続化結果の報告
 
-### Step 2: item の読み込み
-
-各 intake item を読み込み、内容を把握する。委譲接続点の詳細は `agentdev-intake-pipeline` を参照
-
-### Step 3: レビュー、評価
-
-各 item を評価する。詳細、委譲接続点は `agentdev-intake-pipeline` を参照
-
-### Step 4: 分類の提示
-
-各 item の評価結果を分類（採用/ 保留/ 却下）と共に提示する。
-見出しは `## Findings / Capture候補` とする。
-詳細は `agentdev-intake-pipeline` を参照
-
-### Step 4a: 発動条件判定（経路C、任意）
-
-暫定分類生成後、ユーザ提示前に adversarial-review を発動するかを判定する（REQ-{NNNN}-{NNN}、REQ-{NNNN}-{NNN}）。本 Step は review 呼出（Step 4b）と分離された発動条件判定 Step であり、review 呼出そのものは行わない。
-
-判定基準:
-
-- default-on（原則実行、REQ-{NNNN}-{NNN}）: 暫定分類の意味的決定が存在する場合に発動する。ユーザー明示指定は通常発動の必須条件ではない
-- skip 条件（REQ-{NNNN}-{NNN}）: inbox 項目が1件のみで暫定分類が自明（単一区分、意味的決定なし）、または inbox 空（Step 2 で終了）の場合、省略して従来フローを継続できる。skip 判断のためだけの新規 HITL、承認点は追加しない
-- ユーザー明示指定時: skip 条件の該当にかかわらず必ず「発動」とする（REQ-{NNNN}-{NNN}）。明示指定は起動時引数、対話中の指示、extension（`.agentdev/extensions/commands/intake-promote.yaml`）の `rules` により表明される
-
-判定結果が「非発動」の場合は Step 4b をスキップし、Step 4 の暫定分類をそのまま Step 5 へ渡し従来フローを維持する（REQ-{NNNN}-{NNN}）。既存の HITL（G06, G07, G08）、自動実行ルール（REQ-{NNNN}-{NNN}）、破壊的変更制約（G18）は変更しない。
-
-詳細な候補判断基準は `agentdev-intake-pipeline` を参照。
-
-### Step 4b: adversarial-review 呼出（経路C、任意）
-
-Step 4a で「発動」と判定された場合に限り adversarial-review を呼び出す（REQ-{NNNN}-{NNN}）。本 Step は発動条件判定（Step 4a）と分離された review 呼出 Step であり、発動条件の再判定は行わない。
-
-review 対象は Step 4 で生成された暫定分類（各 item の採用/保留/却下、変更種別、根拠）とする。呼出タイミングは Step 5「ユーザー確認」開始前、結果反映先は intake-promote 本体とする（詳細は `agentdev-intake-pipeline` 参照）。
-
-- accepted finding を得た場合: 呼出元（intake-promote 本体）が暫定分類へ finding を反映し、反映後の分類を Step 5 へ渡す（REQ-{NNNN}-{NNN}）。adversarial-review 自身は反映を行わない
-- unresolved な本質的争点が残る場合: Step 5 のユーザー確認で既存 HITL 経由で扱い、後続の保存、inbox 削除等の不可逆処理へは進まない（REQ-{NNNN}-{NNN}）
-- 呼出失敗時（スキル不在、起動異常、timeout 等）: silent skip を禁止し、利用不能を報告した上で従来フローと既存 QG/HITL を維持する（REQ-{NNNN}-{NNN}）
-
-共通契約（任意性、副作用禁止、accepted finding 反映責務、再 review 条件、停止条件、呼出失敗時取扱い）の正規所有者は adversarial-review SPEC「adversarial-review caller integration 共通契約」節（REQ-{NNNN}）であり、本 command 定義は再定義しない。
-
-### Step 5: ユーザー確認
-
-評価、分類結果をユーザーに提示し、明示的な承認を得る（判断の確定、REQ）。
-詳細は `agentdev-intake-pipeline` を参照。
-委譲接続点: 親エージェントのみが承認確認と次フェーズ進行判断を行う
-
-**分類承認後の自動実行（REQ）**: Step 5 で分類が確定（採用/保留/却下のいずれか）した場合、Step 6〜10（採用 item 整形 / promoted 保存 / inbox 削除 / git pull / commit-push）は追加確認なしで自動実行する。
-分類未確定、修正中の場合は進まない。
-
-### Step 6: 採用 item の整形
-
-採用と判定された item を backlog-review 向けに整形する。
-詳細は `agentdev-intake-pipeline` を参照。
-委譲接続点: サブエージェントは整形案のみを返し、親エージェントが保存対象本文を確定する
-
-### Step 7: 保存
-
-`.agentdev/intake/promoted/` に保存する。
-詳細は `agentdev-intake-pipeline` を参照。
-委譲接続点: 親エージェントのみが保存する
-
-### Step 8: 振り分け
-
-確定した分類に基づいて item を振り分ける。
-詳細は `agentdev-intake-pipeline` を参照。
-委譲接続点: 親エージェントのみが移動を行う
-
-### Step 9: 実行前同期（git pull）
-
-`git pull --ff-only` を実行する。失敗時の扱い、親エージェントのみが git 操作を行う点は `agentdev-intake-pipeline` を参照
-
-### Step 10: .agentdev/intake 変更の commit と push
-
-`.agentdev/intake/` 配下の変更のみを commit/push する（分類承認後の自動実行、REQ）。詳細、親エージェントのみが commit/push を行う点は `agentdev-intake-pipeline` を参照
-
-
-### Step 11: 完了報告
-
-
-完了報告templateに従って出力。
-template: .opencode/commands/agentdev/templates/intake-promote/standard.md。
-分類結果（採用、保留、却下の件数、一覧）と git 永続化結果（変更有無、ファイル一覧、commit hash、push 成否）を含める
+各 STEP の詳細（開始条件・結果・手順・resume point・関連 Capability Skill 連携）は `agentdev-workflow-intake-promote` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
 ## エラー処理
 
@@ -156,7 +80,7 @@ template: .opencode/commands/agentdev/templates/intake-promote/standard.md。
 - G08: 分類未確定のままの自動確定、自動進行は行わない（REQ）。ユーザーが「確定」を明示的に指示してから次フェーズに進む。確定後の自動進行は REQ で許容される。
 
 ### 破壊的変更制約
-- G18: 破壊的変更（inbox 大量削除、重要 item の誤分類是正等）は Step 5 承認とは別に明示承認を維持する（REQ）
+- G18: 破壊的変更（inbox 大量削除、重要 item の誤分類是正等）は STEP-3（HITL）承認とは別に明示承認を維持する（REQ）
 
 ### 形式制約
 - G09: workflow 管理成果物として扱わない

--- a/src/opencode/commands/agentdev/learning-promote.md
+++ b/src/opencode/commands/agentdev/learning-promote.md
@@ -31,134 +31,19 @@ description: inbox.mdから正規化、分類、8軸評価、HITL確定を経て
 - `.agentdev/learning/deferred.md`（inbox からの移動分を追記）
 - `.agentdev/learning/inbox.md`（ヘッダーのみにクリア）
 
-## 手順
+## workflow
 
-### Step 1: inbox.md 読込
+本コマンドは workflow 実装本体を `agentdev-workflow-learning-promote` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}）。同スキルが7 STEP の control plane として制御構造を所有する。各 STEP は resume point を持ち、durable state（inbox.md / deferred.md / evaluation-report.md / promoted/ の実ファイル状態、分類確定状態）から再開点を再構成する（DEC-{N}）。
 
-ファイルなし → エラー終了（「先に `agentdev-learning-capture` skill で学びを追加してください」）。`---` 区切りエントリをカウント、0件 → 「分析対象の学びがありません」と終了
+- **STEP-1** 入力読込・正規化 — inbox.md 読込（不在時はエラー終了、0件時は終了）、deferred.md 読込、旧フォーマット正規化
+- **STEP-2** 評価 — 問題クラス分類、8軸評価スコアリング、禁止条件フィルタリングゲート、evaluation-report.md 生成・更新
+- **STEP-3** 判定 — 廃棄判定（11カテゴリ + duplicate）、既存対策確認、昇華可能性評価（無条件の自動REQ化禁止、living pool 維持）
+- **STEP-4** review（経路D） — adversarial-review 発動条件判定・review 呼出・accepted finding 反映（evaluation-report 戻しループ、skip 条件該当時は省略）
+- **STEP-5** HITL — 判定結果提示・ユーザー承認（判断の確定、REQ）
+- **STEP-6** 永続化 — `git pull --ff-only`、採用済み成果物生成（staging 領域のみ）、deferred 移動（原子的操作）、prune、commit/push
+- **STEP-7** 完了報告 — 8軸評価サマリ、判定結果、後続ルート、git 永続化結果の報告
 
-### Step 2: deferred.md 読込
-
-存在すれば読込、不存在は空として扱う
-
-### Step 3: 全エントリの読込と旧フォーマット正規化
-
-`agentdev-learning-pipeline` を参照
-
-### Step 4: 問題クラス分類
-
-`agentdev-learning-pipeline` を参照
-
-### Step 5: 8軸評価スコアリング
-
-`agentdev-learning-pipeline` を参照
-
-### Step 6: evaluation-report.md 生成、更新
-
-`agentdev-learning-pipeline` を参照
-
-### Step 7: 廃棄判定（11カテゴリ + duplicate）
-
-`agentdev-learning-pipeline` を参照
-
-**昇華可能性評価、無条件自動REQ化禁止（REQ）**: 各問題クラスについて恒久契約（REQ/Decision/SPEC）への昇華可能性を評価する。
-8軸評価スコア、禁止条件フィルタリングゲート、既存対策照合を基に昇華可否を判定する。
-**無条件の自動REQ化は禁止する**。
-学びは昇華（`promoted/` → `/agentdev/backlog-review` → `/agentdev/req-define` → `/agentdev/req-save`）を経て初めて REQ 化される。
-学びを直接 REQ 化しない。
-
-**living pool 維持（REQ）**: 昇華不能な知見（`deferred` 判定、情報が断片的、出現回数が少ない等）は `deferred.md` の living pool で維持し、REQ 化しない。`deferred.md` は deferred カテゴリ（11廃棄判定カテゴリの1つ）のエントリだけでなく、未処理・保留中・再評価対象のエントリも保持する多状態の living pool である（AG-{NNN}）。終端保管ではなく、次回 `/agentdev/learning-promote` 実行時に再評価の対象となる。
-
-### Step 8: 既存対策確認
-
-`agentdev-learning-pipeline` を参照
-
-### Step 8-R1: adversarial-review 発動条件判定（経路D）
-
-`agentdev-learning-pipeline` の「adversarial-review 候補判断と内部挿入」節（経路D）を参照。本 Step は発動条件判定のみを行い、review 呼出（Step 8-R2）と分離する（REQ-{NNNN}-{NNN}）。
-
-learning-promote は adversarial-review を原則実行する（default-on、REQ-{NNNN}-{NNN}）。発動条件は次のいずれも満たすこと。
-
-- evaluation-report.md が Step 6 で生成・更新済みであり、Step 7（廃棄判定）と Step 8（既存対策確認）の結果が反映されていること
-- skip 条件（後述）に該当しないこと
-
-- **skip 条件（REQ-{NNNN}-{NNN}）**: inbox.md エントリが1件のみで既存対策との重複が確実（新規性なし、廃棄判定確定）、または inbox.md 空（処理対象なし）の場合、省略して従来フローを継続できる。skip 判断のためだけの新規 HITL、承認点は追加しない
-- **ユーザー明示指定時の必須実行（REQ-{NNNN}-{NNN}）**: ユーザーが adversarial-review を明示的に要求した場合、skip 条件の該当にかかわらず必ず発動する。ただし evaluation-report.md 反映済みは引き続き必須とする
-
-adversarial-review は新規必須工程、QG、承認ゲートとして導入しない（REQ-{NNNN}-{NNN}）。共通 caller integration 契約の正規所有者は `agentdev-adversarial-review` SPEC（REQ-{NNNN}）である。
-
-発動条件成立時は Step 8-R2 へ進む。非成立時は Step 8-R2 を迂回し Step 9 へ進む。
-
-### Step 8-R2: adversarial-review 呼出（経路D）
-
-`agentdev-learning-pipeline` の「adversarial-review 候補判断と内部挿入」節（経路D）を参照。本 Step は review 呼出のみを行い、発動条件判定（Step 8-R1）と分離する（REQ-{NNNN}-{NNN}）。
-
-review 対象は evaluation-report.md のみとする（正規化結果、問題クラス分類、8軸評価スコア、廃棄判定、既存対策照合結果）。inbox → deferred 移動（Step 13）、prune（Step 14）、commit/push（Step 15）等の不可逆処理は未実行である。
-
-呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し（REQ-{NNNN}-{NNN}）、利用不能を報告した上で従来フロー（Step 9 以降）と既存 HITL（Step 10 ユーザー承認）を維持する。
-
-accepted finding は learning-promote が責任を持って判定対象へ反映する（REQ-{NNNN}-{NNN}）。adversarial-review 自身は反映を行わない。
-
-review 反映時（review 対象の意味内容が変更された場合）は Step 6 へ戻り、次の順で関連 Step を再実行する（REQ-{NNNN}-{NNN}、Step 6 戻しループ）。
-
-1. Step 6（evaluation-report 生成、更新）: accepted finding の反映結果を evaluation-report.md へ集約
-2. Step 7（廃棄判定）: 反映後の判定結果で再判定
-3. Step 8（既存対策確認）: 反映後の対策照合結果で再確認
-4. Step 8-R1（発動条件判定）: 再発動可否を判定
-5. Step 8-R2（review 呼出）: REQ-{NNNN}-{NNN} が定める再 review 発動条件（新たな本質的争点が生じ得る場合）を満たす場合のみ再 review
-
-再 review の停止条件（REQ-{NNNN}-{NNN}、4点）を満たした時点でループを離脱し、Step 9 へ進む。新証拠、新前提、異なる failure condition、未評価範囲のいずれも伴わない同一 finding の再起票を禁止する（REQ-{NNNN}-{NNN}）。
-
-unresolved な本質的争点またはユーザー判断事項が残る場合、Step 9（判定結果提示）、Step 10（ユーザー承認）、Step 13（deferred 移動）、Step 14（prune）、Step 15（commit/push）等の不可逆処理へ進まない（REQ-{NNNN}-{NNN}）。unresolved は既存の HITL（Step 10 ユーザー承認）または blocker 扱いへ振り向ける。adversarial-review 自体を恒久的な統制ゲートとしない。
-
-### Step 9: ユーザーへの判定結果提示
-
-`agentdev-learning-pipeline` を参照
-
-### Step 10: ユーザー承認
-
-`agentdev-learning-pipeline` を参照
-
-**判定基準参照**: Step 3〜10 の判定基準、スコアリングルール、提示形式、承認フローは、全て `agentdev-learning-pipeline` の該当 Phase を参照。
-
-### Step 11: 実行前同期（git pull）
-
-- `git pull --ff-only` を実行
-- **失敗時**: 共通 template (`.opencode/commands/agentdev/templates/common/git-error-messages.md`) の該当形式で表示して停止する（自動解消しない）
-
-### Step 12: 採用済み成果物生成（staging領域のみ）
-
-- 出力先: `.agentdev/learning/promoted/{disposal-category}-{name}.md`
-- **`.opencode/` 直接書込禁止**/ **`case-run` への直接受け渡し禁止**（`backlog-review` 経由で RU 化）
-- フォーマット: `agentdev-learning-pipeline` を参照
-
-### Step 13: deferred 移動（原子的操作）
-
-`agentdev-learning-pipeline` の「deferred 移動原子的操作プロシージャ」に従い、当該プロシージャが定める inbox.md 全エントリの deferred.md 追記、書込検証、inbox.md クリアを実行する。本手順は原子的操作であり、検証失敗時は inbox.md を変更せずエラー内容を報告する（データ喪失防止）。
-
-### Step 14: 昇華時 prune（deferred.md からの除去）
-
-- **prune 対象**: staged（採用済み成果物生成済み）/ rejected/ duplicate のエントリのみ
-- **prune 非対象**: deferred/ 未処理のエントリは残す（REQ）
-- **証拠保存**: staged エントリ除去時に採用済み成果物の「元learning item/ 根拠」セクションに保存
-- **自動実行**（REQ）: Step 10 のユーザー承認（判定確定）と同時に prune も承認済みとみなす。staged（根拠は採用済み成果物に保存済み）/ rejected / duplicate（判定理由は記録済み）のエントリは追加確認なしで削除する。
-- 詳細は `agentdev-learning-pipeline` を参照
-
-### Step 15: .agentdev 変更の commit と push
-
-- `git diff --name-only` で `.agentdev/` 配下の変更を確認
-- **変更なし時**: commit/push せず完了報告で「変更なし」と報告
-- **変更あり時**:
- 1. `git add` は `.agentdev/learning/` 配下のみを対象とする。
- 並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い明示パスでステージし、`git commit -- <paths>`（--only pathspec 形式）でコミットする。
- `.agentdev/` 全体の一括スコープは禁止し、スイープ操作（`git add -A`/ `git add .` 等）も禁止
- 2. commit message: `chore(agentdev): promote learning findings`
- 3. `git push` 実行
- 4. **push 失敗時**: 共通 template (`.opencode/commands/agentdev/templates/common/git-error-messages.md`) の該当形式で表示して停止する（完了扱いにしない）
-
-### Step 16: 完了報告
-
-template: `.opencode/commands/agentdev/templates/learning-promote/standard.md`。8軸評価サマリ、判定結果（promote/defer/reject/duplicate 件数）、後続ルート（`/agentdev/backlog-review`）、git 永続化結果（変更有無、ファイル一覧、commit hash、push 成否）を含める
+各 STEP の詳細（開始条件・結果・手順・resume point・関連 Capability Skill 連携）は `agentdev-workflow-learning-promote` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
 ## ガードレール
 
@@ -170,16 +55,16 @@ template: `.opencode/commands/agentdev/templates/learning-promote/standard.md`�
 - G06: ユーザー承認必須: 判定、prune ともに承認なしに実行しない
 - G07: 管理用ファイル（`elevation-ledger.md` 等）は生成しない
 - G08: `learning-refine` への依存禁止: 本コマンドは旧機能を内包し事前実行を前提としない
-- G09: 破壊的変更（inbox.md 全体強制クリア、大量エントリ一括削除等）は Step 10 承認とは別に明示承認を維持する（REQ）
-- G10: 無条件の自動REQ化禁止（REQ）: 学びを直接 REQ 化しない。恒久契約（REQ/Decision/SPEC）への昇華可能性を Step 7 で評価し、昇華可能なもののみ `promoted/` へ出力する。昇華不能な知見は living pool（`deferred.md`）で維持する
-- G11: adversarial-review は default-on（経路D、REQ-{NNNN}-{NNN}）: Step 8-R1（発動条件判定）→ Step 8-R2（review 呼出）を経て原則発動する。skip 条件（inbox.md 1件で重複確実、inbox.md 空）該当時は Step 9 へ従来フローを維持する（REQ-{NNNN}-{NNN}）。ユーザー明示要求時は skip 条件にかかわらず必ず発動する。review 反映時は Step 6 へ戻し関連 Step を再実行する（REQ-{NNNN}-{NNN}）。共通契約（任意性、副作用禁止、再 review 条件、停止条件、呼出失敗時取扱い）は `agentdev-adversarial-review` SPEC（REQ-{NNNN}）が正規所有する
+- G09: 破壊的変更（inbox.md 全体強制クリア、大量エントリ一括削除等）は STEP-5（HITL）承認とは別に明示承認を維持する（REQ）
+- G10: 無条件の自動REQ化禁止（REQ）: 学びを直接 REQ 化しない。恒久契約（REQ/Decision/SPEC）への昇華可能性を STEP-3 で評価し、昇華可能なもののみ `promoted/` へ出力する。昇華不能な知見は living pool（`deferred.md`）で維持する
+- G11: adversarial-review は default-on（経路D、REQ-{NNNN}-{NNN}）: workflow の review STEP（発動条件判定 → review 呼出）を経て原則発動する。skip 条件（inbox.md 1件で重複確実、inbox.md 空）該当時は HITL へ従来フローを維持する（REQ-{NNNN}-{NNN}）。ユーザー明示要求時は skip 条件にかかわらず必ず発動する。review 反映時は evaluation-report 生成 STEP へ戻し関連 STEP を再実行する（REQ-{NNNN}-{NNN}）。共通契約（任意性、副作用禁止、再 review 条件、停止条件、呼出失敗時取扱い）は `agentdev-adversarial-review` SPEC（REQ-{NNNN}）が正規所有する
 
 ## ユーザー確認ポイント、エラー処理
 
 ユーザー確認ポイント、エラー処理表、各成果物のライフサイクル詳細は `agentdev-learning-pipeline` を参照。主要項目のみ本節に抜粋する:
 
-- **Step 9-10**: 廃棄判定結果、8軸評価スコアの確認、修正、承認（判断の確定、REQ）
-- **Step 14**: prune は Step 10 承認と同時に承認済みとみなし自動実行（REQ）。staged/rejected/duplicate の追加確認は不要
+- **HITL（workflow STEP-5）**: 廃棄判定結果、8軸評価スコアの確認、修正、承認（判断の確定、REQ）
+- **prune（workflow 永続化 STEP）**: prune は HITL 承認と同時に承認済みとみなし自動実行（REQ）。staged/rejected/duplicate の追加確認は不要
 - **inbox.md 不在**: エラー終了。「先に `agentdev-learning-capture` skill で学びを追加してください」
 - **git pull/push 失敗**: 構造化エラー表示して停止（push 失敗時は完了扱いにしない）
 - **learning-promote の責務**: normalize → classify → 8-axis eval → evaluation-report → disposal judgment → HITL → 採用済み成果物生成 → archive move → prune。採用済み成果物は `/agentdev/backlog-review` 経由で RU 化後に `/agentdev/req-define` に合流する

--- a/src/opencode/skills/agentdev-workflow-backlog-review/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-backlog-review/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: agentdev-workflow-backlog-review
+description: "backlog-review command の workflow 実装本体。採用済み成果物（intake/learning/inspect の promoted）の検出・読込・分析・暫定分類付与、統合・分割判定・depends_on 依存解決、adversarial-review 経路E、ユーザー承認（RU 生成承認を兼ねる）、矛盾検出、RU 生成・成功成果物削除、git 永続化の各 STEP を独立 resume point として所有する。USE FOR: backlog-review command 実行時の workflow 制御（成果物検出・分析・統合分割判定・依存解決・経路E review 呼出・ユーザー承認・矛盾検出・RU 生成・成果物削除・git 永続化・完了報告）。DO NOT USE FOR: REQ ファイル保存（req-save）、GitHub Issue 作成（case-open）、intake の抽出・promote（intake-promote）、learning pipeline の実行（learning-promote）、REQ 構造診断（agentdev-req-structure-diagnostics）、work_type 判定（agentdev-workflow-lifecycle）、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# backlog-review workflow スキル
+
+backlog-review command の workflow 実装本体。`.agentdev/intake/promoted/*.md`、`.agentdev/learning/promoted/*.md`、`.agentdev/inspect/promoted/*.md` の採用済み成果物を読み込み、分析、統合してユーザーに判定を提示し、承認後に直接 RU（Requirement Unit）を生成する制御構造を所有する。ユーザー承認は RU 作成承認を兼ねる。
+
+backlog-review command は公開 interface（入出力契約・ガードレール・RU フォーマット委譲契約）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md（control plane）と `references/` 配下（各 STEP 詳細）が担う。
+Workflow Skill 固有契約（Command / Workflow Skill / Capability Skill 責務、1:N 分割基準、依存方向、配置契約）は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-backlog-review.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と backlog-review command の公開契約のみを前提とする。SPEC ディレクトリの内部構成は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- backlog-review command の実行時 workflow 制御（全 STEP）
+- 採用済み成果物の検出（引数指定/ 全ディレクトリ切り替え）、読込、分析、暫定分類付与
+- 統合、分割判定、depends_on 依存解決、RU 構成案の確定
+- adversarial-review 経路E の発動条件判定、review 呼出、accepted finding 反映
+- ユーザー承認（RU 生成承認を兼ねる）、矛盾検出、追加判断
+- RU 生成、成功成果物の削除、git 永続化、完了報告（全成功/ partial success/ 対象なしのテンプレート別）
+
+## DO NOT USE FOR
+
+- REQ ファイルの保存（`/agentdev/req-save`）
+- GitHub Issue の作成（`/agentdev/case-open`）
+- intake の抽出、promote（`/agentdev/intake-from-github`、`/agentdev/intake-promote`）
+- learning pipeline の実行（`/agentdev/learning-promote`）
+- REQ 構造診断（`agentdev-req-structure-diagnostics`）
+- work_type 判定、フェーズ定義（`agentdev-workflow-lifecycle`）
+
+## 入力
+
+- backlog-review command から渡される採用済み成果物（`.agentdev/intake/promoted/*.md`、`.agentdev/learning/promoted/*.md`、`.agentdev/inspect/promoted/*.md`）
+- 引数指定時は指定されたファイルパスのみを対象とする。引数なしの場合は全ディレクトリの採用済み成果物を対象とする
+
+## 出力
+
+- `.agentdev/backlog/req-units/RU-*.md`（Requirement Unit）
+- 成功した採用済み成果物の削除
+- RU 生成結果、git 永続化結果を含む完了報告（全成功 / partial success / 対象なしのテンプレート別）
+
+## 副作用
+
+- `.agentdev/backlog/req-units/` 配下への RU ファイル作成
+- RU 生成が成功した採用済み成果物の削除（`.agentdev/{intake,learning,inspect}/promoted/` 配下）
+- `.agentdev/` 配下の変更の commit / push
+- 当該 Workflow Skill は worktree root 配下以外を編集しない（backlog-review command の worktree 隔離に従う）
+
+## Control Plane（STEP 一覧）
+
+backlog-review workflow は次の8 STEP で構成する。各 STEP は resume point を持ち（DEC-{N}、`docs/specs/<workflows/step-reference-contract>.md`）、会話コンテキストに依存せず、durable state（promoted/ 残存成果物、RU-*.md 実ファイルと frontmatter、req-units/ 配下状態）から再開点を再構成する。
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-1 | 実行前同期・成果物検出 | backlog-review 起動 | 対象成果物一覧（0件時は正常終了） | [references/analysis-composition-and-review.md](references/analysis-composition-and-review.md) |
+| STEP-2 | 分析・暫定分類付与 | 対象成果物 1件以上 | 分析結果、RU frontmatter の `tentative_classification` 付与 | [references/analysis-composition-and-review.md](references/analysis-composition-and-review.md) |
+| STEP-3 | 統合・分割判定・depends_on 依存解決 | 分析完了 | RU 構成案（統合・分割判定、depends_on 解決結果） | [references/analysis-composition-and-review.md](references/analysis-composition-and-review.md) |
+| STEP-4 | review（adversarial-review 経路E） | RU 構成案確定 | review 結果反映（矛盾は STEP-6 へ引継ぎ。skip 時は従来フロー継承） | [references/analysis-composition-and-review.md](references/analysis-composition-and-review.md) |
+| STEP-5 | HITL（ユーザー承認、RU 生成承認を兼ねる） | RU 構成案確定、review skip または完了 | 承認確定（矛盾なし時は単一承認で RU 生成承認と同時に扱う） | [references/analysis-composition-and-review.md](references/analysis-composition-and-review.md) |
+| STEP-6 | 矛盾検出・追加判断 | 承認確定 | 矛盾検出結果（なし / あり+追加判断、partial success 扱い） | [references/contradiction-ru-and-persistence.md](references/contradiction-ru-and-persistence.md) |
+| STEP-7 | RU 生成・成功成果物削除 | 承認確定、矛盾処理完了 | `.agentdev/backlog/req-units/RU-*.md`、RU 化成功成果物の削除 | [references/contradiction-ru-and-persistence.md](references/contradiction-ru-and-persistence.md) |
+| STEP-8 | Git 永続化・完了報告 | RU 生成・削除完了 | commit/push、完了報告（テンプレート別） | [references/contradiction-ru-and-persistence.md](references/contradiction-ru-and-persistence.md) |
+
+### STEP 間の依存と分岐
+
+- **正常経路**: STEP-1 → STEP-2 → STEP-3 → STEP-4（skip 条件該当時は省略）→ STEP-5 → STEP-6 → STEP-7 → STEP-8
+- **構成、review、承認の順序**: STEP-3（統合、分割判定、depends_on 依存解決）で RU 構成案を確定し、続く STEP-4（adversarial-review 呼出、default-on）を経て、STEP-5（ユーザー承認）で承認を確定する。順序の正規所有者は backlog-review command SPEC「adversarial-review 挿入境界（経路E）」節である
+- **矛盾なしの場合の単一承認**: 後続の STEP-6 で矛盾が検出されない場合、STEP-5 の統合、分割判定承認を RU 生成承認（STEP-7）としても扱う。単一承認で処理し、追加の HITL は不要
+- **対象 0 件**: STEP-1 で正常終了（エラー扱いとしない。「対象なし」を報告）
+- **review unresolved 残存時**: RU 生成（STEP-7）、採用済み成果物削除、Git 永続化（STEP-8）等の後続不可逆処理へ進まない
+
+## Resume Protocol（durable state による再開）
+
+会話コンテキストを権威情報源とせず、durable state から current STEP を再構成する（DEC-{N}）。優先順位は `<workflows/input-resolution-and-durable-state>` SPEC に従う。
+
+1. SSoT 再構成: `.agentdev/{intake,learning,inspect}/promoted/` と `.agentdev/backlog/req-units/` の実ファイル状態
+2. identifier 保持: 成果物パス、RU-ID（RU frontmatter の `source_type`、`generated_by`、`status`、`depends_on`、`tentative_classification`、`sources`）
+3. 最小 scalar: RU 生成数、統合・分割数、矛盾数
+4. runtime artifact: RU 構成案、adversarial-review findings（REQ-{NNNN} lifecycle）
+
+### current STEP 再構成規則
+
+| durable state の観察結果 | 再開 STEP | 承認状態の解釈 |
+|---|---|---|
+| promoted に成果物残存、req-units に該当 RU なし | STEP-2（分析から。RU 構成案は promoted 実ファイルから再構築） | 未承認（HITL をやり直す） |
+| RU 生成済み（req-units に RU 存在）、対応 promoted が削除済み | STEP-8（git 永続化から） | 承認済み（RU 実ファイルが承認・生成証跡。再承認を求めない） |
+| RU 生成済み、対応 promoted が残存 | STEP-7（成果物削除から） | 承認済み |
+| 対象成果物 0 件 | 正常終了（「対象なし」報告のみ） | - |
+
+HITL（STEP-5）の承認状態は単独では durable state に記録されない。RU 実ファイル（STEP-7 の成果物）を承認証跡として扱い、証跡がない場合は未承認と解釈して STEP-5 をやり直す。不可逆処理（RU 生成、採用済み成果物削除）は承認確定後にのみ実行する。
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-backlog-integration`: 採用済み成果物の読込、分析、統合・分割判定、depends_on 依存解決、矛盾検出、RU 生成ルール（frontmatter、セクション構成、採番、upstream handoff 転記）。経路E の review 候補判断と内部手続き
+- `agentdev-adversarial-review`: 経路E の review 呼出（共通契約の正規所有者は adversarial-review SPEC、REQ-{NNNN}）
+- `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング、構造化エラー形式）
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open。document-model SPEC の文書7分類モデルは extension 経由で参照）
+
+## Workflow Extension 読込
+
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-backlog-review.yaml`、`kind: workflow-extension`）を読み込む場合がある（DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-backlog-review/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、backlog-review command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+
+## 共通制約
+
+- **RU フォーマット**: RU-*.md の構造（frontmatter: `source_type`, `generated_by`, `generated_at`, `status`, `depends_on`, `tentative_classification`, `sources` / 本文: Sources, Source Summary, 統合理由, 要件化の方向）は `agentdev-backlog-integration` を正とする。`tentative_classification` は document-model SPEC（extension 経由）の文書7分類モデル（REQ、挙動SPEC、カタログSPEC、guide、learning維持、作業記録、対象外）のいずれかを記録する。暫定分類は後続 `/agentdev/req-define` で最終確定される候補であり、本 workflow は確定しない
+- **session由来RU**: `source_type: chat` かつ `generated_by: session` の RU は、一時成果物ライフサイクル要件と artifact-contracts SPEC「RU アーティファクト契約（session由来RU）」セクションを正規原本とする（frontmatter 必須フィールド、二段階承認、`agreement_confirmed_at`、session 論理URI、RU 本文必須8セクション、永続ID 採番）。本 workflow は再定義しない
+- **単純コピー禁止**: 採用済み成果物のパススルー（単純コピー）を生成しない。`depends_on` に採用済み成果物パスを指定しない（RU-ID のみ許容）
+- **削除条件**: RU 生成が成功した採用済み成果物のみを削除する（当該成果物が RU に取り込まれ、RU ファイルの生成が確認できた場合のみ）。RU 化に失敗した成果物、矛盾により除外された成果物は残置する
+- **非更新対象**: `.agentdev/intake/inbox/`、`.agentdev/learning/inbox.md`、`.agentdev/learning/deferred.md` を更新しない
+- **矛盾検出時**: ユーザーの指示を待ち、自動的に解決しない。矛盾する artifact を RU 化せずユーザーに確認する。矛盾しない artifact は通常通り RU 化する（partial success）
+- **破壊的変更の明示承認**: 矛盾解消、要件仕様スコープ変更、大量成果物削除等は明示承認を維持する
+- **git 永続化**: 並列実行安全ステージングプロシージャに従い明示パスでステージする。生成した RU は `.agentdev/backlog/req-units/` 配下、削除した採用済み成果物は `.agentdev/{intake,learning,inspect}/promoted/` 配下の各パスを `git add <path>`/ `git rm <path>` で明示的にステージする。`.agentdev/` 全体の一括 `git add` は禁止。commit message は `chore(agentdev): generate requirement units via backlog-review`。`git commit -- <paths>`（--only pathspec 形式）を実行し `git push` を行う。失敗時は構造化エラーメッセージを表示して停止する
+- **完了報告**: 全て成功時は `.opencode/commands/agentdev/templates/backlog-review/standard.md`、partial success（矛盾あり）時は `partial.md`、採用済み成果物なし時は `zero-promoted.md` に従う。RU 生成結果、git 永続化結果を含め、次のコマンド（`/agentdev/req-define`）を提示する
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **`<workflows/step-reference-contract>` SPEC**: STEP reference 構造、resume point
+- **`<workflows/input-resolution-and-durable-state>` SPEC**: durable state 優先順位、current STEP 再構成
+- **`docs/decisions/DEC-{N}.md`**: Command / Workflow Skill / Capability Skill 責務3層分化と1:N分割原則
+- **`docs/decisions/DEC-{N}.md`**: STEP resume point と会話記憶非依存
+- **backlog-review command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）

--- a/src/opencode/skills/agentdev-workflow-backlog-review/references/analysis-composition-and-review.md
+++ b/src/opencode/skills/agentdev-workflow-backlog-review/references/analysis-composition-and-review.md
@@ -1,0 +1,207 @@
+# STEP 詳細: 実行前同期・成果物検出 / 分析・暫定分類 / 統合分割判定 / review / HITL（backlog-review）
+
+> 本 reference は `agentdev-workflow-backlog-review` SKILL.md の Control Plane STEP-1〜STEP-5 詳細である。SKILL.md は control plane として STEP 遷移を管理し、本 reference は各 STEP の実行詳細を提供する。
+
+## 目次
+
+- STEP-1: 実行前同期・成果物検出
+- STEP-2: 分析・暫定分類付与
+- STEP-3: 統合・分割判定・depends_on 依存解決
+- STEP-4: review（adversarial-review 経路E）
+- STEP-5: HITL（ユーザー承認、RU 生成承認を兼ねる）
+
+## STEP-1: 実行前同期・成果物検出
+
+### Purpose
+
+実行前同期を行い、対象の採用済み成果物を検出する。
+
+### Input Resolution
+
+- backlog-review command から渡される引数（ファイルパス指定）の有無（durable state 最優先は promoted/ 実ファイル）
+- ドメイン状態永続化プロシージャは `agentdev-git-worktree` に従う
+
+### Preconditions
+
+- backlog-review command が起動されている
+
+### Procedure
+
+1. `git pull --ff-only` を実行する。失敗時は構造化エラーメッセージを表示して停止する（`agentdev-git-worktree` と同一のエラー形式。自動解消しない）
+2. 引数の有無に応じて対象を切り替える。引数なしの場合は三ディレクトリ（`.agentdev/intake/promoted/*.md`、`.agentdev/learning/promoted/*.md`、`.agentdev/inspect/promoted/*.md`）から採用済み成果物を検出する。引数ありの場合は指定されたファイルパスのみを対象とし、存在しないパスはエラー報告してスキップする
+3. 検出結果を判定する。0件の場合は正常終了とする（エラー扱いとしない。完了報告で「対象なし」と報告）。1件以上の場合はファイルパス昇順で STEP-2 へ進む
+
+### Result
+
+- 対象成果物一覧（ファイルパス昇順）
+
+### Evidence
+
+- 検出結果（対象ディレクトリ、ファイルパス一覧）
+
+### Completion Verification
+
+- 引数指定時は指定パスの存在確認結果が記録されていること
+- 対象 0 件時に正常終了扱いであること
+
+### Resume-Idempotency
+
+- promoted/ 実ファイルから検出を再構築できる。読み取りのみのため再実行に副作用がない
+
+## STEP-2: 分析・暫定分類付与
+
+### Purpose
+
+各成果物を読み込み、分析し、RU 候補ごとに暫定分類を付与する。
+
+### Input Resolution
+
+- STEP-1 の対象成果物一覧（durable state: promoted/ 実ファイル）
+- 分析基準、前工程からの引き継ぎメタデータ付与ルールは `agentdev-backlog-integration` の公開操作契約に従う
+- document-model SPEC（extension 経由）の文書7分類モデルを参照する
+
+### Preconditions
+
+- 対象成果物が 1件以上検出済みであること
+
+### Procedure
+
+1. 各採用済み成果物を読み込み、分析する
+2. 各 RU 候補について、document-model SPEC（extension 経由）の文書7分類モデル（REQ、挙動SPEC、カタログSPEC、guide、learning維持、作業記録、対象外）を参照して暫定分類を付与する
+3. 分析結果と併せて RU frontmatter に `tentative_classification` として記録する（記録は STEP-7 の RU 生成時。本 STEP は付与内容を確定する）
+
+### Result
+
+- 分析結果、暫定分類付与結果
+
+### Evidence
+
+- 各成果物の分析結果、暫定分類（文書7分類モデルのいずれか）
+
+### Completion Verification
+
+- 全 RU 候補に暫定分類が付与されていること
+
+### Resume-Idempotency
+
+- promoted/ 実ファイルから分析・暫定分類を再構築できる。不可逆処理を含まないため再実行に副作用がない
+
+## STEP-3: 統合・分割判定・depends_on 依存解決
+
+### Purpose
+
+採用済み成果物の統合、分割を判定し、depends_on 依存を解決して RU 構成案を確定する。
+
+### Input Resolution
+
+- STEP-2 の分析結果、暫定分類（中断時は promoted/ 実ファイルから STEP-2 を再構築して導出する）
+- 統合、分割判定基準、depends_on 依存解決ルールは `agentdev-backlog-integration` の公開操作契約に従う
+
+### Preconditions
+
+- STEP-2 完了（分析・暫定分類付与済み）
+
+### Procedure
+
+1. 統合、分割判定を行う（N:1 統合 / 1:N 分割 / 1:1）
+2. depends_on 依存解決を行う（未解決、循環、並べ替え可能性の検証）
+3. RU 構成案（統合・分割判定結果、depends_on 解決結果、暫定分類付与結果）を確定する
+
+### Result
+
+- RU 構成案
+
+### Evidence
+
+- RU 構成案（統合・分割の判断根拠、depends_on 検証結果）
+
+### Completion Verification
+
+- 全成果物が RU 構成案のいずれかに割り当てられていること
+- depends_on に unresolved、循環が残っていないこと
+
+### Resume-Idempotency
+
+- promoted/ 実ファイルから RU 構成案を再構築できる。不可逆処理を含まないため再実行に副作用がない
+
+## STEP-4: review（adversarial-review 経路E）
+
+### Purpose
+
+RU 構成案の意味的決定を adversarial-review で検証し、accepted finding を RU 構成案へ反映する。発動条件判定と review 呼出を分離して実施する。
+
+### Input Resolution
+
+- STEP-3 で確定した RU 構成案（runtime artifact。中断時は promoted/ 実ファイルから再構築する）
+- 候補判断基準、内部手続きは `agentdev-backlog-integration` の公開操作契約に従う
+- 共通 caller integration 契約の正規所有者は adversarial-review SPEC（REQ-{NNNN}）である
+
+### Preconditions
+
+- STEP-3 完了（RU 構成案確定済み）
+- 挿入境界、発動条件、順序、矛盾取扱いの正規所有者は backlog-review command SPEC「adversarial-review 挿入境界（経路E）」節である
+
+### Procedure
+
+1. **発動条件判定**: RU 構成案（統合・分割判定、depends_on 依存解決）に意味的決定が存在する場合に発動する（default-on）。ユーザー明示指定は通常発動の必須条件ではない。skip 条件（RU 構成要素が1件のみで統合・分割判定不要、depends_on 解決不要、矛盾検出対象が存在しない）該当時は省略して従来フロー（STEP-5 以降）を継続する。skip 判断のためだけの新規 HITL、承認点は追加しない。ユーザー明示指定時は skip 条件の該当にかかわらず必ず発動する
+2. **review 呼出**: 発動と判定された場合のみ `agentdev-adversarial-review` を起動する。審議対象は RU 構成案（統合・分割判定結果、depends_on 解決結果、暫定分類付与結果）。呼出契約、返却契約、副作用境界は `agentdev-adversarial-review` と delegation-contracts SPEC（`semantic_review`、書き込み禁止型）を正とする
+3. **accepted finding 反映**: accepted finding の RU 構成案への反映は本 workflow（呼出元）の責務である。反映後に RU 構成案の意味内容が変更された場合、必要な既存検証（depends_on 再解決、矛盾検出再実行）を行い、意味内容変更から新たな本質的争点が生じ得る場合のみ再 review を発動できる。同一 finding を新証拠・新前提・異なる failure condition・未評価範囲なしに再起票しない
+4. **矛盾の扱い**: review 審議で採用済み成果物間の矛盾が指摘された場合、当該矛盾は STEP-6（既存矛盾検出）へ引き渡す。adversarial-review 自身は矛盾を自動解決せず、矛盾の判定、partial success 扱い、ユーザー追加判断への委ねは STEP-6 の既存矛盾検出ロジックが正である
+5. **unresolved 時の取扱い**: unresolved な本質的争点またはユーザー判断事項が残る場合、RU 生成（STEP-7）、採用済み成果物削除、Git 永続化（STEP-8）等の後続不可逆処理へ進まない
+6. **呼出失敗時**: silent skip を禁止し、従来フロー（STEP-5 以降）を維持する
+
+### Result
+
+- review 結果反映済み RU 構成案（skip 時、呼出失敗時は STEP-3 の構成案をそのまま継承）
+
+### Evidence
+
+- 発動条件判定結果（発動/ skip と根拠）、review 呼出記録、accepted finding と反映結果（発動時）
+
+### Completion Verification
+
+- 発動条件判定が記録されていること（発動・skip いずれも）
+- 発動時は accepted finding の反映結果が RU 構成案へ反映済みであること
+
+### Resume-Idempotency
+
+- review は書き込み禁止型（`semantic_review`）のため再呼出に副作用がない。promoted/ 実ファイルから RU 構成案を再構築し、発動条件判定からやり直す
+
+## STEP-5: HITL（ユーザー承認、RU 生成承認を兼ねる）
+
+### Purpose
+
+RU 構成案をユーザーに提示し、明示的な承認を得る。ユーザー承認は RU 作成承認を兼ねる。
+
+### Input Resolution
+
+- STEP-3 / STEP-4 の RU 構成案（中断時は promoted/ 実ファイルから再構築する）
+- 承認フローは `agentdev-backlog-integration` の公開操作契約に従う
+
+### Preconditions
+
+- RU 構成案確定、STEP-4 skip または review 完了であること
+
+### Procedure
+
+1. RU 構成案（統合・分割判定、depends_on 解決結果、暫定分類）をユーザーに提示する
+2. ユーザーの修正指示を受け付け、必要に応じて STEP-3 をやり直す
+3. 明示的な承認を得て承認を確定する
+4. 後続の STEP-6 で矛盾が検出されない場合、本 STEP の統合、分割判定承認を RU 生成承認（STEP-7）としても扱う。単一承認で処理し、追加の HITL は不要
+5. 破壊的変更（矛盾解消、要件仕様スコープ変更、大量成果物削除等）は明示承認を維持する
+
+### Result
+
+- 承認確定（RU 生成承認を兼ねる）
+
+### Evidence
+
+- RU 構成案の提示とユーザー承認の対話記録
+
+### Completion Verification
+
+- RU 構成案がユーザー承認済みであること
+
+### Resume-Idempotency
+
+- 承認状態は単独では durable state に記録されない。RU 実ファイル（STEP-7 の成果物）を承認証跡として扱い、証跡がない場合は未承認と解釈して本 STEP をやり直す。承認前の再実行に副作用はない

--- a/src/opencode/skills/agentdev-workflow-backlog-review/references/contradiction-ru-and-persistence.md
+++ b/src/opencode/skills/agentdev-workflow-backlog-review/references/contradiction-ru-and-persistence.md
@@ -1,0 +1,136 @@
+# STEP 詳細: 矛盾検出 / RU 生成・成果物削除 / Git 永続化・完了報告（backlog-review）
+
+> 本 reference は `agentdev-workflow-backlog-review` SKILL.md の Control Plane STEP-6〜STEP-8 詳細である。SKILL.md は control plane として STEP 遷移を管理し、本 reference は各 STEP の実行詳細を提供する。
+
+## 目次
+
+- STEP-6: 矛盾検出・追加判断
+- STEP-7: RU 生成・成功成果物削除
+- STEP-8: Git 永続化・完了報告
+
+## STEP-6: 矛盾検出・追加判断
+
+### Purpose
+
+採用済み成果物間の矛盾を検出し、検出された場合のみユーザーに追加判断を求める。
+
+### Input Resolution
+
+- STEP-5 で承認確定した RU 構成案（中断時は promoted/ 実ファイルから再構築する）
+- 矛盾検出ロジック、出力形式は `agentdev-backlog-integration` の公開操作契約に従う
+- STEP-4 の review で指摘された矛盾は本 STEP へ引き継がれる（矛盾の判定、partial success 扱い、ユーザー追加判断への委ねは本 STEP の既存ロジックが正）
+
+### Preconditions
+
+- 承認確定済み（STEP-5 完了）
+
+### Procedure
+
+1. RU 構成案に含まれる採用済み成果物間の矛盾を検出する
+2. 矛盾が検出されない場合: そのまま STEP-7 へ進む（単一承認で RU 生成扱い。追加の HITL は不要）
+3. 矛盾が検出された場合のみ、ユーザーに追加判断を求める。矛盾する artifact を RU 化せずユーザーに確認する。自動解決しない
+4. 矛盾しない artifact は通常通り RU 化する（partial success）
+
+### Result
+
+- 矛盾検出結果（なし / あり + ユーザー追加判断結果、partial success 扱いの確定）
+
+### Evidence
+
+- 矛盾検出結果、追加判断の対話記録（検出時）
+
+### Completion Verification
+
+- 矛盾検出の実行結果が記録されていること
+- 検出時に自動解決していないこと（ユーザー判断を経ていること）
+
+### Resume-Idempotency
+
+- promoted/ 実ファイルから矛盾検出を再実行できる。不可逆処理を含まないため再実行に副作用がない
+
+## STEP-7: RU 生成・成功成果物削除
+
+### Purpose
+
+RU を生成し、RU 生成が成功した採用済み成果物のみを削除する。
+
+### Input Resolution
+
+- STEP-5 で承認確定した RU 構成案、STEP-6 の矛盾検出結果（durable state: promoted/ 実ファイル、RU-ID）
+- RU 生成ルール、frontmatter スキーマ、depends_on 検証は `agentdev-backlog-integration` の公開操作契約に従う
+- session由来RU の生成形式は一時成果物ライフサイクル要件と artifact-contracts SPEC「RU アーティファクト契約（session由来RU）」セクションを正規原本とする
+
+### Preconditions
+
+- 承認確定、矛盾処理完了であること
+- 矛盾により除外された成果物がある場合は、ユーザーの追加判断が確定していること
+
+### Procedure
+
+1. RU 構成案に基づき `.agentdev/backlog/req-units/RU-*.md` を生成する（frontmatter: `source_type`, `generated_by`, `generated_at`, `status`, `depends_on`, `tentative_classification`, `sources` / 本文: Sources, Source Summary, 統合理由, 要件化の方向）
+2. session由来RU（`source_type: chat`、`generated_by: session`）の場合は、正規原本（一時成果物ライフサイクル要件、artifact-contracts SPEC「RU アーティファクト契約（session由来RU）」）へ委譲した要件（二段階承認、frontmatter 必須フィールド、`agreement_confirmed_at`、session 論理URI、RU 本文必須8セクション、永続ID 採番）に従う
+3. depends_on 検証を実行する（RU-ID のみ許容、unresolved、循環の検証）
+4. RU 生成が成功した採用済み成果物のみを削除する。削除条件は当該成果物が RU に取り込まれ、RU ファイルの生成が確認できた場合のみ。RU 化に失敗した成果物、矛盾により除外された成果物は残置する
+5. 削除結果を記録する
+
+### Result
+
+- `.agentdev/backlog/req-units/RU-*.md`
+- RU 化成功成果物の削除、残置成果物の記録
+
+### Evidence
+
+- 生成済み RU のファイルパス一覧、削除/ 残置の成果物一覧
+
+### Completion Verification
+
+- RU 構成案の全 RU について RU ファイルが生成されていること（矛盾除外分を除く）
+- RU 生成成功分の成果物のみが削除されていること
+
+### Resume-Idempotency
+
+- 生成済みの RU は再生成しない。req-units/ と promoted/ の実ファイル状態から削除未完了の成果物を特定し、残処理のみ実行する
+- RU 実ファイルの存在が承認・生成証跡となる
+
+## STEP-8: Git 永続化・完了報告
+
+### Purpose
+
+`.agentdev/` 配下の変更を commit / push し、完了報告を出力して workflow を終了する。
+
+### Input Resolution
+
+- STEP-7 の結果（durable state: req-units/、promoted/ 実ファイル）
+- ドメイン状態永続化プロシージャは `agentdev-git-worktree` に従う
+
+### Preconditions
+
+- RU 生成・削除が完了していること
+
+### Procedure
+
+1. `git diff --name-only` で `.agentdev/` 配下の変更を確認する
+2. 変更なし時は commit/push せず完了報告で「変更なし」と報告する
+3. 変更あり時、並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い明示パスでステージする。生成した RU は `.agentdev/backlog/req-units/` 配下、削除した採用済み成果物は `.agentdev/{intake,learning,inspect}/promoted/` 配下の各パスを `git add <path>`/ `git rm <path>` で明示的にステージする。`.agentdev/` 全体の一括 `git add` は禁止
+4. commit message は `chore(agentdev): generate requirement units via backlog-review` とする
+5. `git commit -- <paths>`（--only pathspec 形式）を実行し、`git push` を行う。失敗時は構造化エラーメッセージを表示して停止する
+6. 完了報告をテンプレート別に出力する。全て成功時は `.opencode/commands/agentdev/templates/backlog-review/standard.md`、partial success（矛盾あり）時は `partial.md`、採用済み成果物なし時は `zero-promoted.md` に従う。RU 生成結果、git 永続化結果を含め、次のコマンド（`/agentdev/req-define`）を提示する
+
+### Result
+
+- commit/push 済み（変更あり時）
+- 完了報告（テンプレート別）
+
+### Evidence
+
+- commit hash、push 成否、完了報告の出力
+
+### Completion Verification
+
+- RU 生成結果と git 永続化結果が完了報告に含まれていること
+- partial success 時に該当テンプレートを使用していること
+
+### Resume-Idempotency
+
+- commit 済みの変更は再コミットしない。`git diff --name-only` の結果から未永続化の変更を特定し、残処理のみ実行する
+- 報告は出力のみのため再実行に副作用がない

--- a/src/opencode/skills/agentdev-workflow-intake-capture/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-intake-capture/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: agentdev-workflow-intake-capture
+description: "intake-capture command の workflow 実装本体。ユーザーの手動入力から intake item を生成し、`.agentdev/intake/inbox/` へ保存、git 永続化、完了報告までの保存専用 workflow を所有する。capture-only型であり STEP model 対象外（resume point / export / import なし）。USE FOR: intake-capture command 実行時の workflow 実行（入力受領・intake item 生成・ファイル名生成・実行前同期・保存・git 永続化・完了報告）。DO NOT USE FOR: GitHub Issue 作成（case-open）、採用可否の判断・review・分類・振り分け（intake-promote）、learning item の保存・分類・昇華（learning-capture、learning-promote）、GitHub クローズ済み Issue/PR からの残課題抽出（intake-from-github）、work_type 判定（agentdev-workflow-lifecycle）、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# intake-capture workflow スキル
+
+intake-capture command の workflow 実装本体。ユーザーの手動入力から未分類の作業候補、不整合、規約違反、未回収課題を intake item として `.agentdev/intake/inbox/` に保存する保存専用 workflow を所有する。GitHub Issue の作成、採用可否の判断、review、整形、分類は行わない。
+
+intake-capture command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md が担う（workflow 実装が単純なため references/ を持たない）。
+Workflow Skill 固有契約（Command / Workflow Skill / Capability Skill 責務、1:N 分割基準、依存方向、配置契約）は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-intake-capture.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と intake-capture command の公開契約のみを前提とする。SPEC ディレクトリの内部構成は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- intake-capture command の実行時 workflow 実行（全工程）
+- ユーザーの手動入力の intake item 化（推奨標準形への整理、推測・補完の禁止）
+- intake item の `.agentdev/intake/inbox/` への保存、ファイル名生成、git 永続化、完了報告
+
+## DO NOT USE FOR
+
+- GitHub Issue の作成（`/agentdev/case-open`）
+- 採用可否の判断、review、分類、振り分け（`/agentdev/intake-promote`）
+- learning item の保存、分類、昇華（`agentdev-learning-capture` skill、`/agentdev/learning-promote`）
+- GitHub クローズ済み Issue/PR からの残課題抽出（`/agentdev/intake-from-github`）
+- work_type 判定、フェーズ定義（`agentdev-workflow-lifecycle`）
+
+## 入力
+
+- intake-capture command から渡されるユーザーの自然言語による変更候補の記述
+- 任意で観測元、影響、判断保留事項の指定
+
+## 出力
+
+- `.agentdev/intake/inbox/YYYY-MM-DD-{topic-slug}.md` に保存された intake item
+- git 永続化結果（変更有無、ファイル一覧、commit hash、push 成否）を含む完了報告
+
+## 副作用
+
+- `.agentdev/intake/inbox/` 配下へのファイル作成
+- `.agentdev/intake/` 配下の変更の commit / push
+- 当該 Workflow Skill は worktree root 配下以外を編集しない（intake-capture command の worktree 隔離に従う）
+
+## workflow model（capture-only型、STEP model 対象外）
+
+本スキルは capture-only型の workflow であり、STEP model の対象外である（REQ-{NNNN}-{NNN}）。resume point / export / import を持たない。工程は逐次実行し、中断時は workflow を最初から再実行する。保存済みファイルとの重複はファイル名への連番付与で吸収するため、再実行は安全である。
+
+| 工程 | 名称 | 内容 |
+|---|---|---|
+| 工程-1 | 入力の受領 | ユーザーから変更候補の内容を受領する。自然言語で記述された内容をそのまま取り扱う |
+| 工程-2 | intake item の生成 | 入力を推奨標準形に整理する。ユーザーが明示的に指定していないセクションは推測・補完せず省略する |
+| 工程-3 | ファイル名の生成・実行前同期 | `YYYY-MM-DD-{topic-slug}.md` 形式でファイル名を生成する。`git pull --ff-only` を実行する |
+| 工程-4 | 保存・永続化 | `.agentdev/intake/inbox/` へ保存し、`.agentdev/intake/` 配下の変更を commit / push する |
+| 工程-5 | 完了報告 | 完了報告 template に従って出力する。git 永続化結果を含める |
+
+## Intake Item 形式
+
+intake item は以下の推奨標準形に従う Markdown 成果物とする。
+workflow 管理用の frontmatter、状態フィールド、重複排除キーは持たない。
+
+```markdown
+# {タイトル}
+
+## 観測
+{何が観測されたか}
+
+## 今回扱わない理由
+{なぜ今すぐ対応しないのか}
+
+## 影響
+{影響の評価}
+
+## レビューで決めること
+{レビューで判断すべき点}
+
+## 根拠（任意）
+{補足情報・証拠}
+```
+
+セクションに関する制約:
+
+- 各セクションの見出し名は固定しない。ユーザーの入力に合わせて整理する
+- 必須セクション、省略不可セクションを設けない
+- 内容がないセクションを形式維持のためだけに作成しない
+- frontmatter、状態値、メタデータフィールドを必須にしない
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング、構造化エラー形式）
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+- `agentdev-workflow-orchestration`: intake と learning の capture 振り分け基準（作業知見のみで具体的修正対象がない内容は learning 対象）
+
+## Workflow Extension 読込
+
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-intake-capture.yaml`、`kind: workflow-extension`）を読み込む場合がある（DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-intake-capture/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、intake-capture command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+
+## 共通制約
+
+- **保存専用**: GitHub Issue の作成、採用可否の判断、review、整形、分類、item の変更・更新を行わない（command 側ガードレール G01〜G06 の詳細実装）
+- **補完禁止**: ユーザーの入力に含まれない情報を自動生成・推論して記載しない。元の意図を保ったまま整理する（G11、G13）
+- **保存先**: `.agentdev/intake/inbox/` のみ（G12）。ディレクトリが存在しない場合は作成する。同名ファイルが存在する場合は `{topic-slug}-2`、`{topic-slug}-3` のように連番を付与する
+- **topic-slug 生成**: タイトルから生成する（小文字英数字、ハイフン区切り、30文字以内）。日付は実行時のシステム日付（`YYYY-MM-DD`）
+- **git 永続化**: commit message は `chore(agentdev): capture intake item`（Conventional Commits 形式）。変更なし時は commit/push せず完了報告で「変更なし」と報告する。push 失敗時は構造化エラー形式で停止する（完了扱いにしない）
+- **実行前同期**: `git pull --ff-only` 失敗時は共通 template（`.opencode/commands/agentdev/templates/common/git-error-messages.md`）の「Git 同期エラー」形式で表示して停止する（自動解消しない）
+- **完了報告**: template は `.opencode/commands/agentdev/templates/intake-capture/standard.md` に従う
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **`docs/decisions/DEC-{N}.md`**: Command / Workflow Skill / Capability Skill 責務3層分化と1:N分割原則
+- **intake-capture command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）

--- a/src/opencode/skills/agentdev-workflow-intake-from-github/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-intake-from-github/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: agentdev-workflow-intake-from-github
+description: "intake-from-github command の workflow 実装本体。クローズ済み GitHub Issue/PR の本文・コメントから未回収の変更候補を抽出し、intake item として `.agentdev/intake/inbox/` に保存、git 永続化、サマリーレポート、完了報告までの保存専用 workflow を所有する。capture-only型であり STEP model 対象外（resume point / export / import なし）。USE FOR: intake-from-github command 実行時の workflow 実行（期間解釈・データ取得・構造的検出・LLM 全文解析・intake item 生成・保存・git 永続化・サマリーレポート）。DO NOT USE FOR: GitHub Issue 作成（case-open）、採用可否の判断・review・分類（intake-promote）、learning item の保存・分類・昇華（learning-capture、learning-promote）、Issue/PR へのコメント投稿やマーカー付与（backlog-review）、work_type 判定（agentdev-workflow-lifecycle）、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# intake-from-github workflow スキル
+
+intake-from-github command の workflow 実装本体。クローズ済みの GitHub Issue/PR の本文、コメントから未回収の変更候補を抽出し、intake item として `.agentdev/intake/inbox/` に保存する保存専用 workflow を所有する。GitHub Issue の作成、採用可否の判断、review、整形、分類は行わない。
+
+intake-from-github command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md が担う（抽出の判定基準は Capability Skill へ委譲し、references/ を持たない）。
+Workflow Skill 固有契約（Command / Workflow Skill / Capability Skill 責務、1:N 分割基準、依存方向、配置契約）は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-intake-from-github.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と intake-from-github command の公開契約のみを前提とする。SPEC ディレクトリの内部構成は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- intake-from-github command の実行時 workflow 実行（全工程）
+- 期間指定・Issue/PR 番号指定の解釈とクローズ済み Issue/PR のデータ取得
+- 構造的検出、LLM 全文解析による残課題抽出、intake item 生成
+- `.agentdev/intake/inbox/` への保存、git 永続化、抽出サマリーレポート、完了報告
+
+## DO NOT USE FOR
+
+- GitHub Issue の作成（`/agentdev/case-open`）
+- 採用可否の判断、review、分類、振り分け（`/agentdev/intake-promote`）
+- learning item の保存、分類、昇華（`agentdev-learning-capture` skill、`/agentdev/learning-promote`）
+- Issue/PR へのコメント投稿、マーカー付与（`/agentdev/backlog-review`）
+- 手動入力からの intake item 保存（`/agentdev/intake-capture`）
+- work_type 判定、フェーズ定義（`agentdev-workflow-lifecycle`）
+
+## 入力
+
+- intake-from-github command から渡されるユーザーの自然言語による期間指定（「直近1週間」「今月」「2026-05-02から」等）
+- または特定の Issue/PR 番号の指定
+
+## 出力
+
+- `.agentdev/intake/inbox/YYYY-MM-DD-{topic-slug}.md` に保存された intake item（候補ごとに1ファイル）
+- 抽出サマリーレポート（ユーザー確認用）
+- git 永続化結果（変更有無、ファイル一覧、commit hash、push 成否）を含む完了報告
+
+## 副作用
+
+- `.agentdev/intake/inbox/` 配下へのファイル作成
+- `.agentdev/intake/` 配下の変更の commit / push
+- GitHub Issue/PR の読み取り（書き込みは行わない）
+- 当該 Workflow Skill は worktree root 配下以外を編集しない（intake-from-github command の worktree 隔離に従う）
+
+## workflow model（capture-only型、STEP model 対象外）
+
+本スキルは capture-only型の workflow であり、STEP model の対象外である（REQ-{NNNN}-{NNN}）。resume point / export / import を持たない。工程は逐次実行し、中断時は workflow を最初から再実行する。抽出の再実行は読み取りのみのため安全であり、保存済みファイルとの重複はファイル名への連番付与で吸収する。
+
+| 工程 | 名称 | 内容 |
+|---|---|---|
+| 工程-1 | 期間解釈 | 期間指定または Issue/PR 番号指定を解釈する（抽出アルゴリズムは `agentdev-intake-pipeline`） |
+| 工程-2 | データ取得 | クローズ済み Issue/PR のデータを取得する（gh CLI、`agentdev-gh-cli` の読み取り手続き） |
+| 工程-3 | 構造的検出 | 抽出ルールに基づき構造的に残課題候補を検出する（`agentdev-intake-pipeline`） |
+| 工程-4 | LLM 全文解析 | キーワードリスト、コンテキスト付与ルールに基づき全文解析する（`agentdev-intake-pipeline`） |
+| 工程-5 | intake item 生成・実行前同期 | item 生成ルール、ファイル名規則に従い item を生成する（`agentdev-intake-pipeline`）。`git pull --ff-only` を実行する |
+| 工程-6 | 保存・永続化 | `.agentdev/intake/inbox/` へ保存し、`.agentdev/intake/` 配下の変更を commit / push する |
+| 工程-7 | サマリーレポート提示 | 抽出結果をサマリーとしてユーザーに提示する（対象期間、対象数、抽出候補数、保存先、一覧表） |
+| 工程-8 | 完了報告 | 完了報告 template に従って出力する。git 永続化結果を含める |
+
+## Intake Item 形式
+
+intake item は `agentdev-workflow-intake-capture` と同一の推奨標準形（観測、今回扱わない理由、影響、レビューで決めること、根拠（任意））を使用する。
+frontmatter、状態フィールド、重複排除キーは持たない。
+各セクションの見出し名は固定せず、抽出内容に合わせて整理する。
+内容がないセクションを作成しない。
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-intake-pipeline`: GitHub 残課題抽出の判定基準（期間解釈、データ取得、構造的検出、LLM 全文解析、item 生成ルール、ファイル名規則）
+- `agentdev-gh-cli`: GitHub Issue/PR の安全な読み取り手続き
+- `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング、構造化エラー形式）
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+
+## Workflow Extension 読込
+
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-intake-from-github.yaml`、`kind: workflow-extension`）を読み込む場合がある（DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-intake-from-github/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、intake-from-github command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+
+## 共通制約
+
+- **保存専用**: GitHub Issue の作成、採用可否の判断、review、整形、分類を行わない。Issue/PR へのコメント投稿、マーカー付与も行わない（command 側ガードレール G01〜G04 の詳細実装）
+- **データ取得**: GitHub Issue/PR のデータ取得は `gh` CLI のみ使用する（GitHub API 直接呼び出し不可、G09）。対象はクローズ済み Issue/PR のみ（オープン中は対象外、G10）。読み取り操作は `agentdev-gh-cli` に従う（G11）
+- **保存先**: `.agentdev/intake/inbox/` のみ（G12）。ディレクトリが存在しない場合は作成する。同名ファイルが存在する場合は連番を付与する
+- **成果物本文 verbatim**: 保存対象ファイル本文は verbatim で扱う。判定結果、調査過程、中間ログ、読解メモは要約し、成果物パス、根拠、capture候補へ圧縮して返す（G13）
+- **git 永続化**: commit message は `chore(agentdev): capture intake items from github`（Conventional Commits 形式）。変更なし時は commit/push せず完了報告で「変更なし」と報告する。push 失敗時は構造化エラー形式で停止する（完了扱いにしない）
+- **実行前同期**: `git pull --ff-only` 失敗時は共通 template（`.opencode/commands/agentdev/templates/common/git-error-messages.md`）の「Git 同期エラー」形式で表示して停止する（自動解消しない）
+- **サマリーレポート**: 対象期間、対象 Issue/PR 数、抽出候補数、保存先、候補一覧表（番号、タイトル、元 Issue/PR、ファイル名）を含める
+- **完了報告**: template は `.opencode/commands/agentdev/templates/intake-from-github/standard.md` に従う
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **`docs/decisions/DEC-{N}.md`**: Command / Workflow Skill / Capability Skill 責務3層分化と1:N分割原則
+- **intake-from-github command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）

--- a/src/opencode/skills/agentdev-workflow-intake-promote/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-intake-promote/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: agentdev-workflow-intake-promote
+description: "intake-promote command の workflow 実装本体。inbox 内 intake item の classification（確認・読込・評価・暫定分類）、review（adversarial-review 経路C）、HITL（ユーザー承認・分類確定）、persistence（採用 item 整形・promoted 保存）、destructive handling（振り分け・inbox 削除・reject 即時削除・破壊的変更の明示承認・git 永続化）の各 STEP を独立 resume point として所有する。USE FOR: intake-promote command 実行時の workflow 制御（inbox 確認・item 読込・評価・暫定分類提示・経路C review 呼出・ユーザー承認・採用 item 整形・promoted 保存・振り分け・inbox 削除・git 永続化・完了報告）。DO NOT USE FOR: GitHub Issue 作成（case-open）、RU 生成（backlog-review）、learning pipeline の実行（learning-promote）、inbox item の新規保存（intake-capture、intake-from-github）、work_type 判定（agentdev-workflow-lifecycle）、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# intake-promote workflow スキル
+
+intake-promote command の workflow 実装本体。`.agentdev/intake/inbox/` 内の intake item を直接読み込み、内部 review フェーズで分類したのち、採用 item を `backlog-review` に渡せる採用済み成果物に整形する制御構造を所有する。classification → review → HITL → persistence → destructive handling の各段階を独立 resume point として構成する。
+
+intake-promote command は公開 interface（入出力契約・ガードレール・分類値契約）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md（control plane）と `references/` 配下（各 STEP 詳細）が担う。
+Workflow Skill 固有契約（Command / Workflow Skill / Capability Skill 責務、1:N 分割基準、依存方向、配置契約）は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-intake-promote.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と intake-promote command の公開契約のみを前提とする。SPEC ディレクトリの内部構成は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- intake-promote command の実行時 workflow 制御（全 STEP）
+- inbox 確認、item 読込、レビュー評価、暫定分類提示（classification）
+- adversarial-review 経路C の発動条件判定、review 呼出、accepted finding 反映（review）
+- 分類結果のユーザー提示、承認、確定（HITL）
+- 採用 item 整形、`.agentdev/intake/promoted/` への保存（persistence）
+- 振り分け（採用 inbox 削除、保留残置、reject 即時削除）、破壊的変更の明示承認、git 永続化、完了報告（destructive handling）
+
+## DO NOT USE FOR
+
+- GitHub Issue の作成（`/agentdev/case-open`）
+- RU 生成（`/agentdev/backlog-review`）
+- learning pipeline の入力生成、learning item の保存・分類・昇華（`/agentdev/learning-promote`）
+- inbox item の新規保存（`/agentdev/intake-capture`、`/agentdev/intake-from-github`）
+- work_type 判定、フェーズ定義（`agentdev-workflow-lifecycle`）
+
+## 入力
+
+- intake-promote command から渡される intake item 群（`.agentdev/intake/inbox/` 内の Markdown ファイル）
+- ユーザーによる追加コンテキスト、分類修正指示（対話的に）
+
+## 出力
+
+- 採用 item の採用済み成果物（`.agentdev/intake/promoted/*.md`、フラット構造、`backlog-review` 用）
+- 分類結果レポート（採用/ 保留/ 却下）
+- git 永続化結果を含む完了報告
+
+## 副作用
+
+- `.agentdev/intake/promoted/` 配下へのファイル作成
+- 採用 item の inbox 元ファイル削除、reject item の即時削除（保留 item は inbox に残置）
+- `.agentdev/intake/` 配下の変更の commit / push
+- 当該 Workflow Skill は worktree root 配下以外を編集しない（intake-promote command の worktree 隔離に従う）
+
+## Control Plane（STEP 一覧）
+
+intake-promote workflow は次の6 STEP で構成する。各 STEP は resume point を持ち（DEC-{N}、`docs/specs/<workflows/step-reference-contract>.md`）、classification / review / HITL / persistence / destructive handling の5段階がそれぞれ独立した resume point である。会話コンテキストに依存せず、durable state（inbox / promoted の実ファイル状態、分類確定状態）から再開点を再構成する。
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-1 | classification（inbox 確認・item 読込・評価・暫定分類提示） | inbox item 存在 | 暫定分類表（採用/保留/却下、根拠） | [references/classification-and-review.md](references/classification-and-review.md) |
+| STEP-2 | review（adversarial-review 経路C） | 暫定分類の意味的決定が存在、またはユーザー明示指定 | review 結果反映済み暫定分類（skip 時は STEP-1 結果をそのまま継承） | [references/classification-and-review.md](references/classification-and-review.md) |
+| STEP-3 | HITL（ユーザー確認・分類承認） | 暫定分類確定 | 分類確定（採用/保留/却下、ユーザー承認済み） | [references/hitl-persistence-and-destructive.md](references/hitl-persistence-and-destructive.md) |
+| STEP-4 | persistence（採用 item 整形・promoted 保存） | 分類確定（採用 item あり） | `.agentdev/intake/promoted/` 配下の採用済み成果物 | [references/hitl-persistence-and-destructive.md](references/hitl-persistence-and-destructive.md) |
+| STEP-5 | destructive handling（振り分け・削除・git 永続化） | 分類確定 + 採用済み成果物保存済み（保留のみ確定時は振り分けから） | inbox 振り分け完了（採用削除・保留残置・reject 即時削除）、commit/push 済み | [references/hitl-persistence-and-destructive.md](references/hitl-persistence-and-destructive.md) |
+| STEP-6 | 完了報告 | 振り分け・永続化完了 | 分類結果と git 永続化結果を含む完了報告 | [references/hitl-persistence-and-destructive.md](references/hitl-persistence-and-destructive.md) |
+
+### STEP 間の依存と分岐
+
+- **正常経路**: STEP-1 → STEP-2（skip 条件該当時は省略）→ STEP-3 → STEP-4（採用 item あり時）→ STEP-5 → STEP-6
+- **保留・却下のみ確定時**: STEP-3 → STEP-5（STEP-4 を省略し振り分けから実行）
+- **inbox 空**: STEP-1 で終了（対象なし報告）
+- **review unresolved 残存時**: STEP-3 の既存 HITL 経由で扱い、保存、inbox 削除等の不可逆処理へ進まない
+
+## Resume Protocol（durable state による再開）
+
+会話コンテキストを権威情報源とせず、durable state から current STEP を再構成する（DEC-{N}）。優先順位は `<workflows/input-resolution-and-durable-state>` SPEC に従う。
+
+1. SSoT 再構成: `.agentdev/intake/inbox/` と `.agentdev/intake/promoted/` の実ファイル状態
+2. identifier 保持: item ファイルパス、採用済み成果物パス
+3. 最小 scalar: 採用・保留・却下の件数
+4. runtime artifact: 暫定分類表、adversarial-review findings（REQ-{NNNN} lifecycle）
+
+### current STEP 再構成規則
+
+| durable state の観察結果 | 再開 STEP | 承認状態の解釈 |
+|---|---|---|
+| inbox に item 残存、promoted に対応成果物なし | STEP-1 | 未承認（暫定分類を再構築し HITL をやり直す） |
+| promoted に採用済み成果物保存済み、inbox 元ファイル残存 | STEP-5 | 承認済み（persistence 完了の実ファイルが承認証跡。再承認を求めない） |
+| inbox が空、promoted に成果物存在、commit 未実行 | STEP-5（git 永続化から） | 承認済み |
+| reject 相当の削除完了、commit に却下理由未記録 | STEP-5（commit message 確定から） | 承認済み |
+| 保留 item のみ残存、他の振り分け完了 | STEP-5 の残処理または STEP-6 | 承認済み |
+| 全 item の振り分けと commit/push 完了 | STEP-6（完了報告のみ） | 承認済み |
+
+HITL（STEP-3）の承認状態は単独では durable state に記録されない。そのため、persistence の成果物（promoted 実ファイル）を承認証跡として扱い、証跡がない場合は未承認と解釈して STEP-3 をやり直す。不可逆処理（inbox 削除、reject 即時削除）は承認確定後にのみ実行する。
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-intake-pipeline`: inbox 確認、Review 観点、分類提示形式、採用 item 整形、保存と振り分け、Git 永続化の判定基準。経路C の review 候補判断と内部手続き
+- `agentdev-adversarial-review`: 経路C の review 呼出（共通契約の正規所有者は adversarial-review SPEC、REQ-{NNNN}）
+- `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング、構造化エラー形式）
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+
+## Workflow Extension 読込
+
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-intake-promote.yaml`、`kind: workflow-extension`）を読み込む場合がある（DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-intake-promote/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、intake-promote command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+
+## 共通制約
+
+- **分類承認後の自動実行**: STEP-3 で分類が確定した場合、STEP-4〜STEP-5（採用 item 整形 / promoted 保存 / inbox 削除 / git pull / commit-push）は追加確認なしで自動実行する。分類未確定、修正中の場合は進まない
+- **破壊的変更の明示承認**: inbox 大量削除、重要 item の誤分類是正等の破壊的変更は STEP-3 の分類承認とは別に明示承認を維持する（command 側ガードレール G18 の詳細実装）
+- **保存先**: `.agentdev/intake/promoted/` 直下のみ（フラット構造、G16）。整形結果に frontmatter（route/status 等）、重複排除キー、後続成果物参照を含めない（G10、G11）
+- **元 item 不変**: intake item の元の内容は改変しない（整理、構造化のみ、G02）。元 item の本文に整形結果を書き込まない（G12）
+- **accepted/ 廃止**: `.agentdev/intake/accepted/` を参照、使用しない（G13、G14）
+- **git 永続化**: `.agentdev/intake/` 配下の変更のみを対象とする。commit message は `chore(agentdev): review and promote intake items`（Conventional Commits 形式）。reject item を含む場合は commit message に却下理由を含める（AG-{NNN}、監査証跡の補強）。変更なし時は commit/push せず「変更なし」と報告。push 失敗時は構造化エラー形式で停止（完了扱いにしない）
+- **実行前同期**: `git pull --ff-only` 失敗時は構造化エラーメッセージを表示して停止する（自動解消しない）
+- **完了報告**: template は `.opencode/commands/agentdev/templates/intake-promote/standard.md` に従う。分類結果（採用、保留、却下の件数、一覧）と git 永続化結果を含める
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **`<workflows/step-reference-contract>` SPEC**: STEP reference 構造、resume point
+- **`<workflows/input-resolution-and-durable-state>` SPEC**: durable state 優先順位、current STEP 再構成
+- **`docs/decisions/DEC-{N}.md`**: Command / Workflow Skill / Capability Skill 責務3層分化と1:N分割原則
+- **`docs/decisions/DEC-{N}.md`**: STEP resume point と会話記憶非依存
+- **intake-promote command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）

--- a/src/opencode/skills/agentdev-workflow-intake-promote/references/classification-and-review.md
+++ b/src/opencode/skills/agentdev-workflow-intake-promote/references/classification-and-review.md
@@ -1,0 +1,92 @@
+# STEP 詳細: classification / review（intake-promote）
+
+> 本 reference は `agentdev-workflow-intake-promote` SKILL.md の Control Plane STEP-1 / STEP-2 詳細である。SKILL.md は control plane として STEP 遷移を管理し、本 reference は各 STEP の実行詳細を提供する。
+
+## 目次
+
+- STEP-1: classification（inbox 確認・item 読込・評価・暫定分類提示）
+- STEP-2: review（adversarial-review 経路C）
+
+## STEP-1: classification（inbox 確認・item 読込・評価・暫定分類提示）
+
+### Purpose
+
+inbox 内の intake item を読み込み、評価し、暫定分類（採用/ 保留/ 却下）を提示する。
+
+### Input Resolution
+
+- `.agentdev/intake/inbox/` 内の intake item ファイル群（durable state 最優先。SSoT 再構成）
+- inbox 確認、item 読込、Review 観点、分類提示形式の判定基準は `agentdev-intake-pipeline` の公開操作契約に従う
+
+### Preconditions
+
+- intake-promote command が起動されている
+- inbox に item が存在する（空の場合は対象なしとして正常終了する）
+
+### Procedure
+
+1. `.agentdev/intake/inbox/` 内のファイル一覧を取得し、item 数をカウントする。空の場合はその旨を報告して終了する
+2. 各 intake item を読み込み、内容を把握する
+3. 各 item を Review 観点（観測内容の妥当性・重要性、影響、緊急度・優先度、既存要件との関連、対応方針、intake と learning の振り分け）で評価する
+4. 暫定分類を「## Findings / Capture候補」見出しの分類表（番号、タイトル、分類、後続、備考）として提示する
+
+### Result
+
+- 暫定分類表（各 item の採用/ 保留/ 却下、変更種別、根拠）
+
+### Evidence
+
+- inbox 一覧と各 item の読込結果
+- 暫定分類表（分類と根拠を含む）
+
+### Completion Verification
+
+- inbox 内の全 item が暫定分類表に含まれていること
+- 各 item に分類と根拠が付与されていること
+
+### Resume-Idempotency
+
+- inbox 実ファイルから暫定分類を再構築できる。読み取りのみのため再実行に副作用がない
+
+## STEP-2: review（adversarial-review 経路C）
+
+### Purpose
+
+暫定分類の意味的決定を adversarial-review で検証し、accepted finding を暫定分類へ反映する。発動条件判定と review 呼出を分離して実施する。
+
+### Input Resolution
+
+- STEP-1 の暫定分類表（runtime artifact。中断時は inbox 実ファイルから STEP-1 を再構築して導出する）
+- 発動条件判定、候補判断基準、内部手続きは `agentdev-intake-pipeline` の公開操作契約に従う
+- 共通 caller integration 契約の正規所有者は adversarial-review SPEC（REQ-{NNNN}）である
+
+### Preconditions
+
+- STEP-1 で暫定分類表が生成済みであること
+- 挿入境界、発動条件、順序の正は intake-promote command SPEC「adversarial-review 挿入境界（経路C）」節である
+
+### Procedure
+
+1. **発動条件判定**: 暫定分類の意味的決定が存在する場合に発動する（default-on）。skip 条件（inbox 項目が1件のみで暫定分類が自明、または inbox 空）該当時は省略して従来フローを継続する。skip 判断のためだけの新規 HITL、承認点は追加しない。ユーザー明示指定時は skip 条件の該当にかかわらず必ず発動する（起動時引数、対話中の指示、extension の rules により表明される）
+2. **review 呼出**: 発動と判定された場合のみ `agentdev-adversarial-review` を起動する。審議対象は暫定分類（各 item の採用/保留/却下、変更種別、根拠）。呼出タイミングはユーザー提示（STEP-3）開始前
+3. **結果反映**: accepted finding を得た場合、呼出元（本 workflow）が暫定分類へ finding を反映し、反映後の分類を STEP-3 へ渡す。adversarial-review 自身は反映を行わない
+4. **unresolved 扱**: unresolved な本質的争点が残る場合、既存 HITL（STEP-3）経由で扱い、保存、inbox 削除等の不可逆処理へは進まない
+5. **呼出失敗時**: silent skip を禁止し、利用不能を報告した上で従来フローと既存 QG/HITL を維持する
+
+### Result
+
+- review 結果反映済み暫定分類（skip 時、呼出失敗時は STEP-1 の暫定分類をそのまま継承）
+
+### Evidence
+
+- 発動条件判定結果（発動/ skip と根拠）
+- review 呼出記録、accepted finding と反映結果（発動時）
+
+### Completion Verification
+
+- 発動条件判定が記録されていること（発動・skip いずれも）
+- 発動時は accepted finding の反映結果が暫定分類へ反映済みであること
+
+### Resume-Idempotency
+
+- review 未実施で中断した場合、STEP-1 から暫定分類を再構築して発動条件判定をやり直す。review 自体は書き込み禁止型（`semantic_review`）のため再呼出に副作用がない

--- a/src/opencode/skills/agentdev-workflow-intake-promote/references/hitl-persistence-and-destructive.md
+++ b/src/opencode/skills/agentdev-workflow-intake-promote/references/hitl-persistence-and-destructive.md
@@ -1,0 +1,177 @@
+# STEP 詳細: HITL / persistence / destructive handling / 完了報告（intake-promote）
+
+> 本 reference は `agentdev-workflow-intake-promote` SKILL.md の Control Plane STEP-3〜STEP-6 詳細である。SKILL.md は control plane として STEP 遷移を管理し、本 reference は各 STEP の実行詳細を提供する。
+
+## 目次
+
+- STEP-3: HITL（ユーザー確認・分類承認）
+- STEP-4: persistence（採用 item 整形・promoted 保存）
+- STEP-5: destructive handling（振り分け・削除・git 永続化）
+- STEP-6: 完了報告
+
+## STEP-3: HITL（ユーザー確認・分類承認）
+
+### Purpose
+
+評価、分類結果をユーザーに提示し、明示的な承認を得て分類を確定する（判断の確定）。
+
+### Input Resolution
+
+- STEP-2 の暫定分類（runtime artifact。中断時は inbox 実ファイルから STEP-1 を再構築して導出する）
+- ユーザー確認手続き、承認フローは `agentdev-intake-pipeline` の公開操作契約に従う
+
+### Preconditions
+
+- 暫定分類が確定していること（STEP-1 完了、STEP-2 skip または反映済み）
+
+### Procedure
+
+1. 各 item の分類と理由を提示する
+2. ユーザーの追加コンテキスト、分類の修正指示を受け付ける
+3. ユーザーの明示的な承認なしに保存、移動へ進まない
+4. 全 item の分類が確定するまで対話を継続する
+5. 分類未確定のままの自動確定、自動進行は行わない。ユーザーが「確定」を明示的に指示してから次 STEP に進む
+6. 破壊的変更（inbox 大量削除、重要 item の誤分類是正等）は本 STEP の分類承認とは別に明示承認を得る
+
+### Result
+
+- 分類確定（採用/ 保留/ 却下、ユーザー承認済み）。確定後、STEP-4〜STEP-5 は追加確認なしで自動実行する
+
+### Evidence
+
+- 分類提示とユーザー承認の対話記録（確定した分類結果）
+
+### Completion Verification
+
+- 全 item の分類がユーザー承認済みであること
+
+### Resume-Idempotency
+
+- 承認状態は単独では durable state に記録されない。promoted 実ファイル（STEP-4 の成果物）を承認証跡として扱い、証跡がない場合は未承認と解釈して本 STEP をやり直す。承認前の再実行に副作用はない
+
+## STEP-4: persistence（採用 item 整形・promoted 保存）
+
+### Purpose
+
+採用と判定された item を backlog-review 向けに整形し、`.agentdev/intake/promoted/` に保存する。
+
+### Input Resolution
+
+- STEP-3 で確定した採用 item（durable state は inbox 実ファイル。中断再開時、promoted 実ファイルの存在が承認済み証跡となる）
+- 整形、保存の判定基準は `agentdev-intake-pipeline` の公開操作契約に従う
+
+### Preconditions
+
+- 分類確定済み（STEP-3 完了）
+- 採用 item が存在する（保留・却下のみ確定時は本 STEP を省略する）
+
+### Procedure
+
+1. 観測内容、影響、課題を整理する
+2. backlog-review が分析しやすい形式に構造化する（観測内容、影響、課題、既存要件との関連）
+3. 複数 item を束ねる場合は統合内容を整理する
+4. `.agentdev/intake/promoted/` が存在しない場合は作成する
+5. ファイル名は `YYYY-MM-DD-{topic-slug}.md` とする（元 item 名を維持するか、束ねた内容に応じた名前にする）
+6. 成果物を `.agentdev/intake/promoted/` 直下にフラット配置する。frontmatter に route や status を記録しない
+
+### Result
+
+- `.agentdev/intake/promoted/` 配下の採用済み成果物
+
+### Evidence
+
+- 保存済み成果物のファイルパス一覧
+
+### Completion Verification
+
+- 採用 item 全てについて promoted 配下に成果物が存在すること
+- 整形結果に frontmatter、重複排除キー、後続成果物参照が含まれていないこと
+
+### Resume-Idempotency
+
+- 保存済みの成果物は再保存しない（ファイル名重複時は連番付与）。promoted 実ファイルの存在から本 STEP 完了を再構成できる
+
+## STEP-5: destructive handling（振り分け・削除・git 永続化）
+
+### Purpose
+
+確定した分類に基づいて item を振り分け、inbox 元ファイルの削除（不可逆処理）と git 永続化を実行する。
+
+### Input Resolution
+
+- STEP-3 で確定した分類、STEP-4 の採用済み成果物（durable state: inbox / promoted 実ファイル）
+- 保存と振り分け、Git 永続化の判定基準は `agentdev-intake-pipeline` の公開操作契約に従う
+- ドメイン状態永続化プロシージャは `agentdev-git-worktree` に従う
+
+### Preconditions
+
+- 分類確定済み。採用 item がある場合は採用済み成果物の保存が確認できていること
+- 破壊的変更に該当する場合は明示承認済みであること
+
+### Procedure
+
+1. 採用 item の元 inbox item を削除する（`.agentdev/intake/archive/promoted/` への移動は廃止）
+2. 保留 item は `.agentdev/intake/inbox/` に残す
+3. 却下 item は即時削除する（`.agentdev/intake/archive/rejected/` への移動は廃止）
+4. `git pull --ff-only` を実行する。失敗時は構造化エラーメッセージを表示して停止する（自動解消しない）
+5. `git diff --name-only` で `.agentdev/intake/` 配下の変更ファイルを確認する。変更なしの場合は commit/push せず完了報告で「変更なし」と報告する
+6. `git add` は `.agentdev/intake/` 配下の変更ファイルのみを対象とする（明示パス指定）
+7. commit message は `chore(agentdev): review and promote intake items`（Conventional Commits 形式）。reject item を含む場合は当該 item の却下理由を commit message に含める（AG-{NNN}、監査証跡の補強）
+8. `git push` を実行する。push 失敗時は構造化エラーメッセージを表示し、完了扱いにしない
+
+### Result
+
+- inbox 振り分け完了（採用削除・保留残置・reject 即時削除）
+- commit/push 済み（変更あり時）
+
+### Evidence
+
+- 振り分け結果（削除ファイル、残置ファイルの一覧）
+- commit hash、push 成否
+
+### Completion Verification
+
+- 採用 item の inbox 元ファイルが削除済みであること
+- 保留 item が inbox に残置されていること
+- 却下 item が削除済みで、reject を含む commit message に却下理由が記録されていること
+
+### Resume-Idempotency
+
+- 削除済み item は再削除しない。inbox / promoted 実ファイルの残置・削除状態から未完了の振り分けを特定し、残処理のみ実行する
+- commit 未実行の削除がある場合は git 永続化（手順 4〜8）から再開する
+
+## STEP-6: 完了報告
+
+### Purpose
+
+分類結果と git 永続化結果を報告して workflow を終了する。
+
+### Input Resolution
+
+- STEP-3〜STEP-5 の結果（durable state: inbox / promoted 実ファイル、commit hash）
+
+### Preconditions
+
+- 振り分け・永続化が完了していること（または変更なしと確認済みであること）
+
+### Procedure
+
+1. 完了報告 template（`.opencode/commands/agentdev/templates/intake-promote/standard.md`）に従って出力する
+2. 分類結果（採用、保留、却下の件数、一覧）と git 永続化結果（変更有無、ファイル一覧、commit hash、push 成否）を含める
+3. 次ステップ（`/agentdev/backlog-review`）の提示のみを行い、自動起動しない
+
+### Result
+
+- 完了報告
+
+### Evidence
+
+- 完了報告の出力
+
+### Completion Verification
+
+- 分類結果と git 永続化結果が完了報告に含まれていること
+
+### Resume-Idempotency
+
+- 報告は出力のみのため再実行に副作用がない

--- a/src/opencode/skills/agentdev-workflow-learning-promote/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-learning-promote/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: agentdev-workflow-learning-promote
+description: "learning-promote command の workflow 実装本体。inbox.md エントリの読込・正規化、問題クラス分類・8軸評価・evaluation-report 生成、廃棄判定・既存対策確認、adversarial-review 経路D、ユーザー承認（HITL）、採用済み成果物生成・deferred 移動・prune・git 永続化の各 STEP を独立 resume point として所有する。USE FOR: learning-promote command 実行時の workflow 制御（正規化・分類・評価・廃棄判定・経路D review 呼出・HITL 承認・採用済み成果物生成・deferred 移動・prune・git 永続化・完了報告）。DO NOT USE FOR: 学びの検知・抽出・inbox.md 蓄積（learning-capture）、RU 生成（backlog-review）、intake pipeline の実行（intake-promote）、REQ ファイル保存（req-save）、`.opencode/` への直接反映、work_type 判定（agentdev-workflow-lifecycle）、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# learning-promote workflow スキル
+
+learning-promote command の workflow 実装本体。`.agentdev/learning/inbox.md` の学びエントリを読み込み、正規化、問題クラス分類、8軸評価、廃棄判定、既存対策確認、HITL承認を経て採用済み成果物を生成する制御構造を所有する。`.opencode/` への直接配置、直接反映は行わない（反映ルート: promoted → `/agentdev/backlog-review` → `/agentdev/req-define` → `/agentdev/req-save` → `/agentdev/case-open` → `/agentdev/case-run`）。
+
+learning-promote command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md（control plane）と `references/` 配下（各 STEP 詳細）が担う。
+Workflow Skill 固有契約（Command / Workflow Skill / Capability Skill 責務、1:N 分割基準、依存方向、配置契約）は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-learning-promote.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と learning-promote command の公開契約のみを前提とする。SPEC ディレクトリの内部構成は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- learning-promote command の実行時 workflow 制御（全 STEP）
+- inbox.md / deferred.md の読込、旧フォーマット正規化
+- 問題クラス分類、8軸評価スコアリング、evaluation-report.md 生成・更新
+- 廃棄判定（11カテゴリ + duplicate）、既存対策確認、昇華可能性評価
+- adversarial-review 経路D の発動条件判定、review 呼出、evaluation-report 戻しループ
+- ユーザーへの判定結果提示、承認（HITL）
+- 採用済み成果物生成（staging 領域のみ）、deferred 移動（原子的操作）、prune、git 永続化、完了報告
+
+## DO NOT USE FOR
+
+- 学びの検知、抽出、inbox.md への自律蓄積（`agentdev-learning-capture` skill）
+- RU 生成（`/agentdev/backlog-review`）
+- intake pipeline の実行（`/agentdev/intake-promote`）
+- REQ ファイル保存、無条件の自動REQ化（`/agentdev/req-save` 経由の昇華ルートのみ）
+- `.opencode/` 配下への直接書込、`case-run` への直接受け渡し
+- work_type 判定、フェーズ定義（`agentdev-workflow-lifecycle`）
+
+## 入力
+
+- learning-promote command から渡される `.agentdev/learning/inbox.md`（必須。未処理の学びエントリ）
+- `.agentdev/learning/deferred.md`（任意。過去エントリ参照用の living pool）
+
+## 出力
+
+- `.agentdev/learning/evaluation-report.md`（8軸評価レポート、評価根拠中間成果物）
+- `.agentdev/learning/promoted/{category}-{name}.md`（採用済み成果物）
+- `.agentdev/learning/deferred.md`（inbox からの移動分を追記、prune 適用）
+- `.agentdev/learning/inbox.md`（ヘッダーのみにクリア）
+- 8軸評価サマリ、判定結果、git 永続化結果を含む完了報告
+
+## 副作用
+
+- `.agentdev/learning/` 配下の inbox.md、deferred.md、evaluation-report.md、promoted/ の更新
+- `.agentdev/learning/` 配下の変更の commit / push
+- 当該 Workflow Skill は worktree root 配下以外を編集しない（learning-promote command の worktree 隔離に従う）
+
+## Control Plane（STEP 一覧）
+
+learning-promote workflow は次の7 STEP で構成する。各 STEP は resume point を持ち（DEC-{N}、`docs/specs/<workflows/step-reference-contract>.md`）、会話コンテキストに依存せず、durable state（inbox.md / deferred.md / evaluation-report.md / promoted/ の実ファイル状態、分類確定状態）から再開点を再構成する。
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-1 | 入力読込・正規化 | inbox.md にエントリ存在 | 正規化済みエントリ群（deferred.md 読込含む） | [references/analysis-and-review.md](references/analysis-and-review.md) |
+| STEP-2 | 評価（分類・8軸・evaluation-report） | 正規化済みエントリ確定 | 問題クラス分類、8軸評価スコア、evaluation-report.md 生成・更新 | [references/analysis-and-review.md](references/analysis-and-review.md) |
+| STEP-3 | 判定（廃棄判定・既存対策確認） | evaluation-report.md 反映済み | 処分区分判定（11カテゴリ + duplicate）、既存対策照合結果、昇華可能性評価 | [references/analysis-and-review.md](references/analysis-and-review.md) |
+| STEP-4 | review（adversarial-review 経路D） | evaluation-report.md に STEP-2/STEP-3 結果反映済み | review 結果反映（evaluation-report 戻しループ含む。skip 時は従来フロー継承） | [references/analysis-and-review.md](references/analysis-and-review.md) |
+| STEP-5 | HITL（判定結果提示・ユーザー承認） | STEP-3 完了、STEP-4 skip または反映済み | 判定確定（promote/defer/reject/duplicate、ユーザー承認済み） | [references/hitl-and-persistence.md](references/hitl-and-persistence.md) |
+| STEP-6 | 永続化（成果物生成・deferred 移動・prune・commit/push） | 判定確定 | 採用済み成果物、deferred 移動済み、prune 済み、クリア済み inbox.md、commit/push | [references/hitl-and-persistence.md](references/hitl-and-persistence.md) |
+| STEP-7 | 完了報告 | 永続化完了 | 8軸評価サマリ、判定結果、後続ルート、git 永続化結果を含む完了報告 | [references/hitl-and-persistence.md](references/hitl-and-persistence.md) |
+
+### STEP 間の依存と分岐
+
+- **正常経路**: STEP-1 → STEP-2 → STEP-3 → STEP-4（skip 条件該当時は省略）→ STEP-5 → STEP-6 → STEP-7
+- **evaluation-report 戻しループ（review 反映時）**: STEP-4 の accepted finding 反映で意味内容が変更された場合、STEP-2 → STEP-3 → STEP-4（発動条件判定）の順で再実行し、再 review 発動条件を満たす場合のみ再 review。停止条件（4点）を満たした時点でループを離脱し STEP-5 へ進む
+- **inbox.md 空または不在**: STEP-1 で終了（不在時はエラー終了）
+- **unresolved 残存時**: STEP-5（判定結果提示）、STEP-6（deferred 移動、prune、commit/push）等の不可逆処理へ進まない
+
+## Resume Protocol（durable state による再開）
+
+会話コンテキストを権威情報源とせず、durable state から current STEP を再構成する（DEC-{N}）。優先順位は `<workflows/input-resolution-and-durable-state>` SPEC に従う。
+
+1. SSoT 再構成: `.agentdev/learning/` 配下の inbox.md、deferred.md、evaluation-report.md、promoted/ の実ファイル状態
+2. identifier 保持: エントリ区切り（`---`）、問題クラス、採用済み成果物パス
+3. 最小 scalar: promote/defer/reject/duplicate の件数、8軸評価スコア
+4. runtime artifact: 正規化結果、adversarial-review findings（REQ-{NNNN} lifecycle）
+
+### current STEP 再構成規則
+
+| durable state の観察結果 | 再開 STEP | 承認状態の解釈 |
+|---|---|---|
+| inbox.md にエントリ残存、evaluation-report.md なしまたは未反映 | STEP-1 / STEP-2 | 未承認（分析を再構築し HITL をやり直す） |
+| evaluation-report.md 生成済み、inbox.md エントリ残存（deferred 未移動）、promoted なし | STEP-3 / STEP-4 / STEP-5 | 未承認（evaluation-report は判定資料であり承認証跡ではない） |
+| promoted に採用済み成果物生成済み、または inbox.md クリア・deferred.md 追記済み | STEP-6（残処理から） | 承認済み（永続化成果物が承認証跡。再承認を求めない） |
+| inbox.md クリア、promoted なし（全 defer/reject/duplicate） | STEP-6（prune / commit から） | 承認済み |
+| 全永続化と commit/push 完了 | STEP-7（完了報告のみ） | 承認済み |
+
+HITL（STEP-5）の承認状態は単独では durable state に記録されない。採用済み成果物（promoted/）、inbox.md クリア、deferred.md 追記のいずれかを承認証跡として扱い、証跡がない場合は未承認と解釈して STEP-5 をやり直す。不可逆処理（deferred 移動、prune、採用済み成果物生成）は承認確定後にのみ実行する。
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-learning-pipeline`: inbox entry schema、正規化ルール、問題クラス分類基準、8軸評価ディメンション、evaluation-report schema、処分区分（11カテゴリ + duplicate）、既存対策照合、採用済み成果物スキーマ、prune 方針、deferred 移動の原子的操作契約。経路D の review 候補判断と内部手続き
+- `agentdev-adversarial-review`: 経路D の review 呼出（共通契約の正規所有者は adversarial-review SPEC、REQ-{NNNN}）
+- `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング、構造化エラー形式）
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+
+## Workflow Extension 読込
+
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-learning-promote.yaml`、`kind: workflow-extension`）を読み込む場合がある（DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-learning-promote/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、learning-promote command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+
+## 共通制約
+
+- **無条件の自動REQ化禁止**: 学びを直接 REQ 化しない。恒久契約（REQ/Decision/SPEC）への昇華可能性を STEP-3 で評価し、昇華可能なもののみ `promoted/` へ出力する。学びは昇華（`promoted/` → `/agentdev/backlog-review` → `/agentdev/req-define` → `/agentdev/req-save`）を経て初めて REQ 化される
+- **living pool 維持**: 昇華不能な知見（deferred 判定、情報が断片的、出現回数が少ない等）は `deferred.md` の living pool で維持し、REQ 化しない。`deferred.md` は deferred カテゴリのエントリだけでなく、未処理・保留中・再評価対象のエントリも保持する多状態の living pool である（AG-{NNN}）。終端保管ではなく、次回実行時に再評価の対象となる
+- **prune 対象**: staged（採用済み成果物生成済み）/ rejected / duplicate のエントリのみ。deferred / 未処理のエントリは残す。staged エントリ除去時に採用済み成果物の「元learning item/ 根拠」セクションに証拠を保存する。STEP-5 のユーザー承認（判定確定）と同時に prune も承認済みとみなし、追加確認なしで削除する
+- **直接反映禁止**: 採用済み成果物は `.agentdev/learning/promoted/` のみに生成する。`.opencode/` 直接書込、`case-run` への直接受け渡しは禁止（`/agentdev/backlog-review` 経由のみ）
+- **evaluation-report.md**: 本 workflow が生成、管理する（外部コマンドの事前生成に依存しない）。毎回上書きされ長期履歴ではない
+- **破壊的変更の明示承認**: inbox.md 全体強制クリア、大量エントリ一括削除等は STEP-5 の承認とは別に明示承認を維持する
+- **git 永続化**: `git add` は `.agentdev/learning/` 配下のみを対象とする（明示パス、`git commit -- <paths>` の --only pathspec 形式）。`.agentdev/` 全体の一括スコープ、スイープ操作は禁止。commit message は `chore(agentdev): promote learning findings`。変更なし時は commit/push せず「変更なし」と報告。push 失敗時は構造化エラー形式で停止（完了扱いにしない）
+- **実行前同期**: `git pull --ff-only` 失敗時は共通 template（`.opencode/commands/agentdev/templates/common/git-error-messages.md`）の該当形式で表示して停止する（自動解消しない）
+- **完了報告**: template は `.opencode/commands/agentdev/templates/learning-promote/standard.md` に従う。8軸評価サマリ、判定結果（promote/defer/reject/duplicate 件数）、後続ルート（`/agentdev/backlog-review`）、git 永続化結果を含める
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **`<workflows/step-reference-contract>` SPEC**: STEP reference 構造、resume point
+- **`<workflows/input-resolution-and-durable-state>` SPEC**: durable state 優先順位、current STEP 再構成
+- **`docs/decisions/DEC-{N}.md`**: Command / Workflow Skill / Capability Skill 責務3層分化と1:N分割原則
+- **`docs/decisions/DEC-{N}.md`**: STEP resume point と会話記憶非依存
+- **learning-promote command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）

--- a/src/opencode/skills/agentdev-workflow-learning-promote/references/analysis-and-review.md
+++ b/src/opencode/skills/agentdev-workflow-learning-promote/references/analysis-and-review.md
@@ -1,0 +1,173 @@
+# STEP 詳細: 入力読込・正規化 / 評価 / 判定 / review（learning-promote）
+
+> 本 reference は `agentdev-workflow-learning-promote` SKILL.md の Control Plane STEP-1〜STEP-4 詳細である。SKILL.md は control plane として STEP 遷移を管理し、本 reference は各 STEP の実行詳細を提供する。
+
+## 目次
+
+- STEP-1: 入力読込・正規化
+- STEP-2: 評価（分類・8軸・evaluation-report）
+- STEP-3: 判定（廃棄判定・既存対策確認）
+- STEP-4: review（adversarial-review 経路D）
+
+## STEP-1: 入力読込・正規化
+
+### Purpose
+
+inbox.md の学びエントリと deferred.md を読み込み、旧フォーマットを正規化する。
+
+### Input Resolution
+
+- `.agentdev/learning/inbox.md`（必須。durable state 最優先）
+- `.agentdev/learning/deferred.md`（任意。不存在は空として扱う）
+- 正規化ルール、entry schema は `agentdev-learning-pipeline` の公開操作契約に従う
+
+### Preconditions
+
+- learning-promote command が起動されている
+- inbox.md が存在する（不存在時はエラー終了。「先に `agentdev-learning-capture` skill で学びを追加してください」）
+
+### Procedure
+
+1. inbox.md を読み込む。ファイルなしの場合はエラー終了する
+2. `---` 区切りエントリをカウントする。0件の場合は「分析対象の学びがありません」と終了する
+3. deferred.md を読み込む（存在すれば。不存在は空として扱う）
+4. 全エントリを読み込み、旧フォーマット正規化を行う（解析時のみ。元ファイルは不変）
+
+### Result
+
+- 正規化済みエントリ群、deferred.md の既存エントリ
+
+### Evidence
+
+- inbox.md のエントリ数、正規化の適用結果
+
+### Completion Verification
+
+- 全エントリが読み込まれ、正規化済みであること
+
+### Resume-Idempotency
+
+- inbox.md / deferred.md 実ファイルから読込・正規化を再構築できる。元ファイルを変更しないため再実行に副作用がない
+
+## STEP-2: 評価（分類・8軸・evaluation-report）
+
+### Purpose
+
+正規化済みエントリを問題クラスへ分類し、8軸評価でスコアリングし、evaluation-report.md を生成・更新する。
+
+### Input Resolution
+
+- STEP-1 の正規化済みエントリ群（中断時は inbox.md 実ファイルから STEP-1 を再構築して導出する）
+- 問題クラス分類基準、8軸評価ディメンション、evaluation-report schema は `agentdev-learning-pipeline` の公開操作契約に従う
+
+### Preconditions
+
+- STEP-1 完了（正規化済みエントリ確定）
+
+### Procedure
+
+1. 問題クラス分類を行う（根本原因 + 再発条件 + 予防策が同じ単位、最小2エントリ）
+2. 8軸評価スコアリングを行う（加重合計 /40）
+3. 禁止条件フィルタリングゲートを適用する（ADR 候補除外。`agentdev-decision-guidelines` の除外基準を必須適用）
+4. evaluation-report.md を生成・更新する（毎回上書き。履歴蓄積しない）
+
+### Result
+
+- 問題クラス分類、8軸評価スコア、evaluation-report.md
+
+### Evidence
+
+- evaluation-report.md（生成・更新済み）
+
+### Completion Verification
+
+- 全エントリが問題クラスへ分類され、8軸評価が付与されていること
+- evaluation-report.md に評価根拠が反映されていること
+
+### Resume-Idempotency
+
+- evaluation-report.md は毎回上書きされるため、再実行は冪等である。 inbox.md 実ファイルから評価を再構築できる
+
+## STEP-3: 判定（廃棄判定・既存対策確認）
+
+### Purpose
+
+各問題クラスの処分区分（11カテゴリ + duplicate）を判定し、既存対策と照合し、昇華可能性を評価する。
+
+### Input Resolution
+
+- STEP-2 の evaluation-report.md（durable state。実ファイルから再取得する）
+- 処分区分、反映先マッピング、既存対策照合、prune 方針の判定基準は `agentdev-learning-pipeline` の公開操作契約に従う
+
+### Preconditions
+
+- evaluation-report.md が生成・更新済みであること
+
+### Procedure
+
+1. 廃棄判定（11カテゴリ + duplicate）を行う
+2. 昇華可能性評価を行う。8軸評価スコア、禁止条件フィルタリングゲート、既存対策照合を基に昇華可否を判定する。無条件の自動REQ化は禁止する
+3. 既存対策確認を行う（「新規X化」より「既存Xへ反映」を優先）
+4. 昇華不能な知見（deferred 判定、情報が断片的、出現回数が少ない等）は deferred.md の living pool で維持する対象として確定する
+
+### Result
+
+- 処分区分判定結果、既存対策照合結果、昇華可能性評価
+
+### Evidence
+
+- 判定結果（promote/defer/reject/duplicate 候補と根拠）
+
+### Completion Verification
+
+- 全問題クラスに処分区分が付与されていること
+- 既存対策との照合結果が記録されていること
+
+### Resume-Idempotency
+
+- 判定は evaluation-report.md と inbox.md 実ファイルから再構築できる。不可逆処理を含まないため再実行に副作用がない
+
+## STEP-4: review（adversarial-review 経路D）
+
+### Purpose
+
+evaluation-report.md を adversarial-review で検証し、accepted finding を判定対象へ反映する。発動条件判定と review 呼出を分離して実施する。
+
+### Input Resolution
+
+- STEP-2 / STEP-3 の結果が反映された evaluation-report.md（durable state）
+- 経路D の候補判断、呼出タイミング、evaluation-report 戻しループの実行詳細は `agentdev-learning-pipeline` の公開操作契約に従う
+- 共通 caller integration 契約の正規所有者は adversarial-review SPEC（REQ-{NNNN}）である
+
+### Preconditions
+
+- evaluation-report.md が STEP-2 で生成・更新済みであり、STEP-3（廃棄判定）と既存対策確認の結果が反映されていること
+- 挿入境界、発動条件の正は learning-promote command SPEC の経路D 節である
+
+### Procedure
+
+1. **発動条件判定**: 次のいずれも満たす場合に発動する（default-on）。evaluation-report.md 反映済み、skip 条件非該当。skip 条件は inbox.md エントリが1件のみで既存対策との重複が確実（新規性なし、廃棄判定確定）、または inbox.md 空。skip 判断のためだけの新規 HITL、承認点は追加しない
+2. **ユーザー明示指定時**: skip 条件の該当にかかわらず必ず発動する。ただし evaluation-report.md 反映済みは引き続き必須とする
+3. **review 呼出**: 発動と判定された場合のみ `agentdev-adversarial-review` を起動する。review 対象は evaluation-report.md のみとする（正規化結果、問題クラス分類、8軸評価スコア、廃棄判定、既存対策照合結果）。inbox → deferred 移動、prune、commit/push 等の不可逆処理は未実行であることを確認する
+4. **accepted finding 反映**: 本 workflow が責任を持って判定対象へ反映する。adversarial-review 自身は反映を行わない
+5. **evaluation-report 戻しループ**: review 反映時（review 対象の意味内容が変更された場合）は STEP-2 へ戻り、STEP-2（evaluation-report 生成・更新）→ STEP-3（廃棄判定）→ STEP-4 発動条件判定 → 再 review 発動条件（新たな本質的争点が生じ得る場合）を満たす場合のみ再 review、の順で再実行する。停止条件（4点）を満たした時点でループを離脱し STEP-5 へ進む。新証拠、新前提、異なる failure condition、未評価範囲のいずれも伴わない同一 finding の再起票を禁止する
+6. **unresolved 扱い**: unresolved な本質的争点またはユーザー判断事項が残る場合、STEP-5（判定結果提示）、STEP-6（deferred 移動、prune、commit/push）等の不可逆処理へ進まない。unresolved は既存の HITL（STEP-5 ユーザー承認）または blocker 扱いへ振り向ける
+7. **呼出失敗時**: silent skip を禁止し、利用不能を報告した上で従来フロー（STEP-5 以降）と既存 HITL を維持する
+
+### Result
+
+- review 結果反映済み evaluation-report.md（skip 時、呼出失敗時は従来フローを継承）
+
+### Evidence
+
+- 発動条件判定結果（発動/ skip と根拠）、review 呼出記録、accepted finding と反映結果（発動時）
+
+### Completion Verification
+
+- 発動条件判定が記録されていること（発動・skip いずれも）
+- 発動時は accepted finding の反映結果が evaluation-report.md へ反映済みであること
+- ループ離脱時に unresolved が残っていないこと（残る場合は不可逆処理へ進んでいないこと）
+
+### Resume-Idempotency
+
+- review は書き込み禁止型（`semantic_review`）のため再呼出に副作用がない。evaluation-report.md 実ファイルから反映状態を再構築できる

--- a/src/opencode/skills/agentdev-workflow-learning-promote/references/hitl-and-persistence.md
+++ b/src/opencode/skills/agentdev-workflow-learning-promote/references/hitl-and-persistence.md
@@ -1,0 +1,132 @@
+# STEP 詳細: HITL / 永続化 / 完了報告（learning-promote）
+
+> 本 reference は `agentdev-workflow-learning-promote` SKILL.md の Control Plane STEP-5〜STEP-7 詳細である。SKILL.md は control plane として STEP 遷移を管理し、本 reference は各 STEP の実行詳細を提供する。
+
+## 目次
+
+- STEP-5: HITL（判定結果提示・ユーザー承認）
+- STEP-6: 永続化（成果物生成・deferred 移動・prune・commit/push）
+- STEP-7: 完了報告
+
+## STEP-5: HITL（判定結果提示・ユーザー承認）
+
+### Purpose
+
+廃棄判定結果、8軸評価スコアをユーザーに提示し、確認、修正の機会を経て明示的な承認を得て判定を確定する（判断の確定）。
+
+### Input Resolution
+
+- STEP-2〜STEP-4 の評価・判定結果（中断時は evaluation-report.md と inbox.md 実ファイルから再構築する）
+- 提示形式、承認フローは `agentdev-learning-pipeline` の公開操作契約に従う
+
+### Preconditions
+
+- STEP-3 完了、STEP-4 skip または反映済みであること
+
+### Procedure
+
+1. 廃棄判定結果、8軸評価スコアを提示する
+2. ユーザーによる確認、修正を受け付ける
+3. ユーザー承認なしに採用済み成果物を生成しない。判定、prune ともに承認なしに実行しない
+4. 破壊的変更（inbox.md 全体強制クリア、大量エントリ一括削除等）は本 STEP の承認とは別に明示承認を維持する
+
+### Result
+
+- 判定確定（promote/defer/reject/duplicate、ユーザー承認済み）。STEP-6 は追加確認なしで自動実行する（prune も承認済みとみなす）
+
+### Evidence
+
+- 判定提示とユーザー承認の対話記録（確定した判定結果）
+
+### Completion Verification
+
+- 全問題クラスの判定がユーザー承認済みであること
+
+### Resume-Idempotency
+
+- 承認状態は単独では durable state に記録されない。promoted/ 成果物、inbox.md クリア、deferred.md 追記のいずれかを承認証跡として扱い、証跡がない場合は未承認と解釈して本 STEP をやり直す。承認前の再実行に副作用はない
+
+## STEP-6: 永続化（成果物生成・deferred 移動・prune・commit/push）
+
+### Purpose
+
+判定確定に基づいて採用済み成果物を生成し、deferred 移動（原子的操作）、prune、git 永続化を実行する。
+
+### Input Resolution
+
+- STEP-5 で確定した判定（durable state: inbox.md / deferred.md / promoted/ 実ファイル）
+- 採用済み成果物スキーマ、deferred 移動の原子的操作契約、prune 方針は `agentdev-learning-pipeline` の公開操作契約に従う
+- ドメイン状態永続化プロシージャは `agentdev-git-worktree` に従う
+
+### Preconditions
+
+- 判定確定済み（STEP-5 完了）
+- 破壊的変更に該当する場合は明示承認済みであること
+
+### Procedure
+
+1. `git pull --ff-only` を実行する。失敗時は共通 template（`.opencode/commands/agentdev/templates/common/git-error-messages.md`）の該当形式で表示して停止する（自動解消しない）
+2. 採用済み成果物を `.agentdev/learning/promoted/{disposal-category}-{name}.md` に生成する（staging 領域のみ。`.opencode/` 直接書込、`case-run` への直接受け渡し禁止）
+3. deferred 移動（原子的操作）を実行する。`agentdev-learning-pipeline` の deferred 移動操作契約（入力: inbox.md 全エントリと deferred.md、出力: 追記済み deferred.md とクリア済み inbox.md、停止条件: 検証失敗時は inbox.md を変更せずエラー内容を報告）に従い、全エントリの deferred.md 追記、書込検証、inbox.md クリア（ヘッダーのみ）を実行する。データ喪失防止のため検証失敗時は inbox.md を変更しない
+4. prune を実行する。対象は staged（採用済み成果物生成済み）/ rejected / duplicate のエントリのみ。deferred / 未処理のエントリは残す。staged エントリ除去時に採用済み成果物の「元learning item/ 根拠」セクションに証拠を保存する。追加確認なしで削除する（STEP-5 承認と同時に承認済みとみなす）
+5. `git diff --name-only` で `.agentdev/learning/` 配下の変更を確認する。変更なし時は commit/push せず STEP-7 で「変更なし」と報告する
+6. 変更あり時、`git add` は `.agentdev/learning/` 配下のみを対象とする（明示パス指定、並列実行安全ステージングプロシージャ準拠）。`git commit -- <paths>`（--only pathspec 形式）でコミットする。`.agentdev/` 全体の一括スコープ、スイープ操作（`git add -A`/ `git add .` 等）は禁止
+7. commit message は `chore(agentdev): promote learning findings` とする
+8. `git push` を実行する。push 失敗時は共通 template の該当形式で表示して停止する（完了扱いにしない）
+
+### Result
+
+- 採用済み成果物（`.agentdev/learning/promoted/`）
+- 追記済み deferred.md、prune 適用済み deferred.md、クリア済み inbox.md
+- commit/push 済み（変更あり時）
+
+### Evidence
+
+- 生成済み成果物パス一覧、deferred 移動の検証結果、prune 結果、commit hash、push 成否
+
+### Completion Verification
+
+- 採用判定分の成果物が promoted/ に存在すること
+- inbox.md がヘッダーのみにクリアされていること
+- prune 対象外（deferred / 未処理）のエントリが deferred.md に残存していること
+
+### Resume-Idempotency
+
+- 生成済みの採用済み成果物は再生成しない。promoted/、deferred.md、inbox.md の実ファイル状態から未完了の処理を特定し、残処理のみ実行する
+- deferred 移動は原子的操作であり、検証失敗時は inbox.md が変更されていないため再実行可能である
+- commit 未実行の変更がある場合は git 永続化（手順 5〜8）から再開する
+
+## STEP-7: 完了報告
+
+### Purpose
+
+8軸評価サマリ、判定結果、後続ルート、git 永続化結果を報告して workflow を終了する。
+
+### Input Resolution
+
+- STEP-5〜STEP-6 の結果（durable state: promoted/、deferred.md、inbox.md、commit hash）
+
+### Preconditions
+
+- 永続化が完了していること（または変更なしと確認済みであること）
+
+### Procedure
+
+1. 完了報告 template（`.opencode/commands/agentdev/templates/learning-promote/standard.md`）に従って出力する
+2. 8軸評価サマリ、判定結果（promote/defer/reject/duplicate 件数）、後続ルート（`/agentdev/backlog-review`）、git 永続化結果（変更有無、ファイル一覧、commit hash、push 成否）を含める
+
+### Result
+
+- 完了報告
+
+### Evidence
+
+- 完了報告の出力
+
+### Completion Verification
+
+- 判定結果と git 永続化結果が完了報告に含まれていること
+
+### Resume-Idempotency
+
+- 報告は出力のみのため再実行に副作用がない


### PR DESCRIPTION
## 概要

OU-003（Issue #2103、親 Epic #2099）: intake / learning / backlog 系 5 Command（intake-capture / intake-from-github / intake-promote / learning-promote / backlog-review）を Workflow Skill へ移管する。intake-capture / intake-from-github は capture-only型（STEP model 対象外）、intake-promote は classification → review → HITL → persistence → destructive handling の各段階を独立 resume point として持つ。

Refs #2103

## 実装内容

### Workflow Skill 5件新設（`src/opencode/skills/agentdev-workflow-{name}/`）

| Workflow Skill | 型 | STEP / 工程 構成 |
|---|---|---|
| agentdev-workflow-intake-capture | capture-only型（STEP model 対象外） | 工程-1〜5（入力受領 → item 生成 → ファイル名生成・実行前同期 → 保存・永続化 → 完了報告） |
| agentdev-workflow-intake-from-github | capture-only型（STEP model 対象外） | 工程-1〜8（期間解釈 → データ取得 → 構造的検出 → LLM 全文解析 → item 生成・同期 → 保存・永続化 → サマリー → 完了報告） |
| agentdev-workflow-intake-promote | STEP resume 型 | STEP-1 classification / STEP-2 review（経路C）/ STEP-3 HITL / STEP-4 persistence / STEP-5 destructive handling / STEP-6 完了報告 |
| agentdev-workflow-learning-promote | STEP resume 型（標準 STEP model） | STEP-1 入力読込・正規化 / STEP-2 評価 / STEP-3 判定 / STEP-4 review（経路D）/ STEP-5 HITL / STEP-6 永続化 / STEP-7 完了報告 |
| agentdev-workflow-backlog-review | STEP resume 型（標準 STEP model） | STEP-1 同期・検出 / STEP-2 分析・暫定分類 / STEP-3 統合分割判定 / STEP-4 review（経路E）/ STEP-5 HITL / STEP-6 矛盾検出 / STEP-7 RU 生成・削除 / STEP-8 永続化・報告 |

- capture-only型 2件は SKILL.md 本文と Command dispatch の双方で「STEP model の対象外（resume point / export / import なし）」を明記し、STEP resume を要求する記述を持たない
- STEP resume 型 3件の各 STEP は STEP reference 8 要素（Purpose / Input Resolution / Preconditions / Procedure / Result / Evidence / Completion Verification / Resume-Idempotency）を持ち、SKILL.md は durable state 優先順位と current STEP 再構成規則（Resume Protocol）を所有する
- 全 SKILL.md の description に soft guard（直接起動抑制句）を付与
- workflow extension 読込契約（`.agentdev/extensions/skills/agentdev-workflow-{name}.yaml`、`kind: workflow-extension` + 必要に応じ internal.yaml）を標準セクションとして保有する。実ファイル作成は OU-006 管轄のため本 PR では `.agentdev/extensions/**` を一切作成・編集していない

### thin Command 化（`src/opencode/commands/agentdev/{5件}.md`）

- 手順実装本体を Workflow Skill へ移行し、Command 本文は public interface（入出力契約・ガードレール・分類値・RU フォーマット委譲等の公開契約）と Workflow Skill dispatch のみに縮小（5ファイル合計 453 行削除・58 行追加）
- Capability Skill 内部参照の名レベル化: 「Split Rule」節参照、「adversarial-review 候補判断と内部挿入」節参照、「deferred 移動原子的操作プロシージャ」参照等のセクション名依存を除去し、Capability Skill 名 + 公開操作契約（入力・出力・停止条件）の記述へ解消
- 旧手順 Step 番号へのガードレール参照（G09 / G10 / G11 / G18 等）を workflow STEP 表現へ更新
- Public IF（frontmatter description / 入力 / 出力 / ガードレール / 分類値）は無変更

## 完了条件

- [x] 5 Command 本文が public interface / guardrails / Workflow Skill dispatch のみを所有し、workflow 実装本体を複製していないこと（AC-02、AG-003）
- [x] 5 Workflow Skill が存在し、独立実行可能であること（AC-01、TS-001 subcheck）
- [x] intake-promote Workflow Skill が classification → review → HITL → persistence → destructive handling の各 STEP を独立 resume point として持ち、durable state で resume 可能であること（TS-002）
- [x] capture-only型（intake-capture / intake-from-github）の Workflow Skill が STEP model 対象外（resume point / export / import なし）として設計されていること（REQ-027-003、CR-003。STEP resume を要求する記述が存在しないこと）
- [x] learning-promote / backlog-review Workflow Skill の STEP reference / resume model / durable state / Input Resolution 契約が成立していること（TS-002）
- [x] 5 Command に soft guard（REQ-027-002）が付与されていること
- [x] 5 Command 本文から Capability Skill 内部 reference への直接依存が存在しないこと（名レベル参照であること）
- [x] Public IF に意図しない変更がないこと（変更は不要であり完了。変更が必要と判明した場合は blocked として判断を返す所定の経路を維持）

## テスト結果

### TS-001（5 Command 検証）

- Command 所有内容: 5 Command とも手順セクションを削除し、入出力・ガードレール・workflow dispatch のみ（thin 化後行数 65 / 71 / 100 / 72 / 69、いずれも 150 行以内）
- Workflow Skill 存在・独立実行: 5 Skill が存在し、purpose / 入力 / 出力 / 副作用 / 工程または STEP 一覧 / 共通制約を自足する
- soft guard 付与: 5 SKILL.md description の DO NOT USE FOR に「単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制」句を付与（OpenCode 1.18.15 で runtime 有効な description による guard のみ、agentdev-skill-authoring SPEC 準拠）
- Capability 境界の名レベル参照: `agentdev-[a-z-]*/references/` パス依存 0 件、セクション名依存（Split Rule 等）0 件を機械検査

### TS-002（STEP resume 型 3 Skill。capture-only型は REQ-027-003 / CR-003 により除外）

- STEP reference 8 要素: 全 21 STEP（intake-promote 6 + learning-promote 7 + backlog-review 8）について 8 要素の出現数を機械検査し、全 STEP で過不足なく一致
- conversation memory 非依存: 3 Skill とも Resume Protocol セクションで durable state 優先順位（SSoT 再構成 > identifier 保持 > 最小 scalar > runtime artifact）と current STEP 再構成規則を定義

### TS-006（intake-promote 代表シナリオ、設計検証）

durable-state 追跡表（シナリオ × STEP × durable state × 期待結果）。実ランタイム実行は OU-008a 管轄であり、本 PR は Workflow Skill の Resume Protocol・STEP reference に対する設計検証として実施した。

| シナリオ | 中断点 | 再開時の durable state 観察 | 再開 STEP | 期待結果 |
|---|---|---|---|---|
| accept（採用） | なし | — | — | promoted 保存、inbox 元ファイル削除、commit/push、完了報告 |
| accept・HITL 前中断 | STEP-2 完了後 | inbox 残存、promoted なし | STEP-1（暫定分類を再構築し HITL やり直し） | 未承認扱い。承認済みと誤認しない |
| accept・HITL 後中断 | STEP-4 完了後 | promoted 保存済み、inbox 元ファイル残存 | STEP-5（振り分けから） | promoted 実ファイルを承認証跡として再承認を求めない。削除 + commit/push のみ実行 |
| defer（保留） | なし | inbox 残存（保留）、promoted なし | — | inbox 残置、削除しない |
| reject（却下） | なし | inbox から即時削除、commit 未実行 | — | 即時削除、commit message に却下理由を記録 |
| review あり（経路C） | review 呼出前後 | 暫定分類は runtime artifact、review は semantic_review（書き込み禁止型） | STEP-1 再構築 → STEP-2 発動条件判定やり直し | accepted finding 反映後に HITL。再呼出の副作用なし |
| review なし（skip） | なし | skip 判定（inbox 1件自明 / inbox 空） | — | 従来フロー継続、HITL は必須のまま |

HITL 前後で中断しても承認済み・未承認を誤認しない設計: HITL 承認状態は単独では durable state に記録されないため、persistence 成果物（promoted 実ファイル）を承認証跡とし、証跡がない場合は未承認と解釈して HITL をやり直す。不可逆処理（inbox 削除、reject 即時削除）は承認確定後にのみ実行する。

### TS-103（Skill / Command 品質査読）

- Skill 品質: frontmatter は name / description のみ（YAML スカラー、バッククォートなし）、description 3人称 + USE FOR / DO NOT USE FOR、参照深度 1 階層、100 行超 reference 3件に目次付与、フォワードスラッシュ、runtime path（`.opencode/`）使用 → 未解決違反 0 件
- Command 品質: frontmatter description 単一、行数 65〜100（150 行運用上限内）、実行時パス使用、Step 細分番号なし → 未解決違反 0 件

### 機械検査

| 検査 | 結果 |
|---|---|
| check_distribution_boundary.ts --profile source --json（Step 7-1） | ok=true、failures 0（concrete_id_hits 0 / concrete_path_hits 0 / fixed_url_hits 0、IR-046/047/048 0 件、276 ファイル走査） |
| check_command_format.ts | OK |
| check_executor_notation.ts | ok=true（IR-050/051 違反 0、393 ファイル走査） |
| bun test skills_structure.test.ts（src/opencode fallback、REQ-018-001） | 390 pass / 0 fail |
| bun test commands_structure.test.ts（同上） | 49 pass / 0 fail |
| 新規 11 ファイルの符号化 | UTF-8（BOM なし）・LF（CRLF 0 件） |

lint_skills.ts は走査ルートを `.opencode/skills` に固定しており、本 worktree ではジャンクション未伝播のため配布 Skill を走査できない（worktree 構造的制約、REQ-018-001）。同等検査を src/opencode/ SoT パスから手動実施した（frontmatter 検査、目次・参照深度・名レベル参照・符号化検査）。`.agentdev/extensions/` は本 PR で未作成（OU-006 管轄）のため check_extensions.ts の新規検査対象は存在しない。

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| Workflow Skill 新設数 | 5件（SKILL.md 5 + references 6） | 5 Command 分 | PASS |
| thin Command 化後行数 | 65 / 71 / 100 / 72 / 69 行 | 各 150 行以内 | PASS |
| STEP reference 8 要素充足 | 21 / 21 STEP | 全 STEP | PASS |
| soft guard 付与数 | 5 / 5 | 全 Workflow Skill | PASS |
| Capability 内部参照残存 | 0 件 | 0 件 | PASS |
| distribution boundary 違反 | 0 件 | 0 件 | PASS |
| 構造テスト | 439 pass / 0 fail | fail 0 | PASS |

## Findings / Capture候補

### intake

- 発見元: OU-003 実装時の検証工程（lint_skills.ts 実行）
- 内容: lint_skills.ts は走査ルートを `.opencode/skills` に固定しており、worktree（ジャンクション未伝播）環境で配布 Skill を走査できない。skills_structure.test.ts / commands_structure.test.ts は REQ-018-001 の src/opencode fallback を持つが lint_skills.ts は持たない
- 分類: intake（lint_skills.ts への src/opencode fallback または走査ルート引数追加の検討）

### learning

- 該当なし

## SPEC確定候補

該当なし
