### PR TITLE
feat(agentdev): core 8 Command の Workflow Skill 移行と thin Command 化（OU-002、Refs #2102）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/baselines/ir-055-baseline.json
+++ b/.opencode/skills/repo-agentdev-integrity/baselines/ir-055-baseline.json
@@ -1,54 +1,12 @@
 {
   "version": 1,
   "rule_id": "IR-055",
-  "generated_at": "2026-08-10",
+  "generated_at": "2026-08-14",
   "entries": [
     {
       "file": "src/opencode/commands/agentdev/README.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 1
-    },
-    {
-      "file": "src/opencode/commands/agentdev/backlog-review.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 13
-    },
-    {
-      "file": "src/opencode/commands/agentdev/case-close.md",
-      "pattern": "/repo/",
-      "severity": "strict",
-      "count": 1
-    },
-    {
-      "file": "src/opencode/commands/agentdev/case-close.md",
-      "pattern": "docs/specs/",
-      "severity": "heuristic",
-      "count": 1
-    },
-    {
-      "file": "src/opencode/commands/agentdev/case-close.md",
-      "pattern": "repo-*",
-      "severity": "strict",
-      "count": 1
-    },
-    {
-      "file": "src/opencode/commands/agentdev/case-open.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 16
-    },
-    {
-      "file": "src/opencode/commands/agentdev/case-run.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 21
-    },
-    {
-      "file": "src/opencode/commands/agentdev/case-run.md",
-      "pattern": "repo-*",
-      "severity": "strict",
       "count": 1
     },
     {
@@ -64,12 +22,6 @@
       "count": 6
     },
     {
-      "file": "src/opencode/commands/agentdev/inspect-promote.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 16
-    },
-    {
       "file": "src/opencode/commands/agentdev/inspect-skills.md",
       "pattern": "docs/guides/",
       "severity": "heuristic",
@@ -82,58 +34,10 @@
       "count": 5
     },
     {
-      "file": "src/opencode/commands/agentdev/intake-promote.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 12
-    },
-    {
-      "file": "src/opencode/commands/agentdev/learning-promote.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 18
-    },
-    {
-      "file": "src/opencode/commands/agentdev/req-define.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 12
-    },
-    {
-      "file": "src/opencode/commands/agentdev/req-save.md",
-      "pattern": "/repo/",
-      "severity": "strict",
-      "count": 1
-    },
-    {
-      "file": "src/opencode/commands/agentdev/req-save.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 2
-    },
-    {
-      "file": "src/opencode/commands/agentdev/req-save.md",
-      "pattern": "docs/specs/",
-      "severity": "heuristic",
-      "count": 2
-    },
-    {
-      "file": "src/opencode/commands/agentdev/spec-save.md",
-      "pattern": "/repo/",
-      "severity": "strict",
-      "count": 1
-    },
-    {
       "file": "src/opencode/commands/agentdev/spec-save.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 10
-    },
-    {
-      "file": "src/opencode/skills/agentdev-adversarial-review/SKILL.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 24
+      "count": 6
     },
     {
       "file": "src/opencode/skills/agentdev-adversarial-review/SKILL.md",
@@ -143,27 +47,9 @@
     },
     {
       "file": "src/opencode/skills/agentdev-adversarial-review/references/adversarial-review-protocol.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 8
-    },
-    {
-      "file": "src/opencode/skills/agentdev-adversarial-review/references/adversarial-review-protocol.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
       "count": 1
-    },
-    {
-      "file": "src/opencode/skills/agentdev-artifact-graph/SKILL.md",
-      "pattern": "DEC-NNN",
-      "severity": "strict",
-      "count": 5
-    },
-    {
-      "file": "src/opencode/skills/agentdev-artifact-graph/SKILL.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 16
     },
     {
       "file": "src/opencode/skills/agentdev-artifact-graph/SKILL.md",
@@ -176,60 +62,6 @@
       "pattern": "repo-*",
       "severity": "strict",
       "count": 1
-    },
-    {
-      "file": "src/opencode/skills/agentdev-artifact-graph/SKILL.md",
-      "pattern": "src/opencode/",
-      "severity": "strict",
-      "count": 1
-    },
-    {
-      "file": "src/opencode/skills/agentdev-artifact-graph/references/augmentation.md",
-      "pattern": "DEC-NNN",
-      "severity": "strict",
-      "count": 2
-    },
-    {
-      "file": "src/opencode/skills/agentdev-artifact-graph/references/augmentation.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 5
-    },
-    {
-      "file": "src/opencode/skills/agentdev-artifact-graph/references/augmentation.md",
-      "pattern": "repo-*",
-      "severity": "strict",
-      "count": 1
-    },
-    {
-      "file": "src/opencode/skills/agentdev-artifact-graph/references/verification.md",
-      "pattern": "DEC-NNN",
-      "severity": "strict",
-      "count": 1
-    },
-    {
-      "file": "src/opencode/skills/agentdev-artifact-graph/references/verification.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 4
-    },
-    {
-      "file": "src/opencode/skills/agentdev-artifact-graph/scripts/README.md",
-      "pattern": "DEC-NNN",
-      "severity": "strict",
-      "count": 1
-    },
-    {
-      "file": "src/opencode/skills/agentdev-artifact-graph/scripts/README.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 1
-    },
-    {
-      "file": "src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/README.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 13
     },
     {
       "file": "src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/README.md",
@@ -245,33 +77,9 @@
     },
     {
       "file": "src/opencode/skills/agentdev-backlog-integration/SKILL.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 14
-    },
-    {
-      "file": "src/opencode/skills/agentdev-backlog-integration/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
       "count": 1
-    },
-    {
-      "file": "src/opencode/skills/agentdev-backlog-integration/references/integration-judgment.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 12
-    },
-    {
-      "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 14
-    },
-    {
-      "file": "src/opencode/skills/agentdev-case-run-execution-adapter/references/adversarial-review-integration.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 23
     },
     {
       "file": "src/opencode/skills/agentdev-command-authoring/SKILL.md",
@@ -341,12 +149,6 @@
     },
     {
       "file": "src/opencode/skills/agentdev-git-worktree/references/worktree-operations.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 2
-    },
-    {
-      "file": "src/opencode/skills/agentdev-git-worktree/references/worktree-operations.md",
       "pattern": "src/opencode/",
       "severity": "strict",
       "count": 3
@@ -361,7 +163,7 @@
       "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
       "pattern": "src/opencode/",
       "severity": "strict",
-      "count": 7
+      "count": 6
     },
     {
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
@@ -388,28 +190,10 @@
       "count": 1
     },
     {
-      "file": "src/opencode/skills/agentdev-intake-pipeline/SKILL.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 7
-    },
-    {
-      "file": "src/opencode/skills/agentdev-intake-pipeline/references/intake-promotion.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 6
-    },
-    {
       "file": "src/opencode/skills/agentdev-learning-capture/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
       "count": 1
-    },
-    {
-      "file": "src/opencode/skills/agentdev-learning-pipeline/SKILL.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 2
     },
     {
       "file": "src/opencode/skills/agentdev-learning-pipeline/references/disposition-and-artifact-schema.md",
@@ -418,22 +202,10 @@
       "count": 4
     },
     {
-      "file": "src/opencode/skills/agentdev-learning-pipeline/references/promote-judgment-logic.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 9
-    },
-    {
       "file": "src/opencode/skills/agentdev-quality-gates/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
       "count": 1
-    },
-    {
-      "file": "src/opencode/skills/agentdev-quality-gates/references/qg-2-acceptance-criteria-coverage.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 6
     },
     {
       "file": "src/opencode/skills/agentdev-quality-gates/references/qg-4-final-acceptance.md",
@@ -523,7 +295,7 @@
       "file": "src/opencode/skills/agentdev-req-structure-diagnostics/references/req-structure-review.md",
       "pattern": "src/opencode/",
       "severity": "strict",
-      "count": 8
+      "count": 6
     },
     {
       "file": "src/opencode/skills/agentdev-skill-authoring/SKILL.md",
@@ -535,18 +307,6 @@
       "file": "src/opencode/skills/agentdev-skill-authoring/references/review-protocol.md",
       "pattern": "src/opencode/",
       "severity": "strict",
-      "count": 1
-    },
-    {
-      "file": "src/opencode/skills/agentdev-spec-file-manager/SKILL.md",
-      "pattern": "docs/specs/",
-      "severity": "heuristic",
-      "count": 1
-    },
-    {
-      "file": "src/opencode/skills/agentdev-spec-file-manager/references/spec-lifecycle-application.md",
-      "pattern": "docs/specs/",
-      "severity": "heuristic",
       "count": 1
     },
     {
@@ -580,16 +340,34 @@
       "count": 1
     },
     {
-      "file": "src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_child.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
+      "file": "src/opencode/skills/agentdev-workflow-req-save/references/indexes-and-persistence.md",
+      "pattern": "docs/specs/",
+      "severity": "heuristic",
+      "count": 1
+    },
+    {
+      "file": "src/opencode/skills/agentdev-workflow-req-save/references/precheck-and-req-ops.md",
+      "pattern": "docs/specs/",
+      "severity": "heuristic",
+      "count": 1
+    },
+    {
+      "file": "src/opencode/skills/agentdev-workflow-spec-save/SKILL.md",
+      "pattern": "docs/specs/",
+      "severity": "heuristic",
+      "count": 6
+    },
+    {
+      "file": "src/opencode/skills/agentdev-workflow-spec-save/references/placement-and-save.md",
+      "pattern": "docs/specs/",
+      "severity": "heuristic",
       "count": 2
     },
     {
-      "file": "src/opencode/skills/agentdev-workflow-templates/templates/issue_desc_feature.md",
-      "pattern": "REQ-NNNN",
-      "severity": "strict",
-      "count": 2
+      "file": "src/opencode/skills/agentdev-workflow-spec-save/references/verification-and-persistence.md",
+      "pattern": "docs/specs/",
+      "severity": "heuristic",
+      "count": 6
     }
   ]
 }

--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -8,7 +8,9 @@ description: req-save→spec-save→case-open→case-run→case-closeを順次�
 
 ## workflow 実装の権威情報源
 
-本コマンドの workflow 実装本体（Step 1〜8 の詳細、Wave 反復制御、bounded parent decision resolution、コンフリクト解消モデル Level 2/3、adversarial-review 停止伝播 経路H、結果状態の4次元集約、L1 タイムスタンプ計測、orchestration stage モデル、子 task bg task 破棄検知時の回復）は `agentdev-workflow-case-auto` Workflow Skill を権威情報源とする（責務3層分化、workflow-skill-model SPEC 準拠）。本コマンド定義は公開 interface / dispatch のみを所有し、workflow 実装本体を複製しない。case-auto は下位 workflow（req-save / spec-save / case-open / case-run / case-close）の契約確定後に上位 orchestrator として振る舞う。
+本コマンドの workflow 実装本体（Step 1〜8 の詳細、Wave 反復制御、bounded parent decision resolution、コンフリクト解消モデル Level 2/3、adversarial-review 停止伝播 経路H、結果状態の4次元集約、L1 タイムスタンプ計測、orchestration stage モデル、子 task bg task 破棄検知時の回復）は `agentdev-workflow-case-auto` Workflow Skill を権威情報源とする（責務3層分化、workflow-skill-model SPEC 準拠）。本コマンド定義は公開 interface / dispatch のみを所有し、workflow 実装本体を複製しない。case-auto は下位 workflow（req-save / spec-save / case-open / case-run / case-close）の契約確定後の上位 orchestrator として振る舞う。
+
+**下位 workflow の権威情報源（REQ-{NNNN}-{NNN}/{NNN}）**: 各工程は対応する Workflow Skill を権威情報源として読み込む。委譲工程（req-save / spec-save / case-open / case-close）の委譲先 subagent は `agentdev-workflow-req-save`、`agentdev-workflow-spec-save`、`agentdev-workflow-case-open`、`agentdev-workflow-case-close` を権威情報源として読み込み、工程固有手続きの再実装を回避する。case-run インライン実行の読込主体は case-auto 自身であり、`agentdev-workflow-case-run` を権威情報源として読み込む（起動手段は harness 責務）。case-auto は下位 workflow 詳細処理を複製しない。
 
 ## project extensions
 
@@ -22,59 +24,53 @@ description: req-save→spec-save→case-open→case-run→case-closeを順次�
 ## 出力
 
 - REQ/Decision artifact_actions がある場合: REQ/Decisionファイル + GitHub Issue + 実装済みブランチ + PR + マージ済み + クローズ済み
-- artifact_actions に応じた各工程の出力（工程分岐は Step 3 参照）
+- artifact_actions に応じた各工程の出力（工程分岐は STEP-3 参照）
 
-## 手順（Step 概要）
+## workflow
 
-各 Step の実装詳細、判定基準、状態遷移、入力モード分岐、停止条件、停止理由分類、完了報告フォーマットは `agentdev-workflow-case-auto` を参照。本コマンド定義は Step 名と公開契約のみを列挙する。
+本コマンドは workflow 実装本体を `agentdev-workflow-case-auto` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}〜004、REQ-{NNNN}-{NNN}）。同スキルが8 STEP の control plane として制御構造を所有する。
 
-### Step 1: 入力解決
+### Step 1: 入力解決・開始時刻記録
 
-実行開始時刻（JST）を `case_auto_started_at` に記録し、入力モード（Issue番号/URL 入力モード または 要件doc入力モード）を分岐する。要件doc入力モードのサブ分岐（引数なしデフォルト、明示パス指定、セッション指定キーワード、特定不可）と複数draft読み込み時の順序制御の詳細は `agentdev-workflow-case-auto` 参照。
+`case_auto_started_at`（JST）記録、入力モード分岐（Issue番号/URL または 要件doc、サブ分岐と順序制御の詳細は workflow skill 参照）
 
 ### Step 2: work_type 読取
 
-入力要件docの `draft-data` から work_type を取得する（参考情報、パイプライン分岐の判定には使用しない）。
+`draft-data` から work_type を取得（参考情報、パイプライン分岐の判定には使用しない）
 
-### Step 3: 工程分岐（`work_type` 固定分岐ではなく `artifact_actions` 存在による動的判定）
+### Step 3: 工程分岐
 
-Issue番号/URL 入力時は case-run → case-close へ分岐（req-save、spec-save、case-open、work_type読取スキップ）。要件doc入力時は `artifact_actions` 存在による動的判定で req-save / spec-save / case-open / case-run / case-close へ分岐する。`auto_gate preflight`（`auto_gate.auto_ready` が false または未解決 item 残る場合の停止）の詳細は `agentdev-workflow-case-auto` 参照。
+`work_type` 固定分岐ではなく `artifact_actions` 存在による動的判定。auto_gate preflight
 
-### Step 4: 各工程の実行
+### Step 4: orchestration 実行
 
-各工程を委譲起動（req-save / spec-save / case-open / case-close）またはインライン実行（case-run、AG-{NNN}/{NNN}）する。実行モデル原則、工程別契約、QG-{N}〜QG-{N} の継承、L1 タイムスタンプ計測、インライン実行時のコンテキスト管理、結果状態の4次元集約、Wave 反復制御（Step 4-1）、OU 処理順序、クリーンアップ検証ゲート、委譲起動判定、Subagent 委譲プロトコル、orchestration stage モデル、子 task bg task 破棄検知時の回復の各詳細は `agentdev-workflow-case-auto` を参照。case-run インライン実行時も case-run.md を authoritative source として読み込む。各工程の結果に基づいて次工程へ進むか停止条件（Step 7）を判定する。req-save/case-open の委譲に draft path と OU ID のみを渡す（OU 本文の切り出しは行わない）。OU の統合・分割・REQ 操作分類・Issue 階層判定を再評価しない（各工程の判定結果に従う）。
+各工程を委譲起動（req-save / spec-save / case-open / case-close）またはインライン実行（case-run、AG-{NNN}/{NNN}）。orchestration stage モデル（stage 1 case-open / stage 2 case-run bg task 最大5件 / stage 3 case-close）、Wave 反復制御、L1 タイムスタンプ計測、結果状態の4次元集約、子 task bg task 破棄検知時の回復の詳細は workflow skill 参照。req-save/case-open の委譲に draft path と OU ID のみを渡す（OU 本文の切り出しは行わない）
 
 ### Step 5: 工程間の状態引き継ぎ
 
-各工程の起動結果（Issue番号、PR番号）を次工程の入力として渡す。RU ファイルパス（case-open 委譲の RU 削除で使用）、capture 対象情報（case-close 委譲の learning/intake capture で使用）を最終工程まで保持する。
+Issue番号、PR番号、RU ファイルパス、capture 対象情報を最終工程まで保持
 
 ### Step 6: 複数REQ対応
 
-req-save 委譲の出力から複数 REQ doc または scale:large を検出した場合、case-auto は case-open の Issue 構造ルールを使用（G13）。req-save から case-open への状態引き継ぎ時、複数 REQ doc の保存結果をフィルタリング・再評価なしでそのまま渡す（G14）。Epic Issue 化の判定には関与しない（G21）。case-open の判定結果に従う。
+複数 REQ doc または scale:large 検出時は case-open の Issue 構造ルールへ委譲（G13/G14/G21、再評価なし）
 
-### Step 7: 停止条件の検出
+### Step 7: 停止条件の検出・停止理由分類
 
-11項目の停止条件のいずれかを検出した場合、実行を停止し停止理由・現在地点・再開可能な次コマンドを報告する。停止時タイミング情報の追記（`case_auto_started_at`、停止時刻、経過時間、工程別タイムスタンプ内訳）を含める。停止条件の全量、停止時タイミング情報フォーマットの詳細は `agentdev-workflow-case-auto` 参照。
-
-### Step 7-1: 停止理由分類
-
-Step 7 の停止条件を8分類軸で報告する（HITL 境界の変更ではなく、再開コマンド選択とユーザー通知の精度向上が目的）。各分類の定義、対応停止条件、再開コマンド候補の詳細は `agentdev-workflow-case-auto` 参照。
+11項目の停止条件を8分類軸（7軸＋上位合意矛盾/新規ユーザー判断）で報告。停止時タイミング情報の追記を含む
 
 ### Step 8: 完了報告
 
-最終工程（case-close 委譲）の完了報告をそのまま出力する。Epic Issue を伴う Wave 反復実行時は、完了・blocked・failed 子Issue 一覧を含める（Epic Issue 本文ステータス追跡テーブルから読み取り、case-auto は書き込まない、G16）。停止時は完了済み OU・進行中 OU・未実行 OU・再開可能な次コマンドを報告する。完了報告の全項目（停止理由分類、タイムスタンプ内訳、インライン実行記録、orchestration stage 別結果、結果状態の4次元報告）の詳細は `agentdev-workflow-case-auto` 参照。**OU処理ループ**: Standard flow の case-close 完了後に未処理 OU が残存する場合は次 OU の処理を Step 2 から開始（全 OU 処理完了時のみ全体完了報告）。
+最終工程の完了報告、OU処理ループ（未処理 OU 残存時は次 OU を Step 2 から）、L1 タイムスタンプ内訳、結果状態の4次元報告
 
-## adversarial-review 由来の停止伝播（経路H）
+**adversarial-review 由来の停止伝播（経路H）**: 下位 command から adversarial-review 由来の user-decision-required + decision_context を受領した場合、当該 execution_unit の自走を停止し、ユーザー判断を待機する。受領形式、自走停止、ユーザー提示、resume point、再開、case-auto が行わないこと（review 直接起動、finding 解釈、採否、再評価の禁止）の詳細は `agentdev-workflow-case-auto` スキルを参照。user-decision-required は STEP-7 の HITL 境界停止条件分類とは独立する停止理由分類である。
 
-Step 4（各工程の実行）で下位 command から adversarial-review 由来の user-decision-required + decision_context を受領した場合、case-auto は当該 execution_unit の自走を停止し、ユーザー判断を待機する。受領形式、自走停止、ユーザー提示、resume point、再開、case-auto が行わないこと（review 直接起動、finding 解釈、採否、再評価の禁止）の実装詳細は `agentdev-workflow-case-auto` の `references/stop-and-decision-resolution.md`（STEP-{N}）を参照。停止伝播契約の SSoT は case-auto command SPEC「adversarial-review 由来の停止伝播（経路H）」節、workflow-contracts SPEC、delegation-contracts SPEC が正である。user-decision-required は Step 7-1 の HITL 境界停止条件分類とは独立する停止理由分類である。停止報告（Step 8）には user-decision-required を停止理由分類として含める。
+**bounded parent decision resolution**: case-auto は下位 command から受領した decision_context を限定的に自律解決する。自律解決、作業仮定で継続、上位合意矛盾、新規ユーザー判断事項、resume 機構、中央集約 review engine 非化の詳細は `agentdev-workflow-case-auto` スキルを参照。case-auto は raw finding を解釈、採否、候補反映しない（AG-{NNN}）。
 
-## bounded parent decision resolution
+**コンフリクト解消モデル（3レベルエスカレーション）**: Level 1（case-close、`git rebase` による機械的解消）、Level 2（case-auto、コンフリクト文脈付きインライン case-run 再実行 AG-{NNN}、最大2回）、Level 3（case-auto、マージ順序変更、blocked 単位の隔離）の詳細は `agentdev-workflow-case-auto` スキルを参照。機械的競合（rebase で自動解決可能）は停止条件に含まず、Level 1 で case-close が解消する。
 
-case-auto は下位 command から受領した decision_context を限定的に自律解決する。default-on + skip policy と case-auto の自走性を両立し、ユーザー停止を本質的な場面へ集約する。自律解決、作業仮定で継続、上位合意矛盾、新規ユーザー判断事項、resume 機構、中央集約 review engine 非化の実装詳細は `agentdev-workflow-case-auto` の `references/stop-and-decision-resolution.md`（STEP-{N}）を参照。解決範囲、作業仮定の明示要件、停止理由分類の詳細は case-auto command SPEC「bounded parent decision resolution」節、delegation-contracts SPEC「case-auto による decision_context の限定的親判断解決」節、workflow-contracts SPEC「bounded parent decision resolution と停止・resume 伝播」節が正である。case-auto は raw finding を解釈、採否、候補反映しない（AG-{NNN}）。
+各 STEP の詳細（開始条件・結果・手順・resume point・関連 Capability Skill 連携）は `agentdev-workflow-case-auto` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
-## コンフリクト解消モデル（3レベルエスカレーション）
-
-PR マージコンフリクト発生時（case-close Step 4-2 からのエスカレーション受領時）は、3レベルのエスカレーションで解消を図る。Level 1（case-close、`git rebase` による機械的解消）は case-close Step 4-2 の責務。Level 2（case-auto、コンフリクト文脈付きインライン case-run 再実行 AG-{NNN}、最大2回）、Level 3（case-auto、マージ順序変更、blocked 単位の隔離）の実装詳細は `agentdev-workflow-case-auto` の `references/conflict-resolution-and-reporting.md`（STEP-{N}）を参照。機械的競合（rebase で自動解決可能）は停止条件に含まず、Level 1 で case-close が解消する。停止条件の段階化（Level 2 再委譲上限回数試行後停止、発生元非依存でアクセス可能文脈を総動員）の詳細も同節参照。
+**soft guard（REQ-{NNNN}-{NNN}、OpenCode 1.18.15 向け）**: 本コマンドの workflow 実装本体は `agentdev-workflow-case-auto` が所有する。同 Workflow Skill は `/agentdev/case-auto` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わないこと。OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため、本宣言を soft guard として機能させる。
 
 ## ガードレール
 
@@ -87,7 +83,7 @@ PR マージコンフリクト発生時（case-close Step 4-2 からのエスカ
 - G06: docs/ REQ/ ADR/ SPEC/ command reference/ guide の更新を自走対象に含める
 
 ### 委譲・参照制約
-- G07: case-auto は委譲工程（req-save/ spec-save/ case-open/ case-close）を各コマンドの委譲契約に従って委譲起動する。各工程は対応するコマンド定義を authoritative source として実行する（手順の case-auto 定義内再実装は回避）。case-run はインライン実行する（標準動作、AG-{NNN}）。**委譲起動不能時**（AG-{NNN}）: Step 4「委譲起動判定」に従い `delegation-unavailable` として報告する。委譲工程のインライン実行への切替えは行わない。genuine blocker（実装上の問題、スコープ外操作等）は Step 7 停止条件として扱い、`delegation-unavailable` 対象外とする。case-run インライン実行時の実行担当サブエージェントへの委譲失敗は case-run result 契約に従い処理し、本 `delegation-unavailable` 停止条件には該当しない
+- G07: case-auto は委譲工程（req-save/ spec-save/ case-open/ case-close）を各コマンドの委譲契約に従って委譲起動する。各工程は対応する Workflow Skill を権威情報源として実行する（手順の case-auto 定義内再実装は回避、REQ-{NNNN}-{NNN}）。case-run はインライン実行する（標準動作、AG-{NNN}、`agentdev-workflow-case-run` を権威情報源として読み込む、REQ-{NNNN}-{NNN}）。**委譲起動不能時**（AG-{NNN}）: STEP-4「委譲起動判定」に従い `delegation-unavailable` として報告する。委譲工程のインライン実行への切替えは行わない。genuine blocker（実装上の問題、スコープ外操作等）は STEP-7 停止条件として扱い、`delegation-unavailable` 対象外とする。case-run インライン実行時の実行担当サブエージェントへの委譲失敗は case-run result 契約に従い処理し、本 `delegation-unavailable` 停止条件には該当しない
 - G08: 工程固有の詳細手順とcase-auto定義が矛盾する場合、工程固有処理は既存コマンド定義を優先し、自走境界、入力解決、工程間制御はcase-auto定義を優先する。各工程の実行は対応するコマンド定義に従う（case-run インライン実行時も case-run.md に従う）
 - G09: 既存のreq-save/ spec-save/ case-open/ case-run/ case-closeの責務を変更しない。委譲起動、インライン実行は起動方式の変更であり、各コマンドの責務、ガードレール、成果物を変更しない
 - G13: case-auto は Issue 階層決定ロジックを持ってはならない。複数 REQ doc または scale:large の場合は case-open の Issue 構造ルールに委譲する
@@ -98,7 +94,7 @@ PR マージコンフリクト発生時（case-close Step 4-2 からのエスカ
 - G19: case-auto は orchestration pre-reader として case-open 完了前のみ req_draft を読み込み、case-open 成功後は invalid post-case reader として req_draft を読まないこと。case-open 成功後の停止、再開、完了処理は Issue と Epic（Epic Issue のステータス追跡テーブル含む）だけで成立させること。クリーンアップ検証ゲート（ドラフト削除検証）は case-open 完了後に実行すること。独自の OU 状態管理を持たないこと
 - G20: OU 間依存は queue dependency として扱い、依存関係があるだけでは Epic Issue 化しないこと
 - G21: case-auto は Epic Issue 化の判定に関与しないこと。case-open の判定結果に従うこと
-- G27: 各工程の起動は工程別契約（Step 4 の契約表）に従うこと。inputs に指定された情報のみを渡し、output_contract に指定された結果のみを受領する
+- G27: 各工程の起動は工程別契約（STEP-4 の契約表）に従うこと。inputs に指定された情報のみを渡し、output_contract に指定された結果のみを受領する
 - G28: case-auto は委譲工程の完了結果（Issue/PR番号、pass/warn/fail）のみを親コンテキストに保持し、委譲工程内部の調査過程、中間ログ、読解メモを親コンテキストに累積しないこと。case-run インライン実行時のコンテキスト管理は harness の機能で対応し、親コンテキスト非累積は case-run インライン実行時の例外として取り扱う
 - G29: case-auto の所有対象は入力解決、auto_gate確認、artifact_actions基準工程決定、入力引き渡し、永続状態再読込、継続停止再開判定、完了進行未実行報告、壁時計時間計測、case-run インライン実行時の準備/クリーンアップフェーズのオーケストレーション手順、orchestration stage 分離、orchestration stage 2 の固定並列数、bg task の状態管理、破棄検知、状態別回復、orchestration stage 1 と 3 の直列集約に限定する。bg task API、実行エージェント選定、実行担当サブエージェント内部の推論、context 管理、retry、heartbeat、エラー解析は harness の責務とする
 - G30: subagent 委譲時の category 選定は委譲先 command の責務と category 名の意味的距離を評価して決定すること。事務的手続き（Issue 作成、VERIFY、状態遷移等）には `unspecified-high` を推奨し、`writing` category は執筆作業（docs 記述、REQ/ ADR/ SPEC 本文執筆等）のみに限定すること
@@ -114,7 +110,4 @@ PR マージコンフリクト発生時（case-close Step 4-2 からのエスカ
 ### 実行時パス制約
 - G11: 既存コマンド定義を読み込む際、source path を実行時パスに読み替えてはならない。コマンド定義内のパス参照は記述された通りに解釈し、source path を実行時参照先として使用しない
 - G12: 委譲先コマンドの実行時 Read/ Glob に source path 固定参照を含めない
-- G33: 子 task bg task 破棄検知時の回復で、未コミット変更の帰属が確認できない場合に強制 commit を行わない。整合確認できない場合は当該子 task を `blocked` とし、「未コミット変更の帰属不明」（Step 7 停止条件 (10)）として報告する（AG-{NNN}）
-
-
-
+- G33: 子 task bg task 破棄検知時の回復で、未コミット変更の帰属が確認できない場合に強制 commit を行わない。整合確認できない場合は当該子 task を `blocked` とし、「未コミット変更の帰属不明」（STEP-7 停止条件 (10)）として報告する（AG-{NNN}）

--- a/src/opencode/commands/agentdev/case-close.md
+++ b/src/opencode/commands/agentdev/case-close.md
@@ -35,17 +35,39 @@ last-write-wins 競合防止は case-close の単一書き手で維持される�
 
 本コマンドは workflow 実装本体を `agentdev-workflow-case-close` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}）。同スキルが6 STEP（+ Epic Wave クローズ E1〜E6）の control plane として制御構造を所有する。
 
-- **STEP-1** Issue 番号解決・ルーティング — ユーザー入力・セッション会話から番号取得、Epic Issue 判定（ステータス追跡テーブル存在時は Epic Wave ルートへ）、単一 Issue ルートでは重複ファイルチェック（merge/pull 実行前）
-- **STEP-2** QG-{N} 達成判定 — 完了条件チェックボックス評価・更新（case-close 専任責務）、観点8 PR対象範囲 vs 全体 評価スコープ判定、test strategy 処理完了確認
-- **STEP-3** docs 検証・SPEC 確定 — 機能追加・共通検証、targeted docs guard（`--workflow case-close --files`）、IR-{NNN} check_extensions.ts、SPEC 確定フロー（昇格 / spec-save 提案 / 見送り）
-- **STEP-4** PR マージ・コンフリクト解消 — mergeable UNKNOWN ポーリング、squash merge、先行 commit 検出（REQ）、コンフリクト Level 1 rebase パス（実装変更せず rebase のみ、Level 2/3 は case-auto エスカレーション）、`--delete-branch` 使用禁止
-- **STEP-5** Post-merge・Issue クローズ — CI 通過確認、Issue 本文更新、Issue close（理由: completed）
-- **STEP-6** クリーンアップ・Capture 回収・永続化 — worktree/branch 削除（隔離 worktree のみ `git checkout .` 可、main worktree は禁止）、親Epic 自動クローズ判定（全子Issue CLOSED）、実行前同期（重複ファイルチェック再実行、git main 同期リスク事前検出）、学び検知（エージェント自律）、Capture 回収（PR 本文→intake/learning 分離、Epic 横断回収）、`.agentdev/` commit/push、完了報告（結果状態の分離報告）
-- **STEP-E1〜E6** Epic Wave クローズ（Epic Issue 番号入力時のみ） — 現在 Wave の PR作成済み子Issue を一括マージ・クローズ、Epic status table 更新（単一書き手 case-close のみ）、最終 Wave 判定（全子Issue completed → Epic クローズ、以外は残 Wave 通知）
+### Step 1: Issue 番号解決・ルーティング
+
+ユーザー入力・セッション会話から番号取得、Epic Issue 判定（ステータス追跡テーブル存在時は Epic Wave ルートへ）、単一 Issue ルートでは重複ファイルチェック（merge/pull 実行前）
+
+### Step 2: QG-{N} 達成判定
+
+完了条件チェックボックス評価・更新（case-close 専任責務）、観点8 PR対象範囲 vs 全体 評価スコープ判定、test strategy 処理完了確認
+
+### Step 3: docs 検証・SPEC 確定
+
+機能追加・共通検証、targeted docs guard（`--workflow case-close --files`）、IR-{NNN} check_extensions.ts、SPEC 確定フロー（昇格 / spec-save 提案 / 見送り）
+
+### Step 4: PR マージ・コンフリクト解消
+
+mergeable UNKNOWN ポーリング、squash merge、先行 commit 検出（REQ）、コンフリクト Level 1 rebase パス（実装変更せず rebase のみ、Level 2/3 は case-auto エスカレーション）、`--delete-branch` 使用禁止
+
+### Step 5: Post-merge・Issue クローズ
+
+CI 通過確認、Issue 本文更新、Issue close（理由: completed）
+
+### Step 6: クリーンアップ・Capture 回収・永続化
+
+worktree/branch 削除（隔離 worktree のみ `git checkout .` 可、main worktree は禁止）、親Epic 自動クローズ判定（全子Issue CLOSED）、実行前同期（重複ファイルチェック再実行、git main 同期リスク事前検出）、学び検知（エージェント自律）、Capture 回収（PR 本文→intake/learning 分離、Epic 横断回収）、`.agentdev/` commit/push、完了報告（結果状態の分離報告）
+
+**Step E1〜E6: Epic Wave クローズ（Epic Issue 番号入力時のみ）**
+
+現在 Wave の PR作成済み子Issue を一括マージ・クローズ、Epic status table 更新（単一書き手 case-close のみ）、最終 Wave 判定（全子Issue completed → Epic クローズ、以外は残 Wave 通知）
 
 各 STEP の詳細（開始条件・結果・手順・resume point・関連 Capability Skill 連携）は `agentdev-workflow-case-close` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
-**共通ルール**（全 STEP 適用、詳細は workflow skill 参照）: VERIFY（gh CLI 書込後は毎回 `agentdev-gh-cli` VERIFY 操作で検証）、コメントテンプレート準拠（【必須】セクション確認、欠落時は再生成）
+**共通ルール**（全 STEP 適用、詳細は workflow skill 参照）: VERIFY（gh CLI 書込後は毎回 `agentdev-gh-cli` VERIFY 操作で検証）、コメントテンプレート選定・準拠（`agentdev-workflow-templates` の選定ルール、【必須】セクション確認、欠落時は再生成）
+
+**soft guard（REQ-{NNNN}-{NNN}、OpenCode 1.18.15 向け）**: 本コマンドの workflow 実装本体は `agentdev-workflow-case-close` が所有する。同 Workflow Skill は `/agentdev/case-close` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わないこと。OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため、本宣言を soft guard として機能させる。
 
 ## ガードレール
 

--- a/src/opencode/commands/agentdev/case-open.md
+++ b/src/opencode/commands/agentdev/case-open.md
@@ -24,16 +24,35 @@ description: 要件定義をもとにGitHub Issueを作成する
 
 本コマンドは workflow 実装本体を `agentdev-workflow-case-open` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}）。同スキルが6 STEP の control plane として制御構造を所有する。
 
-- **STEP-1** 引き継ぎ・OU 選択 — `agentdev_handoff: true` 判定、OU モード時は OU 選択ゲート
-- **STEP-2** Issue 本文生成・execution contract 確定 — QG-{N} 検証、test_strategy 埋め込み、EC-{N}〜EC-{N} 確定
-- **STEP-3** 構成判定・preflight — 単一REQ → Standard flow、複数REQ/`scale: large`/複数 OU → Epic flow、execution_unit 構成、preflight 5項目
-- **STEP-4** adversarial-review（経路F）— default-on、skip 条件（Standard flow で単一 OU 機械的確定）該当時は省略、ユーザー明示指定時は強制発動、4パターン再実行ルール
-- **STEP-5** Issue 作成（Epic flow / Standard flow）— Epic Issue + 子Issue（OU単位、最大5件並列）、または Standard Issue、OU 結果書き戻し
-- **STEP-6** 終了処理・クリーンアップ — コメント追加、draft/RU 削除（Form Zero、即時 commit/push）、削除残存検証、完了報告
+### Step 1: 引き継ぎ・OU 選択
+
+`agentdev_handoff: true` 判定、OU モード時は OU 選択ゲート
+
+### Step 2: Issue 本文生成・execution contract 確定
+
+QG-{N} 検証、test_strategy 埋め込み、EC-{N}〜EC-{N} 確定
+
+### Step 3: 構成判定・preflight
+
+単一REQ → Standard flow、複数REQ/`scale: large`/複数 OU → Epic flow、execution_unit 構成、preflight 5項目
+
+### Step 4: adversarial-review（経路F）
+
+default-on、skip 条件（Standard flow で単一 OU 機械的確定）該当時は省略、ユーザー明示指定時は強制発動、4パターン再実行ルール
+
+### Step 5: Issue 作成（Epic flow / Standard flow）
+
+Epic Issue + 子Issue（OU単位、最大5件並列）、または Standard Issue、OU 結果書き戻し
+
+### Step 6: 終了処理・クリーンアップ
+
+コメント追加、draft/RU 削除（Form Zero、即時 commit/push）、削除残存検証、完了報告
 
 各 STEP の詳細（開始条件・結果・手順・resume point・関連 Capability Skill 連携）は `agentdev-workflow-case-open` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
-**共通ルール**（全 STEP 適用、詳細は workflow skill 参照）: VERIFY（gh CLI 書込後は毎回 `agentdev-gh-cli` VERIFY 操作で検証）、テンプレート準拠（テンプレート読込後は毎回【必須】セクションの完備を確認、【任意】は内容がある場合のみ含める、欠落時は再生成）。並列上限と3つの「5件」文脈（case-open の Step 8 子Issue 並列は case-run Wave 内子 Issue 並列と同一上限、5件）の詳細も workflow skill 参照
+**共通ルール**（全 STEP 適用、詳細は workflow skill 参照）: VERIFY（gh CLI 書込後は毎回 `agentdev-gh-cli` VERIFY 操作で検証）、テンプレート選定・準拠（`agentdev-workflow-templates` の選定ルール、テンプレート読込後は毎回【必須】セクションの完備を確認、【任意】は内容がある場合のみ含める、欠落時は再生成）。並列上限と3つの「5件」文脈（case-open の Step 8 子Issue 並列は case-run Wave 内子 Issue 並列と同一上限、5件）の詳細も workflow skill 参照
+
+**soft guard（REQ-{NNNN}-{NNN}、OpenCode 1.18.15 向け）**: 本コマンドの workflow 実装本体は `agentdev-workflow-case-open` が所有する。同 Workflow Skill は `/agentdev/case-open` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わないこと。OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため、本宣言を soft guard として機能させる。
 
 ## ガードレール
 

--- a/src/opencode/commands/agentdev/case-run.md
+++ b/src/opencode/commands/agentdev/case-run.md
@@ -6,7 +6,7 @@ description: 単一 Issue または単一 Wave（Epic Issue 指定時: 現在 re
 
 Case に対して実装実行を実行担当サブエージェント経由で委譲し、その result を処理する。case-run 本体は orchestration に専念し、実装実行そのものは行わない。常に git worktree を使用
 
-**スコープ**: case-run は単一 Issue または単一 Wave を処理する。Epic 全体（複数 Wave）の処理、Wave 境界（PR マージ）は case-close の責務であり、case-run は扱わない。1 Wave の実行（PR作成まで）で return する。複数 Issue の一括実行、Wave 順序制御にまたがるオーケストレーションは case-auto の責務（workflow-contracts SPEC SC-{NNN}、extension 経由で解決）。3フェーズ構成で各フェーズは独立して再実行可能（べき等性）。フェーズ間エラー時は Step 1 の再開判定から再開できる
+**スコープ**: case-run は単一 Issue または単一 Wave を処理する。Epic 全体（複数 Wave）の処理、Wave 境界（PR マージ）は case-close の責務であり、case-run は扱わない。1 Wave の実行（PR作成まで）で return する。複数 Issue の一括実行、Wave 順序制御にまたがるオーケストレーションは case-auto の責務（workflow-contracts SPEC SC-{NNN}、extension 経由で解決）
 
 ## project extensions
 
@@ -23,134 +23,45 @@ Case に対して実装実行を実行担当サブエージェント経由で委
 - 成功: 実装済みブランチ + GitHub PR（実行担当サブエージェントが作成）。**case-run の成功成果は PR 作成である**。Epic Wave 実行時は子Issue ごとに PR が作成される
 - blocked / failed / delegation-unavailable: blocker 詳細は Issue コメントに SSoT として記録される（実行担当サブエージェント責務）
 
-## フェーズ構成（case-run internal lifecycle）
+## workflow
 
-本節の「フェーズ」は case-run internal lifecycle（単一 Issue または Wave 内の準備、実装、提出）を指す。case-auto が管理する orchestration stage（command 間進行、stage 1 case-open / stage 2 case-run / stage 3 case-close）とは別の概念（responsibility-boundary-purification SPEC「case 実行責務の 4 用語と所有者」参照）。case-run は case-run internal lifecycle のみを所有し、orchestration stage を複製しない。3フェーズ: 準備フェーズ（Steps 2-5、再開条件: worktree+ブランチが存在しない）、実行担当サブエージェント委譲フェーズ（Steps 6-7、再開条件: PR未作成 or result 未確定）、クリーンアップフェーズ（Step 8、再開条件: result=completed-pr）。各フェーズは独立して再実行可能（べき等性）
+本コマンドは workflow 実装本体を `agentdev-workflow-case-run` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。同スキルは単一 Issue 実行（single workflow）と Epic Wave 実行（epic-wave workflow）を1:N に分離した control plane を所有し、実行契約差異（target cardinality / parallelism / fan-out・fan-in / child task recovery / partial result / Wave-level completion）を明示的に扱う。
 
-## 手順
+### Phase single（単一 Issue 実行モード）
 
-### Step 1: フェーズ判定（再開ポイント検出、実行モード分岐）
+3フェーズ構成で各フェーズは独立して再実行可能（べき等性）。フェーズ間エラー時は再開判定 STEP から再開できる:
 
-`agentdev-workflow-orchestration` に従い、再開フェーズを判定する（Issue番号解決、引数パース、妥当性確認、実行パス分岐、成果物チェックの詳細は同 skill 参照）。再開が必要なフェーズをユーザーに通知（準備フェーズから開始する場合は省略）。**実行モード分岐**: (1) 単一 Issue 実行モード（引数が非 Epic Issue 番号の場合、当該1 Issue を実行担当サブエージェントに委譲、後述 Step 2-8）、(2) Epic Wave 実行モード（`case-run #epic`、引数が Epic Issue 番号の場合、現在 ready な Wave の子Issue を並列委譲 最大5件、詳細は後述「Epic Wave 実行モード」セクション）。いずれのモードでも他Issue の実装履歴や Epic 全体の実装過程を前提としない
+- **STEP-S1** フェーズ判定・再開ポイント検出 — 実行モード分岐、引き継ぎ停止判定
+- **STEP-S2** Issue 抽出・確認・判定 — execution contract 消費境界適用
+- **STEP-S3** Worktree 作成・ブランチ準備・前置 gate 群 — precondition gate、QG-{N} 前置 staleness check、targeted docs guard、配布依存境界 事前チェック、L2 計測
+- **STEP-S4** 実行担当サブエージェント委譲 — adapter protocol、経路G（委譲内 adversarial-review）、L2 計測
+- **STEP-S5** result 処理・配布依存境界 最終 gate — result 4状態処理、Step 7-1 相当 gate
+- **STEP-S6** worktree クリーンアップ確認・完了報告 — L2 内訳含む
 
-**前工程からの引き継ぎ停止判定**: Issue 本文、要件doc本文に `agentdev_handoff: true` が含まれる場合、リポジトリ種別に応じて分岐（詳細は `agentdev-workflow-lifecycle` runtime-package-boundary 参照）: self-hosting リポジトリ（ジャンクション or 実ディレクトリ）では履歴メタデータとして通常の case workflow を実施、consumer リポジトリ（コピー配置等）では実装を開始せず停止し agent-dev-flow repository への手動取り込み対象として報告
+### Phase epic-wave（`case-run #epic` 受領時）
 
-### Step 2〜4: 抽出・確認・判定
+現在 ready な Wave の子Issue を並列実行（最大5件、3つの「5件」文脈の (1)）。1 Wave の実行（PR作成まで）で return し、Wave 境界（マージ）は扱わない。同一コマンド再実行で次 Wave に進む（べき等、Epic Issue 本文から進行状況判定）:
 
-- **Step 2**: Issue本文から要件docと受け入れ基準を抽出（べき等性: worktreeとブランチが既に存在する場合、Step 5をスキップして Step 6 へ移行）。`agentdev-req-analysis` のチェックボックス品質基準で検証
-- **Step 3**: 関連Decision特定（`docs/decisions/README.md` を読み込み、関連Decisionがあれば個別に読み込み、実装がDecisionの決定事項に矛盾しないことを確認）
-- **Step 4**: work_type 判定（`agentdev-workflow-lifecycle` に従い bugfix/feature/maintenance/docs_chore を判定、scale は feature のみ standard/large、workflow_route は都度導出し保存しない）
+- **STEP-W1** Epic Issue 解析・Wave 選択 — 入力ソース無区別（本来の Epic flow + Standard flow 起因の独立 OU 自動 Epic 化）
+- **STEP-W2** fan-out 準備 — `git fetch origin`、子Issue worktree 群、前置 gate 群適用
+- **STEP-W3** fan-out 並列委譲 — 最大5件、子Issue ごとに STEP-S4 と同一委譲契約
+- **STEP-W4** fan-in・結果集約 — partial result 保持、child task recovery、compaction 復元
+- **STEP-W5** Wave 完了報告・return — result 状態別一覧
 
-### Step 4-1: execution contract 消費境界（REQ-{NNNN}）
+各 STEP の詳細（開始条件・結果・手順・resume point・関連 Capability Skill 連携）、実行契約差異表、使用検査ツール（check_changed_docs.ts / check_extensions.ts / check_distribution_boundary.ts / test_strategy）、エラー処理、テスト戦略（TS）標準手順は `agentdev-workflow-case-run` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
-case-run は Issue に確定済みの execution contract を消費境界として扱う。消費原則、runtime-only 判断の維持、blocked 遷移と case-update 連携、新旧 Issue 互換運用、work_type/scale 確認の縮約は case-run command SPEC（extension 経由）「execution contract 消費境界」節を正とする。本 Step は消費原則を Step 2〜4 の読取・確認結果へ適用することを宣言する。
+### Step 7-1: 配布依存境界の最終変更経路 gate（実装後）
 
-- **契約消費原則**: 完了条件、test strategy、必須品質統制を実行契約として扱う。完了条件の不足、曖昧さ、矛盾、実現不能を検出した場合は自律補完せず blocked とする。test strategy を新規設計せず記録済み項目を実行する。必須品質統制の適用要否を再判断せず記録済み test strategy を実行する。work_type/scale/Issue structure を再分類して実行契約を変更しない
-- **runtime-only 判断の維持**: worktree 状態確認（REQ-{NNNN}-{NNN}）、QG-{N} 前置 staleness check（Step 5-3、REQ-{NNNN}-{NNN}）、実 diff 検査、実装結果・test 実行結果は case-run の安全検査として維持し、execution contract 確定へ移管しない
-- **blocked 遷移と case-update 連携**: 完了条件の不足・曖昧さ・矛盾・実現不能の検出、scope-affecting impact candidate の発見（既存 scope 内を超える変更が必要）、関連 ADR への適合確認で新たな拘束 ADR の必要性が判明した場合、必須品質統制の追加変更が必要な場合、Issue metadata・構造・実態の矛盾検出時は blocked とし、Issue 更新は case-update へ委譲する（case-run 単独では Issue 本文を書き換えない）
-- **新旧 Issue 互換運用**: Issue 本文の execution contract 必須セクション（Execution Contract セクション、必須品質統制セクション）存在有無により新旧 Issue を識別する（presence-based 判定）。必須セクション存在: 新契約 Issue として扱い上記契約消費原則を適用。必須セクション不存在: legacy Issue として扱い、新契約項目欠落のみを理由に一律 blocked にしない（AG-{NNN}、REQ-{NNNN}-{NNN}）
-- **work_type/scale 確認の縮約**: Step 4 の work_type 確認は再分類ではなく metadata 整合確認へ縮約して維持する（AG-{NNN}、REQ-{NNNN}-{NNN}）
+result が `completed-pr` の場合、worktree クリーンアップに進む前に、実装後の実際の worktree HEAD に対して配布依存境界の最終 gate を行う（実装担当サブエージェントが追加した変更も含めて検査する）。
 
-### Step 5: Worktree作成、ブランチ準備
+- **実行条件**: result が `completed-pr` であり、PR 対象ファイルに `src/opencode/{commands,skills}/**` 変更を含む場合。当該変更を含まない PR（docs のみ等）ではスキップする
+- **実行コマンド**: `bun run .opencode/skills/<integrity-detector-skill>/scripts/check_distribution_boundary.ts --profile source --json`。現在の worktree（実装後 HEAD）の配布物ソースツリーを検査する
+- **検出結果の分類**: 検査エラー（読込不能、未分類エントリ、adapter 起動失敗）は全て gate-not-passed として扱う。clean として通過させない
+- **違反検出時の停止契約**（adapter result `blocked` とは区別）: 違反検出時は PR 本文の `## Findings / Capture候補` セクションに `### distribution-boundary` 小見出しで記録し、クリーンアップへ進まず case-run を停止する。adapter result は `completed-pr` のまま変更せず、adapter result 契約の `blocked`（Issue コメント SSoT を伴う blocker）へ上書きしない。next action は同一 Issue で case-run を再実行し違反を修正する（worktree+ブランチ存活時は委譲 STEP から再開、べき等）。case-close へは進めない（case-close 側で同一 gate が停止するため前段で停止する）
 
-`agentdev-git-worktree` に従って実行。`origin/main` をベースとして明示的に指定。べき等チェック: worktree既存時は作成スキップ。**Wave 実行時、PR merge 後再開時は worktree 作成前に `git fetch origin` を実行し origin/main の鮮度を確認すること**。詳細手順は `agentdev-git-worktree` 参照
+手続きの詳細は `agentdev-workflow-case-run` スキル（references/delegation-and-result.md の STEP-S5）を参照する。
 
-**L2 タイムスタンプ計測（REQ）**: 本 Step の開始時刻、終了時刻（JST）を記録し、worktree 設定時間を計測する。計測結果は Step 8 完了報告の L2 内訳に含める
-
-**Step 5-1**: 親Epicステータス更新（`agentdev-epic-tracker` 参照）
-
-**Step 5-2**: worktree precondition gate（実行担当サブエージェント起動前の隔離検証）。`agentdev-git-worktree` の「worktree 内判定ヘルパー」に従い、当該 Issue の worktree+ブランチが作成済みであり、現在 worktree 内にいることを検証する。検証失敗時（worktree 未作成、メインリポジトリにいる）は実行担当サブエージェントを起動**せず**停止し、Step 5（Worktree作成、ブランチ準備）へ戻るようユーザーに報告する。Step 6 へ進んではならない。本 gate は適用範囲対象外「case-run の worktree 隔離フェーズ（構造的に保証済み）」の前提を保護する機構である
-
-### Step 5-3: QG-{N} 前置 staleness check（実装作業開始前、REQ〜034）
-
-`agentdev-quality-gates` の「case-run 前置 staleness check（REQ〜034）」に従い、ファイルパス現行存在確認、検査結果件数再計測、差異検出時の引き渡し・case-update 連携を実行する。本検査は QG-{N} 本体（Step 6 委譲先が実施する PR 作成直前ゲート）とは独立した前置検査であり、QG-{N} deviation 分類運用、QG-{N} 本体実施要否には影響しない。差異非検出時はそのまま Step 5-4 へ進む
-
-### Step 5-4: docs/** 変更時の targeted docs guard
-
-PR 対象ファイルに docs/** 変更を含む場合、Step 6（実行担当サブエージェント起動）の委譲前に targeted docs guard を行う。本検査は QG-{N} 本体・QG-{N} 前置 staleness check（Step 5-3）とは独立した前置 docs 整合性検査であり、3つの検査は順序依存を持たず、それぞれの実施要否に影響しない
-
-**実行条件**: PR 対象ファイルに docs/** 変更を含む場合に実行する。docs/** 変更を含まない PR（コードのみ、SCRIPT のみ等）ではスキップする（QG-{N} 限定原則を維持、docs全体grep ではなく変更ファイル限定の targeted 検査）
-
-**実行コマンド**: `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref origin/main --json`。変更ファイルは worktree 内の git diff から取得する（`--base-ref origin/main` または `--files <changed-paths>`）。case-run は worktree 環境（マージ前）で実行されるため `--base-ref` を使用する（`--files` は case-close 等、main 環境（マージ後）向け）。case-run プロファイル固有の追加ルールとして `full_docs_check_recommended` 判定は持たない（case-close の責務）
-
-**検出結果の記録、連携**: 検出結果（failures の strict severity）は PR 本文の `## Findings / Capture候補` セクションに `### docs-integrity` 小見出しで記録する（実行担当サブエージェント責務）。case-update へ連携し、Issue 本文の更新を委譲する（case-run 単独では Issue 本文を書き換えない）
-
-### Step 5-5: 配布依存境界の事前委譲チェック（オプション）
-
-PR 対象ファイルに `src/opencode/{commands,skills}/**` 変更を含む場合、Step 6（実行担当サブエージェント起動）の委譲前に配布依存境界の事前チェックを実施できる。本チェックは予備的であり、本式の最終 gate は Step 7-1（実装後）で実行される。事前チェックで違反を検出した場合は委譲プロンプトで実行担当サブエージェントに引き渡す
-
-### case-run が使用する検査ツール
-
-case-run が使用する検査ツール（integrity 契約 SPEC「Workflow × 使用ツールマトリックス」参照）: check_changed_docs.ts（--workflow case-run、PR 対象ファイルに docs/** 変更を含む場合に Step 6 委譲前に実行、AG-{NNN}）、check_extensions.ts（IR-{NNN}、`.opencode/commands/agentdev/**/*.md`, `.opencode/skills/agentdev-*/SKILL.md`, `.opencode/skills/agentdev-*/references/**/*.md`, `.agentdev/extensions/**` のいずれかを変更した場合に実行）、check_distribution_boundary.ts（--profile source、Step 7-1 で実装後 worktree の実際の src/opencode/ を検査、DEC-{N} 決定4、REQ-{NNNN}-{NNN} 最終 gate 基底再利用）、test_strategy（Issue 完了条件検証）。上記は全て肯定表現である
-
-### Step 6: 実行担当サブエージェント起動（委譲）
-
-実装実行を adapter skill（`agentdev-case-run-execution-adapter`）を読み込んだ実行担当サブエージェントへ委譲する（委譲 prompt 内で実行 command を指定）。起動手段は AGENTS.md および references/<harness>.md 参照。adapter protocol は `agentdev-case-run-execution-adapter` skill 参照
-
-**L2 タイムスタンプ計測（REQ）**: 委譲起動直前・直後に壁時計タイムスタンプ（JST、REQ の時刻形式に準拠）を記録し、実行担当サブエージェント実行時間を計測。併せて Step 5（Worktree作成）と Step 8（worktree クリーンアップ）の開始・終了時刻を記録する。計測した L2 タイムスタンプは Step 7 result、Step 8 完了報告に含める（case-auto が L1 計測で case-run 委譲の壁時計時間を読み取る際の内訳として使用）
-
-**委譲プロンプト、staleness check 結果の引き渡し（REQ）、test strategy 項目の test-fix ループ（REQ）、実行担当サブエージェントの責務（目標分解、各 criterion に observable evidence を要求、品質ゲートの実行、test-fix ループ）、委譲起動失敗・異常終了時の扱い（即 `failed` とせず実装完了・検証未完了として扱う）の詳細は `agentdev-case-run-execution-adapter` スキルを参照**
-
-**case-run が直接行わない（実行担当サブエージェントの責務）**: work plan生成、実装実行、TDD、乖離検出（QG-{N}）、specs更新、関連ドキュメント整合性確認、ローカル検証、PR本文作成、PR作成、デプロイ検証。**実行担当サブエージェントへの引き渡し**: 割り当てられた1 Issue の Issue番号、worktree root（相対パス指定、worktree内制約）、ブランチ名。**PR URL 受領**: 実行担当サブエージェントが直接 PR 作成を行い、PR URL を委譲 result として返却する（PR URL フォールバック検索は使用しない）。**外部実行ハーネスの中間成果物**: plan artifact 等の中間成果物を AgentDevFlow の永続成果物として扱わない、最終結果は PR URL で受領する。**完了条件チェックボックス**: 実行担当サブエージェントは完了条件チェックボックスを更新しない（case-close QG-{N} の責務）。**Findings/Capture 候補**: 実行担当サブエージェントが PR 本文の `## Findings / Capture候補` に記録する。**SPEC確定候補**: 実装時に発見された SPEC レベルの詳細（schema、enum、判定表、内部アルゴリズム等）は、実行担当サブエージェントが PR 本文の `## SPEC確定候補` セクションに記録する（`## Findings / Capture候補` とは別セクション、混在させない）。SPEC確定候補は case-close Step 3 で SPEC 確定チェックの入力となる
-
-### Step 6-1: adapter 委譲内 adversarial-review 統合（経路G、REQ-{NNNN}-{NNN}/011）
-
-case-run 経路G の adversarial-review 挿入境界。本 Step は case-run 本体の Step 構造へ review 呼出を直接挿入せず、Step 6 委譲内で実施される review 統合を宣言する。挿入境界、委譲内実施、実装方針限定、blocked 遷移の正規所有者は case-run command SPEC「adversarial-review 挿入境界（経路G: adapter 委譲内）」節であり、本 Step は実行時投影先である。adapter 委譲内の内部手続き（実装方針形成、review 呼出、結果反映、blocked 遷移）の詳細は `agentdev-case-run-execution-adapter` スキル（SPEC「adversarial-review 統合（実装方針→review→結果反映）」節、references/adversarial-review-integration.md）を参照。
-
-**case-run 本体は実装方針を生成・審査しない（REQ-{NNNN}-{NNN}）**: 実装方針の形成、adversarial-review 呼出、結果反映は Step 6 委譲内で agentdev-case-run-execution-adapter の委譲契約に従い、最初の実装変更前に実施する。case-run 本体（Step 1〜8 の orchestration）が実装方針を生成、保持、審査するステップを新設しない。委譲 result（4状態）のみで adapter 委譲内の結果を受領する。
-
-**実装方針限定（REQ-{NNNN}-{NNN}）**: adapter 委譲内で形成する実装方針は、既確定 Issue 本文、REQ、Decision、SPEC を実現する内部選択（関数配置、命名、データ構造の選択、実装の並び順等）に限定する。実装方針は既確定文書へ矛盾しない内部選択の範囲内で review 審議対象となる。実装方針が既確定 Issue/REQ/Decision/SPEC の変更、追加、撤回を必要とする場合、実行担当サブエージェントは実装を開始せず blocked へ遷移する。
-
-**blocked 遷移（REQ-{NNNN}-{NNN}、REQ-{NNNN}-{NNN}）**: adapter 委譲内で次のいずれかに該当する場合、実行担当サブエージェントは result を `blocked` として返却する。(1) 実装方針が既確定 Issue/REQ/Decision/SPEC の変更、追加、撤回を必要とする（REQ-{NNNN}-{NNN}）。(2) 要件、仕様に問題（欠落、矛盾、曖昧さ、実現不可能な条件等）を検出した（REQ-{NNNN}-{NNN}）。(3) adversarial-review 審議で unresolved な本質的争点またはユーザー判断事項が残り、実装の最初の変更（不可逆処理）へ進めない（REQ-{NNNN}-{NNN}）。blocked 詳細本文は Issue コメントに SSoT として記録され、Step 7 で処理される。実行担当サブエージェントは要件、仕様問題を検出した場合、勝手に仕様変更、REQ 黙示変更、Decision 再解釈を行わず、必ず blocked 経路へ入る（G02）。
-
-**発動条件（REQ-{NNNN}-{NNN}、REQ-{NNNN}-{NNN}）**: case-run は adversarial-review を原則実行する（default-on、REQ-{NNNN}-{NNN}）。発動条件判定は adapter 委譲内で実行担当サブエージェントが行う。skip 条件（実装方針が自明: 既確定 SPEC の機械的反映、単一ファイル編集等、意味的決定なし）該当時は省略して従来フローを継続できる（REQ-{NNNN}-{NNN}）。ユーザー明示指定時は skip 条件にかかわらず必ず発動する（REQ-{NNNN}-{NNN}）。case-run 本体は発動条件の有無を判定、伝達しない。
-
-**従来フロー維持（REQ-{NNNN}-{NNN}）**: skip 条件該当時、呼出失敗時（REQ-{NNNN}-{NNN}）のいずれの場合も、adapter 委譲内の従来フロー（実装方針形成、実装、検証、PR 作成）を維持する。review 呼出を行わず、実装方針形成から直接実装、検証、PR 作成へ進む。case-run 本体の従来フロー（Step 1〜8）も維持し、Step 6 委譲の結果は Step 7 で4状態として受領する。
-
-**accepted finding 反映と再 review（REQ-{NNNN}-{NNN}/007）**: accepted finding の実装方針への反映は adapter 委譲内の実行担当サブエージェント責務である。反映後に実装方針の意味内容が変更された場合、adapter 委譲内で必要な既存検証を再実行し、意味内容変更から新たな本質的争点が生じ得る場合のみ再 review を発動できる。同一 finding を新証拠・新前提・異なる failure condition・未評価範囲なしに再起票しない。
-
-### Step 7: 実行担当サブエージェント result 処理
-
-実行担当サブエージェントが返す4状態（`agentdev-case-run-execution-adapter` の result 契約）のいずれかを処理する:
-
-- **completed-pr**: 実装完了、PR作成済み。PR番号を受け取りクリーンアップStepへ。成功成果は PR 作成である
-- **blocked**: 回答可能な blocker。詳細本文は Issue コメントに SSoT として記録済み（実行担当サブエージェント責務）。エラー処理に従い停止、ユーザー報告
-- **failed**: repository context で回答不能な blocker。詳細本文は Issue コメントに構造化して記録済み（実行担当サブエージェント責務）。エラー処理に従い停止、ユーザー報告
-- **delegation-unavailable**: 実行インフラが委譲を起動できなかった状態。実行未試行のため `pending` に戻す
-
-**L2 タイムスタンプ受け渡し（REQ）**: result 状態（completed-pr/blocked/failed）にかかわらず、Step 5（worktree 設定）、Step 6（実行担当サブエージェント実行）で計測した L2 タイムスタンプを result に含める。case-auto は本 L2 内訳を case-run 委譲の L1 壁時計時間の内訳として読み取る
-
-### Step 7-1: 配布依存境界の最終変更経路 gate（実装後、REQ-{NNNN}-{NNN} 再利用、DEC-{N}）
-
-result が `completed-pr` の場合、Step 8（クリーンアップ）に進む前に、実装後の実際の worktree HEAD に対して配布依存境界の最終 gate を行う。本 gate は実装担当サブエージェントが追加した変更も含めて実際の worktree HEAD で検査する（Oracle finding 5: post-implementation gate）。
-
-**実行条件**: result が `completed-pr` であり、PR 対象ファイルに `src/opencode/{commands,skills}/**` 変更を含む場合に実行する。当該変更を含まない PR（docs のみ等）ではスキップする
-
-**実行コマンド**: `bun run .opencode/skills/<integrity-detector-skill>/scripts/check_distribution_boundary.ts --profile source --json`。現在の worktree（実装後 HEAD）の配布物ソースツリーを検査する
-
-**検出結果の分類**: 検査エラー（読込不能、未分類エントリ、adapter 起動失敗）は全て gate-not-passed として扱う（DEC-{N} 決定5、TS-{NNN}）。clean として通過させない
-
-**違反検出時の停止契約（adapter result `blocked` とは区別）**: 違反検出時は PR 本文の `## Findings / Capture候補` セクションに `### distribution-boundary` 小見出しで記録し、Step 8 へ進まず case-run を停止する。adapter result は `completed-pr` のまま変更せず、adapter result 契約の `blocked`（Issue コメント SSoT を伴う実行担当サブエージェント起因の blocker）へ上書きしない。停止理由は「配布依存境界 最終 gate 違反（PR 本文記録済み）」と報告し、SSoT は PR 本文とする（`blocked`/ `failed` の SSoT である Issue コメントは使用しない）。next action は同一 Issue で case-run を再実行し違反を修正する（worktree+ブランチ存活時は Step 5 をスキップし Step 6 から再開、べき等）。case-close へは進めない（case-close STEP-{N} で同一 gate が停止するため前段で停止する）
-
-### Step 8: worktree クリーンアップ確認 + 完了報告
-
-- 未コミット変更あり: 報告してユーザーの指示に従う。自動的な破棄、コミットは行わない
-- 未コミット変更なし: 完了報告へ。runtime workspace のクリーンアップは harness の責務であり、case-run は関与しない
-- 完了報告templateに従って出力（実行担当サブエージェント result 状態、PR番号を含める）
-- **L2 タイムスタンプ計測（REQ、REQ）**: 本 Step（worktree クリーンアップ）の開始時刻、終了時刻（JST）を記録し、worktree クリーンアップ時間を計測する。完了報告に L2 タイムスタンプ内訳（worktree 設定時間、実行担当サブエージェント実行時間、worktree クリーンアップ時間）を含める
-
-## Epic Wave 実行モード（`case-run #epic` 受領時）
-
-Epic Issue 番号を受け取った場合、現在 ready な Wave の子Issue を並列実行する。1 Wave の実行（PR作成まで）で return し、Wave 境界（マージ）は扱わない。同一コマンド再実行で次 Wave に進む（べき等、Epic Issue 本文から進行状況判定）。**Epic Issue の入力ソース（REQ/088）**: Epic Issue は本来の Epic flow（マルチREQ、`scale: large`）に加え、Standard flow 起因の独立 OU 自動 Epic 化（case-open が `depends_on` 空、L0 相当の独立 OU を検出して Epic 化）によるものも含む。case-run は入力ソースを区別せず、Epic Wave モデル（ADR、最大5件並列委譲）で一様に処理する。フロー詳細（Epic Issue 本文読込、現在 ready な Wave の子Issue 特定、`git fetch origin` 実行、子Issue の worktree 作成、各子Issue の並列委譲、全委譲完了待機、結果収集、return）は `agentdev-epic-tracker` を参照。Wave 境界（PR マージ）は case-close の責務。`completed-pr` となった子Issue を次 Wave へ進めるためには、case-close でマージ後に再度 `case-run #epic` を実行する（べき等）
-
-
-## テスト戦略（TS）標準手順
-
-関数削除を伴う Issue の test strategy 標準手順（L-014、PR #1140 / #1139 Epic #1138 由来）。共用関数の包括的削除による破壊的変更を防止する。関数削除を伴う Issue の test strategy に、削除対象関数の全使用箇所 grep 確認手順を追加する（標準手順: 削除対象関数名で `scripts/` 配下を grep し、対象スコープ外の使用箇所が 0 件であることを確認、残存する場合は削除を中止し Findings に記録）。詳細は `agentdev-req-analysis` を参照
-
-## エラー処理
-
-エラー発生時の対応は `agentdev-workflow-orchestration` に従う。実行担当サブエージェント result が blocked/ failed の場合、Issue コメント（SSoT）を参照して停止理由、再開ポイントをユーザーに報告する。実行担当サブエージェント内の自律修正ループ（同一入力の機械的再試行、検証ループ）は `agentdev-case-run-execution-adapter`/ `agentdev-workflow-orchestration` に従う
+**soft guard（REQ-{NNNN}-{NNN}、OpenCode 1.18.15 向け）**: 本コマンドの workflow 実装本体は `agentdev-workflow-case-run` が所有する。同 Workflow Skill は `/agentdev/case-run` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わないこと。OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため、本宣言を soft guard として機能させる。
 
 ## ガードレール
 
@@ -175,6 +86,3 @@ intake/ learning 境界は `agentdev-workflow-orchestration`（capture-boundarie
 - G14: スコープ拡大禁止。発見は記録し修正は後続処理に委ねる
 - G15/G16/G17/G21: intake 候補、learning 候補を区別して記録し混ぜた単一成果物にしない。`.agentdev/intake/inbox/`、`.agentdev/learning/inbox.md` の直接変更禁止。capture 情報は PR 本文経由のみ case-close に引き継ぐ（capture 境界の詳細は `agentdev-workflow-orchestration` 参照、case-run の capture 責務は記録のみ）
 - G27: SPEC確定候補（実装で発見された SPEC レベル詳細）は PR 本文の `## SPEC確定候補` セクションに記録し、`## Findings / Capture候補` とは混在させない。SPEC確定候補の確定、SPEC ファイルへの反映判断は case-close の責務
-
-
-

--- a/src/opencode/commands/agentdev/case-update.md
+++ b/src/opencode/commands/agentdev/case-update.md
@@ -26,38 +26,29 @@ description: 既存Caseの本文更新、コメント追加、またはREQファ
 
 - 更新されたIssue本文 または 追加されたコメント または 更新されたREQファイル または レビューNGコメント
 
-## 手順
+## workflow
+
+本コマンドは workflow 実装本体を `agentdev-workflow-case-update` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。同スキルが4 STEP の control plane として制御構造を所有する。
 
 ### Step 1: Issue番号解決
 
-詳細は `agentdev-workflow-routing` を参照。委譲接続点: サブエージェントは候補番号抽出のみを返し、親エージェントが確認、停止を判断する
+ユーザー入力・セッション会話から番号取得（一覧取得禁止）
 
-### Step 2: 現在のIssue状態を取得
+### Step 2: 現在のIssue状態取得
 
 `agentdev-workflow-lifecycle` で現在フェーズを判定
 
 ### Step 3: 更新内容に応じて分岐
 
-- **`--body`**: Issue作成時に使用されたテンプレートに従って更新する。詳細は `agentdev-workflow-routing` を参照。委譲接続点: サブエージェントは本文案と必須セクション検査のみを返し、親エージェントが Issue 本文更新手続き（`agentdev-gh-cli`）を行う
-- **`--comment`**: 更新コメントを追加する。詳細は `agentdev-workflow-routing` を参照。委譲接続点: サブエージェントはコメント案と必須セクション検査のみを返し、親エージェントが投稿する
-- **`--req`**: REQファイル更新を行う。case-update --req は直接 commit+push を行う（req-save への委譲は行わない）。詳細は `agentdev-workflow-routing` を参照。委譲接続点: サブエージェントは関連REQ候補、APPEND/UPDATE候補、根拠のみを返し、親エージェントがファイル更新とcommit/pushを行う
-- **`--review-ng`**: レビューNG時の専用フローを実行する。詳細は `agentdev-workflow-routing` を参照。委譲接続点: サブエージェントは乖離タイプ候補、推奨アクション、更新漏れ候補のみを返し、親エージェントがコメント投稿とREQ更新判断を行う
+`--body`（テンプレート構造維持更新）/ `--comment`（コメント追加）/ `--req`（REQファイル更新、直接 commit+push）/ `--review-ng`（レビューNG専用フロー、QG-{N} 乖離検出結果引用）。APPEND vs UPDATE 判定基準と各フローの詳細は workflow skill 参照
 
 ### Step 4: 完了報告
 
-完了報告templateに従って出力。更新種別に応じた種別を選択:
-- --body → .opencode/commands/agentdev/templates/case-update/body.md
-- --comment → .opencode/commands/agentdev/templates/case-update/comment.md
-- --req → .opencode/commands/agentdev/templates/case-update/req.md（変数: {APPEND/UPDATE}, {REQ番号}, {セクション名}）
-- --review-ng → .opencode/commands/agentdev/templates/case-update/review-ng.md（変数: {乖離タイプ}, {REQ番号}, {推奨アクション}）
-- 更新種別の推論: ユーザー入力、直前のレビュー結果、対象Issue/REQ、会話文脈から推論。推論不能時のみユーザーに指定を求めて停止
+更新種別に応じた種別を選択: `--body` → `templates/case-update/body.md`、`--comment` → `templates/case-update/comment.md`、`--req` → `templates/case-update/req.md`、`--review-ng` → `templates/case-update/review-ng.md`
 
-## APPEND vs UPDATE 判定基準
+各 STEP の詳細（開始条件・結果・手順・resume point・関連 Capability Skill 連携）は `agentdev-workflow-case-update` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
-| 判定 | 条件 | 例 |
-|------|------|----|
-| APPEND | 要件テーブルへの行追加、適用範囲の拡張 | 受け入れ基準の追加、新規要件の追加 |
-| UPDATE | 既存セクションの内容修正 | テキスト置換、要件の文言修正、適用範囲の変更 |
+**soft guard（REQ-{NNNN}-{NNN}、OpenCode 1.18.15 向け）**: 本コマンドの workflow 実装本体は `agentdev-workflow-case-update` が所有する。同 Workflow Skill は `/agentdev/case-update` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わないこと。OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため、本宣言を soft guard として機能させる。
 
 ## ガードレール
 
@@ -81,5 +72,3 @@ description: 既存Caseの本文更新、コメント追加、またはREQファ
 
 ### 出力制約
 - G11: 成果物本文（Issue本文、PR本文、commit message、保存対象ファイル本文、テンプレート成果物）はverbatimで返す。判定結果、調査過程、中間ログ、読解メモは要約、成果物パス、根拠、親判断事項、capture候補へ圧縮して返す
-
-

--- a/src/opencode/commands/agentdev/req-define.md
+++ b/src/opencode/commands/agentdev/req-define.md
@@ -7,6 +7,8 @@ description: 要件を整理、定義する（機能追加、バグ修正共通�
 機能追加またはバグ修正の要件を整理、定義する。
 壁打ちフェーズで使用。
 
+**draft-data 入力・出力**: 本コマンドは構造化 `draft-data`（`# draft-data` fenced YAML block）を扱う。対話の進行は durable state（入力ファイル、draft 下書き、`status` frontmatter）から再構成され、会話コンテキストのみを resume source としない。
+
 ## 入力
 
 - ユーザーの自然言語による機能追加/バグ修正の説明
@@ -30,103 +32,57 @@ description: 要件を整理、定義する（機能追加、バグ修正共通�
 - extension が破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する
 - 詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
-## session由来RU 消費契約（参照）
+## workflow
 
-`source_type: chat` かつ `generated_by: session` のRU（session由来RU）を受領した場合、一時成果物ライフサイクル要件と artifact-contracts SPEC「RU アーティファクト契約（session由来RU）」セクションを正規原本として `logical_key` によるRU案特定、`session:...` 論理URI の非解決、必須8セクション読み取り契約、`tentative_classification` → 最終分類の扱いを扱う。本コマンドは同契約を再定義せず、各項目の判定基準、検証観点は正規原本（一時成果物ライフサイクル要件 + artifact-contracts SPEC）へ委譲する
+本コマンドは workflow 実装本体を `agentdev-workflow-req-define` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。同スキルが11 STEP の対話型 control plane として制御構造を所有する。
 
-## 手順
+### Step 1: セッションコンテキスト検知・入力解決
 
-### Step 1: セッションコンテキスト検知（引数なし単体実行時のみ）
+6項目推論（信頼度付き）、明示入力ファイル・RU 自動検出、session由来RU 消費契約
 
-`agentdev-req-analysis` に従い、当該セッション履歴・現在コンテキストから6項目（要件内容、work_type、scale、Decision、構造化、適用範囲）を推論し信頼度付きで表示。Confirmed のみで要件doc自足可能なら Step 3 以降へ、部分的不足で補足質問解消可能なら壁打ち（Step 3）へ、有効な Requirement Source 構成不能なら Step 2（RU 自動検出）へ。引数ありの場合は Step 2 から開始
+### Step 2: 壁打ち対話
 
-### Step 2: 明示入力ファイルの読み込み（指定時）
+深掘り、前工程からの引き継ぎ判定（`agentdev_handoff`）
 
-Read tool で読み込み、壁打ちの初期コンテキストとして扱う。
-複数ファイル指定時は全て読み込む。
-引数なしの場合で、かつ Step 1 でセッション履歴、現在コンテキストから有効な Requirement Source を構成できなかった場合のみ、`.agentdev/backlog/req-units/RU-*.md` の存在を確認し1件なら自動検出。
-0件なら Step 3 へ。
-2件以上なら候補一覧を表示し自動選択しない。
-セッション履歴、現在コンテキストおよび RU のいずれからも有効な入力を構成できない場合、壁打ち対話を開始する
+### Step 3: 既存REQ照合
 
-  **2-1. session由来RU 受領時**: 読み込んだRU が `source_type: chat`、`generated_by: session` の場合、「session由来RU 消費契約（参照）」セクションに従う。`session:...` 論理URI の解決、必須8セクション読み取り契約、`tentative_classification` → 最終分類の扱いは正規原本（一時成果物ライフサイクル要件、artifact-contracts SPEC）へ委譲する
+CREATE 前 APPEND/UPDATE 評価、定量的データ検証、SPLIT 予兆計測
 
-### Step 3: 壁打ち対話
+### Step 4: 要件展開
 
-`agentdev-req-analysis` に従って深掘り。明示入力ファイルがある場合、その内容を開始点として活用
+変更影響候補抽出、分類ゲート、Decision要否確認ゲート、test strategy 定義
 
- **3-1. 前工程からの引き継ぎ判定**: 入力が AgentDevFlow 本体、配布 command、配布 skill、配布 template、配布 script の不具合または改善点を対象とする場合、`agentdev-workflow-lifecycle` に従い前工程からの引き継ぎ用 RU 入力として整理する。現在プロジェクトの通常要件docとして定義せず、出力に `agentdev_handoff: true` を含める
+### Step 5: Decision判断
 
-### Step 4: 既存REQ照合
+Decision判断記録（`new:{topic-slug}`、ファイル作成は req-save）
 
-`agentdev-req-file-manager` の照合方法論に従って実行。
-CREATE 前に APPEND/UPDATE 候補を必ず評価すること。
-要件の分割が必要な場合は保存操作ではなく requirements review 候補として扱うこと。
-操作分類結果は `draft-data` の `artifact_actions` に記録
+### Step 6: 要件doc生成
 
- **4-1. 定量的データ検証**: `glob docs/requirements/<REQ-*>.md`（および副次的に `glob docs/decisions/<DEC-*>.md`）で実ファイル列挙と AGENTS.md 等の文書記載レンジとの乖離を確認・解消する。詳細は `agentdev-req-analysis` を参照
+構造化 `draft-data`（operation_units、artifact_actions、test_strategy、review_dispositions）
 
- **4-2. SPLIT 予兆計測（既存REQ）**: APPEND/UPDATE 対象の既存 REQ の健全性メトリクス（要件行数、関心分類数、成果物種別数）を計測し、req-health-metrics SPEC（extension 経由）の定量閾値で SPLIT シグナルを算出。合計 2 以上の場合、APPEND 実施前にユーザーへ SPLIT 要否を提案。計測対象は当該 REQ の要件テーブル行（`^| REQ-NNNN-MMM |`）。閾値、計算式の詳細は `agentdev-req-analysis` を参照
+### Step 7: work_type・Scale 判定
 
-### Step 5: 要件展開
+4値分類、feature のみ standard/large
 
-`agentdev-req-analysis` の分析観点に従って網羅。詳細ゲート、委譲接続点は `agentdev-req-analysis` の各 Phase を参照:
+### Step 8: adversarial-review（経路A）
 
-- **5-1. 変更影響候補抽出**: 変更影響候補を抽出しドラフトに保持。RU からの対象領域キーワード抽出、glob/grep での関連 REQ/Decision/SPEC 事前特定、サブエージェント調査委譲への調査優先対象リスト（ヒント）構築、実ファイル完全列挙の維持。詳細は `agentdev-req-analysis`「調査スコープ洗練手順」参照
-- **5-2. 分類ゲート（REQ 最終分類確定）**: 各要件行候補を「変更後仕様」/「反映作業」に分類。REQ/SPEC 境界判定を行い SPEC 保存対象を `artifact_actions`（`artifact: spec`）に分離。RU 暫定分類（`tentative_classification`）があれば document-model SPEC（extension 経由）の文書7分類モデルへ照らして最終分類を確定し上書き
-- **5-3. 文書分類妥当性検証**: REQ 要件行に SPEC 分離基準違反残留がないか検出。検出時は SPEC 保存対象へ移送（安定契約例外は対象外）
-- **5-4. Decision要否確認ゲート**: Decision候補・既存REQ/Decision/SPEC との衝突候補・責務境界変更を含む場合、`agentdev-architecture-advisory` へ委譲。出力は 4 ラベル構造（確定事項/推定事項/ユーザー確認事項/ブロッカー）。soft-contract（Decision）。ブロッカーまたは未決事項残存時は壁打ち（Step 3）へ差し戻し
-- **5-5. 実行主体分類表（REQ）**: 委譲契約を定義する場合、各委譲について実行主体分類表（adapter skill / command / subagent / harness）を必須。詳細は delegation-contracts SPEC（extension 経由）参照。委譲を含まない要件では省略可
-- **5-6. test strategy 定義（REQ, REQ）**: 各合意項目（AG-*）の検証方法を test strategy として定義。3要素構造（`verification` / `pass_criteria` / `on_failure`）を必須とし、`on_failure` を持たない検証項目は含めない。項目識別子は `TS-NNN`、`on_failure` アクション種別は `fix-and-reverify` / `record-in-findings` の2値。シリアライズ形式の詳細は req-define command SPEC（extension 経由）の draft-data test_strategy フィールドスキーマ参照
+default-on、skip 条件該当時は省略、ユーザー明示指定時は強制発動
 
-### Step 6: Decision判断
+### Step 9: ドラフト保存
 
-`agentdev-decision-guidelines`（manual reference）に従ってDecision判断を記録（Decisionファイル作成は req-save で実行）。各副ステップ（6-1: 既存Decision重複確認、6-2: Decision禁止ゲート、6-3: 判断根拠記録、6-4: 作業手段Decision拒否ゲート、6-5: Decision番号指定形式 `new:{topic-slug}`）の詳細、委譲接続点は `agentdev-req-analysis` を参照
+`.agentdev/drafts/req-draft-{topic-slug}.md` へ保存
 
-### Step 7: 要件doc生成
+### Step 10: 要件doc確認
 
-テンプレート: `.opencode/commands/agentdev/templates/req-define/req-draft.md` を Read → 構造化 `draft-data` 形式に従って生成。原本は構造化された `# draft-data` fenced YAML block。Step 6-2/5-3 で分離した SPEC 候補は `artifact_actions`（`artifact: spec`）として統合し `## SPEC候補` 補助セクションは出力しない。保存対象は単一の `artifact_actions` 配列に統合する
+ユーザーに提示（承認は求めず提示のみ）
 
-各副ステップ（7-1: 定義完全性ゲート QG-{N}、7-2: operation_units 生成、7-2a: depends_on/recommended_order 定義、7-3: artifact_actions 生成、7-3a: target_area/content 形式、7-3b: SPEC action 分類根拠出力、7-4: test_strategy 生成、7-5: review_dispositions 生成）の詳細、フィールドスキーマ、委譲接続点は `agentdev-req-analysis` の req-define detailed gates、および req-define command SPEC（extension 経由）の各フィールドスキーマを参照。`target_spec`、`spec_logical_division`、`canonical_owner`、`on_failure`、`review_dispositions` の出力形式も同 SPEC を正とする
+### Step 11: 完了報告
 
-### Step 8: work_type 判定
+work_type・scale 別種別の選択（`templates/req-define/` 配下）
 
-ラベルに基づき4値分類（bugfix/feature/maintenance/docs_chore）。bugfix + Decision必要時は feature に昇格
+各 STEP の詳細（開始条件・結果・手順・resume point・関連 Capability Skill 連携）は `agentdev-workflow-req-define` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
-### Step 9: Scale判断（feature のみ）
-
-`agentdev-workflow-lifecycle` で standard/large を判定。large 時はユーザーと分解計画を協議。9-1 実装スコープシグナル確認（ドラフト内に修正候補リスト、検出事項カタログ、影響ファイル一覧等の実装詳細セクション存在時に large 昇格判定、昇格理由をユーザー提示）の詳細は `agentdev-workflow-lifecycle` を参照
-
-### adversarial-review 挿入境界（経路A、REQ-{NNNN}-{NNN}）
-
-Step 9（Scale判断: feature）または Step 8（work_type 判定: feature 以外）完了後、Step 10（ドラフト保存）の前に挿入する。req-define は adversarial-review を原則実行する（default-on、REQ-{NNNN}-{NNN}）。発動条件判定と review 呼出を分離する（REQ-{NNNN}-{NNN}）。
-
-- **発動条件判定（REQ-{NNNN}-{NNN}、REQ-{NNNN}-{NNN}）**: default-on で発動する。skip 条件（Scale=L0 で Decision判断対象なし、意味的決定なし）該当時は省略して従来フロー（review を挿入せず Step 10 へ進む）を継続できる（REQ-{NNNN}-{NNN}）。ユーザー明示指定時は skip 条件にかかわらず必ず発動する（REQ-{NNNN}-{NNN}）。skip 判断のためだけの新規 HITL、承認点は追加しない。
-- **review 呼出（REQ-{NNNN}-{NNN}）**: 発動条件判定で発動と判定された場合、要件候補（draft-data、`agreed_items`、`artifact_actions`、Decision判断結果、Scale判断結果）を対象に adversarial-review を呼び出す。委譲契約は delegation-contracts SPEC（extension 経由）「adversarial-review との委譲契約接続」節に従う。
-  - Decision finding は Step 6（Decision判断）へ戻し再評価する。要件展開に関わる finding は該当 Step へ戻す。accepted finding の反映は呼出元の責務である（REQ-{NNNN}-{NNN}）。
-  - 未解決のユーザー判断事項が残る場合、Step 10（ドラフト保存）へ進まない（REQ-{NNNN}-{NNN}）。工程委譲起源であるため既存 status に unresolved 判断事項を付加する（REQ-{NNNN}-{NNN}）。
-  - 呼出失敗時は silent skip を禁止し、従来フローを維持する（REQ-{NNNN}-{NNN}）。
-
-詳細な挿入境界は req-define command SPEC（extension 経由）「adversarial-review 挿入境界（経路A）」節を正とする。
-
-### Step 10: ドラフト保存
-
-全 work_type（feature/ bugfix/ maintenance/ docs_chore）で `.agentdev/drafts/req-draft-{topic-slug}.md` に保存。Step 7 の構造化 `draft-data` 形式（`# draft-data` fenced YAML block）で保存する。標準データモデル fields（`work_type`, `scale`, `summary`, `auto_gate`, `agreed_items`, `artifact_actions`, `conflict_resolutions`, `operation_units`, `test_strategy`, `review_dispositions`, `case_open_hints`）を保持する。`workflow_route` は派生値として保存しない。後続工程の分岐は `artifact_actions` の存在で決定する（`artifact: req`/`adr` → req-save、`artifact: spec` → spec-save）。`operation_units` を含め、`execution_groups` は出力しない。`summary` 等の人間可読セクションは補助的であり下流処理の正として扱われない
-
-各副ステップ（10-1: 実装詳細の分離、10-2: auto_gate 完了ゲート、10-2a: 未確定内容の auto_ready 抑止）の詳細、stop_reasons 記録形式、代表 fixture、引用誤検知除外パターンは req-define command SPEC（extension 経由）「未確定内容の auto_ready 抑止」節、および `agentdev-req-analysis` の req-define detailed gates を参照
-
-### Step 11: 要件doc確認
-
-生成した要件docをユーザーに提示（承認は求めず提示のみ）。差し戻し時は壁打ち継続（Step 2 へ）。次コマンド実行を確定の意思表示として扱う
-
-各副ステップ（11-1: 複数RU同時入力受付、11-2: 統合/分離判定、11-3: 操作単位ごとの出力生成、11-4: Epic 規模検出時の記録、11-5: Wave 候補/依存関係の記録、11-6: OU 構造検証）の詳細、委譲接続点は `agentdev-req-analysis` を参照。11-2 では生成ドラフト自身の健全性メトリクス（要件行数、関心分類数、成果物種別数）を計測し、req-health-metrics SPEC（extension 経由）の閾値で SPLIT シグナルを算出して合意内容に反映する（新規 CREATE ドラフトで要件行数が 51 行超の場合は SPLIT 要否をユーザーへ提案）
-
-### Step 12: 完了報告
-
-完了報告templateに従って出力。work_type に応じた種別を選択:
- - feature standard → .opencode/commands/agentdev/templates/req-define/feature.md
- - feature large (Epic)規模 → .opencode/commands/agentdev/templates/req-define/feature-epic.md
- - bugfix/ maintenance/ docs_chore → .opencode/commands/agentdev/templates/req-define/lightweight.md
+**soft guard（REQ-{NNNN}-{NNN}、OpenCode 1.18.15 向け）**: 本コマンドの workflow 実装本体は `agentdev-workflow-req-define` が所有する。同 Workflow Skill は `/agentdev/req-define` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わないこと。OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため、本宣言を soft guard として機能させる。
 
 ## ガードレール
 
@@ -148,5 +104,3 @@ Step 9（Scale判断: feature）または Step 8（work_type 判定: feature 以
 - G16: Decision判断が必要な変更（Decision要否確認ゲート）では Decision 判断前に `agentdev-architecture-advisory` を参照する。アーキテクチャ助言サブエージェントは Decision 要否、推奨方向、設計リスク、根拠を返し、最終的な Decision 作成判断は親エージェントが行う
 - G17: アーキテクチャ助言サブエージェントの助言は親エージェントが分類し、未確認事項を要件本文へ混入させない。同サブエージェントはファイル編集主体ではない
 - G19: test strategy 項目は verification（検証手順）、pass_criteria（合格基準）、on_failure（不合格時の処置）の3要素を完全に持つこと（REQ）。on_failure（不合格時の処置）を持たない検証項目は test strategy に含めないこと（REQ）。3要素のいずれかが欠落する項目を検出した場合、保存前に QG-{N} が fail として扱う（REQ）
-
-

--- a/src/opencode/commands/agentdev/req-save.md
+++ b/src/opencode/commands/agentdev/req-save.md
@@ -25,86 +25,61 @@ req-defineで生成された壁打ち成果物をREQ/Decisionファイルとし�
 
 本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/req-save.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
-## 手順
+## workflow
+
+本コマンドは workflow 実装本体を `agentdev-workflow-req-save` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。同スキルが12 STEP の control plane として制御構造（事前チェック、REQ ファイル操作、整合性検証、永続化）を所有する。
 
 ### Step 1: 事前チェック
 
-`draft-data` の `artifact_actions` を確認し、`artifact: req` または `artifact: decision` の entry が含まれるか判定する。
-REQ/Decision 対象 artifact_actions がない場合は no-op 完了（後続の case-open へ進むよう完了報告で案内）。
-`work_type` による停止は廃止する。
-旧形式 draft（`artifact_actions` フィールドなし）の場合は従来どおり全 req-operation を処理する（後方互換）
+`artifact_actions` の `artifact: req`/`artifact: decision` 有無判定、no-op 完了、旧形式 draft 後方互換
 
 ### Step 2: ドラフト読込
 
-`.agentdev/drafts/req-draft-*.md` を読み込む → 最新の1件を対象とする。見つからない場合はエラーで中止（先に `/agentdev/req-define` を実行してください）。**読込時 hash 記録**: `git rev-parse HEAD` で読込時点の commit hash を記録する
+最新ドラフト特定、読込時 commit hash 記録
 
-### Step 3: ドラフト検証
+### Step 3: ドラフト検証・処理対象確定
 
-`draft-data` の必須フィールド（artifact_actions, operation_units, topic_slug）が存在することを確認。欠損時はエラーで中止
-
-**Step 3-1**: 分類ゲート検査（CREATE対象REQの要件テーブル検査）、**Step 3-2**: 文書分類適合確認（REQ/Decision 保存前のドキュメント種別確認）。詳細、委譲接続点は `agentdev-req-file-manager` を参照
-
-**Step 3-3**: REQ/Decision artifact_actions 処理ゲート。ドラフトの `artifact_actions` から `artifact: req`/ `artifact: decision` の entry を処理対象とする（draft 全体を処理し、OU ごとに分割しない）。`artifact_actions` に REQ/Decision entry がない場合 → no-op 完了。`operation_units` 存在時は OU ID 指定があれば当該 OU 配下のみ、未指定時は draft 全体を処理対象。`artifact_actions` フィールドがない（旧形式 draft）の場合は従来どおり全 req-operation を処理（後方互換）。`artifact: spec` の entry は spec-save コマンドの対象であり処理しない
+必須フィールド検証、分類ゲート検査、artifact_actions 処理ゲート
 
 ### Step 4: REQ ファイル操作
 
-`agentdev-req-file-manager` の判定ロジックと採番ルールに従って実行。Step 3-3 で処理対象とした `artifact_actions`（`artifact: req`/`artifact: decision`）の全 entry を処理する（draft 全体を処理し、OU ごとの消費は行わない）。`artifact_actions` フィールドがない場合は従来どおり全 req-operation を処理する（後方互換）。委譲接続点: サブエージェントはCREATE/APPEND/UPDATE候補、SPLIT候補、REQ再構成候補を返し、親エージェントがファイル保存を行う。詳細は `agentdev-req-file-manager` を参照
+CREATE/APPEND/UPDATE、決定的スクリプト呼出、QG-{N}（適用結果の整合性検証）、3フェーズ分離
 
-**決定的処理のスクリプト呼出（REQ、AG-{NNN}）**: REQ番号採番、要件行ID採番、frontmatter id↔ファイル名整合性確認は `agentdev-artifact-validation` の公開検証契約（RU-{NNNNNNNN}-01 合意）および `agentdev-req-file-manager` SKILL.md「Scripts（決定的処理）」で規定する決定的スクリプトを bash 経由で呼び出して実行する。LLM 推論で代替しない。具体的な CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照
+### Step 5: インデックス・ハブ更新
 
-**Step 4-0**: QG-{N}（適用結果の整合性検証、REQ/082、AG-{NNN}）。REQ/Decision ファイル保存前に `agentdev-quality-gates` の QG-{N} を「適用結果の整合性検証」として実行。採番結果、マージ結果、インデックス、変更範囲の妥当性を決定的スクリプトの JSON 結果で機械的に確認。fail 時は保存を停止し req-define へ差し戻し。**REQ**: req-save の QG-{N} は内容の品質を再検証せず、それは req-define の QG-{N} の責務。**Step 4-1**: 語彙、責務、runtime境界矛盾の防止（Step 4 完了後に既知の矛盾を検出可能な範囲で防止）。**Step 4-2**: Catalog entry 確認（APPEND 時。関連 integrity-rule-catalog SPEC（extension 経由）の catalog entry 有無を確認、未記載時はユーザーへ追記を促す、`docs/specs/` 配下は直接編集しない G02）。**Step 4-3**: 複数 REQ/Decision ファイルの3フェーズ分離（REQ/093、後述「case-auto 並列委譲モデル」参照）。Step 4-1/4-2 の詳細は `agentdev-req-file-manager` を参照
-
-### Step 5: インデックス、ハブ更新
-
-詳細は `agentdev-req-file-manager` を参照。委譲接続点: 親エージェントのみが `docs/` ファイルを更新する
-
-**エントリ存在確認のスクリプト呼出（REQ、AG-{NNN}、AG-{NNN}）**: README へのエントリ追加後に `agentdev-artifact-validation` の公開検証契約（RU-{NNNNNNNN}-01 合意、`check-entry-existence`）で登録を検証する。具体的な CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照
+README エントリ登録（check-entry-existence 検証）
 
 ### Step 6: Decision ファイル作成
 
-`artifact_actions` に `artifact: decision` の entry が含まれる場合のみ → `agentdev-decision-file-manager` に従って Decision ファイルを作成。作成後、`docs/README.md` にDecisionセクションが存在しない場合は追加し、Decisionエントリを記載
+`artifact: decision` entry のみ、妥当性再検証ゲート、採番 max+1
 
 ### Step 7: docs 変更整合性検証
 
-REQ番号の連続性確認、frontmatter の `id` とファイル名の一致を確認。frontmatter id ↔ ファイル名整合性確認は `agentdev-artifact-validation` の公開検証契約で決定的スクリプトを実行（REQ/Decision 保存時）。CLI 形式は同 SKILL.md を参照
+REQ番号連続性、frontmatter id↔ファイル名整合
 
 ### Step 8: README 索引影響確認
 
-REQ/Decision/SPEC操作が `docs/README.md`、各 README（`docs/requirements/README.md`、`docs/decisions/README.md`、`docs/specs/README.md`）の索引に影響するか確認。影響がある場合は更新、ない場合は「README 索引更新なし」。README 索引更新は導線の更新であり、要件、判断、仕様の更新ではない。
+索引更新、targeted docs guard、extension 更新要否確認
 
-**targeted docs guard（REQ）**: 変更 REQ ファイルと連動ファイル（`docs/requirements/README.md`、`docs/README.md`、`AGENTS.md`）に対し `check_changed_docs.ts --workflow req-save --files <changed REQ files> --json` を実行。`failures` に strict severity を含む場合は修正して再実行。`full_docs_check_recommended` true 時は `/repo/docs-check` をユーザーに提案
+### Step 9: 変更範囲検証・リモート同期
 
-**extension 更新要否（REQ）**: REQ/Decision 追加/移動/削除が `.agentdev/extensions/**` へ影響するか確認。該当 REQ/Decision を context に列挙している extension がある場合、paths も更新対象。必要時はユーザーへ指示を仰ぐ（直接編集しない）
-
-**エントリ存在確認（REQ、AG-{NNN}）**: `agentdev-artifact-validation` の公開検証契約（`check-entry-existence`）で REQ/Decision エントリの README 索引への存在を確認する
-
-### Step 9: 変更範囲検証
-
-**決定的処理のスクリプト呼出（REQ、AG-{NNN}）**: `git diff --name-only` で変更ファイル一覧を取得し、許可パスリスト（G02）との照合を `agentdev-artifact-validation` の公開検証契約（`check-change-impact`、RU-{NNNNNNNN}-01 合意）で実行。許可範囲外の変更を検出したらエラー内容をユーザーに報告して指示を待つ（自動破棄しない）。`violations` が空でない場合は G02 違反として報告し指示を待つ
-
-**Step 9-1**: リモート同期と hash 検証。**Step 9-2**: RU パス保存禁止。詳細、委譲接続点は `agentdev-req-file-manager` を参照
+check-change-impact、`git pull --ff-only` 後の hash 一致検証
 
 ### Step 10: ドラフト status 更新
 
-ドラフト `draft-data` の `status`（frontmatter）を `saved` に更新。commit/push より前に更新し commit 対象に含める（push 後の status 更新は永続化されないため禁止）
+`status: saved`（commit 対象に含める）
 
-### Step 11: コミット、プッシュ
+### Step 11: コミット・プッシュ
 
-`agentdev-conventional-commits` に従ってコミットメッセージを生成し、main ブランチに push。Step 10 の status 変更を commit 対象に含める。並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、`git add <path>` で明示パスステージし、`git commit -- <paths>`（--only pathspec 形式）でコミットする。スイープ操作（`git add -A`/ `git add .` 等）は禁止
-
-**Step 11-1**: REQ/Decision artifact_actions 処理結果の保存（ドラフトに複数 entry がある場合）。保存する内容: (a) 保存したREQドキュメントのリスト（REQ番号含む）(b) 各 artifact_action から保存したREQドキュメントへのマッピング (c) ソースRUからREQ操作へのマッピング (d) case-open で消費可能な形式での保存結果
-
-**OU 結果の書き戻し**: ドラフトに `operation_units` セクションがある場合、各 OU の `result` に (a) 保存したREQドキュメント一覧 (b) OU 操作と保存先REQ doc の対応 (c) source RUとOU操作の対応 (d) case-open が入力として扱える保存結果 を書き戻す
-
-**Step 11-2**: Issue作成の責任分離。req-save はREQドキュメントの保存中に Issue を作成しない（case-open の責任範囲）
+明示パスステージ、`git commit -- <paths>`、OU 結果書き戻し
 
 ### Step 12: 完了報告
 
-完了報告 template に従って出力。実行結果に応じて `templates/req-save/` 配下の種別（`split-detected.md` / `epic.md` / `standard.md`）を選択
+種別選択（`templates/req-save/` 配下: split-detected / epic / standard）
 
-## case-auto 並列委譲モデル（REQ/093）
+各 STEP の詳細（開始条件・結果・手順・resume point・関連 Capability Skill 連携）は `agentdev-workflow-req-save` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
-req-save は複数 REQ/Decision ファイルの変更案作成、検査を並列化できる（REQ）。3 フェーズ（1. 採番バッチ[直列] / 2. ファイル作成[並列・最大5件] / 3. インデックス更新[直列]）で分離する。G07（commit 前 status 更新）はフェーズ3で維持し、直列集約対象（採番、index 更新、draft 更新、commit、push）は並列委譲の完了を待ってから実行する（REQ）。詳細は `agentdev-req-file-manager` を参照
+**soft guard（REQ-{NNNN}-{NNN}、OpenCode 1.18.15 向け）**: 本コマンドの workflow 実装本体は `agentdev-workflow-req-save` が所有する。同 Workflow Skill は `/agentdev/req-save` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わないこと。OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため、本宣言を soft guard として機能させる。
 
 ## ガードレール
 
@@ -119,7 +94,7 @@ req-save は複数 REQ/Decision ファイルの変更案作成、検査を並列
 - G04: ドラフトファイルが存在しない場合は実行不可（エラーで中止）
 - G05: REQ番号は連番、一意であること（空き番号の再利用禁止）→ `agentdev-req-file-manager` に従う
 - G06: 要件doc構造は `doc_requirement.md` テンプレートに厳密に従うこと。【必須】セクションの欠落は禁止
-- G07: ドラフトのstatus更新（`saved`）は commit/push より前に実行し、commit対象に含めること。push後のstatus更新は永続化されないため禁止
+- G07: ドラフトのstatus更新（`saved`）は commit/push より前に実施し、commit対象に含めること。push後のstatus更新は永続化されないため禁止
 - G08: Step 9-1 の `git pull --ff-only` 後、読込時 hash と pull 後 hash の一致検証を必須とすること。一致しない場合は評価、承認をやり直すこと
 
 ### Decision妥当性再検証ゲート

--- a/src/opencode/commands/agentdev/spec-save.md
+++ b/src/opencode/commands/agentdev/spec-save.md
@@ -16,98 +16,63 @@ req-save の G02（SPEC 編集禁止）を緩和するものではなく、SPEC 
 ## 出力
 
 - `docs/specs/<**/*>.md`（既存 SPEC への追記 or 新規 SPEC 作成）
-- `.agentdev/drafts/req-draft-{topic-slug}.md`（SPEC artifact_actions 消費済みフラグの status 更新、Step 8 で実施）
-
-## SPEC ライフサイクル
-
-SPEC ファイル frontmatter の `status`（`draft` / `accepted` / `superseded`）の遷移契機、CREATE/APPEND/UPDATE 時の適用規則、`superseded` 遷移、SPEC 一覧表登録の詳細は `agentdev-spec-file-manager/references/spec-lifecycle-application.md` を正とする。要点: 新規 SPEC 作成時は `status: draft` を付与、既存 SPEC へ追記時は `status` を変更しない、`draft` → `accepted` 昇格は case-close の責務
+- `.agentdev/drafts/req-draft-{topic-slug}.md`（SPEC artifact_actions 消費済みフラグの status 更新）
 
 ## project extensions
 
 本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/spec-save.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。extension に列挙されていない `docs/specs/**` 内部パスを固定知識として読みに行かない。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
-## 手順
+## workflow
+
+本コマンドは workflow 実装本体を `agentdev-workflow-spec-save` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。同スキルが11 STEP の control plane として制御構造（配置先解決、SPEC ファイル操作、整合確認、永続化）を所有する。
 
 ### Step 1: 事前チェック
 
-ドラフトの `draft-data` の `artifact_actions` から `artifact: spec` entry の有無を確認する（全 work_type 対象、`work_type` による判定は廃止）。SPEC 対象 artifact_actions がない場合は no-op で完了。ドラフトが存在しない場合はエラーで中止（先に `/agentdev/req-define` を実行してください）
-
+`artifact: spec` entry 有無判定（全 work_type 対象）、no-op 完了、旧形式 draft 後方互換
 
 ### Step 2: SPEC artifact_actions 読込
 
-
-ドラフトの `draft-data` の `artifact_actions` から `artifact: spec` の entry を読み込む。
-`artifact_actions` フィールドが存在しない（旧形式 draft）場合は SPEC 保存対象なしと判定し、no-op で完了（後方互換）。
-`artifact: spec` entry が空の場合も no-op で完了。
-各 action の `target`（file path または `new:{slug}`）、`operation`（create/update）、`content` を処理対象とする
+処理対象 entry（target、operation、content）確定
 
 ### Step 3: 配置先解決
 
-各 SPEC action の `target`（または `target_spec: {operation, domain, slug}` 構造化）から配置先 SPEC を解決する。既存 SPEC パス（例: `docs/specs/{domain}/<existing-spec>.md`、または `target_spec: {operation: update, domain, slug}`）→ 当該 SPEC へ追記（`update` 操作）。`target_spec: {operation: create, domain, slug}` → 新規 SPEC 作成（`create` 操作、ファイル名 `docs/specs/{domain}/{slug}.md`）。同一 `target` の action は1つの SPEC へ集約する
-
-**決定的処理のスクリプト呼出（REQ、AG-{NNN}）**: 配置先 SPEC が既存か新規か、`target_area` が存在するかの判定は `agentdev-spec-file-manager` SKILL.md「Scripts（決定的処理）」が規定する決定的スクリプト（`search-target-area.ts`）を bash 経由で呼び出して実行する（LLM 推論で代替しない）。CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md および `agentdev-spec-file-manager/references/target-area-matching.md` を参照
+既存パス vs `new:{slug}` / `target_spec` 構造化、`search-target-area.ts` による決定的判定
 
 ### Step 4: SPEC 分離基準の最終確認
 
-各 SPEC action が SPEC に置くべき内容の基準に適合するか再確認。安定契約例外相当の内容は REQ 側に残すべきものとして除外し、完了報告の follow-up に明示
+安定契約例外の除外と follow-up 明示
 
 ### Step 5: SPEC ファイル操作
 
-`draft-data` の `artifact_actions`（`artifact: spec`）の全 entry を処理する:
-
-- **create**: 新規 SPEC ファイルを frontmatter（`title`, `status: draft`, `created`, `updated`）付きで作成し、action の `content` をセクションとして記載
-- **update**: `target_area` 指定時（operation が `update`/`spec-update`）は `agentdev-spec-file-manager/references/target-area-matching.md` のセクション置換ロジックで対象セクションを `content` で置換（REQ）。`target_area` 未指定時は既存 SPEC ファイルの該当セクションへ `content` を追記（後方互換、REQ）。frontmatter `updated` を更新、`status` は変更しない
-
-**target_area 見出し検索のスクリプト呼出（REQ、AG-{NNN}）**: `update` 操作における `target_area` 見出し検索は `search-target-area.ts` で実行する。Step 3 の結果（`matches`）を用いてセクション範囲を特定し `content` で置換。`matches` 空 → スキップし follow-up 記録、複数マッチ → G09 に従い置換拒否。CLI 形式、stdin JSON 入力、stdout schema は `agentdev-spec-file-manager` SKILL.md、`agentdev-spec-file-manager/references/target-area-matching.md` を参照
-
-**Step 5-1**: 複数 SPEC action の並列化（REQ/093）。異なる `target` パスの SPEC create/update は並列化可能（最大5件）。同一 SPEC ファイルへの複数 action は順序依存のため直列サブセットとして分離する。詳細は `agentdev-spec-file-manager` を参照
-
-**Step 5-2**: SPEC 宣言付与（CREATE/UPDATE）。req-define が `artifact_actions`（`artifact: spec`）の各 entry へ出力した `spec_logical_division` と `canonical_owner` を読み取り、SPEC frontmatter または冒頭宣言節へ宣言として付与する。CREATE で宣言なしで完了することを禁止。UPDATE で宣言未宣言かつ分類値が `unknown` 以外に確定の場合は宣言を補完、`unknown` または欠落の場合は警告して処理を継続（soft-contract、宣言欠落だけで保存拒否しない）。既存 SPEC の一括更新は行わず、未変更 SPEC へ遡及的に宣言を付与しない（段階適用）
+create（frontmatter `status: draft` 付き）/ update（target_area セクション置換、後方互換追記）、並列化（最大5件）、SPEC 宣言付与
 
 ### Step 6: インデックス整合
 
-新規 SPEC 作成時は `docs/specs/README.md`（SPEC 一覧）に追加する。既存 SPEC 追記時は README 更新不要。新規 SPEC 作成後に `agentdev-artifact-validation` の公開検証契約（`check-entry-existence`、RU-{NNNNNNNN}-01 合意）で登録を検証する。CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照
+新規 SPEC の `docs/specs/README.md` 一覧登録（check-entry-existence 検証）
 
 ### Step 7: SPEC 一覧整合確認
 
-SPEC 新規作成時は `docs/specs/README.md` の SPEC 一覧表に追加済みであることを確認する（Step 6 で実施済みの場合は重複確認）。SPEC 一覧表の整合は SPEC 探索導線の維持に必要な更新のみを対象とし、要件、判断、仕様の更新は含まない。
-
-**extension 更新要否の確認（REQ）**: SPEC の追加、移動、分割が `.agentdev/extensions/**` に影響するか確認する。移動または分割により extension 参照先 SPEC パスが変わる場合、当該 extension の context paths を更新する。extension 参照先 SPEC を移動した場合はエラーとし、spec-save 自身は移動を完了させずユーザー判断を仰ぐ（IR-{NNN} check #5 strict 違反を防止）。SPEC 新規作成で既存 command/skill の実行時参照が増える場合、対応 extension の `context` への追加をユーザーに提案する（直接編集しない）
-
-**targeted docs guard（REQ）**: 変更 SPEC ファイルと連動ファイル（`docs/specs/README.md`）に対し `check_changed_docs.ts --workflow spec-save --files <changed SPEC files> --json` を実行。`failures` に strict severity を含む場合は保存工程を継続せず修正して再実行。`spec_readme_update_required` が true の場合は Step 6 の更新要否判定に反映。`full_docs_check_recommended` が true の場合は `/repo/docs-check` をユーザーに提案
+targeted docs guard、extension 更新要否確認
 
 ### Step 8: ドラフト status 更新
 
-ドラフトの SPEC artifact_actions 消費状態を記録する（`draft-data` に SPEC 消費済みフラグを付与）。commit/push より前に更新し、commit 対象に含める
+SPEC 消費済みフラグ（commit 対象に含める）
 
 ### Step 9: 変更範囲検証
 
-**決定的処理のスクリプト呼出（REQ、AG-{NNN}）**: `git diff --name-only` で変更ファイル一覧を取得し、許可パスリスト（G02）との照合を `agentdev-artifact-validation` の公開検証契約（`check-change-impact`、RU-{NNNNNNNN}-01 合意）で実行。許可範囲外の変更を検出したらエラーで報告し指示を待つ（自動破棄しない）。`violations` が空でない場合は G02 違反として報告し指示を待つ。CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照
+check-change-impact
 
-### Step 10: コミット、プッシュ
+### Step 10: コミット・プッシュ
 
-`agentdev-conventional-commits` に従い main ブランチに push。Step 8 の status 変更を commit 対象に含める。並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、`git add <path>` で明示パスステージし、`git commit -- <paths>`（--only pathspec 形式）でコミットする。スイープ操作は禁止
+明示パスステージ、`git commit -- <paths>`
 
 ### Step 11: 完了報告
 
-完了報告 template に従い、保存した SPEC 一覧（新規/追記別）、スキップ有無、follow-up（安定契約例外で除外した候補）を出力
+保存した SPEC 一覧（新規/追記別）、スキップ有無、follow-up
 
-## 検証観点
+各 STEP の詳細（開始条件・結果・手順・resume point・関連 Capability Skill 連携）は `agentdev-workflow-spec-save` スキルの `references/` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない（REQ-{NNNN}-{NNN}）。
 
-- **品質ゲート（適用結果の整合性検証、AG-{NNN}、REQ）**: `target_area` 置換結果の整合性（Step 5 の `search-target-area.ts` 結果と置換後本体の一致）、SPEC status の整合性（新規作成時 `status: draft`、既存追記時 `status` 変更なし）、インデックスの整合性（`docs/specs/README.md` エントリと新規 SPEC の一致、Step 6 の `check-entry-existence.ts` 結果）、変更範囲の妥当性（Step 9 の `check-change-impact.ts` 結果）を各決定的スクリプトの JSON 結果で機械的に確認。**REQ**: spec-save の品質ゲートは内容の品質（SPEC 分離基準適合性等）を再検証せず、それは req-define の QG-{N} の責務（Step 4 SPEC 分離基準の最終確認は実施するが、これは分離基準の最終チェックであり内容品質の再審査ではない）
-- **SPEC 分離基準適合性（REQ）**: 各 action の `content` が SPEC に置くべき内容か（Step 4）
-- **frontmatter 完全性**: 新規作成時の `title`, `status: draft`, `created`, `updated`（G05）
-- **宣言付与の整合性**: CREATE で `spec_logical_division` と `canonical_owner` が frontmatter または冒頭宣言節へ付与されていること。UPDATE で宣言未宣言かつ分類値が `unknown` 以外の場合に補完されていること（Step 5-2）
-- **配置先解決の正確性**: 既存パス vs `new:{slug}` の判定、重複候補統合（Step 3）
-- **変更範囲検証**: `docs/specs/**` と `.agentdev/drafts/**` 以外の変更を含まないこと（Step 9）
-
-## target_area ベースのセクション置換ロジック（REQ/028）
-
-`operation: update` / `operation: spec-update` で action の `target_area` が指定された場合、spec-save は `agentdev-spec-file-manager/references/target-area-matching.md` のマッチング規則に従い、対象 SPEC ファイル内で `target_area` に一致する見出し行を検索しセクション置換を行う。複数マッチ時の挙動（G09 で置換拒否）、未検出時の挙動（スキップし follow-up 報告、operation を spec-create 推奨）、後方互換（target_area 未指定時は従来「追記」動作）の詳細は同 reference を参照
-
-## case-auto 並列委譲モデル（REQ/093）
-
-spec-save は複数 SPEC ファイルの変更案作成、検査を並列化できる（REQ）。異なる `target` パスの SPEC create/update は L0（完全独立）のため並列可能（最大5件）。同一 SPEC ファイルへの複数 action のみ順序依存のため直列サブセットとして分離する。直列集約対象（採番、index 更新、draft 更新、commit、push）は並列委譲の完了を待ってから実行する（REQ）。最終的な commit/push は明示パス指定（`git add <path>` + `git commit -- <paths>`）で一括実行する。詳細は `agentdev-spec-file-manager` を参照
+**soft guard（REQ-{NNNN}-{NNN}、OpenCode 1.18.15 向け）**: 本コマンドの workflow 実装本体は `agentdev-workflow-spec-save` が所有する。同 Workflow Skill は `/agentdev/spec-save` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わないこと。OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため、本宣言を soft guard として機能させる。
 
 ## ガードレール
 
@@ -133,7 +98,7 @@ spec-save は複数 SPEC ファイルの変更案作成、検査を並列化で�
 - G11: SPEC status 昇格（draft → accepted）の判定は case-close の責務。spec-save は accepted を付与しない
 
 ### Issue 作成制約
-- G12: spec-save は Issue を作成してはならない。Issue 作成は case-open の責務
+- G12: spec-save は Issue を作成してはならない。Issue 作成は case-open の責任
 
 ## エラー処理
 

--- a/src/opencode/skills/agentdev-workflow-case-auto/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-auto/SKILL.md
@@ -93,6 +93,27 @@ case-auto workflow は次の8 STEP で構成する。各 STEP は resume point �
 - **bounded parent decision**: STEP-{N} → STEP-{N}（decision_context 受領時）→ 自律解決時は STEP-{N} へ戻る、上位合意矛盾/新規ユーザー判断時は STEP-{N} 停止経路へ
 - **コンフリクトエスカレーション**: STEP-{N}（case-close 委譲時）→ STEP-{N}（Level 1 失敗時）→ 解消時は STEP-{N} へ戻る、Level 3 失敗時は STEP-{N} 停止経路へ
 
+### resume protocol
+
+- 再開点は durable state から再構成する: `case_auto_started_at` と L1 工程別タイムスタンプ、Issue/PR の存在と番号、Epic Issue 本文のステータス追跡テーブル（Wave 進行）、draft の有無（case-open 完了前のみ pre-reader）、各工程の完了結果
+- 停止時報告に再開点と再開可能な次コマンドを明示し、会話コンテキストの記憶に依存しない。case-open 成功後の再開は Issue と Epic だけで成立させる（orchestration pre-reader 契約）
+
+### termination
+
+- 正常終了: 全工程完了（OU処理ループを含む全 OU 処理完了）時の完了報告まで
+- 停止終了: 11項目の停止条件いずれかの検出時（停止理由分類済み報告）。bounded parent decision resolution での上位合意矛盾・新規ユーザー判断。経路H の user-decision-required。コンフリクト Level 3 失敗
+- 委譲起動不能時: `delegation-unavailable` として報告（委譲工程のインライン実行への切替えは行わない）
+
+## 下位 Workflow Skill 連携（上位 orchestrator）
+
+本スキルは上位 orchestrator として次の下位 Workflow Skill を名レベルで参照する（REQ-{NNNN}-{NNN}/{NNN}）。下位 workflow の契約詳細を複製しない。
+
+- `agentdev-workflow-req-save`: req-save 工程（委譲起動、委譲先 subagent が権威情報源として読み込む）
+- `agentdev-workflow-spec-save`: spec-save 工程（同上）
+- `agentdev-workflow-case-open`: case-open 工程（同上）
+- `agentdev-workflow-case-run`: case-run 工程（case-auto 自身がインライン実行の読込主体として読み込む、起動手段は harness 責務）
+- `agentdev-workflow-case-close`: case-close 工程（委譲起動、委譲先 subagent が権威情報源として読み込む）
+
 ## 主要 Capability Skill 連携
 
 本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。

--- a/src/opencode/skills/agentdev-workflow-case-auto/references/conflict-resolution-and-reporting.md
+++ b/src/opencode/skills/agentdev-workflow-case-auto/references/conflict-resolution-and-reporting.md
@@ -4,11 +4,22 @@
 
 ## STEP-{N}: コンフリクト解消 Level 2/3
 
-### 開始条件
+### Purpose
+
+case-close からエスカレーションされた PR マージコンフリクトを Level 2（インライン case-run 再実行）と Level 3（オーケストレーション級判断）で解消する。
+
+### Input Resolution
+
+1. SSoT 再構成: 両 PR の diff、コンフリクト箇所、マージ順序候補
+2. identifier 保持: PR番号群、Issue番号群
+3. 最小 scalar: Level 2 再実行回数（最大2回、元の並列実行を含む計3回）
+4. runtime artifact: なし
+
+### Preconditions
 
 - PR マージコンフリクト発生時（case-close から Level 1 失敗エスカレーション受領時）
 
-### 手順
+### Procedure
 
 PR マージコンフリクト発生時は、以下3レベルのエスカレーションで解消を図る。各レベルを試行しても解消できない場合のみ次のレベルへ進む。**機械的競合（rebase で自動解決可能）は停止条件に含まず**、Level 1 で case-close が解消する（Level 1 は case-close の責務、本 STEP では Level 2/3 の case-auto 責務を定義する）。
 
@@ -20,18 +31,41 @@ PR マージコンフリクト発生時は、以下3レベルのエスカレー�
 
 Level 2 コンフリクト文脈付きインライン case-run 再実行（AG-{NNN}）、Level 3 オーケストレーション級判断、発生元非依存、停止条件の段階化の詳細は `agentdev-workflow-orchestration` を参照。
 
-### 結果
+### Result
 
 - コンフリクト解消（Level 2 or 3 で解消時）→ STEP-{N} へ戻り再マージ
 - 解消不能時（Level 3 失敗）→ STEP-{N} 停止経路（停止条件 (8)）
 
+### Evidence
+
+- Level 別の試行記録（再実行回数、マージ順序変更、blocked 隔離）、解消/停止の判定結果
+
+### Completion Verification
+
+- 各レベルを試行しても解消できない場合のみ次レベルへ進んでいること。機械的競合を停止条件に含めていないこと
+
+### Resume-Idempotency
+
+- Level 2 再実行は回数上限（最大2回）を durable に数え、上限到達時は Level 3 へ遷移する。解消済みコンフリクトの再処理は行わない
+
 ## STEP-{N}: 完了報告
 
-### 開始条件
+### Purpose
+
+全工程完了または停止判定時の完了報告を、L1 タイムスタンプと結果状態4次元の集約を含めて出力する。
+
+### Input Resolution
+
+1. SSoT 再構成: 各工程の完了結果、Epic Issue 本文ステータス追跡テーブル（読取のみ）、L1 工程別タイムスタンプ
+2. identifier 保持: Issue番号、PR番号、OU ID
+3. 最小 scalar: 開始時刻・終了時刻・所要時間
+4. runtime artifact: なし
+
+### Preconditions
 
 - 全工程完了 または 停止判定（STEP-{N}/5/6/7 のいずれか）
 
-### 手順
+### Procedure
 
 最終工程（case-close 委譲）の完了報告をそのまま出力する。Epic Issue を伴う Wave 反復実行時は、完了・blocked・failed 子Issue 一覧を含める（Epic Issue 本文ステータス追跡テーブルから読み取り、case-auto は書き込まない、G16）。停止時は完了済み OU・進行中 OU・未実行 OU・再開可能な次コマンドを報告する。
 
@@ -57,10 +91,22 @@ Level 2 コンフリクト文脈付きインライン case-run 再実行（AG-{N
 
 Standard flow の case-close 完了後に未処理 OU が残存する場合は次 OU の処理を STEP-{N} から開始（全 OU 処理完了時のみ全体完了報告）。
 
-### 結果
+### Result
 
 - 完了報告出力（停止時フォーマットを含む）
 - L1 タイムスタンプ、4次元集約、OU処理ループ状態
+
+### Evidence
+
+- 完了報告出力（停止理由分類、タイムスタンプ内訳、stage 別結果、結果状態4次元、OU処理ループ状態）
+
+### Completion Verification
+
+- warn を pass へ変換せず集約していること。Phase 0 成功と OU 完了を別々に報告していること。Epic Issue 本文のステータス追跡テーブルから読み取りのみで書き込んでいないこと（G16）
+
+### Resume-Idempotency
+
+- 報告のみで副作用を持たない。停止時は完了済み OU・進行中 OU・未実行 OU・再開可能な次コマンドを durable state（Issue/Epic）から再構成して報告する
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-auto/references/input-resolution-and-orchestration.md
+++ b/src/opencode/skills/agentdev-workflow-case-auto/references/input-resolution-and-orchestration.md
@@ -2,13 +2,30 @@
 
 > 本 reference は `agentdev-workflow-case-auto` SKILL.md の Control Plane STEP-{N}, STEP-{N}, STEP-{N} 詳細である。入力解決、work_type 読取・工程分岐、orchestration 実行（stage モデル、Wave 反復、bg task 管理）を提供する。
 
+## 目次
+
+- STEP-{N}: 入力解決・開始時刻記録
+- STEP-{N}: work_type 読取・工程分岐
+- STEP-{N}: orchestration 実行
+
 ## STEP-{N}: 入力解決・開始時刻記録
 
-### 開始条件
+### Purpose
+
+実行開始時刻を記録し、入力モード（Issue番号/URL 入力 or 要件doc入力）を確定する。
+
+### Input Resolution
+
+1. SSoT 再構成: `.agentdev/drafts/req-draft-*.md`（要件doc入力モード時）
+2. identifier 保持: Issue番号/URL、draft パス
+3. 最小 scalar: `case_auto_started_at`（JST）
+4. runtime artifact: なし
+
+### Preconditions
 
 - case-auto command から入力が渡されている
 
-### 手順
+### Procedure
 
 実行開始時刻を JST（Etc/GMT-{N}）で記録し `case_auto_started_at` に保持。STEP-{N}（停止時報告）・STEP-{N}（完了報告）での所要時間算出の基準として使用。
 
@@ -20,18 +37,41 @@
   - (4) 特定不可: 停止
   - 複数draft読み込み時の順序制御は各draftの `operation_units` から `recommended_order` / `depends_on` に基づき決定
 
-### 結果
+### Result
 
 - 入力モード確定（Issue番号/URL入力 or 要件doc入力）
 - `case_auto_started_at` 記録
 
+### Evidence
+
+- 入力引数の解釈結果、`case_auto_started_at` の値、対象 draft パス一覧（要件doc入力モード時）
+
+### Completion Verification
+
+- 入力モードが一意に確定していること（特定不可時は停止）
+
+### Resume-Idempotency
+
+- 読取と記録のみで副作用を持たない。`case_auto_started_at` は durable state として停止時報告・完了報告で再利用する
+
 ## STEP-{N}: work_type 読取・工程分岐
 
-### 開始条件
+### Purpose
+
+`artifact_actions` 存在による動的判定で工程順序を確定し、auto_gate preflight を実施する。
+
+### Input Resolution
+
+1. SSoT 再構成: draft-data（`work_type`、`artifact_actions`、`auto_gate`）
+2. identifier 保持: なし
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
 
 - STEP-{N} で入力解決完了
 
-### 手順
+### Procedure
 
 入力要件doc の `draft-data` から work_type を取得（参考情報、パイプライン分岐の判定には使用しない）。
 
@@ -47,17 +87,40 @@
 
 `draft-data` の `auto_gate.auto_ready` が false または未解決 item（unresolved_questions/ unresolved_conflicts/ out_of_repo_operations/ stop_reasons）が残る場合は停止。
 
-### 結果
+### Result
 
 - 工程順序確定（req-save, spec-save, case-open, case-run, case-close の部分集合）
 
+### Evidence
+
+- `artifact_actions` の entry 種別、auto_gate preflight 判定結果
+
+### Completion Verification
+
+- 工程順序が一意に確定していること（auto_gate 不合格時は停止）
+
+### Resume-Idempotency
+
+- draft-data からの読取のみで副作用を持たない
+
 ## STEP-{N}: orchestration 実行
 
-### 開始条件
+### Purpose
+
+確定した工程順序に従い各工程を委譲起動またはインライン実行し、orchestration stage モデル・Wave 反復・bg task 管理を制御する。
+
+### Input Resolution
+
+1. SSoT 再構成: 各工程の durable state（REQ/Decision/SPEC ファイル、Issue/PR、Epic Issue 本文）
+2. identifier 保持: Issue番号、PR番号、OU ID、draft パス、RU パス
+3. 最小 scalar: L1 工程別タイムスタンプ、stage 2 並列数（最大5件）
+4. runtime artifact: なし（委譲工程内部の過程は親コンテキストに累積しない G28）
+
+### Preconditions
 
 - STEP-{N} で工程順序確定
 
-### 手順
+### Procedure
 
 実行モデル原則、工程別契約（req-save+spec-save 統合委譲 AG-{NNN}、case-open、case-run インライン実行 AG-{NNN}/002、case-close）、QG-{N}〜QG-{N} の継承、タイムスタンプ計測（L1）、インライン実行時のコンテキスト管理、結果状態の4次元集約、case-open 完了後の分岐（Standard flow / Epic Issue flow、クリーンアップ検証ゲート）、Wave 反復制御、OU 処理順序、クリーンアップ検証ゲート、委譲起動判定（AG-{NNN}、delegation-unavailable 停止条件）、Subagent 委譲プロトコル（category 選定ガイドライン、MUST NOT DO 必須化）、orchestration stage モデル、子 task bg task 破棄検知時の回復（AG-{NNN}〜AG-{NNN}、3状態分類、ライフサイクル分離）の各詳細は `agentdev-workflow-orchestration`、`agentdev-case-run-execution-adapter`、`agentdev-git-worktree`、各対応 skill を参照。case-run インライン実行時も case-run.md を authoritative source として読み込む。
 
@@ -98,12 +161,24 @@ req-save 委譲の出力から複数 REQ doc または scale:large を検出し�
 - 必須依存のない execution_unit 群は並列
 - 3つの「5件」文脈の区別に注意
 
-### 結果
+### Result
 
 - 各工程の実行結果（Issue/PR番号、pass/warn/fail）
 - orchestration stage 別結果・フォールバック理由・破棄回復記録
 - 結果状態の4次元（工程結果 / artifact_action 適用結果 / 定義適用工程の完了状態 / OU ライフサイクル完了状態、warn 変換禁止）
 - L1 タイムスタンプ内訳
+
+### Evidence
+
+- 各工程の起動結果（Issue/PR番号）、stage 別結果、L1 工程別タイムスタンプ、結果状態4次元の集約値
+
+### Completion Verification
+
+- 全工程の結果が4状態/結果状態4次元で受領済みであること。停止条件該当時は STEP-{N}（stop-and-decision-resolution）へ遷移していること
+
+### Resume-Idempotency
+
+- 各工程の durable state（Issue/PR、REQ/Decision/SPEC ファイル、Epic Issue 本文）から進捗を再構成する。完了済み工程を再実行しない（case-open 成功後は draft を読まない G19）
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-auto/references/stop-and-decision-resolution.md
+++ b/src/opencode/skills/agentdev-workflow-case-auto/references/stop-and-decision-resolution.md
@@ -2,13 +2,30 @@
 
 > 本 reference は `agentdev-workflow-case-auto` SKILL.md の Control Plane STEP-{N}, STEP-{N}, STEP-{N} 詳細である。停止条件検出（11項目）・停止理由分類（7軸＋上位合意矛盾/新規ユーザー判断）、adversarial-review 経路H 停止伝播、bounded parent decision resolution（限定的親判断解決）を提供する。
 
+## 目次
+
+- STEP-{N}: 停止条件検出・停止理由分類
+- STEP-{N}: adversarial-review 経路H 停止伝播
+- STEP-{N}: bounded parent decision resolution
+
 ## STEP-{N}: 停止条件検出・停止理由分類
 
-### 開始条件
+### Purpose
+
+11項目の停止条件を検出し、停止理由を分類軸で報告して再開可能な次コマンドを提示する。
+
+### Input Resolution
+
+1. SSoT 再構成: 各工程の結果、Issue/PR 状態、`case_auto_started_at` と L1 工程別タイムスタンプ
+2. identifier 保持: Issue番号、PR番号、OU ID
+3. 最小 scalar: 停止時刻、経過時間
+4. runtime artifact: なし
+
+### Preconditions
 
 - STEP-{N} で各工程の結果を受領
 
-### 手順
+### Procedure
 
 #### 停止条件（11項目）
 
@@ -48,19 +65,42 @@
 
 execution_unit 分割可能性があるにも関わらず case-open が停止した場合、「req-define 合意要件からの逸脱」ではなく「command 契約・実装不整合」として報告する（case-open の契約・実装不整合であり要件doc 側の問題ではない）。各分類の定義、対応停止条件、再開コマンド候補の詳細は `agentdev-workflow-orchestration` を参照。
 
-### 結果
+### Result
 
 - 停止判定（11項目のいずれか）
 - 停止理由分類（9軸のいずれか）
 - 停止時タイミング情報
 
+### Evidence
+
+- 検出した停止条件と根拠、停止理由分類、停止時タイミング情報（開始時刻、停止時刻、経過時間、工程別内訳）
+
+### Completion Verification
+
+- 停止条件非該当時は次工程へ継続していること。該当時は停止理由・現在地点・再開可能な次コマンドが報告されていること
+
+### Resume-Idempotency
+
+- 停止判定は各工程の durable state からの評価であり副作用を持たない。再開時は停止報告の再開ポイントから再構成する
+
 ## STEP-{N}: adversarial-review 経路H 停止伝播
 
-### 開始条件
+### Purpose
+
+下位 command から受領した adversarial-review 由来の user-decision-required + decision_context を伝播し、当該 execution_unit の自走を停止してユーザー判断を待機する。
+
+### Input Resolution
+
+1. SSoT 再構成: decision_context（下位 command が構造化したもの）
+2. identifier 保持: Issue番号、execution_unit ID
+3. 最小 scalar: なし
+4. runtime artifact: なし（raw finding は解決対象としない）
+
+### Preconditions
 
 - STEP-{N}（各工程の実行）で下位 command から adversarial-review 由来の user-decision-required + decision_context を受領
 
-### 手順
+### Procedure
 
 case-auto は当該 execution_unit の自走を停止し、ユーザー判断を待機する。停止伝播契約の詳細は case-auto command SPEC（project extension 経由参照）「adversarial-review 由来の停止伝播（経路H）」節を正とする。
 
@@ -72,19 +112,42 @@ case-auto は当該 execution_unit の自走を停止し、ユーザー判断を
 
 case-auto は経路H において review 直接起動、finding 解釈、採否、再評価を行わない。これらは下位 command の責務であり、case-auto は伝播と再開のみを担う。user-decision-required は STEP-{N} の HITL 境界停止条件分類とは独立する停止理由分類である。停止報告（STEP-{N}）には user-decision-required を停止理由分類として含める。
 
-### 結果
+### Result
 
 - 当該 execution_unit の自走停止
 - decision_context のユーザー提示
 - resume point 記録
 
+### Evidence
+
+- user-decision-required の受領形式（case-run 起源 / 工程委譲起源）、decision_context、resume point 記録
+
+### Completion Verification
+
+- 当該 execution_unit のみ停止し、他 ready 対象が継続（部分停止）していること。ユーザー提示と resume point が記録されていること
+
+### Resume-Idempotency
+
+- ユーザー判断解決後、resume point（durable state: Issue/PR 状態、委譲起点）から再開する。再 review 要否は case-auto が独自判断しない
+
 ## STEP-{N}: bounded parent decision resolution
 
-### 開始条件
+### Purpose
+
+下位 command から受領した decision_context を限定的に自律解決し、default-on + skip policy と自走性を両立する。
+
+### Input Resolution
+
+1. SSoT 再構成: 現行正規成果物（REQ、Decision、SPEC、Issue その他合意済み情報）
+2. identifier 保持: Issue番号、execution_unit ID
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
 
 - 下位 command から decision_context を受領
 
-### 手順
+### Procedure
 
 case-auto は下位 command から受領した decision_context を限定的に自律解決する。default-on + skip policy と case-auto の自走性を両立し、ユーザー停止を本質的な場面へ集約する。解決範囲、作業仮定の明示要件、停止理由分類の詳細は case-auto command SPEC（project extension 経由参照）「bounded parent decision resolution」節、delegation-contracts SPEC「case-auto による decision_context の限定的親判断解決」節、workflow-contracts SPEC「bounded parent decision resolution と停止・resume 伝播」節が正である。
 
@@ -98,10 +161,22 @@ case-auto は下位 command から受領した decision_context を限定的に�
 - **resume**: 回答、根拠、作業仮定を下位 command へ返し、既存 resume point から処理を継続する。新規永続結果型は導入しない。adversarial-review 再実行要否は adversarial-review 側の再 review 契約に従い case-auto は独自判断しない
 - **中央集約 review engine とはならない**: case-auto は raw finding を解釈、採否、候補反映しない。下位 command が構造化した decision_context のみを解決対象とし、raw finding を case-auto へそのまま渡さない（AG-{NNN}）
 
-### 結果
+### Result
 
 - 自律解決時: 回答・根拠・作業仮定を下位 command へ返し resume
 - 上位合意矛盾/新規ユーザー判断時: STEP-{N} 停止経路へ
+
+### Evidence
+
+- decision_context の分類（自律解決/作業仮定/上位合意矛盾/新規ユーザー判断）、回答と根拠（自律解決時）、作業仮定の明示（作業仮定継続時）
+
+### Completion Verification
+
+- 分類が4分類のいずれかであり、作業仮定で継続時に仮定と根拠が明示されていること。raw finding を解決対象にしていないこと
+
+### Resume-Idempotency
+
+- 回答・根拠・作業仮定を下位 command へ返し既存 resume point（durable state）から継続する。新規永続結果型は導入しないため再実行は冪等
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
@@ -92,6 +92,16 @@ case-close workflow は次の STEP で構成する。Epic Wave クローズは S
 
 配布依存境界の最終 gate は single-Issue ルート（STEP-3 Step 3-1）と Epic Wave ルート（STEP-E4-0）の両方で、PR マージ前に必ず経由する共用事前マージ seam である。両ルートとも同一 detector（`check_distribution_boundary.ts` 経由の `lib/distribution-boundary.ts`、IR-{NNN}）を呼び出し、どちらかのルートだけ gate を省略しない（DEC-{N}「事前書き込み gate と最終 gate の契約」、case-run Step 7-1 と case-close で同一 detector を再利用）。gate 違反時は両ルートとも PR マージを停止する。
 
+### resume protocol
+
+- 再開点は durable state から再構成する: Issue 本文の完了条件チェックボックス状態、PR の mergeable/マージ済み状態、HEAD commit hash、SPEC `status` frontmatter、worktree・ブランチの存在、Capture 回収済みファイルの存在
+- 各 STEP の再実行はべき等であり、マージ済み PR への再マージ、更新済みチェックボックスの再評価を発生させない
+
+### termination
+
+- 正常終了: 単一 Issue ルートはクリーンアップ・Capture 回収・永続化 STEP の完了報告まで。Epic Wave ルートは最終 Wave 判定（Epic クローズ または 残 Wave 通知）まで
+- 停止終了: 未達チェックボックス残存（構造化エラー）、QG-4 不合格、配布依存境界 最終 gate 違反、mergeable ポーリング上限超過、Level 1 rebase 失敗（case-auto エスカレーション）
+
 ## 主要 Capability Skill 連携
 
 本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。

--- a/src/opencode/skills/agentdev-workflow-case-close/references/cleanup-and-capture.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/cleanup-and-capture.md
@@ -2,34 +2,77 @@
 
 > 本 reference は `agentdev-workflow-case-close` SKILL.md の Control Plane STEP-5, STEP-6 詳細である。Post-merge テスト戦略検証、Issue クローズ、worktree/branch 削除、親Epic 自動クローズ判定、実行前同期、Capture 回収、学び検知、ドメイン状態永続化、完了報告を提供する。
 
+## 目次
+
+- STEP-5: Post-merge テスト戦略検証・Issue クローズ
+- STEP-6: クリーンアップ・Capture 回収・永続化
+
 ## STEP-5: Post-merge テスト戦略検証・Issue クローズ
 
-### 開始条件
+### Purpose
+
+マージ後のみ確認可能な項目（CI 通過等）を反映して Issue 本文を更新し、Issue をクローズする。
+
+### Input Resolution
+
+1. SSoT 再構成: PR の CI 状態、Issue 本文（テスト戦略チェックボックス）
+2. identifier 保持: Issue番号、PR番号
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
 
 - 単一 Issue クローズ ルート
 - STEP-4 で PR マージ完了
 
-### Step 5: Post-merge テスト戦略検証
+### Procedure
+
+#### Step 5: Post-merge テスト戦略検証
 
 マージ後のみ確認可能な項目（CI通過等）を反映。Issue 本文更新手続き（`agentdev-gh-cli`）で更新 → VERIFY。
 
-### Step 6: Issue クローズ
+#### Step 6: Issue クローズ
 
 Issue close 手続き（理由: completed、`agentdev-gh-cli`）。
 
-### 結果
+### Result
 
 - CI 通過確認、Issue 本文更新
 - Issue close 完了
 
+### Evidence
+
+- CI 状態確認結果、Issue 本文更新の VERIFY 結果、Issue close 結果
+
+### Completion Verification
+
+- テスト戦略チェックボックスが更新済みであり（G10）、Issue がクローズ済みであること
+
+### Resume-Idempotency
+
+- Issue の OPEN/CLOSED 状態（durable state）で再開点を判定する。クローズ済み Issue の再クローズは行わない
+
 ## STEP-6: クリーンアップ・Capture 回収・永続化
 
-### 開始条件
+### Purpose
+
+worktree/branch 削除、親Epic 自動クローズ判定、実行前同期、Capture 回収、学び検知、ドメイン状態永続化、完了報告を実施する。
+
+### Input Resolution
+
+1. SSoT 再構成: PR 本文（`## Findings / Capture候補`）、Epic Issue 本文（`Parent: #{N}`、子Issue 状態）、git 状態
+2. identifier 保持: Issue番号、親Epic 番号
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
 
 - 単一 Issue クローズ ルート
 - STEP-5 で Issue クローズ完了
 
-### Step 7: ブランチ、worktree 削除
+### Procedure
+
+#### Step 7: ブランチ、worktree 削除
 
 `agentdev-git-worktree` の worktree 削除手順に従う。
 
@@ -43,7 +86,7 @@ Issue close 手続き（理由: completed、`agentdev-gh-cli`）。
 - リモートブランチ削除
 - 削除失敗時は警告表示して停止すること
 
-### Step 8: 親Epic Issue 更新
+#### Step 8: 親Epic Issue 更新
 
 `agentdev-epic-tracker` スキル参照。
 
@@ -53,26 +96,26 @@ Issue close 手続き（理由: completed、`agentdev-gh-cli`）。
 - **子Issue 状態事前取得**: Issue 補助データ読込手続き（`agentdev-gh-cli`）で全子Issue の OPEN/CLOSED 状態を一覧取得しログ出力
 - **Epic 自動クローズ判定**: 全子Issue CLOSED → 自動クローズ。1件以上 OPEN → スキップ
 
-### Step 9: 実行前同期
+#### Step 9: 実行前同期
 
-#### Step 9-1: 重複ファイルチェック再実行
+##### Step 9-1: 重複ファイルチェック再実行
 
 `git pull --ff-only` 直前に、`agentdev-git-worktree` の「PR merge 前重複ファイルチェック」プロシージャを再実行する（L-013、PR #1128 由来、共有 main worktree で Step 1-1 実行時点から Step 9-1 実行までの間に並列セッションが加えた未コミット変更を検知するため）。重複ファイルを検出した場合、構造化エラーで停止しユーザーによる対応（stash/commit/checkout）を促すこと。
 
-#### Step 9-2: git main 同期リスク事前検出・代替同期手順選択（REQ）
+##### Step 9-2: git main 同期リスク事前検出・代替同期手順選択（REQ）
 
 `agentdev-git-worktree` の「git main 同期リスク事前検出プロシージャ（REQ）」に従い、worktree 状態（dirty tree）・並列実行による ref lock 競合・非 main ブランチ占有の3リスク事前検出と代替同期手順選択を実行する。`agentdev-git-worktree` に従い `git pull --ff-only` を実行（ローカル変更事前チェック、hash 検証、不一致時は評価・承認のやり直し）。
 
-### Step 10: 学びの検知・抽出・Capture 回収
+#### Step 10: 学びの検知・抽出・Capture 回収
 
-#### 学び検知
+##### 学び検知
 
 `agentdev-learning-capture` スキル（manual reference）に従い、エージェントが自ら学びの有無を判断（**ユーザーに学びの有無を問うことは禁止**）。
 
 - 学びあり → `.agentdev/learning/inbox.md` に直接追記 → 通知
 - 採用済み成果物取り込み判定 → `agentdev-learning-pipeline`（manual reference）の deferred ルール
 
-#### Capture 回収責務
+##### Capture 回収責務
 
 PR 本文の `## Findings / Capture候補` セクションから intake/ learning を分離回収する。
 
@@ -82,13 +125,13 @@ PR 本文の `## Findings / Capture候補` セクションから intake/ learnin
 - **Capture 境界**: intake/ learning 境界は `agentdev-workflow-orchestration`（capture-boundaries）を参照。intake と learning を別々の成果物として扱う
 - **一時会話コンテキスト不入力**: case-run の一時会話コンテキスト（ローカル変数、中間ファイル等）を capture の入力として使用しない。capture 情報の入力源は PR 本文のみ
 
-### Step 11: ドメイン状態永続化
+#### Step 11: ドメイン状態永続化
 
 `agentdev-git-worktree` に従い `.agentdev/` 配下を commit/push。learning と intake を同一 commit に含める。
 
 > **auto-close 回避の留意点**: 本コマンド名 `case-close` は "close" を含む複合語。コミットメッセージに `(case-close #N)` 等のコマンド名と Issue 番号の近接表記を用いると、GitHub が "close" を auto-close キーワードと誤認し Issue を意図せずクローズするリスクがある。コミットメッセージのフォーマットは `agentdev-conventional-commits` skill の「GitHub auto-close 回避ガイドライン」に従い、コマンド名と Issue 番号を分離し `#` 記号による近接参照を避けること（例: `case-close for Issue N`）
 
-### Step 12: 完了報告
+#### Step 12: 完了報告
 
 完了報告 template に従って出力。結果状態に応じた種別を選択。
 
@@ -100,7 +143,7 @@ PR 本文の `## Findings / Capture候補` セクションから intake/ learnin
 
 GitHub 完了後に `.agentdev` push 失敗の場合は standard 種別を使用してはならない。**結果状態の分離報告**: GitHub 側完了状態、`.agentdev` 永続化状態、ブランチ削除状態を独立して報告。
 
-### 結果
+### Result
 
 - worktree/branch 削除完了
 - 親Epic 自動クローズ判定・更新完了
@@ -109,6 +152,18 @@ GitHub 完了後に `.agentdev` push 失敗の場合は standard 種別を使用
 - 学び検知完了
 - `.agentdev/` 永続化完了
 - 完了報告出力
+
+### Evidence
+
+- worktree・ブランチ削除結果、親Epic 更新の VERIFY 結果、重複ファイルチェックとリスク検出結果、Capture 回収ファイル群、`.agentdev/` commit hash と push 結果、完了報告出力
+
+### Completion Verification
+
+- worktree/branch 削除が完了（失敗時は警告表示して停止）していること。Capture 回収が intake/learning 分離済みであること。結果状態の分離報告（GitHub 側、`.agentdev` 永続化、ブランチ削除）がなされていること
+
+### Resume-Idempotency
+
+- worktree・ブランチの非存在、Capture 回収済みファイル、`.agentdev/` の commit/push 状態（durable state）で再開点を判定する。削除済みリソースの再削除、回収済み capture の再回収を行わない
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-close/references/docs-and-spec-promotion.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/docs-and-spec-promotion.md
@@ -2,17 +2,28 @@
 
 > 本 reference は `agentdev-workflow-case-close` SKILL.md の Control Plane STEP-3 詳細である。docs/ 検証、targeted docs guard、IR-{NNN} check_extensions.ts、SPEC 確定フロー（draft → accepted 昇格）を提供する。
 
-## 開始条件
+## Purpose
+
+PR マージ前の docs 検証、拡張検査、配布依存境界 最終 gate を実施し、SPEC 確定フロー（draft → accepted 昇格）を処理する。
+
+## Input Resolution
+
+1. SSoT 再構成: PR 変更ファイル一覧、PR 本文（`## SPEC確定候補`）、対象 SPEC frontmatter `status`
+2. identifier 保持: PR番号、Issue番号、SPEC パス
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+## Preconditions
 
 - 単一 Issue クローズ ルート
 - STEP-2 で QG-4 合格
 
-## 結果
+## Result
 
-- docs/ 検証合格（targeted docs guard、IR-{NNN}）
+- docs/ 検証合格（targeted docs guard、IR-{NNN}、配布依存境界 最終 gate）
 - SPEC 確定フロー処理完了（昇格 / spec-save 提案 / 見送り）
 
-## 手順
+## Procedure
 
 ### docs/ 検証
 
@@ -74,6 +85,18 @@ SPEC status 昇格タイミング（draft → accepted）の詳細、frontmatter
 - `check_extensions.ts`（IR-{NNN}、配布物パターンのいずれかを変更した場合に実行）
 - `check_distribution_boundary.ts`（`--profile source`、PR 変更ファイルが配布 command/skill ソース面に含まれる場合に実行、DEC-{N} 決定4、REQ-{NNNN}-{NNN} 最終 gate 基底再利用）
 - test_strategy（QG-4 完了条件確認）
+
+## Evidence
+
+- targeted docs guard、check_extensions.ts、check_distribution_boundary.ts の各 JSON 結果、SPEC 確定フローの処理パターン（a/b/c）
+
+## Completion Verification
+
+- targeted docs guard の `failures` に strict severity を含まないこと。check_extensions.ts の IR-{NNN} 違反がないこと。配布依存境界 最終 gate が合格（または違反時はマージ停止）であること
+
+## Resume-Idempotency
+
+- 各検査は読取であり再実行可能。SPEC 昇格は frontmatter `status`（durable state）で判定し、`accepted` 済みの場合は再昇格しない
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-close/references/epic-wave-close.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/epic-wave-close.md
@@ -2,18 +2,29 @@
 
 > 本 reference は `agentdev-workflow-case-close` SKILL.md の Control Plane STEP-E1〜E6 詳細である。Epic Issue 番号入力時（ステータス追跡テーブル存在時）の現在 Wave の一括クローズ、Epic status table 更新、最終 Wave 判定を提供する。
 
-## 開始条件
+## Purpose
+
+Epic Issue 番号入力時（ステータス追跡テーブル存在時）に現在 Wave の子Issue を一括マージ・クローズし、Epic status table を更新、最終 Wave 判定を行う。
+
+## Input Resolution
+
+1. SSoT 再構成: Epic Issue 本文（ステータス追跡テーブル）、現在 Wave の子Issue 本文・PR 本文群
+2. identifier 保持: Epic Issue番号、子Issue番号群、PR番号群
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+## Preconditions
 
 - STEP-1 で Epic Issue と判定（ステータス追跡テーブル存在）
 
-## 結果
+## Result
 
 - 現在 Wave の全子Issue マージ、クローズ完了（E4-0 最終 gate 違反子Issue は `blocked` としてマージ対象外、Epic status table へ反映）
 - Epic status table 更新完了（単一書き手 case-close のみ）
 - Epic Issue 完了条件チェックボックス最終評価・更新（QG-4 観点8、中間 Wave vs 最終 Wave 評価スコープ切替）
 - 最終 Wave 判定結果（Epic クローズ または 残 Wave 通知）
 
-## 手順
+## Procedure
 
 現在 Wave の PR 作成済み子Issue を一括マージ、クローズし、Epic status table を更新する。最終 Wave 判定後に Epic Issue クローズ または 残 Wave 通知を行う。
 
@@ -72,6 +83,18 @@ QG-4 観点8 に基づく評価スコープ切替（中間 Wave vs 最終 Wave�
 - `agentdev-epic-tracker` 準拠
 
 詳細手順、判定基準、再読込 VERIFY、未達項目残存時の停止条件は `agentdev-epic-tracker` を正とする。
+
+## Evidence
+
+- Epic Issue 本文読取結果、E4-0 最終 gate の JSON 結果（子Issue 別）、マージ・クローズ結果、Epic status table 更新の VERIFY 結果、最終 Wave 判定根拠
+
+## Completion Verification
+
+- E4-1 対象が E4-0 合格子Issue のみであること。`blocked`/`failed` を `completed` に上書きしていないこと。Epic status table 更新後の再読込 VERIFY が合格であること
+
+## Resume-Idempotency
+
+- Epic Issue 本文のステータス追跡テーブル（durable state、case-close 単一書き手）で子Issue のマージ・クローズ進捗を再構成する。処理済み子Issue の再マージを行わない
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-close/references/issue-resolution-and-qg4.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/issue-resolution-and-qg4.md
@@ -4,11 +4,22 @@
 
 ## STEP-1: Issue 番号解決・ルーティング
 
-### 開始条件
+### Purpose
+
+Issue 番号を解決し、単一 Issue クローズと Epic Wave クローズの処理ルートを確定する。
+
+### Input Resolution
+
+1. SSoT 再構成: Issue 本文（ステータス追跡テーブル有無、`agentdev-gh-cli` の安全な読み取り手順）
+2. identifier 保持: Issue番号（ユーザー入力またはセッション内会話）
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
 
 - case-close command から Issue 番号が渡されている
 
-### 手順
+### Procedure
 
 ユーザー入力またはセッション内会話から番号を取得。複数候補時は直近を優先して確認。検出不可時はユーザーに指定を求めて停止。
 
@@ -21,18 +32,41 @@
 
 `agentdev-git-worktree` の「PR merge 前重複ファイルチェック」プロシージャに従い、ローカル未コミット変更ファイルと対象 PR 変更ファイルの重複を検出、停止条件の判定を行う。PR 補助データ読込手続き（`agentdev-gh-cli`）実行不可時は後方互換性として STEP-6（実行前同期）でフォールバック検出を維持する。
 
-### 結果
+### Result
 
 - 処理ルート確定（単一 Issue クローズ or Epic Wave クローズ）
 - 単一 Issue クローズ時: 重複ファイルチェック結果
 
+### Evidence
+
+- Issue 番号の入手経路、Issue 本文読取結果、ステータス追跡テーブル有無の判定根拠、重複ファイルチェック結果
+
+### Completion Verification
+
+- 処理ルートが一意に確定していること
+
+### Resume-Idempotency
+
+- 読取と判定のみで副作用を持たない。再実行時は同一 Issue 本文から同一ルート判定に到達する
+
 ## STEP-2: QG-4 達成判定（前提確認）
 
-### 開始条件
+### Purpose
+
+Issue 本文の完了条件チェックボックスを最終評価・更新し、達成判定（QG-4）を行う。
+
+### Input Resolution
+
+1. SSoT 再構成: Issue 本文（完了条件チェックボックス）、PR 本文（capture 入力源）、test strategy セクション
+2. identifier 保持: Issue番号、PR番号
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
 
 - 単一 Issue クローズ ルート（STEP-1 でテーブル不存在判定）
 
-### 手順
+### Procedure
 
 達成判定、完了ゲート（QG-4）→ `agentdev-quality-gates` の QG-4（Final Acceptance Gate）に従い、Issue本文の完了条件チェックボックスを最終評価、更新する。判定基準、検査観点は `agentdev-quality-gates` の QG-4 を参照。
 
@@ -41,11 +75,23 @@
 - 手順、再 grep/再検査/再計測、事後確認（再読込 VERIFY）、未達項目残存時の停止（G08）、test strategy 処理完了確認（REQ、未処理項目が残る場合は構造化エラーで停止）の詳細は `agentdev-quality-gates` の QG-4 を参照
 - PR 存在確認
 
-### 結果
+### Result
 
 - 完了条件チェックボックス評価・更新完了（再読込 VERIFY 済み）
 - 観点8 評価スコープ確定
 - test strategy 処理完了確認
+
+### Evidence
+
+- 完了条件チェックボックスの評価結果と更新後の再読込 VERIFY 結果、観点8 評価スコープ判定、test strategy 処理完了状態
+
+### Completion Verification
+
+- 未達チェックボックスが残っていないこと（残る場合は構造化エラーで停止）。更新後の再読込 VERIFY が合格であること
+
+### Resume-Idempotency
+
+- Issue 本文のチェックボックス状態（durable state、更新後に再読込）で評価済み否かを再構成する。更新済みチェックボックスを再評価しない
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-close/references/pr-merge-and-conflict.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/pr-merge-and-conflict.md
@@ -2,18 +2,29 @@
 
 > 本 reference は `agentdev-workflow-case-close` SKILL.md の Control Plane STEP-4 詳細である。PR squash マージ、mergeable UNKNOWN ポーリング、先行 commit 検出、コンフリクト Level 1 rebase パスを提供する。
 
-## 開始条件
+## Purpose
+
+PR を squash マージし、mergeable UNKNOWN ポーリング、先行 commit 検出、コンフリクト Level 1 rebase パスを処理する。
+
+## Input Resolution
+
+1. SSoT 再構成: PR の mergeable 状態、ローカル/remote の commit 状態
+2. identifier 保持: PR番号、Issue番号
+3. 最小 scalar: ポーリング試行回数（上限は gh-cli 手続き側が所有）
+4. runtime artifact: なし
+
+## Preconditions
 
 - 単一 Issue クローズ ルート
 - STEP-3 で docs 検証合格
 
-## 結果
+## Result
 
 - マージ済みPR
 - HEAD commit hash 記録
 - コンフリクト Level 1 解消完了、または case-auto Level 2/3 エスカレーション
 
-## 手順
+## Procedure
 
 ### Step 4-0: squash merge 前の mergeable UNKNOWN ポーリング
 
@@ -49,6 +60,18 @@ squash merge がコンフリクトで失敗した場合（Step 4 のリトライ
 - **実装変更は行わず** rebase のみ
 - **rebase 自動解決時**: squash merge（Step 4）へ戻り再マージ
 - **rebase コンフリクト発生時**: case-auto へエスカレーションして停止する（コンフリクト解消モデル Level 2/3 は case-auto の責務）
+
+## Evidence
+
+- mergeable 状態とポーリング記録、merge 結果と HEAD commit hash、対応記録コメントの VERIFY 結果、先行 commit 検出・処理結果、rebase 試行結果
+
+## Completion Verification
+
+- PR がマージ済みであり、HEAD commit hash が記録されていること。Level 1 rebase 失敗時はエスカレーション停止していること
+
+## Resume-Idempotency
+
+- マージ済み PR（durable state）で再実行を判定し、再マージしない。ポーリングとリトライは gh-cli 手続きの契約に従い冪等再実行可能
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-open/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/SKILL.md
@@ -85,6 +85,16 @@ case-open workflow は次の6 STEP で構成する。各 STEP は resume point �
 - **Epic flow（単一REQ `scale: large`、マルチREQ、複数 OU）**: STEP-{N} → STEP-{N} → STEP-{N}（Epic ルート、execution_unit 構成）→ STEP-{N} → STEP-{N}（Epic flow、子Issue 並列作成）→ STEP-{N}
 - **adversarial-review skip 条件**: Standard flow で単一 OU の機械的確定、Wave 分割なし（REQ-{NNNN}-{NNN}）。ユーザー明示指定時は強制発動（REQ-{NNNN}-{NNN}）
 
+### resume protocol
+
+- 再開点は durable state から再構成する: draft-data（`status`、`auto_gate`、`artifact_actions`）、GitHub Issue の存在と本文、RU ファイルの存在、削除 commit（Form Zero の残存検証）
+- 処理済み draft/RU は削除済み（durable state）で判定し、会話コンテキストの記憶に依存しない。Epic/子Issue 作成の進捗は Issue 本文のステータス追跡テーブルが正である
+
+### termination
+
+- 正常終了: 終了処理・クリーンアップ STEP の完了報告出力まで（draft/RU 削除残存検証合格を含む）
+- 停止終了: `auto_gate.auto_ready` が false、未解決質問、未解決衝突、repo 外操作、停止理由が残る場合。preflight 不合格、子Issue 上限超過、QG-{N} fail
+
 ## 主要 Capability Skill 連携
 
 本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。

--- a/src/opencode/skills/agentdev-workflow-case-open/references/adversarial-review-integration.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/references/adversarial-review-integration.md
@@ -2,19 +2,32 @@
 
 > 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-{N} 詳細である。adversarial-review 挿入境界（経路F、REQ-{NNNN}-{NNN}）の発動条件判定と review 呼出、結果反映を提供する。
 
-## 開始条件
+## Purpose
+
+経路F の adversarial-review を原則実行し（default-on）、execution structure・Issue 本文候補・完了条件の本質的争点を Issue 作成前に解消する。
+
+## Input Resolution
+
+1. SSoT 再構成: execution structure、Issue 本文候補、完了条件（QG-{N} 検証済み）
+2. identifier 保持: なし
+3. 最小 scalar: なし
+4. runtime artifact: review 対象の草案（Issue 作成前のため durable state は draft-data）
+
+## Preconditions
 
 - STEP-{N} で execution structure が確定している
 - STEP-{N} で Issue 本文候補・完了条件（QG-{N} 検証済み）が生成されている
 
-## 挿入境界
+## Procedure
+
+### 挿入境界
 
 execution structure、Issue 本文候補、完了条件を構成した後、**最初の GitHub Issue 作成の前**に挿入する。
 
 - **Epic flow の場合**: STEP-{N}（テンプレート読込）、Epic Issue 本文生成完了後、Epic Issue 作成の前
 - **Standard flow の場合**: preflight（STEP-{N}）完了後、関連ADR特定の前
 
-## 発動条件判定（REQ-{NNNN}-{NNN}、REQ-{NNNN}-{NNN}）
+### 発動条件判定（REQ-{NNNN}-{NNN}、REQ-{NNNN}-{NNN}）
 
 case-open は adversarial-review を**原則実行する**（default-on、REQ-{NNNN}-{NNN}）。発動条件判定と review 呼出を分離する（REQ-{NNNN}-{NNN}）。
 
@@ -22,7 +35,7 @@ case-open は adversarial-review を**原則実行する**（default-on、REQ-{N
 - **ユーザー明示指定時**: skip 条件にかかわらず必ず発動する（REQ-{NNNN}-{NNN}）
 - **skip 判断のためだけの新規 HITL、承認点は追加しない**
 
-## review 呼出（REQ-{NNNN}-{NNN}）
+### review 呼出（REQ-{NNNN}-{NNN}）
 
 発動条件判定で発動と判定された場合、次の3者を対象に adversarial-review を呼び出す。
 
@@ -32,7 +45,7 @@ case-open は adversarial-review を**原則実行する**（default-on、REQ-{N
 
 委譲契約は delegation-contracts SPEC（extension 経由）「adversarial-review との委譲契約接続」節に従う。
 
-## 結果反映
+### 結果反映
 
 - execution structure に関わる finding は STEP-{N}（execution-unit-and-preflight）へ戻し再評価
 - Issue 本文、完了条件に関わる finding は該当 STEP へ戻す
@@ -56,6 +69,22 @@ review の結果反映で review 対象の意味内容が変更された場合�
 ### 呼出失敗時の扱い
 
 呼出失敗時は silent skip を禁止し、従来フローを維持する（REQ-{NNNN}-{NNN}）。
+
+## Result
+
+- review 結果反映（発動時: accepted finding 反映、4パターン再実行ルール適用 / skip 時: 従来フロー継続）
+
+## Evidence
+
+- 発動条件判定結果、review 呼出記録、findings と反映結果、4パターン再実行の実行状態
+
+## Completion Verification
+
+- 発動時: unresolved なユーザー判断事項が残っていないこと（残る場合は Issue 作成 STEP へ進まない）。skip 時: skip 条件該当の根拠が記録されていること
+
+## Resume-Idempotency
+
+- review 実行は read-only（書き込み禁止型）であり副作用を持たない。同一 finding を新証拠なしに再起票しない
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-open/references/execution-unit-and-preflight.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/references/execution-unit-and-preflight.md
@@ -2,16 +2,22 @@
 
 > 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-{N} 詳細である。execution_unit 構成（連結成分アルゴリズム、3軸判断）と規模判定、構成生成事前検証（preflight）を提供する。
 
-## 開始条件
+## Purpose
+
+execution_unit 構成（連結成分アルゴリズム、3軸判断）と規模判定により実行ルートを確定し、構成生成事前検証（preflight）を実施する。
+
+## Input Resolution
+
+1. SSoT 再構成: 要件doc（`operation_units`、`depends_on`、`scale`）、関連 REQ/Decision
+2. identifier 保持: OU ID、REQ-ID
+3. 最小 scalar: 子Issue 数、Wave 同時実行数（preflight 上限検証）
+4. runtime artifact: なし
+
+## Preconditions
 
 - STEP-{N} で Issue 本文候補（execution contract 確定済み）が生成されている
 
-## 結果
-
-- execution structure 確定（Standard flow / 単一REQ Epic flow / マルチREQ Epic flow、Wave 構成）
-- preflight 5項目 合格
-
-## 手順
+## Procedure
 
 ### マルチREQ 入力判定
 
@@ -48,6 +54,23 @@ Standard/Epic/混在構成の全ルートで GitHub Issue 作成前に共通の�
 5. 全 OU が execution_unit へ割当・欠落重複なし
 
 **検証失敗時**: 上限超過または構成不備を検出した場合は Issue 作成呼び出しを行わず停止する。検証失敗時はドラフト削除、RU ファイル削除を実施せず再開可能な状態で停止。
+
+## Result
+
+- execution structure 確定（Standard flow / 単一REQ Epic flow / マルチREQ Epic flow、Wave 構成）
+- preflight 5項目 合格
+
+## Evidence
+
+- 実行ルート判定根拠（入力要件doc数、`scale`）、execution_unit 構成（OU → Wave → Issue マッピング）、preflight 5項目の検証結果
+
+## Completion Verification
+
+- preflight 5項目が全て合格であること（不合格時は Issue 作成を行わず停止）
+
+## Resume-Idempotency
+
+- 構成判定は draft-data からの読取であり副作用を持たない。検証失敗で停止した場合は同一 draft から再実行できる（ドラフト・RU は削除しないため再開可能）
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-open/references/handoff-and-ou-gate.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/references/handoff-and-ou-gate.md
@@ -2,16 +2,22 @@
 
 > 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-{N} 詳細である。SKILL.md は control plane として STEP 遷移を管理し、本 reference は STEP-{N} の実行詳細を提供する。
 
-## 開始条件
+## Purpose
+
+処理対象（全要件doc / 指定 OU / 自律選択 OU）を確定し、前工程からの引き継ぎ停止判定を行う。
+
+## Input Resolution
+
+1. SSoT 再構成: 要件doc（構造化 `draft-data`、`operation_units` セクション）
+2. identifier 保持: OU ID（指定時）、RU-ID
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+## Preconditions
 
 - case-open command から要件doc（構造化 `draft-data`）が渡されている
 
-## 結果
-
-- 処理対象が確定（全要件doc、または指定 OU、または自律選択 OU）
-- 引き継ぎ停止判定（self-hosting vs consumer）が完了
-
-## 手順
+## Procedure
 
 ### 引き継ぎ停止判定
 
@@ -27,6 +33,23 @@
   - OU 1件なら自動選択
   - 2件以上なら execution_unit 構成を生成し、STEP-{N}（execution-unit-and-preflight）へ分岐
 - **`operation_units` セクションがない場合**: 従来どおり全要件docを処理（後方互換）
+
+## Result
+
+- 処理対象が確定（全要件doc、または指定 OU、または自律選択 OU）
+- 引き継ぎ停止判定（self-hosting vs consumer）が完了
+
+## Evidence
+
+- 要件doc 読取結果、`agentdev_handoff` 判定根拠、OU 選択結果
+
+## Completion Verification
+
+- 処理対象が一意に確定していること（OU 複数時は execution_unit 構成生成へ分岐していること）
+
+## Resume-Idempotency
+
+- 読取と判定のみで副作用を持たない。再実行時は同一 draft から同一の処理対象確定に到達する
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-open/references/issue-body-and-execution-contract.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/references/issue-body-and-execution-contract.md
@@ -2,17 +2,22 @@
 
 > 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-{N} 詳細である。Issue 本文生成と execution contract（EC-{N}〜EC-{N}）確定の手順を提供する。
 
-## 開始条件
+## Purpose
+
+Issue 本文候補を生成し、execution contract（EC-{N}〜EC-{N}）を確定する。
+
+## Input Resolution
+
+1. SSoT 再構成: 要件doc（draft-data、`agreed_items`、`artifact_actions`、`test_strategy`、`review_dispositions`）、対象 REQ/Decision/SPEC、関連 ADR（Decision）
+2. identifier 保持: REQ-ID、DEC-ID、OU ID、AG-ID
+3. 最小 scalar: なし
+4. runtime artifact: Issue 本文候補ファイル（委譲接続点経由）
+
+## Preconditions
 
 - STEP-{N} で処理対象が確定している
 
-## 結果
-
-- Issue 本文候補（execution contract EC-{N}〜EC-{N} 反映済み）
-- QG-{N} 完了条件網羅性検証合格
-- test_strategy 埋め込み済み（3 要素構造）
-
-## 手順
+## Procedure
 
 ### Issue 本文生成（委譲接続点）
 
@@ -77,6 +82,24 @@ Issue 作成前に変更影響候補を探索し、scope、完了条件、test s
 
 - **VERIFY**: gh CLI 書込後は毎回 `agentdev-gh-cli` VERIFY 操作で検証
 - **テンプレート準拠**: テンプレート読込後は毎回【必須】セクションの完備を確認、【任意】は内容がある場合のみ含める、欠落時は再生成
+
+## Result
+
+- Issue 本文候補（execution contract EC-{N}〜EC-{N} 反映済み）
+- QG-{N} 完了条件網羅性検証合格
+- test_strategy 埋め込み済み（3 要素構造）
+
+## Evidence
+
+- Issue 本文候補のファイルパス、QG-{N} 検証結果、EC-{N}〜EC-{N} 確定結果、test_strategy 反映状態
+
+## Completion Verification
+
+- QG-{N} が合格であり（fail 時は req-define 差し戻し推奨）、execution contract 必須セクションが本文候補へ付与されていること
+
+## Resume-Idempotency
+
+- 本文候補はファイルパス（durable state）で保持するため、中断再開時は候補ファイルを再読込して未実行の確定ステップのみ再実行する
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-open/references/issue-creation-flows.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/references/issue-creation-flows.md
@@ -2,15 +2,30 @@
 
 > 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-{N} 詳細である。Epic flow（Step 5-9）と Standard flow（Step 10-12）の制御、GitHub Issue 作成手続きを提供する。
 
-## 開始条件
+## Purpose
+
+Epic flow（Step 5-9）または Standard flow（Step 10-12）の制御に従い GitHub Issue を作成し、OU 結果を書き戻す。
+
+## Input Resolution
+
+1. SSoT 再構成: execution structure、Issue 本文候補、関連Decision（`docs/decisions<README>.md`）
+2. identifier 保持: `{epic_number}`、子Issue 番号、OU ID
+3. 最小 scalar: 子Issue 並列数（最大5件）
+4. runtime artifact: Issue 本文候補ファイル
+
+## Preconditions
 
 - STEP-{N} で execution structure が確定している
 - STEP-{N} で adversarial-review skip または review 完了（unresolved なし）
 
-## 結果
+## Result
 
 - GitHub Issue 作成済み（親Epic + 子Issue群、または Standard Issue）
 - OU 結果の書き戻し（`operation_units` の `result` フィールド）
+
+## Procedure
+
+実行ルート（Epic flow / Standard flow）は STEP-{N} の execution structure による。各 flow の手順は以下のとおり。
 
 ## Epic flow（Step 5-9、`scale: large` またはマルチREQ または複数 OU）
 
@@ -75,6 +90,18 @@ case-open、case-auto、case-run で参照される「5件」上限は文脈ご�
 | (3) execution_unit 全体並列 | 上限なし | 必須依存がない execution_unit 群は全て並列実行可能 |
 
 case-open の Step 8「子 Issue 作成の並列化」は **(1) に該当**。3文脈は別なので混同しない。
+
+## Evidence
+
+- 作成済み Issue 番号（Epic、子Issue 群、Standard）、`agentdev-gh-cli` VERIFY 結果、OU 結果書き戻し状態
+
+## Completion Verification
+
+- 全ての Issue 作成で VERIFY 合格済みであること。子Issue 本文の先頭行に `Parent: #{epic_number}` があること。全子Issue 作成完了後に Epic 本文ステータス追跡テーブルを更新していること（部分更新でないこと）
+
+## Resume-Idempotency
+
+- Issue 番号（durable state）で作成済みを判定し、未作成分のみ作成する。Epic 本文更新は直列集約（単一書き手）で再実行冪等
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-open/references/termination-and-cleanup.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/references/termination-and-cleanup.md
@@ -2,18 +2,29 @@
 
 > 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-{N} 詳細である。コメント追加、draft/RU 削除（Form Zero）、完了報告を提供する。
 
-## 開始条件
+## Purpose
+
+Issue 作成後の共通終了処理（コメント追加、draft/RU 削除、完了報告）を実施する。
+
+## Input Resolution
+
+1. SSoT 再構成: 作成済み Issue 番号、draft ファイルパス、RU ファイルパス
+2. identifier 保持: Issue番号、topic-slug、RU-ID
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+## Preconditions
 
 - STEP-{N} で GitHub Issue 作成が完了している
 
-## 結果
+## Result
 
 - Issue へのコメント追加完了（テンプレート準拠）
 - draft/RU 削除完了（Form Zero、即時 commit + push）
 - draft/RU 削除残存検証合格
 - 完了報告出力
 
-## 手順
+## Procedure
 
 ### Step 13: コメント追加（共通終了処理）
 
@@ -50,6 +61,18 @@ Step 14/14-1 の削除コミット後に `git push` を即時実行（case-run �
 - マルチREQ Epic → `templates/case-open/multi-req-epic.md`
 
 **Capture結果 小節**: case-open 実行中に実観測した deviation を `agentdev-learning-capture` skill または `agentdev-intake-pipeline`（自動capture向け item 生成操作）へ委譲して保存した場合、保存した capture 成果物のパス・分類・保存結果のみを含める（capture 本体は含めない、成果物が無い場合は省略、共通意味契約は `artifact-contracts` SPEC「Capture結果 小節」節参照）。
+
+## Evidence
+
+- コメント追加の VERIFY 結果、削除 commit hash と push 結果、`git status --porcelain` による残存検証結果、完了報告出力
+
+## Completion Verification
+
+- draft/RU 削除残存検証が合格であること（作業ツリー、index に残存なし）。削除 commit の即時 push が成功していること
+
+## Resume-Idempotency
+
+- 削除済みパス（durable state: ファイル非存在、commit history）で再開点を判定する。コメント追加・完了報告は読取冪等であり、未実行分のみ再実行する
 
 ## resume point
 

--- a/src/opencode/skills/agentdev-workflow-case-run/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: agentdev-workflow-case-run
+description: "case-run command の workflow 実装本体。単一 Issue 実行（single workflow）と Epic Wave 実行（epic-wave workflow）の 1:N 分離構成を所有する。single は3フェーズ（準備・実行担当サブエージェント委譲・クリーンアップ）のべき等実行、epic-wave は現在 ready な Wave の子Issue 並列委譲（最大5件）、fan-out・fan-in、partial result、child task recovery を制御する。USE FOR: case-run command 実行時の workflow 制御（single Issue 実行・Epic Wave 実行・再開フェーズ判定・委譲・result 4状態処理・前置 gate・最終 gate・L2 タイムスタンプ計測）。DO NOT USE FOR: Issue 作成（case-open）、PR マージ・Issue close・Capture 回収（case-close）、最大自走 orchestration（case-auto）、実装実行そのもの（agentdev-case-run-execution-adapter 委譲内）、work_type 判定（agentdev-workflow-lifecycle）、gh CLI I/O 手続き（agentdev-gh-cli）、Wave 構成・Epic 進捗追跡ロジック（agentdev-epic-tracker）、git worktree 操作（agentdev-git-worktree）、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# case-run workflow スキル
+
+case-run command の workflow 実装本体。単一 Issue または単一 Wave の実行を実行担当サブエージェントへ委譲し、その result を処理する制御構造を所有する。case-run 本体は orchestration に専念し、実装実行そのものは行わない。
+
+単一 Issue 実行と Epic Wave 実行は制御構造に実質差異があるため、DEC-{N} の 1:N 分割基準により single workflow と epic-wave workflow の2 workflow として分離する。本 SKILL.md は両 workflow の control plane（選択 dispatch、STEP 一覧、遷移）を所有し、実行契約差異を明示する。
+
+case-run command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md（control plane）と `references/` 配下（各 STEP 詳細）が担う。
+Workflow Skill 固有契約（Command / Workflow Skill / Capability Skill 責務、1:N 分割基準、依存方向、配置契約）は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-case-run.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と case-run command の公開契約のみを前提とする。SPEC ディレクトリの内部構成は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- case-run command の実行時 workflow 制御（全 STEP、両 workflow）
+- 単一 Issue 実行モード（single workflow、3フェーズべき等実行）
+- Epic Wave 実行モード（`case-run #epic`、現在 ready な Wave の子Issue 並列委譲、最大5件）
+- 再開フェーズ判定（Issue番号解決、実行モード分岐、べき等性チェック）
+- 実行担当サブエージェント委譲（adapter protocol、委譲 prompt、L2 タイムスタンプ計測、経路G）
+- result 4状態処理（completed-pr / blocked / failed / delegation-unavailable）
+- 前置 gate 群（worktree precondition gate、QG-{N} 前置 staleness check、targeted docs guard、配布依存境界 事前チェック）と配布依存境界 最終 gate（Step 7-1 相当）
+
+## DO NOT USE FOR
+
+- 要件doc 作成、壁打ち（`/agentdev/req-define`）
+- Issue 作成・execution contract 確定（`/agentdev/case-open`）
+- PR マージ、Issue close、完了条件チェックボックス評価、Capture 回収（`/agentdev/case-close`）
+- 複数 Wave にまたがる自走、Wave 反復制御、Level 2/3 コンフリクト解消（`/agentdev/case-auto`）
+- 実装実行そのもの、work plan 生成、TDD、PR 本文作成（`agentdev-case-run-execution-adapter` 委譲内の実行担当サブエージェント責務）
+- work_type 判定基準の定義（`agentdev-workflow-lifecycle`）
+- 再開ポイント判定・状態機械・CI 対応ループの詳細プロトコル（`agentdev-workflow-orchestration`）
+- Wave 構成・Epic 進捗追跡・ステータス追跡テーブルの詳細（`agentdev-epic-tracker`）
+- gh CLI I/O 手続き、VERIFY（`agentdev-gh-cli`）
+- git worktree 操作の詳細手順（`agentdev-git-worktree`）
+
+## 入力
+
+- Issue番号またはURL（単一 Issue 実行モード）
+- Epic Issue番号またはURL（Epic Wave 実行モード、`case-run #epic`）
+- ブランチ名（自動生成または指定）
+
+## 出力
+
+- 成功: 実装済みブランチ + GitHub PR（実行担当サブエージェントが作成）。Epic Wave 実行時は子Issue ごとに PR が作成される
+- blocked / failed / delegation-unavailable: blocker 詳細は Issue コメントに SSoT として記録される（実行担当サブエージェント責務）
+
+## 副作用
+
+- worktree・ブランチ作成（`agentdev-git-worktree` 経由）
+- 実行担当サブエージェント起動（adapter skill 読込、委譲 prompt 内で実行 command 指定）
+- 親Epic ステータス更新（STEP-S3、`agentdev-epic-tracker` 経由）
+- 当該 Workflow Skill は worktree root 配下以外を編集しない（case-run command の worktree 隔離に従う）
+
+## Workflow 構成（1:N 分離、DEC-{N}）
+
+単一 Issue 実行と Epic Wave 実行は operation 差ではなく制御構造の実質差異であるため、1 workflow への統合ではなく2 workflow への分離を採る。
+
+- **single workflow**: 対象1 Issue。準備・委譲・クリーンアップの3フェーズを順次実行する
+- **epic-wave workflow**: 対象は現在 ready な Wave の子Issue 群（最大5件並列）。fan-out（子Issue ごとの worktree と委譲）と fan-in（全委譲完了待機・結果集約）を制御する
+
+workflow 選択は STEP-S1 の実行モード分岐で確定する（引数が Epic Issue 番号か否か）。Epic 全体（複数 Wave）の処理、Wave 境界（PR マージ）は case-close の責務であり、本 workflow は1 Wave の実行（PR作成まで）で return する。
+
+### 実行契約差異（single vs Epic Wave）
+
+| 契約軸 | single workflow | epic-wave workflow |
+|---|---|---|
+| target cardinality | 1 Issue | 現在 ready な Wave の子Issue 群（1 Wave 分、上限は並列数と同じ5件） |
+| parallelism | 委譲1件（直列） | 子Issue 並列委譲 最大5件（3つの「5件」文脈の (1)） |
+| fan-out / fan-in | fan-out なし。委譲1件の result を直接処理 | fan-out（子Issueごとの worktree+委譲起動）→ fan-in（全委譲完了待機・結果収集） |
+| child task recovery | 対象外（委譲1件） | 子 task 異常終了・破棄検知時は worktree git status と残留変更で帰属を確認し、個別に blocked/failed 分離。帰属不明は強制 commit しない |
+| partial result | 委譲 result が4状態のいずれか1つ | 子Issue ごとの result を独立して保持。一部 blocked/failed でも完了済み子Issue の PR は有効（partial result 許容） |
+| Wave-level completion | Issue 単位の完了（PR 作成）で終了 | 1 Wave の全委譲 result 収集と Wave 完了報告で return。Wave 境界（マージ）と次 Wave 進行は扱わない（case-close + 再実行） |
+
+## Control Plane（STEP 一覧）
+
+各 STEP は resume point を持つ（DEC-{N}、`docs/specs/<workflows/step-reference-contract>.md`）。会話コンテキストに依存せず、durable state（GitHub Issue/PR、Issue コメント、worktree・ブランチの存在、PR URL）から再開点を再構成する。
+
+### single workflow（単一 Issue 実行モード）
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-S1 | フェーズ判定・再開ポイント検出 | case-run 起動（Issue番号受領） | 実行モード確定（single）、再開フェーズ判定、引き継ぎ停止判定 | [references/single.md](references/single.md) |
+| STEP-S2 | Issue 抽出・確認・判定 | 実行モード確定（single） | 要件doc・受け入れ基準抽出、関連Decision 確認、work_type metadata 整合確認、execution contract 消費境界適用 | [references/single.md](references/single.md) |
+| STEP-S3 | Worktree 作成・ブランチ準備・前置 gate 群 | Issue 判定完了 | worktree+ブランチ作成（べき等）、前置 gate 群（precondition / staleness / targeted docs / 事前委譲チェック）合格、L2 計測 | [references/single.md](references/single.md) |
+| STEP-S4 | 実行担当サブエージェント委譲 | STEP-S3 合格（worktree 内検証済み） | 委譲起動、L2 計測、経路G（adapter 委譲内 adversarial-review） | [references/delegation-and-result.md](references/delegation-and-result.md) |
+| STEP-S5 | result 処理・配布依存境界 最終 gate | 委譲 result 受領 | result 4状態処理、Step 7-1 相当の最終 gate 判定、L2 受け渡し | [references/delegation-and-result.md](references/delegation-and-result.md) |
+| STEP-S6 | worktree クリーンアップ確認・完了報告 | result 処理完了（completed-pr 時は最終 gate 合格後） | 未コミット変更確認、完了報告（L2 内訳含む） | [references/single.md](references/single.md) |
+
+### epic-wave workflow（`case-run #epic` 受領時）
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-W1 | Epic Issue 解析・Wave 選択 | case-run 起動（Epic Issue番号受領） | 現在 ready な Wave の子Issue 群確定（入力ソース無区別、REQ/088） | [references/epic-wave.md](references/epic-wave.md) |
+| STEP-W2 | fan-out 準備 | Wave 子Issue 群確定 | `git fetch origin`、子Issue ごとの worktree+ブランチ、前置 gate 群適用（STEP-S3 と同一契約） | [references/epic-wave.md](references/epic-wave.md) |
+| STEP-W3 | fan-out 並列委譲 | fan-out 準備完了 | 子Issue 並列委譲（最大5件、STEP-S4 と同一委譲契約）、L2 計測 | [references/epic-wave.md](references/epic-wave.md) |
+| STEP-W4 | fan-in・結果集約 | 全委譲完了（または異常検知） | 子Issue ごとの result 収集、partial result 保持、child task recovery | [references/epic-wave.md](references/epic-wave.md) |
+| STEP-W5 | Wave 完了報告・return | 結果集約完了 | 1 Wave 分の完了報告（result 状態別一覧）、return（Wave 境界は扱わない） | [references/epic-wave.md](references/epic-wave.md) |
+
+### STEP 間の依存と分岐
+
+- **single**: STEP-S1（single 判定）→ STEP-S2 → STEP-S3 → STEP-S4 → STEP-S5 → STEP-S6。worktree+ブランチ既存時は STEP-S3 の作成をスキップ（べき等）。result が blocked / failed / delegation-unavailable 時は STEP-S5 で停止（STEP-S6 の報告のみ）
+- **epic-wave**: STEP-S1（epic 判定）→ STEP-W1 → STEP-W2 → STEP-W3 → STEP-W4 → STEP-W5。子Issue ごとの委譲は STEP-S4/S5 と同一契約で並列適用する
+- **最終 gate 違反**: STEP-S5 で配布依存境界 最終 gate 違反時、PR 本文に `### distribution-boundary` を記録して停止（adapter result は上書きしない）
+
+### resume protocol
+
+- 再開点は durable state から再構成する: worktree・ブランチの存在（準備フェーズ完了）、PR の存在と PR URL（委譲完了）、Issue コメント（blocked/failed の SSoT）、Epic Issue 本文のステータス追跡テーブル（Wave 進行）
+- フェーズ再開条件: 準備フェーズ（worktree+ブランチが存在しない）、委譲フェーズ（PR 未作成かつ result 未確定）、クリーンアップフェーズ（result が completed-pr）
+- 会話コンテキスト・自然言語の前 STEP result のみを resume source としない。親子 task 状態は Harness から復元し、完了済み子Issue 状態を durable domain state（PR・Issue コメント）と再構成して fan-in 判定を行う
+
+### termination
+
+- 正常終了: single は PR 作成確認とクリーンアップ完了報告まで。epic-wave は1 Wave 分の result 集約と Wave 完了報告まで
+- 停止終了: blocked / failed（Issue コメント SSoT）、delegation-unavailable（Issue を pending へ戻す）、配布依存境界 最終 gate 違反（PR 本文 SSoT）、worktree precondition gate 失敗（実行担当サブエージェント起動前に停止）
+- 引き継ぎ停止: Issue 本文に `agentdev_handoff: true` を含む場合、リポジトリ種別に応じた停止判定（`agentdev-workflow-lifecycle` runtime-package-boundary）
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-workflow-orchestration`: 再開ポイント判定、状態機械、CI 対応ループ、capture 境界、障害伝播
+- `agentdev-case-run-execution-adapter`: 実行担当サブエージェント委譲の adapter protocol、result 4状態契約、経路G
+- `agentdev-git-worktree`: worktree 作成・削除、worktree 内判定ヘルパー、並列実行安全ステージング
+- `agentdev-workflow-lifecycle`: work_type 判定、引き継ぎ停止判定（runtime-package-boundary）
+- `agentdev-epic-tracker`: Epic Issue 本文読込、Wave 子Issue 特定、親Epic ステータス更新
+- `agentdev-req-analysis`: チェックボックス品質基準
+- `agentdev-quality-gates`: QG-{N} 前置 staleness check
+- `agentdev-gh-cli`: Issue 本文読取等の I/O 手続き
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+- integrity checker skill（repo-local）: check_changed_docs.ts（targeted docs guard）、check_extensions.ts（IR-{NNN}）、check_distribution_boundary.ts（配布依存境界）
+
+## internal Workflow Extension 読込
+
+本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-case-run.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、case-run command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+
+## 共通制約
+
+- **スコープ**: 単一 Issue または単一 Wave のみを処理する。Epic 全体（複数 Wave）の一括実行、Wave 境界（PR マージ）は扱わない（workflow-contracts SPEC SC-{NNN}、extension 経由で解決）
+- **実装実行の非所有**: case-run 本体は work plan 生成、実装、TDD、乖離検出、specs 更新、PR 本文作成、PR 作成を行わない（実行担当サブエージェント責務、adapter protocol 参照）
+- **SSoT**: blocked/failed の詳細本文 SSoT は Issue コメント。completed の SSoT は PR 本文。一時会話コンテキスト、中間ファイルは SSoT としない
+- **完了条件チェックボックス**: case-run、実行担当サブエージェントは完了条件チェックボックスを更新しない（case-close QG-{N} の責務）
+- **Findings / SPEC確定候補**: 実行担当サブエージェントが PR 本文の `## Findings / Capture候補` と `## SPEC確定候補` に記録する（別セクション、混在させない）。case-run の capture 責務は記録のみ
+- **外部実行ハーネスの中間成果物**: plan artifact 等を AgentDevFlow の永続成果物として扱わず、最終結果は PR URL で受領する
+- **L2 タイムスタンプ**: worktree 設定、実行担当サブエージェント実行、worktree クリーンアップの各開始・終了時刻（JST）を計測し、完了報告の L2 内訳に含める（case-auto の L1 内訳の入力）
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **`<workflows/step-reference-contract>` SPEC**: STEP reference 構造、resume point
+- **`docs/decisions/DEC-{N}.md`**: Command / Workflow Skill / Capability Skill 責務3層分化と1:N分割原則
+- **`docs/decisions/DEC-{N}.md`**: STEP resume point と会話記憶非依存
+- **case-run command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）

--- a/src/opencode/skills/agentdev-workflow-case-run/references/delegation-and-result.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/references/delegation-and-result.md
@@ -1,0 +1,117 @@
+# 共通委譲・result 処理（delegation-and-result）
+
+> 本 reference は `agentdev-workflow-case-run` SKILL.md の共通 STEP 詳細である。STEP-S4（実行担当サブエージェント委譲）と STEP-S5（result 処理・配布依存境界 最終 gate）を所有する。single workflow から直接参照され、epic-wave workflow からは子Issue ごとの委譲契約として並列適用される。
+
+## 目次
+
+- STEP-S4: 実行担当サブエージェント委譲（経路G 含む）
+- STEP-S5: result 処理・配布依存境界 最終 gate
+
+## STEP-S4: 実行担当サブエージェント委譲（経路G 含む）
+
+### Purpose
+
+実装実行を adapter skill を読み込んだ実行担当サブエージェントへ委譲し、委譲の壁時計時間を計測する。
+
+### Input Resolution
+
+1. SSoT 再構成: Issue 本文（実行契約）、REQ/Decision/SPEC/docs/repository context（委譲先が再取得）
+2. identifier 保持: Issue番号、worktree root（相対パス、`.worktrees/{N}-{type}/`）、ブランチ名
+3. 最小 scalar: L2 タイムスタンプ（委譲起動直前・直後、JST）
+4. runtime artifact: なし（外部実行ハーネスの plan artifact 等は永続成果物としない）
+
+### Preconditions
+
+- STEP-S3（single）または STEP-W2（epic-wave）の前置 gate 群が合格していること（worktree 内検証済み）
+
+### Procedure
+
+- 実装実行を adapter skill（`agentdev-case-run-execution-adapter`）を読み込んだ実行担当サブエージェントへ委譲する（委譲 prompt 内で実行 command を指定）。起動手段は AGENTS.md および references/<harness>.md 参照。adapter protocol は同 skill 参照
+- **L2 タイムスタンプ計測**: 委譲起動直前・直後に壁時計タイムスタンプ（JST）を記録し、実行担当サブエージェント実行時間を計測する。併せて STEP-S3（worktree 設置）と STEP-S6（クリーンアップ）の開始・終了時刻を記録する
+- 委譲プロンプト、staleness check 結果の引き渡し、test strategy 項目の test-fix ループ、実行担当サブエージェントの責務（目標分解、各 criterion に observable evidence を要求、品質ゲートの実行、test-fix ループ）、委譲起動失敗・異常終了時の扱い（即 `failed` とせず実装完了・検証未完了として扱う）の詳細は `agentdev-case-run-execution-adapter` スキルを参照
+- **引き渡し**: 割り当てられた1 Issue の Issue番号、worktree root（相対パス指定、worktree 内制約）、ブランチ名
+- **PR URL 受領**: 実行担当サブエージェントが直接 PR 作成を行い、PR URL を委譲 result として返却する（PR URL フォールバック検索は使用しない）
+- **case-run 本体は実装方針を生成・審査しない（REQ-{NNNN}-{NNN}）**: 実装方針の形成、adversarial-review 呼出、結果反映は委譲内で adapter の委譲契約に従い、最初の実装変更前に実施する。case-run 本体が実装方針を生成、保持、審査するステップを新設しない。委譲 result（4状態）のみで委譲内の結果を受領する
+- **経路G（adapter 委譲内 adversarial-review、REQ-{NNNN}-{NNN}/011）**: 発動条件判定と review 呼出は adapter 委譲内で実行担当サブエージェントが分離して実施する。default-on、skip 条件（実装方針が自明の場合）該当時は省略して従来フローを継続、ユーザー明示指定時は強制発動。実装方針限定、blocked 遷移（(1) 既確定文書の変更・追加・撤回が必要、(2) 要件・仕様問題の検出、(3) unresolved な本質的争点またはユーザー判断事項が残る）の詳細は `agentdev-case-run-execution-adapter` 参照
+
+### Result
+
+- 委譲 result（4状態: completed-pr / blocked / failed / delegation-unavailable）、L2 タイムスタンプ
+
+### Evidence
+
+- 委譲起動記録、result（PR URL または Issue コメント SSoT）、L2 タイムスタンプ
+
+### Completion Verification
+
+- result が4状態のいずれかで受領されていること。completed-pr 時は PR URL が取得されていること
+
+### Resume-Idempotency
+
+- PR 未作成かつ result 未確定の場合、委譲フェーズから再開できる。委譲起動失敗・異常終了時は即 `failed` とせず実装完了・検証未完了として扱い、worktree の git status と残留変更で帰属を確認する（詳細は adapter skill の異常終了時事後処理参照）
+
+## STEP-S5: result 処理・配布依存境界 最終 gate
+
+### Purpose
+
+委譲 result を4状態契約で処理し、実装後の worktree HEAD に対して配布依存境界の最終 gate を適用する。
+
+### Input Resolution
+
+1. SSoT 再構成: 委譲 result、PR 本文（completed-pr 時）、Issue コメント（blocked/failed 時）、worktree HEAD の実ファイル
+2. identifier 保持: Issue番号、PR番号
+3. 最小 scalar: L2 タイムスタンプ（STEP-S3/S4 計測分の受け渡し）
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-S4 の委譲 result を受領している
+
+### Procedure
+
+- **result 4状態処理**（`agentdev-case-run-execution-adapter` の result 契約）:
+  - **completed-pr**: 実装完了、PR作成済み。PR番号を受け取り最終 gate（後述）へ。成功成果は PR 作成である
+  - **blocked**: 回答可能な blocker。詳細本文は Issue コメントに SSoT として記録済み（実行担当サブエージェント責務）。エラー処理に従い停止、ユーザー報告
+  - **failed**: repository context で回答不能な blocker。詳細本文は Issue コメントに構造化して記録済み。エラー処理に従い停止、ユーザー報告
+  - **delegation-unavailable**: 実行インフラが委譲を起動できなかった状態。実行未試行のため `pending` に戻す
+- **L2 タイムスタンプ受け渡し**: result 状態（completed-pr/blocked/failed）にかかわらず、STEP-S3（worktree 設定）、STEP-S4（実行担当サブエージェント実行）で計測した L2 タイムスタンプを result に含める。case-auto は本 L2 内訳を case-run 委譲の L1 壁時計時間の内訳として読み取る
+- **Step 7-1 相当: 配布依存境界の最終変更経路 gate（実装後、REQ-{NNNN}-{NNN} 再利用、DEC-{N}）**: result が `completed-pr` の場合、STEP-S6 に進む前に、実装後の実際の worktree HEAD に対して最終 gate を行う（実装担当サブエージェントが追加した変更も含めて検査する）
+  - 実行条件: result が `completed-pr` であり、PR 対象ファイルに `src/opencode/{commands,skills}/**` 変更を含む場合。当該変更を含まない PR（docs のみ等）ではスキップする
+  - 実行コマンド: `bun run .opencode/skills/<integrity-detector-skill>/scripts/check_distribution_boundary.ts --profile source --json`。現在の worktree（実装後 HEAD）の配布物ソースツリーを検査する
+  - 検出結果の分類: 検査エラー（読込不能、未分類エントリ、adapter 起動失敗）は全て gate-not-passed として扱う（DEC-{N} 決定5、TS-{NNN}）。clean として通過させない
+  - 違反検出時の停止契約（adapter result `blocked` とは区別）: 違反検出時は PR 本文の `## Findings / Capture候補` セクションに `### distribution-boundary` 小見出しで記録し、STEP-S6 へ進まず case-run を停止する。adapter result は `completed-pr` のまま変更せず、adapter result 契約の `blocked` へ上書きしない。停止理由は「配布依存境界 最終 gate 違反（PR 本文記録済み）」と報告し、SSoT は PR 本文とする。next action は同一 Issue で case-run を再実行し違反を修正する（worktree+ブランチ存活時は STEP-S3 をスキップし STEP-S4 から再開、べき等）。case-close へは進めない
+
+### Result
+
+- result 処理結果（4状態別）、最終 gate 判定（合格 / 違反停止 / スキップ）、L2 受け渡し
+
+### Evidence
+
+- result 状態と PR URL または Issue コメント、最終 gate の JSON 実行結果
+
+### Completion Verification
+
+- 4状態いずれかの処理が完了していること。completed-pr + src/opencode 変更時は最終 gate 合格（または違反記録済み停止）であること
+
+### Resume-Idempotency
+
+- 最終 gate は worktree HEAD に対する読取検査であり再実行可能。違反修正後の再実行で合格すれば同一 result（completed-pr）から STEP-S6 へ進む
+
+## 関連 STEP
+
+- 前: STEP-S3（single.md）/ STEP-W2（epic-wave.md）
+- 次: STEP-S6（single.md）/ epic-wave では STEP-W4 で集約
+
+## 関連 Capability Skill
+
+- `agentdev-case-run-execution-adapter`: adapter protocol、result 契約、経路G、異常終了時事後処理
+- `agentdev-workflow-orchestration`: 障害伝播、capture 境界
+- integrity checker skill（IR-{NNN} detector、repo 固有）: check_distribution_boundary.ts（--profile source）
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G11/G22/G23/G32（単一 Issue または単一 Wave のみ処理、実装実行の委譲、result 4状態契約）
+- G24（完了条件チェックボックスの評価・更新は case-close QG-{N} の責務）
+- G25（blocked/failed の SSoT は Issue コメント、completed の SSoT は PR 本文）
+- G26/G29（外部実行ハーネス中間成果物の非扱い、PR URL 受領）
+- G27（SPEC確定候補は PR 本文の別セクションに記録）

--- a/src/opencode/skills/agentdev-workflow-case-run/references/epic-wave.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/references/epic-wave.md
@@ -1,0 +1,222 @@
+# epic-wave workflow: Epic Wave 実行（epic-wave）
+
+> 本 reference は `agentdev-workflow-case-run` SKILL.md の epic-wave workflow 詳細である。`case-run #epic` 受領時に現在 ready な Wave の子Issue を並列実行する制御（STEP-W1〜W5）を所有する。子Issue ごとの委譲・result 処理は [references/delegation-and-result.md](delegation-and-result.md) の STEP-S4/S5 と同一契約で並列適用する。
+
+## 目次
+
+- STEP-W1: Epic Issue 解析・Wave 選択
+- STEP-W2: fan-out 準備
+- STEP-W3: fan-out 並列委譲
+- STEP-W4: fan-in・結果集約
+- STEP-W5: Wave 完了報告・return
+
+## STEP-W1: Epic Issue 解析・Wave 選択
+
+### Purpose
+
+Epic Issue 本文から現在 ready な Wave の子Issue 群を特定する。
+
+### Input Resolution
+
+1. SSoT 再構成: Epic Issue 本文（ステータス追跡テーブル、Wave 構成、子Issue 状態）
+2. identifier 保持: Epic Issue番号、子Issue番号群
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-S1 で epic-wave 実行モードが確定している（引数が Epic Issue 番号）
+
+### Procedure
+
+Epic Issue 本文を読み込み（`agentdev-epic-tracker` 参照）、現在 ready な Wave の子Issue を特定する。1 Wave の実行（PR作成まで）で return し、Wave 境界（マージ）は扱わない。同一コマンド再実行で次 Wave に進む（べき等、Epic Issue 本文から進行状況判定）。
+
+**Epic Issue の入力ソース（REQ/088）**: Epic Issue は本来の Epic flow（マルチREQ、`scale: large`）に加え、Standard flow 起因の独立 OU 自動 Epic 化（case-open が `depends_on` 空、L0 相当の独立 OU を検出して Epic 化）によるものも含む。入力ソースを区別せず、Epic Wave モデル（ADR、最大5件並列委譲）で一様に処理する。いずれのモードでも他Issue の実装履歴や Epic 全体の実装過程を前提としない。
+
+### Result
+
+- 現在 ready な Wave の子Issue 群（子Issue番号、状態）確定
+
+### Evidence
+
+- Epic Issue 本文読取結果、Wave 選択の根拠（子Issue 状態一覧）
+
+### Completion Verification
+
+- 対象 Wave の子Issue が Epic Issue 本文のステータス追跡テーブルと一致していること。ready 子Issue が0件の場合は完了報告で通知して終了
+
+### Resume-Idempotency
+
+- Wave 選択は Epic Issue 本文（durable state）からの読取であり副作用を持たない。再実行時は最新のテーブルから同一ロジックで Wave を選択する
+
+## STEP-W2: fan-out 準備
+
+### Purpose
+
+子Issue 並列委譲の前提（fetch、worktree 群、前置 gate 群）を整える。
+
+### Input Resolution
+
+1. SSoT 再構成: 子Issue 本文群、Epic Issue 本文
+2. identifier 保持: 子Issue番号群、各ブランチ名
+3. 最小 scalar: L2 タイムスタンプ（子Issue ごとの worktree 設置）
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-W1 で Wave 子Issue 群が確定している
+
+### Procedure
+
+- `git fetch origin` を実行しベースブランチの鮮度を確認する（Wave 実行時、PR merge 後再開時は必須）
+- 子Issue ごとに worktree とブランチを作成する（`agentdev-git-worktree` 参照。べき等チェック: 既存時はスキップ）
+- 子Issue ごとに前置 gate 群（single.md STEP-S3 の STEP-S3-2〜S3-5 と同一契約: worktree precondition gate、QG-{N} 前置 staleness check、docs/** 変更時 targeted docs guard、配布依存境界 事前チェック）を適用する
+- 子Issue ごとの worktree 設置の L2 タイムスタンプを記録する
+
+### Result
+
+- 全子Issue の worktree+ブランチ準備完了（べき等）、前置 gate 群の判定結果、L2 タイムスタンプ
+
+### Evidence
+
+- worktree・ブランチの存在確認結果、各 gate 実行結果、L2 タイムスタンプ
+
+### Completion Verification
+
+- 全子Issue について precondition gate が合格していること（不合格の子Issue は当該子Issue のみ起動停止とし、他子Issue へ伝播させない）
+
+### Resume-Idempotency
+
+- worktree・ブランチ既存時は作成をスキップする。一部子Issue のみ準備済みの再開では未準備分のみ作成する
+
+## STEP-W3: fan-out 並列委譲
+
+### Purpose
+
+Wave 内子Issue を実行担当サブエージェントへ最大5件並列委譲する（3つの「5件」文脈の (1)）。
+
+### Input Resolution
+
+1. SSoT 再構成: 子Issue 本文群（委譲先が再取得）
+2. identifier 保持: 子Issue番号、worktree root（相対パス）、ブランチ名
+3. 最小 scalar: 並列数（最大5件）、L2 タイムスタンプ（子Issue ごとの委譲起動直前・直後）
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-W2 の前置 gate 群が合格している（対象子Issue 分）
+
+### Procedure
+
+各子Issue を [references/delegation-and-result.md](delegation-and-result.md) STEP-S4 と同一契約で実行担当サブエージェントへ委譲する（adapter skill 読込、委譲 prompt 内で実行 command 指定、worktree root 相対パス引き渡し、経路G 含む）。並列数は最大5件とし、超過分は完了順に起動する。子Issue ごとに委譲起動直前・直後の L2 タイムスタンプを記録する。
+
+### Result
+
+- 全子Issue の委譲起動（並列、最大5件）、L2 タイムスタンプ
+
+### Evidence
+
+- 委譲起動記録（子Issue × 起動時刻）、並列数
+
+### Completion Verification
+
+- Wave 内全子Issue の委譲が起動済みであること（起動失敗は result 契約の delegation-unavailable として処理）
+
+### Resume-Idempotency
+
+- PR 未作成かつ result 未確定の子Issue は委譲フェーズから再開できる。完了済み子Issue は再委譲しない（PR 存在で判定）
+
+## STEP-W4: fan-in・結果集約
+
+### Purpose
+
+全委譲の完了を待機し、子Issue ごとの result を独立して集約する（partial result 許容）。
+
+### Input Resolution
+
+1. SSoT 再構成: 各子Issue の委譲 result、PR URL、Issue コメント（blocked/failed SSoT）、各 worktree の git status
+2. identifier 保持: 子Issue番号、PR番号群
+3. 最小 scalar: L2 タイムスタンプ（子Issue ごと）
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-W3 の全委譲が完了（または異常検知）
+
+### Procedure
+
+- 全委譲完了を待機し、各子Issue の result を4状態契約（delegation-and-result.md STEP-S5 と同一処理）で収集する
+- **partial result**: 一部の子Issue が blocked / failed / delegation-unavailable でも、完了済み子Issue の PR は有効として保持する。blocked/failed 子Issue を次 Wave へ進めない、`completed` に上書きしない
+- **child task recovery**: 子 task 異常終了・bg task 破棄検知時は worktree の git status と残留変更で帰属を確認し、個別に blocked / failed へ分離する。帰属が確認できない場合は強制 commit せず当該子 task を blocked とする
+- **compaction 復元**: 会話コンテキスト喪失後は、子 task 状態を Harness から復元し、完了済み子Issue 状態を durable domain state（PR・Issue コメント・Epic Issue 本文）と再構成して fan-in 判定を行う
+
+### Result
+
+- 子Issue ごとの result 一覧（4状態、PR番号）、partial result 保持、回復記録
+
+### Evidence
+
+- result 別子Issue 一覧、PR URL 群、Issue コメント参照、回復処理の記録
+
+### Completion Verification
+
+- Wave 内全子Issue が4状態のいずれかに分類されていること
+
+### Resume-Idempotency
+
+- 集約は durable state（PR、Issue コメント）からの再構成で冪等である。再実行時は既分類の子Issue を再処理しない
+
+## STEP-W5: Wave 完了報告・return
+
+### Purpose
+
+1 Wave 分の結果を集約報告し、Wave 境界を扱わず return する。
+
+### Input Resolution
+
+1. SSoT 再構成: STEP-W4 の集約結果、Epic Issue 本文（読取のみ）
+2. identifier 保持: Epic Issue番号、子Issue番号群、PR番号群
+3. 最小 scalar: L2 タイムスタンプ内訳
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-W4 の結果集約が完了している
+
+### Procedure
+
+完了報告 template に従い、result 状態別（completed-pr / blocked / failed / delegation-unavailable）の子Issue 一覧と PR番号、L2 タイムスタンプ内訳を出力する。Epic Issue 本文ステータス追跡テーブルの更新は行わない（case-close 単一書き手）。`completed-pr` となった子Issue を次 Wave へ進めるためには、case-close でマージ後に再度 `case-run #epic` を実行する（べき等）。
+
+### Result
+
+- 1 Wave 分の完了報告、return（PR 作成まで）
+
+### Evidence
+
+- 完了報告出力（result 別一覧、L2 内訳）
+
+### Completion Verification
+
+- 完了報告に全子Issue の result 状態と PR番号が含まれていること
+
+### Resume-Idempotency
+
+- 報告のみで副作用を持たない。Wave 進行状態は Epic Issue 本文（durable state）が正である
+
+## 関連 STEP
+
+- 前: STEP-S1（single.md、実行モード分岐）
+- 次: なし（Wave 境界は case-close、複数 Wave 制御は case-auto の責務）
+
+## 関連 Capability Skill
+
+- `agentdev-epic-tracker`: Epic Issue 本文読込、Wave 子Issue 特定、子Issue 状態 enum
+- `agentdev-case-run-execution-adapter`: 子Issue ごとの委譲契約
+- `agentdev-git-worktree`: 子Issue worktree 群の作成
+- `agentdev-workflow-orchestration`: fan-out/fan-in、child task recovery の状態管理
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G11/G22/G23/G32（単一 Wave のみ処理、1 Wave の実行で PR 作成まで return、最大5件並列委譲）
+- G24（完了条件チェックボックスの評価・更新は case-close QG-{N} の責務）
+- G25（blocked/failed の SSoT は Issue コメント、completed の SSoT は PR 本文）

--- a/src/opencode/skills/agentdev-workflow-case-run/references/single.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/references/single.md
@@ -1,0 +1,202 @@
+# single workflow: 単一 Issue 実行（single）
+
+> 本 reference は `agentdev-workflow-case-run` SKILL.md の single workflow 詳細である。STEP-S1〜S3（フェーズ判定から前置 gate 群まで）と STEP-S6（クリーンアップ・完了報告）を所有する。STEP-S4/S5 は [references/delegation-and-result.md](delegation-and-result.md) を参照。
+
+## 目次
+
+- STEP-S1: フェーズ判定・再開ポイント検出
+- STEP-S2: Issue 抽出・確認・判定
+- STEP-S3: Worktree 作成・ブランチ準備・前置 gate 群
+- STEP-S6: worktree クリーンアップ確認・完了報告
+
+## STEP-S1: フェーズ判定・再開ポイント検出
+
+### Purpose
+
+実行モード（single / epic-wave）を確定し、durable state から再開フェーズを判定する。
+
+### Input Resolution
+
+1. SSoT 再構成: Issue 本文（`agentdev-gh-cli` 読取）、Epic Issue 本文（ステータス追跡テーブル有無）
+2. identifier 保持: Issue番号（ユーザー入力またはセッション内会話）
+3. 最小 scalar: なし
+4. runtime artifact: なし（会話コンテキストのみに依存しない）
+
+### Preconditions
+
+- case-run command から Issue番号または URL が渡されている
+
+### Procedure
+
+`agentdev-workflow-orchestration` に従い再開フェーズを判定する（Issue番号解決、引数パース、妥当性確認、実行パス分岐、成果物チェックの詳細は同 skill 参照）。再開が必要なフェーズをユーザーに通知する（準備フェーズから開始する場合は省略）。実行モード分岐: 引数が Epic Issue 番号の場合は epic-wave workflow（[references/epic-wave.md](epic-wave.md)）へ。それ以外は本 workflow（STEP-S2）へ。
+
+**前工程からの引き継ぎ停止判定**: Issue 本文、要件doc本文に `agentdev_handoff: true` が含まれる場合、リポジトリ種別に応じて分岐する（詳細は `agentdev-workflow-lifecycle` runtime-package-boundary 参照）。self-hosting リポジトリでは履歴メタデータとして通常の case workflow を実施、consumer リポジトリでは実装を開始せず停止し agent-dev-flow repository への手動取り込み対象として報告する。
+
+### Result
+
+- 実行モード確定（single）、再開フェーズ判定結果、引き継ぎ停止判定結果
+
+### Evidence
+
+- Issue 本文読取結果、実行モード分岐の根拠（Epic 判定の有無）
+
+### Completion Verification
+
+- Issue番号が解決済みであり、実行モードが一意に確定していること
+
+### Resume-Idempotency
+
+- 再実行時は同じ durable state（Issue 本文、worktree・PR の存在）から同一のモード分岐・フェーズ判定に到達する。判定に副作用を持たない
+
+## STEP-S2: Issue 抽出・確認・判定
+
+### Purpose
+
+対象 Issue の実行に必要な情報を抽出し、実行契約の消費境界を適用する。
+
+### Input Resolution
+
+1. SSoT 再構成: Issue 本文（要件doc、受け入れ基準、execution contract セクション）、`docs/decisions/README.md` と関連 Decision 本文
+2. identifier 保持: Issue番号
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-S1 で single 実行モードが確定している
+
+### Procedure
+
+- Issue本文から要件docと受け入れ基準を抽出する（べき等性: worktree とブランチが既に存在する場合、STEP-S3 の作成処理をスキップする）。`agentdev-req-analysis` のチェックボックス品質基準で検証する
+- 関連Decision特定: `docs/decisions/README.md` を読み込み、関連Decisionがあれば個別に読み込み、実装がDecisionの決定事項に矛盾しないことを確認する
+- work_type 判定: `agentdev-workflow-lifecycle` に従い bugfix/feature/maintenance/docs_chore を判定する（scale は feature のみ standard/large、workflow_route は都度導出し保存しない）
+- **execution contract 消費境界（REQ-{NNNN}）**: 完了条件、test strategy、必須品質統制を実行契約として扱う。不足・曖昧さ・矛盾・実現不能を検出した場合は自律補完せず blocked とする。test strategy を新規設計せず記録済み項目を実行する。必須品質統制の適用要否を再判断しない。work_type/scale/Issue structure を再分類して実行契約を変更しない
+  - runtime-only 判断の維持: worktree 状態確認、QG-{N} 前置 staleness check、実 diff 検査、実装結果・test 実行結果は case-run の安全検査として維持する
+  - blocked 遷移と case-update 連携: 完了条件の不足・曖昧さ・矛盾・実現不能、scope-affecting impact candidate の発見、関連 ADR への適合確認で新たな拘束の必要性検出、必須品質統制の追加変更必要性、Issue metadata・構造・実態の矛盾検出時は blocked とし、Issue 更新は case-update へ委譲する（case-run 単独では Issue 本文を書き換えない）
+  - 新旧 Issue 互換運用: execution contract 必須セクション（Execution Contract セクション、必須品質統制セクション）存在有無で新旧 Issue を識別する（presence-based 判定）。必須セクション不存在の legacy Issue は、新契約項目欠落のみを理由に一律 blocked にしない
+  - work_type/scale 確認の縮約: work_type 確認は再分類ではなく metadata 整合確認へ縮約して維持する
+
+### Result
+
+- 要件doc・受け入れ基準抽出済み、関連Decision確認済み、work_type metadata 整合確認済み、execution contract 消費境界適用済み
+
+### Evidence
+
+- Issue 本文読取結果、関連Decision 一覧、消費境界判定結果（blocked 時はその理由）
+
+### Completion Verification
+
+- 抽出情報が Issue 本文と一致し、実行契約の消費原則適用判断が記録されていること
+
+### Resume-Idempotency
+
+- Issue 本文からの抽出は読取のみで副作用を持たない。再実行時は同一の抽出結果になる
+
+## STEP-S3: Worktree 作成・ブランチ準備・前置 gate 群
+
+### Purpose
+
+実行担当サブエージェント起動前の隔離環境を整え、前置 gate 群を合格させる。
+
+### Input Resolution
+
+1. SSoT 再構成: 対象 Issue 本文（変更対象ファイル等）、Epic Issue 本文（STEP-S3-1 親Epic ステータス更新時）
+2. identifier 保持: Issue番号、ブランチ名（自動生成または指定）
+3. 最小 scalar: L2 タイムスタンプ（本 Step 開始・終了時刻、JST）
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-S2 完了（Issue 判定済み）
+
+### Procedure
+
+- **Worktree 作成・ブランチ準備**: `agentdev-git-worktree` に従って実行する。ベースブランチを明示的に指定する。べき等チェック: worktree 既存時は作成をスキップする。Wave 実行時、PR merge 後再開時は worktree 作成前に `git fetch origin` を実行しベースの鮮度を確認する
+- **L2 タイムスタンプ計測**: 本 Step の開始時刻・終了時刻（JST）を記録し、worktree 設定時間を計測する（完了報告の L2 内訳に含める）
+- **STEP-S3-1 親Epic ステータス更新**: `agentdev-epic-tracker` 参照
+- **STEP-S3-2 worktree precondition gate**: `agentdev-git-worktree` の「worktree 内判定ヘルパー」に従い、当該 Issue の worktree+ブランチが作成済みであり、現在 worktree 内にいることを検証する。検証失敗時（worktree 未作成、メインリポジトリにいる）は実行担当サブエージェントを起動せず停止し、STEP-S3 へ戻るようユーザーに報告する
+- **STEP-S3-3 QG-{N} 前置 staleness check**: `agentdev-quality-gates` の「case-run 前置 staleness check」に従い、ファイルパス現行存在確認、検査結果件数再計測、差異検出時の引き渡し・case-update 連携を実行する。本検査は QG-{N} 本体（委譲先が実施する PR 作成直前ゲート）とは独立した前置検査であり、QG-{N} deviation 分類運用、QG-{N} 本体実施要否には影響しない
+- **STEP-S3-4 docs/** 変更時の targeted docs guard: PR 対象ファイルに docs/** 変更を含む場合、委譲前に targeted docs guard を行う（`bun run .opencode/skills/<integrity-detector-skill>/scripts/check_changed_docs.ts --workflow case-run --base-ref <ベース> --json`、変更ファイルは worktree 内の git diff から取得）。docs/** 変更を含まない PR ではスキップする。検出結果（failures の strict severity）は PR 本文の `## Findings / Capture候補` に `### docs-integrity` 小見出しで記録する（実行担当サブエージェント責務）
+- **STEP-S3-5 配布依存境界の事前委譲チェック（オプション）**: PR 対象ファイルに `src/opencode/{commands,skills}/**` 変更を含む場合、委譲前に事前チェックを実施できる。本チェックは予備的であり、本式の最終 gate は STEP-S5（実装後）で実行される。事前チェックで違反を検出した場合は委譲プロンプトで実行担当サブエージェントに引き渡す
+
+**case-run が使用する検査ツール**（integrity 契約 SPEC「Workflow × 使用ツールマトリックス」参照）: check_changed_docs.ts（--workflow case-run、docs/** 変更を含む場合に委譲前に実行）、check_extensions.ts（IR-{NNN}、`.opencode/commands/agentdev/**/*.md`、`.opencode/skills/agentdev-*/SKILL.md`、`.opencode/skills/agentdev-*/references/**/*.md`、`.agentdev/extensions/**` のいずれかを変更した場合に実行）、check_distribution_boundary.ts（--profile source、STEP-S5 で実装後 worktree の実際の src/opencode/ を検査）、test_strategy（Issue 完了条件検証）
+
+### Result
+
+- worktree+ブランチ作成済み（べき等）、前置 gate 群の判定結果、L2 タイムスタンプ記録済み
+
+### Evidence
+
+- worktree・ブランチの存在確認結果、各 gate の実行結果（JSON 等）、L2 タイムスタンプ
+
+### Completion Verification
+
+- STEP-S3-2 precondition gate が合格していること（不合格の場合は次 STEP へ進まない）
+
+### Resume-Idempotency
+
+- worktree・ブランチ既存時は作成をスキップする。gate 群は再実行可能であり、同一 worktree 状態に対して同一判定を返す
+
+## STEP-S6: worktree クリーンアップ確認・完了報告
+
+### Purpose
+
+委譲 result を受領した後の worktree 状態を確認し、L2 内訳を含む完了報告を出力する。
+
+### Input Resolution
+
+1. SSoT 再構成: 委譲 result（PR URL、Issue コメント）、worktree の git status
+2. identifier 保持: Issue番号、PR番号
+3. 最小 scalar: L2 タイムスタンプ（本 Step 開始・終了時刻、JST）
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-S5 で result 処理完了（completed-pr 時は最終 gate 合格後）
+
+### Procedure
+
+- 未コミット変更あり: 報告してユーザーの指示に従う。自動的な破棄、コミットは行わない
+- 未コミット変更なし: 完了報告へ。runtime workspace のクリーンアップは harness の責務であり、case-run は関与しない
+- 完了報告 template に従って出力する（実行担当サブエージェント result 状態、PR番号を含める）
+- 本 Step（worktree クリーンアップ）の開始時刻・終了時刻（JST）を記録し、worktree クリーンアップ時間を計測する。完了報告に L2 タイムスタンプ内訳（worktree 設定時間、実行担当サブエージェント実行時間、worktree クリーンアップ時間）を含める
+
+### Result
+
+- worktree 状態確認結果、完了報告（result 状態、PR番号、L2 内訳）
+
+### Evidence
+
+- git status 結果、完了報告出力
+
+### Completion Verification
+
+- 完了報告に result 状態と L2 内訳が含まれていること
+
+### Resume-Idempotency
+
+- 報告のみの STEP であり副作用を持たない。再実行時は最新の git status と result から再構成する
+
+## 関連 STEP
+
+- 前: STEP-S5（delegation-and-result.md）
+- 次: なし（workflow 終了）
+
+## 関連 Capability Skill
+
+- `agentdev-git-worktree`: worktree 作成、worktree 内判定ヘルパー
+- `agentdev-epic-tracker`: 親Epic ステータス更新
+- `agentdev-quality-gates`: QG-{N} 前置 staleness check
+- `agentdev-workflow-orchestration`: 再開フェーズ判定
+- `agentdev-req-analysis`: チェックボックス品質基準
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G04（全ファイル操作は worktree 内で実行）
+- G30/G31（Step 5-2 precondition gate、worktree root 相対パス引き渡し）
+- G33/G34/G35（QG-{N} 前置 staleness check、差異検出時の引き渡しと case-update 連携）
+
+## 関連ガイドライン
+
+- **テスト戦略（TS）標準手順**: 関数削除を伴う Issue の test strategy には、削除対象関数の全使用箇所 grep 確認手順を含める（L-014、PR #1140 / #1139 Epic #1138 由来。詳細は `agentdev-req-analysis` 参照）
+- **エラー処理**: エラー発生時の対応は `agentdev-workflow-orchestration` に従う。result が blocked/failed の場合、Issue コメント（SSoT）を参照して停止理由、再開ポイントをユーザーに報告する

--- a/src/opencode/skills/agentdev-workflow-case-update/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-update/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: agentdev-workflow-case-update
+description: "case-update command の workflow 実装本体。既存Caseの本文更新（--body）、コメント追加（--comment）、REQファイル更新（--req）、レビューNG専用フロー（--review-ng）の4分岐と Issue番号解決、現在状態取得、完了報告の制御を所有する。USE FOR: case-update command 実行時の workflow 制御（更新種別分岐・テンプレート構造維持・QG-{N} 乖離検出結果引用・APPEND vs UPDATE 判定）。DO NOT USE FOR: Issue 実装・CI 対応・自律修正ループ（case-run）、PR マージ・Issue close（case-close）、要件doc 作成（req-define）、REQ 保存の正式工程（req-save。--req は直接 commit+push を行う）、レビュー拒否タイプ分類・次コマンド推論の定義（agentdev-workflow-routing）、テンプレート選定規則の定義（agentdev-workflow-templates）、gh CLI I/O 手続き（agentdev-gh-cli）、work_type 判定（agentdev-workflow-lifecycle）、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# case-update workflow スキル
+
+case-update command の workflow 実装本体。既存Caseの本文更新、コメント追加、REQファイル更新、レビューNG時対応の制御構造を所有する。主にレビューNG時の対応で使用される。CI/CD修正、自律修正ループは管轄外（case-run の責務）である。
+
+case-update command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md（control plane）と `references/` 配下（各 STEP 詳細）が担う。
+Workflow Skill 固有契約は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-case-update.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と case-update command の公開契約のみを前提とする。SPEC ディレクトリの内部構成は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- case-update command の実行時 workflow 制御（全 STEP）
+- Issue番号解決（ユーザー入力・セッション会話から。一覧取得禁止）
+- 現在のIssue状態取得とフェーズ判定
+- 更新種別分岐（`--body` / `--comment` / `--req` / `--review-ng`）と更新種別推論
+- Issue本文更新（テンプレート構造維持、【必須】セクション検査）
+- コメント追加、REQファイル更新（APPEND vs UPDATE 判定、直接 commit+push）
+- レビューNG専用フロー（QG-{N} 乖離検出結果の引用、乖離タイプ分類、推奨アクション）
+
+## DO NOT USE FOR
+
+- Issue 実装、実行担当サブエージェント委譲、CI/CD修正、自律修正ループ（`/agentdev/case-run`）
+- PR マージ、Issue close、完了条件チェックボックス評価（`/agentdev/case-close`）
+- 要件doc 作成（`/agentdev/req-define`）
+- REQ 保存の正式工程（`/agentdev/req-save`。`--req` は req-save への委譲を行わず直接 commit+push を行う）
+- レビュー拒否タイプ分類・次コマンド推論規則の定義（`agentdev-workflow-routing`）
+- Issue/PR テンプレート選定規則の定義（`agentdev-workflow-templates`）
+- gh CLI I/O 手続き、VERIFY（`agentdev-gh-cli`）
+- work_type 分岐判定基準の定義（`agentdev-workflow-lifecycle`）
+
+## 入力
+
+- Issue番号
+- 更新内容（本文更新 or コメント追加 or REQファイル更新）
+- 更新種別（`--body` / `--comment` / `--req` / `--review-ng`）
+
+## 出力
+
+- 更新されたIssue本文、追加されたコメント、更新されたREQファイル、レビューNGコメントのいずれか
+
+## 副作用
+
+- Issue 本文更新、Issue コメント追加（`agentdev-gh-cli` 経由）
+- REQ ファイル更新と commit+push（`--req` 時、`agentdev-git-worktree` の並列実行安全ステージング準拠）
+- フェーズは変更しない（現在のフェーズを維持、G01）
+
+## Control Plane（STEP 一覧）
+
+case-update workflow は次の4 STEP で構成する。各 STEP は resume point を持つ（DEC-{N}、`docs/specs/<workflows/step-reference-contract>.md`）。会話コンテキストに依存せず、durable state（Issue 本文・コメントの現状、REQ ファイル、git 状態）から再開点を再構成する。
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-1 | Issue番号解決 | case-update 起動 | Issue番号確定 | [references/update-flows.md](references/update-flows.md) |
+| STEP-2 | 現在のIssue状態取得 | Issue番号確定 | 現在フェーズ判定 | [references/update-flows.md](references/update-flows.md) |
+| STEP-3 | 更新内容分岐・実行 | 現在状態取得済み | 更新実行（--body / --comment / --req / --review-ng 別） | [references/update-flows.md](references/update-flows.md) |
+| STEP-4 | 完了報告 | 更新実行完了 | 種別別完了報告 | [references/update-flows.md](references/update-flows.md) |
+
+### STEP 間の依存と分岐
+
+- **標準経路**: STEP-1 → STEP-2 → STEP-3（4分岐）→ STEP-4
+- **更新種別推論**: 種別指定がない場合、ユーザー入力、直前のレビュー結果、対象Issue/REQ、会話文脈から推論する。推論不能時のみユーザーに指定を求めて停止する
+
+### resume protocol
+
+- 再開点は durable state から再構成する: Issue 本文・コメントの現状（更新済み否かの判定）、REQ ファイルの git 状態（commit 済み否か）
+- 更新の重複適用は、更新後の Issue 本文/コメント読戻しと REQ ファイルの git log で検出して回避する
+
+### termination
+
+- 正常終了: STEP-4 の完了報告出力まで
+- 停止終了: Issue番号解決不能（ユーザー指定待ち）、更新種別推論不能（ユーザー指定待ち）
+- フェーズ変更は行わない。CI/CD修正、自律修正ループは実施しない（case-run の管轄）
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-workflow-routing`: Issue番号解決、--body/--comment/--req/--review-ng 各フロー詳細、レビュー拒否タイプ分類
+- `agentdev-workflow-lifecycle`: 現在フェーズ判定、work_type 分岐の参照
+- `agentdev-workflow-templates`: テンプレート選定、コメント/レビューNGコメントの【必須】セクション検査
+- `agentdev-gh-cli`: Issue 本文更新、Issue コメント追加の I/O 手続きと VERIFY
+- `agentdev-quality-gates`: QG-{N} 乖離検出結果の引用（--review-ng 時）
+- `agentdev-git-worktree`: `--req` 時の並列実行安全ステージング
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+
+## internal Workflow Extension 読込
+
+本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-case-update.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、case-update command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+
+## 共通制約
+
+- **フェーズ維持**: フェーズは変更しない（現在のフェーズを維持）
+- **管轄外**: CI/CD修正、自律修正ループは case-update の管轄外（case-run の責務）。REQ更新、レビューNG時のコメント追加、Issue本文更新のみを責務とする
+- **SSoT 整合**: Issue本文と要件docの不整合を防ぐ（G04）
+- **テンプレート構造維持**: `--body` 更新時は Issue 作成時と同じテンプレート構造を維持し、【必須】セクションの欠落がないことを確認してから投稿する
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **`<workflows/step-reference-contract>` SPEC**: STEP reference 構造、resume point
+- **`docs/decisions/DEC-{N}.md`**: Command / Workflow Skill / Capability Skill 責務3層分化と1:N分割原則
+- **`docs/decisions/DEC-{N}.md`**: STEP resume point と会話記憶非依存
+- **case-update command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）

--- a/src/opencode/skills/agentdev-workflow-case-update/references/update-flows.md
+++ b/src/opencode/skills/agentdev-workflow-case-update/references/update-flows.md
@@ -1,0 +1,187 @@
+# STEP-1〜4: Issue番号解決・状態取得・更新分岐・報告（update-flows）
+
+> 本 reference は `agentdev-workflow-case-update` SKILL.md の STEP-1〜STEP-4 詳細である。Issue番号解決、現在状態取得、更新内容分岐（--body / --comment / --req / --review-ng）、完了報告を提供する。
+
+## 目次
+
+- STEP-1: Issue番号解決
+- STEP-2: 現在のIssue状態を取得
+- STEP-3: 更新内容に応じて分岐
+- STEP-4: 完了報告
+
+## STEP-1: Issue番号解決
+
+### Purpose
+
+対象 Issue を特定する。
+
+### Input Resolution
+
+1. SSoT 再構成: なし（番号はユーザー入力またはセッション内会話からのみ取得）
+2. identifier 保持: Issue番号
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- case-update command が起動している
+
+### Procedure
+
+詳細は `agentdev-workflow-routing` を参照。委譲接続点: サブエージェントは候補番号抽出のみを返し、親エージェントが確認、停止を判断する。Issue/PR 一覧取得手続き（`agentdev-gh-cli`）等で open issue 一覧を取得することは禁止（G03）。
+
+### Result
+
+- Issue番号確定
+
+### Evidence
+
+- 番号の入手経路（ユーザー入力 or セッション会話）
+
+### Completion Verification
+
+- 番号が一意に確定していること（解決不能時はユーザーに指定を求めて停止）
+
+### Resume-Idempotency
+
+- 読取のみで副作用を持たない
+
+## STEP-2: 現在のIssue状態を取得
+
+### Purpose
+
+対象 Issue の現在フェーズを判定する。
+
+### Input Resolution
+
+1. SSoT 再構成: Issue 本文（`agentdev-gh-cli` の安全な読み取り手順）
+2. identifier 保持: Issue番号
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-1 で Issue番号が確定している
+
+### Procedure
+
+`agentdev-workflow-lifecycle` で現在フェーズを判定する。
+
+### Result
+
+- 現在フェーズ判定結果
+
+### Evidence
+
+- Issue 本文読取結果、フェーズ判定根拠
+
+### Completion Verification
+
+- フェーズが判定済みであること
+
+### Resume-Idempotency
+
+- 読取のみで副作用を持たない
+
+## STEP-3: 更新内容に応じて分岐
+
+### Purpose
+
+更新種別（--body / --comment / --req / --review-ng）に応じた更新を実行する。
+
+### Input Resolution
+
+1. SSoT 再構成: Issue 本文、対象 REQ ファイル、直前のレビュー結果
+2. identifier 保持: Issue番号、REQ番号
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-2 で現在状態が取得されている
+
+### Procedure
+
+- **`--body`**: Issue作成時に使用されたテンプレートに従って更新する。詳細は `agentdev-workflow-routing` を参照。委譲接続点: サブエージェントは本文案と必須セクション検査のみを返し、親エージェントが Issue 本文更新手続き（`agentdev-gh-cli`）を行う
+- **`--comment`**: 更新コメントを追加する。詳細は `agentdev-workflow-routing` を参照。委譲接続点: サブエージェントはコメント案と必須セクション検査のみを返し、親エージェントが投稿する
+- **`--req`**: REQファイル更新を行う。case-update --req は直接 commit+push を行う（req-save への委譲は行わない）。詳細は `agentdev-workflow-routing` を参照。委譲接続点: サブエージェントは関連REQ候補、APPEND/UPDATE候補、根拠のみを返し、親エージェントがファイル更新と commit/push を行う。APPEND vs UPDATE 判定基準: APPEND は要件テーブルへの行追加、適用範囲の拡張（例: 受け入れ基準の追加、新規要件の追加）。UPDATE は既存セクションの内容修正（例: テキスト置換、要件の文言修正、適用範囲の変更）
+- **`--review-ng`**: レビューNG時の専用フローを実行する。必ず QG-{N}（`agentdev-quality-gates`）の乖離検出結果を引用する（G05）。詳細は `agentdev-workflow-routing` を参照。委譲接続点: サブエージェントは乖離タイプ候補、推奨アクション、更新漏れ候補のみを返し、親エージェントがコメント投稿とREQ更新判断を行う
+
+### Result
+
+- 更新実行（Issue本文 / コメント / REQファイル+commit / レビューNGコメント）
+
+### Evidence
+
+- 更新後の Issue 本文/コメント（`agentdev-gh-cli` VERIFY 結果）、REQ ファイルの commit hash
+
+### Completion Verification
+
+- テンプレート【必須】セクションが全て含まれていることを確認してから投稿していること（G06/G07）。SSoT 整合が維持されていること（G04）
+
+### Resume-Idempotency
+
+- 更新後の Issue 本文・コメントの読戻しで適用済みを検出し、重複適用を回避する。`--req` は REQ ファイルの git log で commit 済み否かを判定する
+
+## STEP-4: 完了報告
+
+### Purpose
+
+更新種別に応じた完了報告を出力する。
+
+### Input Resolution
+
+1. SSoT 再構成: STEP-3 の更新結果
+2. identifier 保持: Issue番号、REQ番号
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-3 の更新が完了している
+
+### Procedure
+
+完了報告 template に従って出力する。更新種別に応じた種別を選択する:
+
+- `--body` → `.opencode/commands/agentdev/templates/case-update/body.md`
+- `--comment` → `.opencode/commands/agentdev/templates/case-update/comment.md`
+- `--req` → `.opencode/commands/agentdev/templates/case-update/req.md`（変数: {APPEND/UPDATE}, {REQ番号}, {セクション名}）
+- `--review-ng` → `.opencode/commands/agentdev/templates/case-update/review-ng.md`（変数: {乖離タイプ}, {REQ番号}, {推奨アクション}）
+
+更新種別の推論: ユーザー入力、直前のレビュー結果、対象Issue/REQ、会話文脈から推論する。推論不能時のみユーザーに指定を求めて停止する。
+
+### Result
+
+- 完了報告出力
+
+### Evidence
+
+- 完了報告本文（種別、更新対象）
+
+### Completion Verification
+
+- 選択種別が更新内容と一致していること
+
+### Resume-Idempotency
+
+- 報告のみで副作用を持たない
+
+## 関連 STEP
+
+- 前: なし（workflow 開始）
+- 次: なし（workflow 終了）
+
+## 関連 Capability Skill
+
+- `agentdev-workflow-routing`: 各更新種別フローの詳細、委譲接続点
+- `agentdev-workflow-lifecycle`: フェーズ判定
+- `agentdev-gh-cli`: Issue 更新・コメント追加の I/O 手続きと VERIFY
+- `agentdev-quality-gates`: QG-{N} 乖離検出結果の引用
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G01/G02（フェーズ維持、管轄外の明確化）
+- G03（Issue番号解決に一覧取得禁止）
+- G04/G05/G06/G07（SSoT 整合、QG-{N} 引用、テンプレート構造維持、【必須】セクション確認）
+- G08/G09（gh CLI 委譲、安全な読み取り手順）

--- a/src/opencode/skills/agentdev-workflow-req-define/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-req-define/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: agentdev-workflow-req-define
+description: "req-define command の workflow 実装本体。セッションコンテキスト検知・入力解決から壁打ち対話、既存REQ照合、要件展開、Decision判断、要件doc（draft-data）生成、work_type・Scale 判定、adversarial-review 経路A、ドラフト保存、要件doc確認、完了報告までの対話型 workflow 制御を所有する。USE FOR: req-define command 実行時の workflow 制御（対話開始・HITL・blocked・resume・draft 生成）。DO NOT USE FOR: REQ/Decision ファイル保存（req-save）、SPEC 保存（spec-save）、Issue 作成（case-open）、要件分析手法・品質基準の定義（agentdev-req-analysis）、REQ ファイル操作（agentdev-req-file-manager）、Decision要否判定（agentdev-decision-guidelines）、work_type・Scale 判定基準（agentdev-workflow-lifecycle）、gh CLI I/O 手続き（agentdev-gh-cli）、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# req-define workflow スキル
+
+req-define command の workflow 実装本体。機能追加またはバグ修正の要件を整理・定義する壁打ち workflow の制御構造を所有する。対話（HITL）と durable state（要件doc draft、RU）の分離を維持し、中断・再開を可能にする。
+
+req-define command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md（control plane）と `references/` 配下（各 STEP 詳細）が担う。
+Workflow Skill 固有契約は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-req-define.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と req-define command の公開契約のみを前提とする。SPEC ディレクトリの内部構成は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- req-define command の実行時 workflow 制御（全 STEP）
+- セッションコンテキスト検知、明示入力ファイル・RU 自動検出（session由来RU 消費契約の適用）
+- 壁打ち対話と前工程からの引き継ぎ判定
+- 既存REQ照合（CREATE 前 APPEND/UPDATE 評価、定量的データ検証、SPLIT 予兆計測）
+- 要件展開（変更影響候補抽出、分類ゲート、文書分類妥当性検証、Decision要否確認ゲート、実行主体分類表、test strategy 定義）
+- Decision判断（Decision候補記録、番号指定形式）
+- 要件doc 生成（構造化 `draft-data`、operation_units、artifact_actions、test_strategy、review_dispositions）
+- work_type 判定・Scale 判断、adversarial-review 挿入境界（経路A）
+- ドラフト保存・要件doc確認・完了報告
+
+## DO NOT USE FOR
+
+- REQ/Decision ファイル保存、採番（`/agentdev/req-save`、`agentdev-req-file-manager`）
+- SPEC ファイル保存（`/agentdev/spec-save`、`agentdev-spec-file-manager`）
+- Issue 作成（`/agentdev/case-open`）
+- 要件分析の観点・Phase 詳細の定義（`agentdev-req-analysis`）
+- Decision要否判定基準（`agentdev-decision-guidelines`）
+- アーキテクチャ助言（`agentdev-architecture-advisory`）
+- work_type・Scale 判定基準の定義（`agentdev-workflow-lifecycle`）
+- 対論型レビュー自体の実行（`agentdev-adversarial-review`、経路Aで呼出のみ）
+- `.agentdev/drafts/**` 以外へのファイル編集
+
+## 入力
+
+- ユーザーの自然言語による機能追加/バグ修正の説明
+- GitHub Issue URL（既存Issueの場合）、エラーログ（バグ修正の場合）
+- ユーザーが明示した入力ファイル（設計メモ、調査メモ、RU `.agentdev/backlog/req-units/RU-*.md` 等、参照専用）
+- req-save SPLIT 検出時の検出事項、inspect-skills 診断結果の検出事項
+
+## 出力
+
+- `.agentdev/drafts/req-draft-{topic-slug}.md`（全 work_type 共通、構造化 `draft-data` 形式）
+
+## 副作用
+
+- `.agentdev/drafts/**` 配下のファイル作成・更新のみ（G03）。`git` コマンドは実行しない（G08）
+- RU、promoted 成果物、inbox.md/deferred.md は読取のみ（参照専用入力）
+
+## Control Plane（STEP 一覧）
+
+req-define workflow は次の11 STEP で構成する。各 STEP は resume point を持つ（DEC-{N}、`docs/specs/<workflows/step-reference-contract>.md`）。対話の進行は durable state（入力ファイル、壁打ちで確定した合議内容を含む draft-data 下書き）から再構成でき、会話コンテキストのみに依存しない。
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-1 | セッションコンテキスト検知・入力解決 | req-define 起動 | 6項目推論（信頼度付き）、入力ソース確定 | [references/input-and-dialogue.md](references/input-and-dialogue.md) |
+| STEP-2 | 壁打ち対話（引き継ぎ判定含む） | 入力ソース確定 | 深掘り済み要件内容、`agentdev_handoff` 判定 | [references/input-and-dialogue.md](references/input-and-dialogue.md) |
+| STEP-3 | 既存REQ照合 | 壁打ち合意内容確定 | 操作分類結果（`artifact_actions` 記録用） | [references/requirement-development.md](references/requirement-development.md) |
+| STEP-4 | 要件展開 | 操作分類確定 | 変更影響候補、分類ゲート、Decision要否確認、test strategy 定義 | [references/requirement-development.md](references/requirement-development.md) |
+| STEP-5 | Decision判断 | 要件展開完了 | Decision判断記録（`new:{topic-slug}` 形式） | [references/requirement-development.md](references/requirement-development.md) |
+| STEP-6 | 要件doc生成 | Decision判断完了 | 構造化 `draft-data`（operation_units、artifact_actions、test_strategy、review_dispositions） | [references/draft-generation.md](references/draft-generation.md) |
+| STEP-7 | work_type・Scale 判定 | 要件doc生成完了 | work_type 4値、scale（feature のみ） | [references/draft-generation.md](references/draft-generation.md) |
+| STEP-8 | adversarial-review（経路A） | STEP-7 完了後、STEP-9 前 | review 結果反映（skip 時は従来フロー継続） | [references/adversarial-review-path-a.md](references/adversarial-review-path-a.md) |
+| STEP-9 | ドラフト保存 | review 完了または skip | `.agentdev/drafts/req-draft-{topic-slug}.md` 保存 | [references/draft-generation.md](references/draft-generation.md) |
+| STEP-10 | 要件doc確認 | ドラフト保存完了 | ユーザー提示済み（承認は求めず提示のみ） | [references/draft-generation.md](references/draft-generation.md) |
+| STEP-11 | 完了報告 | 提示完了 | 種別別完了報告 | [references/draft-generation.md](references/draft-generation.md) |
+
+### STEP 間の依存と分岐
+
+- **標準経路**: STEP-1 → STEP-2 → STEP-3 → STEP-4 → STEP-5 → STEP-6 → STEP-7 → STEP-8（skip 条件該当時は省略）→ STEP-9 → STEP-10 → STEP-11
+- **引数あり開始**: STEP-1 をスキップし STEP-2 から開始できる（明示入力ファイル指定時）
+- **差し戻し**: STEP-4 の Decision要否確認ゲートでブロッカーまたは未決事項残存時は STEP-2 へ。STEP-8 の Decision finding は STEP-5 へ戻し再評価、要件展開関連 finding は該当 STEP へ戻す。STEP-10 差し戻し時は壁打ち継続（STEP-2 へ）
+- **session由来RU**: STEP-1/2 で `source_type: chat` かつ `generated_by: session` のRU を受領した場合、session由来RU 消費契約（一時成果物ライフサイクル要件 + artifact-contracts SPEC が正規原本）に従う
+
+### resume protocol
+
+- 再開点は durable state から再構成する: 入力ファイル（RU、検出事項）、`.agentdev/drafts/` 配下の draft 下書き（STEP-6 生成後）、`draft-data` の `status` と `auto_gate`
+- 対話ターン間の合意内容は draft-data 下書き（runtime artifact、REQ-{NNNN}）へ逐次反映し、会話コンテキスト喪失後も下書きから再開できる
+- 未解決質問・未解決衝突・停止理由は draft の該当フィールドが正であり、会話履歴を権威情報源としない
+
+### termination
+
+- 正常終了: STEP-11 の完了報告出力まで（次コマンド実行を確定の意思表示として扱う）
+- 停止終了: 有効な Requirement Source 構成不能、`agentdev_handoff: true` による前工程引き継ぎ整理、STEP-8 で未解決のユーザー判断事項が残る場合（STEP-9 へ進まない）
+- 実装コードは一切書かない（G01、壁打ちフェーズ）
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-req-analysis`: セッションコンテキスト検知、壁打ち深掘り、分析観点、detailed gates、チェックボックス品質基準
+- `agentdev-req-file-manager`: 既存REQ照合方法論
+- `agentdev-decision-guidelines`: Decision判断基準（manual reference）
+- `agentdev-architecture-advisory`: Decision要否確認ゲートの助言委譲
+- `agentdev-workflow-lifecycle`: work_type・Scale 判定、前工程引き継ぎ判定
+- `agentdev-adversarial-review`: 経路A review 呼出
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+
+## internal Workflow Extension 読込
+
+本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-req-define.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、req-define command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+
+## 共通制約
+
+- **壁打ちフェーズのみ**: 実装コードを書かない。`.agentdev/drafts/**` のみ作成・編集を許可する
+- **参照専用入力**: ユーザーが明示した入力ファイル、RU、promoted 成果物は変更・削除しない。RU の削除は case-open 成功後に実行される
+- **draft-data 形式**: 出力は構造化 `draft-data`（`# draft-data` fenced YAML block）。`operation_units` を出力し、`execution_groups` は出力しない。`workflow_route` は派生値として保存しない（後続工程の分岐は `artifact_actions` の存在で決定）
+- **Issue 階層非決定**: req-define は Issue 階層を決定しない。`depends_on` は case-open の execution_unit 構成が使用する依存情報であり、最終 Issue 構成は case-open が決定する
+- **session由来RU 消費契約**: 正規原本（一時成果物ライフサイクル要件 + artifact-contracts SPEC）へ委譲し、本スキルで再定義しない
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **`<workflows/step-reference-contract>` SPEC**: STEP reference 構造、resume point
+- **`docs/decisions/DEC-{N}.md`**: Command / Workflow Skill / Capability Skill 責務3層分化と1:N分割原則
+- **`docs/decisions/DEC-{N}.md`**: STEP resume point と会話記憶非依存
+- **req-define command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）

--- a/src/opencode/skills/agentdev-workflow-req-define/references/adversarial-review-path-a.md
+++ b/src/opencode/skills/agentdev-workflow-req-define/references/adversarial-review-path-a.md
@@ -1,0 +1,62 @@
+# STEP-8: adversarial-review 挿入境界（経路A）（adversarial-review-path-a）
+
+> 本 reference は `agentdev-workflow-req-define` SKILL.md の STEP-8 詳細である。req-define の adversarial-review 挿入境界（経路A）を提供する。挿入境界の正規所有者は req-define command SPEC（extension 経由）「adversarial-review 挿入境界（経路A）」節であり、本 reference は実行時詳細である。
+
+## STEP-8: adversarial-review（経路A）
+
+### Purpose
+
+要件候補に対して adversarial-review を原則実行し（default-on）、本質的争点を要件確定前に解消する。
+
+### Input Resolution
+
+1. SSoT 再構成: 要件候補（draft-data、`agreed_items`、`artifact_actions`、Decision判断結果、Scale判断結果）
+2. identifier 保持: なし
+3. 最小 scalar: なし
+4. runtime artifact: draft-data 下書き
+
+### Preconditions
+
+- STEP-7（Scale判断: feature）または work_type 判定（feature 以外）が完了しており、STEP-9（ドラフト保存）の前であること
+
+### Procedure
+
+req-define は adversarial-review を原則実行する（default-on、REQ-{NNNN}-{NNN}）。発動条件判定と review 呼出を分離する（REQ-{NNNN}-{NNN}）。
+
+- **発動条件判定（REQ-{NNNN}-{NNN}、REQ-{NNNN}-{NNN}）**: default-on で発動する。skip 条件（Scale=L0 で Decision判断対象なし、意味的決定なし）該当時は省略して従来フロー（review を挿入せず STEP-9 へ進む）を継続できる（REQ-{NNNN}-{NNN}）。ユーザー明示指定時は skip 条件にかかわらず必ず発動する（REQ-{NNNN}-{NNN}）。skip 判断のためだけの新規 HITL、承認点は追加しない
+- **review 呼出（REQ-{NNNN}-{NNN}）**: 発動条件判定で発動と判定された場合、要件候補（draft-data、`agreed_items`、`artifact_actions`、Decision判断結果、Scale判断結果）を対象に adversarial-review を呼び出す。委譲契約は delegation-contracts SPEC（extension 経由）「adversarial-review との委譲契約接続」節に従う
+  - Decision finding は STEP-5（Decision判断）へ戻し再評価する。要件展開に関わる finding は該当 STEP へ戻す。accepted finding の反映は呼出元の責務である（REQ-{NNNN}-{NNN}）
+  - 未解決のユーザー判断事項が残る場合、STEP-9（ドラフト保存）へ進まない（REQ-{NNNN}-{NNN}）。工程委譲起源であるため既存 status に unresolved 判断事項を付加する（REQ-{NNNN}-{NNN}）
+  - 呼出失敗時は silent skip を禁止し、従来フローを維持する（REQ-{NNNN}-{NNN}）
+
+詳細な挿入境界は req-define command SPEC（extension 経由）「adversarial-review 挿入境界（経路A）」節を正とする。
+
+### Result
+
+- review 結果反映（accepted finding の draft-data 反映、差し戻し実施）または skip 判定
+
+### Evidence
+
+- review 呼出記録、finding と反映結果、skip 判定の根拠
+
+### Completion Verification
+
+- 発動時: unresolved なユーザー判断事項が残っていないこと（残る場合は STEP-9 へ進まない）。skip 時: skip 条件該当の根拠が記録されていること
+
+### Resume-Idempotency
+
+- review 実行は read-only（書き込み禁止型）であり副作用を持たない。中断再開時は要件候補（durable state 下書き）を再読込して再呼出できる。同一 finding を新証拠なしに再起票しない
+
+## 関連 STEP
+
+- 前: STEP-7（draft-generation.md）
+- 次: STEP-9（draft-generation.md）
+
+## 関連 Capability Skill
+
+- `agentdev-adversarial-review`: 経路A review の実行（3論理役割、動的レビュー戦略、read-only 境界）
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G01（壁打ちフェーズのみ）
+- 新規 HITL 追加禁止（skip 判断のためだけの承認点を作らない）

--- a/src/opencode/skills/agentdev-workflow-req-define/references/draft-generation.md
+++ b/src/opencode/skills/agentdev-workflow-req-define/references/draft-generation.md
@@ -1,0 +1,224 @@
+# STEP-6/7/9/10/11: 要件doc生成・判定・保存・確認・報告（draft-generation）
+
+> 本 reference は `agentdev-workflow-req-define` SKILL.md の STEP-6、STEP-7、STEP-9、STEP-10、STEP-11 詳細である。要件doc（draft-data）生成、work_type・Scale 判定、ドラフト保存、要件doc確認、完了報告を提供する。STEP-8（経路A）は [references/adversarial-review-path-a.md](adversarial-review-path-a.md) 参照。
+
+## 目次
+
+- STEP-6: 要件doc生成
+- STEP-7: work_type・Scale 判定
+- STEP-9: ドラフト保存
+- STEP-10: 要件doc確認
+- STEP-11: 完了報告
+
+## STEP-6: 要件doc生成
+
+### Purpose
+
+構造化 `draft-data` 形式で要件doc本文を生成する。
+
+### Input Resolution
+
+1. SSoT 再構成: テンプレート `.opencode/commands/agentdev/templates/req-define/req-draft.md`（Read）
+2. identifier 保持: `new:{topic-slug}`、RU-ID
+3. 最小 scalar: なし
+4. runtime artifact: draft-data 下書き（STEP-2〜5 の確定内容）
+
+### Preconditions
+
+- STEP-5 の Decision判断が完了している
+
+### Procedure
+
+テンプレートを Read し、構造化 `draft-data` 形式に従って生成する。原本は構造化された `# draft-data` fenced YAML block である。STEP-5 の Decision禁止ゲート・STEP-4 の文書分類妥当性検証で分離した SPEC 候補は `artifact_actions`（`artifact: spec`）として統合し、`## SPEC候補` 補助セクションは出力しない。保存対象は単一の `artifact_actions` 配列に統合する。
+
+各副ステップ（定義完全性ゲート QG-{N}、operation_units 生成、depends_on/recommended_order 定義、artifact_actions 生成、target_area/content 形式、SPEC action 分類根拠出力、test_strategy 生成、review_dispositions 生成）の詳細、フィールドスキーマ、委譲接続点は `agentdev-req-analysis` の req-define detailed gates、および req-define command SPEC（extension 経由）の各フィールドスキーマを参照。`target_spec`、`spec_logical_division`、`canonical_owner`、`on_failure`、`review_dispositions` の出力形式も同 SPEC を正とする。
+
+### Result
+
+- 構造化 `draft-data`（`work_type`, `scale`, `summary`, `auto_gate`, `agreed_items`, `artifact_actions`, `conflict_resolutions`, `operation_units`, `test_strategy`, `review_dispositions`, `case_open_hints`）
+
+### Evidence
+
+- 生成済み draft-data、QG-{N} 検証結果
+
+### Completion Verification
+
+- 必須 fields が揃い、`execution_groups` を含まないこと。SPEC 候補が `artifact_actions` へ統合済みであること
+
+### Resume-Idempotency
+
+- 生成は冪等である。再実行時は下書きの確定内容から同一構造を再生成する
+
+## STEP-7: work_type・Scale 判定
+
+### Purpose
+
+work_type（4値）と scale（feature のみ）を確定する。
+
+### Input Resolution
+
+1. SSoT 再構成: なし（draft-data 内情報）
+2. identifier 保持: なし
+3. 最小 scalar: work_type、scale
+4. runtime artifact: draft-data
+
+### Preconditions
+
+- STEP-6 で要件docが生成されている
+
+### Procedure
+
+- **work_type 判定**: ラベルに基づき4値分類（bugfix/feature/maintenance/docs_chore）する。bugfix + Decision必要時は feature に昇格する
+- **Scale判断（feature のみ）**: `agentdev-workflow-lifecycle` で standard/large を判定する。large 時はユーザーと分解計画を協議する。実装スコープシグナル確認（ドラフト内に修正候補リスト、検出事項カタログ、影響ファイル一覧等の実装詳細セクション存在時に large 昇格判定、昇格理由をユーザー提示）の詳細は `agentdev-workflow-lifecycle` を参照
+
+### Result
+
+- work_type 確定、scale 確定（feature のみ）
+
+### Evidence
+
+- 判定根拠（ラベル、実装スコープシグナル）
+
+### Completion Verification
+
+- work_type が4値のいずれかであり、feature 以外で scale 判定を実施していないこと
+
+### Resume-Idempotency
+
+- 判定のみで副作用を持たない
+
+## STEP-9: ドラフト保存
+
+### Purpose
+
+要件docをドラフトとして `.agentdev/drafts/` へ保存する。
+
+### Input Resolution
+
+1. SSoT 再構成: なし
+2. identifier 保持: topic-slug
+3. 最小 scalar: なし
+4. runtime artifact: draft-data 本文
+
+### Preconditions
+
+- STEP-8 完了（review 反映済み）または skip 判定済み
+
+### Procedure
+
+全 work_type（feature/bugfix/maintenance/docs_chore）で `.agentdev/drafts/req-draft-{topic-slug}.md` に保存する。STEP-6 の構造化 `draft-data` 形式（`# draft-data` fenced YAML block）で保存する。標準データモデル fields を保持する。`workflow_route` は派生値として保存しない。後続工程の分岐は `artifact_actions` の存在で決定する（`artifact: req`/`adr` → req-save、`artifact: spec` → spec-save）。`summary` 等の人間可読セクションは補助的であり下流処理の正として扱われない。
+
+各副ステップ（実装詳細の分離、auto_gate 完了ゲート、未確定内容の auto_ready 抑止）の詳細、stop_reasons 記録形式、代表 fixture、引用誤検知除外パターンは req-define command SPEC（extension 経由）「未確定内容の auto_ready 抑止」節、および `agentdev-req-analysis` の req-define detailed gates を参照。
+
+### Result
+
+- `.agentdev/drafts/req-draft-{topic-slug}.md` 保存済み
+
+### Evidence
+
+- 保存ファイルパス、`auto_gate` フィールドの値
+
+### Completion Verification
+
+- ファイルが存在し、draft-data 形式として読み戻し可能であること
+
+### Resume-Idempotency
+
+- 同一 topic-slug への再保存は上書きであり冪等。保存済み draft の status は durable state として後続工程（req-save/spec-save）が参照する
+
+## STEP-10: 要件doc確認
+
+### Purpose
+
+生成した要件docをユーザーに提示する（承認は求めず提示のみ）。
+
+### Input Resolution
+
+1. SSoT 再構成: 保存済み draft ファイル
+2. identifier 保持: topic-slug
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-9 でドラフトが保存されている
+
+### Procedure
+
+生成した要件docをユーザーに提示する（承認は求めず提示のみ）。差し戻し時は壁打ち継続（STEP-2 へ）。次コマンド実行を確定の意思表示として扱う。
+
+各副ステップ（複数RU同時入力受付、統合/分離判定、操作単位ごとの出力生成、Epic 規模検出時の記録、Wave 候補/依存関係の記録、OU 構造検証）の詳細、委譲接続点は `agentdev-req-analysis` を参照。統合/分離判定では生成ドラフト自身の健全性メトリクス（要件行数、関心分類数、成果物種別数）を計測し、req-health-metrics SPEC（extension 経由）の閾値で SPLIT シグナルを算出して合意内容に反映する（新規 CREATE ドラフトで要件行数が 51 行超の場合は SPLIT 要否をユーザーへ提案）。
+
+### Result
+
+- ユーザー提示済み、差し戻し判定結果
+
+### Evidence
+
+- 提示済み draft、SPLIT シグナル算出結果（該当時）
+
+### Completion Verification
+
+- 提示が完了していること。差し戻し時は STEP-2 へ遷移していること
+
+### Resume-Idempotency
+
+- 提示は読取のみで副作用を持たない
+
+## STEP-11: 完了報告
+
+### Purpose
+
+work_type・scale に応じた種別の完了報告を出力する。
+
+### Input Resolution
+
+1. SSoT 再構成: 保存済み draft
+2. identifier 保持: topic-slug
+3. 最小 scalar: work_type、scale
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-10 の提示が完了している
+
+### Procedure
+
+完了報告 template に従って出力する。work_type に応じた種別を選択する:
+
+- feature standard → `.opencode/commands/agentdev/templates/req-define/feature.md`
+- feature large (Epic) 規模 → `.opencode/commands/agentdev/templates/req-define/feature-epic.md`
+- bugfix/maintenance/docs_chore → `.opencode/commands/agentdev/templates/req-define/lightweight.md`
+
+### Result
+
+- 完了報告出力
+
+### Evidence
+
+- 完了報告本文（種別、draft パス）
+
+### Completion Verification
+
+- 選択種別が work_type・scale と一致していること
+
+### Resume-Idempotency
+
+- 報告のみで副作用を持たない
+
+## 関連 STEP
+
+- 前: STEP-5（requirement-development.md）、STEP-8（adversarial-review-path-a.md）
+- 次: なし（workflow 終了。後続は req-save / spec-save / case-open）
+
+## 関連 Capability Skill
+
+- `agentdev-req-analysis`: detailed gates、SPLIT シグナル算出
+- `agentdev-workflow-lifecycle`: work_type・Scale 判定
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G03（`.agentdev/drafts/**` のみ作成・編集許可）
+- G09（チェックボックスは測可能で一意）
+- G10（要件doc構造は req-draft.md テンプレート準拠）
+- G12/G13/G14（work_type 判定参照、Issue 階層非決定、operation_units 出力）

--- a/src/opencode/skills/agentdev-workflow-req-define/references/input-and-dialogue.md
+++ b/src/opencode/skills/agentdev-workflow-req-define/references/input-and-dialogue.md
@@ -1,0 +1,105 @@
+# STEP-1/2: 入力解決・壁打ち対話（input-and-dialogue）
+
+> 本 reference は `agentdev-workflow-req-define` SKILL.md の STEP-1、STEP-2 詳細である。セッションコンテキスト検知・入力解決と壁打ち対話を提供する。
+
+## 目次
+
+- STEP-1: セッションコンテキスト検知・入力解決
+- STEP-2: 壁打ち対話（引き継ぎ判定含む）
+
+## STEP-1: セッションコンテキスト検知・入力解決
+
+### Purpose
+
+引数とセッション状態から有効な Requirement Source を構成し、入力ソースを確定する。
+
+### Input Resolution
+
+1. SSoT 再構成: 明示入力ファイル（設計メモ、RU、検出事項）の実ファイル読込
+2. identifier 保持: RU-ID、Issue番号（URL 指定時）
+3. 最小 scalar: なし
+4. runtime artifact: セッション履歴・現在コンテキスト（推論の入力、権威情報源ではない）
+
+### Preconditions
+
+- req-define command が起動している
+
+### Procedure
+
+- **引数なし単体実行時**: `agentdev-req-analysis` に従い、当該セッション履歴・現在コンテキストから6項目（要件内容、work_type、scale、Decision、構造化、適用範囲）を推論し信頼度付きで表示する。Confirmed のみで要件doc自足可能なら STEP-3 以降へ、部分的不足で補足質問解消可能なら壁打ち（STEP-2）へ、有効な Requirement Source 構成不能なら RU 自動検出へ
+- **明示入力ファイル指定時**: Read tool で読み込み、壁打ちの初期コンテキストとして扱う。複数ファイル指定時は全て読み込む
+- **RU 自動検出**: 引数なしでセッションから有効な入力を構成できなかった場合のみ、`.agentdev/backlog/req-units/RU-*.md` の存在を確認し1件なら自動検出する。0件なら STEP-2 へ。2件以上なら候補一覧を表示し自動選択しない
+- **session由来RU 受領時**: 読み込んだRU が `source_type: chat` かつ `generated_by: session` の場合、session由来RU 消費契約に従う。`session:...` 論理URI の解決、必須8セクション読み取り契約、`tentative_classification` → 最終分類の扱いは正規原本（一時成果物ライフサイクル要件、artifact-contracts SPEC）へ委譲する
+- セッション履歴、現在コンテキストおよび RU のいずれからも有効な入力を構成できない場合、壁打ち対話を開始する
+
+### Result
+
+- 入力ソース確定（セッション推論 / 明示ファイル / RU / 対話開始）
+
+### Evidence
+
+- 6項目推論結果（信頼度付き）、読み込んだ入力ファイルの一覧
+
+### Completion Verification
+
+- 入力ソースが一意に確定し、RU 複数候補時は自動選択していないこと
+
+### Resume-Idempotency
+
+- 読取と推論のみで副作用を持たない。再実行時は同一入力から同一のソース確定に到達する
+
+## STEP-2: 壁打ち対話（引き継ぎ判定含む）
+
+### Purpose
+
+`agentdev-req-analysis` に従って要件を深掘りし、合意内容を確定する。
+
+### Input Resolution
+
+1. SSoT 再構成: 明示入力ファイルの内容（開始点として活用）
+2. identifier 保持: RU-ID
+3. 最小 scalar: なし
+4. runtime artifact: 壁打ちで確定した合議内容（draft-data 下書きへ逐次反映）
+
+### Preconditions
+
+- STEP-1 で入力ソースが確定している
+
+### Procedure
+
+`agentdev-req-analysis` に従って深掘りする。明示入力ファイルがある場合、その内容を開始点として活用する。確定した合意内容は都度 draft-data 下書き（runtime artifact）へ反映し、対話ターン依存状態と durable state を分離する。
+
+**前工程からの引き継ぎ判定**: 入力が AgentDevFlow 本体、配布 command、配布 skill、配布 template、配布 script の不具合または改善点を対象とする場合、`agentdev-workflow-lifecycle` に従い前工程からの引き継ぎ用 RU 入力として整理する。現在プロジェクトの通常要件docとして定義せず、出力に `agentdev_handoff: true` を含める。
+
+### Result
+
+- 深掘り済み要件内容、`agentdev_handoff` 判定結果
+
+### Evidence
+
+- draft-data 下書きの合意項目、引き継ぎ判定の根拠
+
+### Completion Verification
+
+- 合意内容が draft-data 下書きに反映されており、未解決質問・未解決衝突が残っていないこと（残る場合は対話継続）
+
+### Resume-Idempotency
+
+- 対話中断後は draft-data 下書きから合意済み内容を再構成し、未解決項目のみ再対話する。合意済み項目を再質問しない
+
+## 関連 STEP
+
+- 前: なし（workflow 開始）
+- 次: STEP-3（requirement-development.md）
+
+## 関連 Capability Skill
+
+- `agentdev-req-analysis`: セッションコンテキスト検知、壁打ち深掘り
+- `agentdev-workflow-lifecycle`: 前工程引き継ぎ判定
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G01（壁打ちフェーズのみ、実装コード禁止）
+- G02（関連ドキュメントの個別ファイル列挙をユーザーに求めない）
+- G04（明示入力ファイルは参照専用、RU 削除しない）
+- G06/G07（inbox.md/deferred.md 直接ロード禁止、採用済み成果物の直読み禁止）

--- a/src/opencode/skills/agentdev-workflow-req-define/references/requirement-development.md
+++ b/src/opencode/skills/agentdev-workflow-req-define/references/requirement-development.md
@@ -1,0 +1,149 @@
+# STEP-3/4/5: 既存REQ照合・要件展開・Decision判断（requirement-development）
+
+> 本 reference は `agentdev-workflow-req-define` SKILL.md の STEP-3、STEP-4、STEP-5 詳細である。既存REQ照合、要件展開（分類ゲート群）、Decision判断を提供する。
+
+## 目次
+
+- STEP-3: 既存REQ照合
+- STEP-4: 要件展開
+- STEP-5: Decision判断
+
+## STEP-3: 既存REQ照合
+
+### Purpose
+
+`agentdev-req-file-manager` の照合方法論に従い、CREATE 前に APPEND/UPDATE 候補を評価する。
+
+### Input Resolution
+
+1. SSoT 再構成: `docs/requirements/<REQ-*>.md` 実ファイル列挙（副次的に `docs/decisions/<DEC-*>.md`）、AGENTS.md 等の文書記載レンジ
+2. identifier 保持: REQ-ID、DEC-ID
+3. 最小 scalar: SPLIT シグナル算出値（要件行数、関心分類数、成果物種別数）
+4. runtime artifact: STEP-2 の合意内容（draft-data 下書き）
+
+### Preconditions
+
+- STEP-2 で合意内容が確定している
+
+### Procedure
+
+- `agentdev-req-file-manager` の照合方法論に従って実行する。CREATE 前に APPEND/UPDATE 候補を必ず評価する。要件の分割が必要な場合は保存操作ではなく requirements review 候補として扱う。操作分類結果は `draft-data` の `artifact_actions` に記録する
+- **定量的データ検証**: `glob docs/requirements/<REQ-*>.md`（および副次的に `glob docs/decisions/<DEC-*>.md`）で実ファイル列挙と AGENTS.md 等の文書記載レンジとの乖離を確認・解消する（詳細は `agentdev-req-analysis` 参照）
+- **SPLIT 予兆計測（既存REQ）**: APPEND/UPDATE 対象の既存 REQ の健全性メトリクス（要件行数、関心分類数、成果物種別数）を計測し、req-health-metrics SPEC（extension 経由）の定量閾値で SPLIT シグナルを算出する。合計 2 以上の場合、APPEND 実施前にユーザーへ SPLIT 要否を提案する。計測対象は当該 REQ の要件テーブル行（`^| REQ-NNNN-MMM |`）
+
+### Result
+
+- 操作分類結果（CREATE / APPEND / UPDATE 候補、SPLIT 候補）、SPLIT シグナル算出結果
+
+### Evidence
+
+- 実ファイル列挙結果、照合判定の根拠、メトリクス計測値
+
+### Completion Verification
+
+- CREATE 前に APPEND/UPDATE 評価が実施済みであること。乖離解消済みであること
+
+### Resume-Idempotency
+
+- docs/ は読取のみであり副作用を持たない。再実行時は同一の照合結果に到達する
+
+## STEP-4: 要件展開
+
+### Purpose
+
+`agentdev-req-analysis` の分析観点に従って網羅し、REQ/Decision/SPEC 境界を確定する。
+
+### Input Resolution
+
+1. SSoT 再構成: 関連 REQ/Decision/SPEC（glob/grep による事前特定）
+2. identifier 保持: REQ-ID、RU 暫定分類
+3. 最小 scalar: なし
+4. runtime artifact: draft-data 下書き
+
+### Preconditions
+
+- STEP-3 で操作分類が確定している
+
+### Procedure
+
+詳細ゲート、委譲接続点は `agentdev-req-analysis` の各 Phase を参照。
+
+- **変更影響候補抽出**: 変更影響候補を抽出しドラフトに保持する。RU からの対象領域キーワード抽出、glob/grep での関連 REQ/Decision/SPEC 事前特定、サブエージェント調査委譲への調査優先対象リスト（ヒント）構築、実ファイル完全列挙の維持（詳細は `agentdev-req-analysis`「調査スコープ洗練手順」参照）
+- **分類ゲート（REQ 最終分類確定）**: 各要件行候補を「変更後仕様」/「反映作業」に分類する。REQ/SPEC 境界判定を行い SPEC 保存対象を `artifact_actions`（`artifact: spec`）に分離する。RU 暫定分類（`tentative_classification`）があれば document-model SPEC（extension 経由）の文書7分類モデルへ照らして最終分類を確定し上書きする
+- **文書分類妥当性検証**: REQ 要件行に SPEC 分離基準違反残留がないか検出する。検出時は SPEC 保存対象へ移送する（安定契約例外は対象外）
+- **Decision要否確認ゲート**: Decision候補・既存REQ/Decision/SPEC との衝突候補・責務境界変更を含む場合、`agentdev-architecture-advisory` へ委譲する。出力は4ラベル構造（確定事項/推定事項/ユーザー確認事項/ブロッカー）。soft-contract（Decision）。ブロッカーまたは未決事項残存時は壁打ち（STEP-2）へ差し戻す
+- **実行主体分類表（REQ）**: 委譲契約を定義する場合、各委譲について実行主体分類表（adapter skill / command / subagent / harness）を必須とする（詳細は delegation-contracts SPEC（extension 経由）参照。委譲を含まない要件では省略可）
+- **test strategy 定義（REQ、REQ）**: 各合意項目（AG-*）の検証方法を test strategy として定義する。3要素構造（`verification` / `pass_criteria` / `on_failure`）を必須とし、`on_failure` を持たない検証項目は含めない。項目識別子は `TS-NNN`、`on_failure` アクション種別は `fix-and-reverify` / `record-in-findings` の2値。シリアライズ形式の詳細は req-define command SPEC（extension 経由）の draft-data test_strategy フィールドスキーマ参照
+
+### Result
+
+- 変更影響候補、最終分類、SPEC 分離結果、Decision要否確認結果、test strategy 定義
+
+### Evidence
+
+- 影響候補リスト、分類判定根拠、助言の4ラベル構造結果、test strategy 項目
+
+### Completion Verification
+
+- 全要件行候補の分類が確定し、SPEC 分離基準違反残留が0件であること。test strategy 項目が全て3要素を持つこと
+
+### Resume-Idempotency
+
+- 判定結果は draft-data 下書きへ反映する。再開時は下書きの確定済み分類を再評価しない
+
+## STEP-5: Decision判断
+
+### Purpose
+
+`agentdev-decision-guidelines`（manual reference）に従ってDecision判断を記録する（Decisionファイル作成は req-save で実行）。
+
+### Input Resolution
+
+1. SSoT 再構成: 既存Decision（`docs/decisions/`）
+2. identifier 保持: Decision番号指定形式 `new:{topic-slug}`
+3. 最小 scalar: なし
+4. runtime artifact: draft-data 下書き
+
+### Preconditions
+
+- STEP-4 の要件展開が完了している
+
+### Procedure
+
+`agentdev-decision-guidelines`（manual reference）に従ってDecision判断を記録する。各副ステップ（既存Decision重複確認、Decision禁止ゲート、判断根拠記録、作業手段Decision拒否ゲート、Decision番号指定形式 `new:{topic-slug}`）の詳細、委譲接続点は `agentdev-req-analysis` を参照。
+
+### Result
+
+- Decision判断記録（`new:{topic-slug}` 形式、判断根拠）
+
+### Evidence
+
+- 重複確認結果、禁止ゲート判定、判断根拠の記録
+
+### Completion Verification
+
+- Decision候補が全て重複確認・禁止ゲート判定を経ており、番号指定形式が正しいこと
+
+### Resume-Idempotency
+
+- 記録は draft-data 下書きへ反映する。ファイル作成は行わないため副作用を持たない
+
+## 関連 STEP
+
+- 前: STEP-2（input-and-dialogue.md）
+- 次: STEP-6（draft-generation.md）
+
+## 関連 Capability Skill
+
+- `agentdev-req-file-manager`: 照合方法論
+- `agentdev-req-analysis`: 分析観点、detailed gates
+- `agentdev-architecture-advisory`: Decision要否確認ゲートの助言委譲
+- `agentdev-decision-guidelines`: Decision判断基準
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G05（docs/ 配下の広範な探索禁止、限定探索は許可）
+- G11（Decision閾値以上の判断は `agentdev-decision-guidelines` へ）
+- G15（SPEC 分離基準該当行の `artifact_actions` 分離）
+- G16/G17（アーキテクチャ助言サブエージェントの参照と未確認事項非混入）
+- G19（test strategy 3要素完全、欠落時は QG-{N} fail 扱い）

--- a/src/opencode/skills/agentdev-workflow-req-save/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-req-save/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: agentdev-workflow-req-save
+description: "req-save command の workflow 実装本体。壁打ち成果物（draft-data）をREQ/Decisionファイルとしてdocs/に保存し、コミット・プッシュする制御を所有する。事前チェック（artifact_actions 判定、no-op）、読込時 hash 記録、REQ ファイル操作（決定的スクリプト呼出、QG-{N} 相当の適用結果整合性検証）、インデックス・ハブ更新、Decision ファイル作成、docs 変更整合性検証、README 索引影響確認、変更範囲検証、ドラフト status 更新（saved）、コミット・プッシュ、3フェーズ並列委譲モデルを提供する。USE FOR: req-save command 実行時の workflow 制御（normal create/update・no-op・validation failure・partial failure・rerun idempotency・commit 前中断・external Git failure 各シナリオ）。DO NOT USE FOR: 要件doc 作成（req-define）、SPEC 保存（spec-save）、Issue 作成（case-open）、REQ ファイル管理・採番ルールの定義（agentdev-req-file-manager）、Decision ファイル管理（agentdev-decision-file-manager）、決定的検証スクリプトの所有（agentdev-artifact-validation）、gh CLI I/O 手続き（agentdev-gh-cli）、git worktree 操作（agentdev-git-worktree）、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# req-save workflow スキル
+
+req-save command の workflow 実装本体。req-define で生成された壁打ち成果物をREQ/Decisionファイルとしてdocs/に保存し、コミット・プッシュする制御構造を所有する。`work_type` による消費判定は廃止し、`artifact_actions` の有無で判定する。
+
+req-save command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md（control plane）と `references/` 配下（各 STEP 詳細）が担う。
+Workflow Skill 固有契約は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-req-save.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と req-save command の公開契約のみを前提とする。SPEC ディレクトリの内部構成は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- req-save command の実行時 workflow 制御（全 STEP）
+- 事前チェック（REQ/Decision 対象 artifact_actions 有無判定、no-op 完了、旧形式 draft 後方互換）
+- ドラフト読込と読込時 commit hash 記録
+- REQ ファイル操作（CREATE/APPEND/UPDATE、決定的スクリプト呼出、QG-{N} 相当の適用結果整合性検証）
+- インデックス・ハブ更新、Decision ファイル作成と妥当性再検証
+- docs 変更整合性検証、README 索引影響確認（targeted docs guard、extension 更新要否確認）
+- 変更範囲検証、リモート同期と hash 検証
+- ドラフト status 更新（saved）、コミット・プッシュ（明示パス、ステータス commit 含む）
+- 複数 REQ/Decision ファイルの3フェーズ並列委譲モデル
+
+## DO NOT USE FOR
+
+- 要件doc 作成、壁打ち（`/agentdev/req-define`）
+- SPEC ファイル保存（`/agentdev/spec-save`、`agentdev-spec-file-manager`）
+- Issue 作成（`/agentdev/case-open`。req-save は Issue を作成しない）
+- REQ ファイル管理・採番ルール・判定ロジックの定義（`agentdev-req-file-manager`）
+- Decision ファイル管理・採番の定義（`agentdev-decision-file-manager`、`agentdev-decision-guidelines`）
+- 決定的検証スクリプトの所有と公開検証契約（`agentdev-artifact-validation`）
+- 要件内容の品質再検証（req-define の QG-{N} の責務）
+- commit message 規約の定義（`agentdev-conventional-commits`）
+- 並列実行安全ステージングの定義（`agentdev-git-worktree`）
+- intake/learning capture（例外: REQ 再構成 intake のみ生成可）
+
+## 入力
+
+- `.agentdev/drafts/req-draft-{topic-slug}.md`（req-define で生成されたドラフト）
+
+## 出力
+
+- `docs/requirements/REQ-{NNNN}.md`（新規/追記/更新）、`docs/requirements/README.md`、`docs/README.md`
+- `docs/decisions/<DEC-NNN>.md`（Decision判断がある場合のみ）
+- `.agentdev/drafts/requirements-review-finding-{topic-slug}.md`（SPLIT検出時のみ）
+- `.agentdev/intake/inbox/req-restructure/*.md`（REQ再構成候補検知時のみ）
+
+## 副作用
+
+- docs/ 配下のファイル作成・更新（G02 許可パスのみ）、ドラフト status 更新
+- main ブランチへの commit・push（明示パスステージ、`agentdev-git-worktree` プロシージャ準拠）
+- Issue は作成しない（G11、case-open の責任範囲）
+
+## Control Plane（STEP 一覧）
+
+req-save workflow は次の12 STEP で構成する。各 STEP は resume point を持つ（DEC-{N}、`docs/specs/<workflows/step-reference-contract>.md`）。会話コンテキストに依存せず、durable state（draft の `status` frontmatter、REQ/Decision ファイル、README エントリ、commit hash、git 状態）から再開点を再構成する。
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-1 | 事前チェック | req-save 起動 | 処理要否判定（no-op or 継続） | [references/precheck-and-req-ops.md](references/precheck-and-req-ops.md) |
+| STEP-2 | ドラフト読込 | 処理対象あり | ドラフト読込済み、読込時 commit hash 記録 | [references/precheck-and-req-ops.md](references/precheck-and-req-ops.md) |
+| STEP-3 | ドラフト検証・処理対象確定 | ドラフト読込済み | 必須フィールド検証、処理対象 entry 確定 | [references/precheck-and-req-ops.md](references/precheck-and-req-ops.md) |
+| STEP-4 | REQ ファイル操作 | 処理対象確定 | REQ/Decision ファイル保存（QG-{N} 相当検証、決定的スクリプト適用） | [references/precheck-and-req-ops.md](references/precheck-and-req-ops.md) |
+| STEP-5 | インデックス・ハブ更新 | REQ ファイル操作完了 | README エントリ登録（check-entry-existence 検証済み） | [references/indexes-and-persistence.md](references/indexes-and-persistence.md) |
+| STEP-6 | Decision ファイル作成 | `artifact: decision` entry 存在 | Decision ファイル作成、ハブ追記 | [references/indexes-and-persistence.md](references/indexes-and-persistence.md) |
+| STEP-7 | docs 変更整合性検証 | ファイル操作完了 | REQ番号連続性、frontmatter id↔ファイル名整合 | [references/indexes-and-persistence.md](references/indexes-and-persistence.md) |
+| STEP-8 | README 索引影響確認 | 整合性検証完了 | 索引更新、targeted docs guard、extension 更新要否確認 | [references/indexes-and-persistence.md](references/indexes-and-persistence.md) |
+| STEP-9 | 変更範囲検証・リモート同期 | 索引確認完了 | check-change-impact 検証、pull と hash 一致検証 | [references/indexes-and-persistence.md](references/indexes-and-persistence.md) |
+| STEP-10 | ドラフト status 更新 | 変更範囲検証合格 | `status: saved`（commit 対象に含む） | [references/indexes-and-persistence.md](references/indexes-and-persistence.md) |
+| STEP-11 | コミット・プッシュ | status 更新済み | 明示パス commit、push、OU 結果書き戻し | [references/indexes-and-persistence.md](references/indexes-and-persistence.md) |
+| STEP-12 | 完了報告 | push 完了 | 種別別完了報告 | [references/indexes-and-persistence.md](references/indexes-and-persistence.md) |
+
+### STEP 間の依存と分岐
+
+- **標準経路**: STEP-1 → STEP-2 → STEP-3 → STEP-4 → STEP-5 → (STEP-6) → STEP-7 → STEP-8 → STEP-9 → STEP-10 → STEP-11 → STEP-12
+- **no-op 経路**: STEP-1 で REQ/Decision 対象 artifact_actions がない場合、no-op 完了（後続の case-open へ進むよう完了報告で案内）
+- **エラー停止**: STEP-3 の必須フィールド欠損、STEP-4 の QG-{N} fail（req-define へ差し戻し）、STEP-9 の変更範囲違反（ユーザーへ報告し指示待ち）
+- **並列委譲**: 複数 REQ/Decision ファイル操作は3フェーズ分離（採番バッチ[直列] / ファイル作成[並列・最大5件] / インデックス更新[直列]）で並列化できる
+
+### resume protocol
+
+- 再開点は durable state から再構成する: draft の `status` frontmatter（`saved` であれば commit/push 済み）、REQ/Decision ファイルの存在、README エントリの存在、`git log` の commit、読込時 hash と pull 後 hash の一致
+- commit 前中断時は `git status` と `git diff --name-only` で変更ファイルを再検出し、未実行 STEP から再開する。`status: saved` への更新は commit/push より前に実施し commit 対象に含める（push 後の status 更新は永続化されないため禁止、G07）
+- external Git failure（pull 失敗、push 拒絶）時はエラーを報告し、同一 durable state からリトライ可能な STEP を明示する
+
+### termination
+
+- 正常終了: STEP-12 の完了報告出力まで（no-op 時は STEP-1 の no-op 完了報告）
+- 停止終了: ドラフト不存在（エラーで中止、req-define を案内）、必須フィールド欠損、QG-{N} fail（req-define 差し戻し）、変更範囲違反（ユーザー指示待ち）、hash 不一致（評価・承認のやり直し）
+- Issue は作成しない。`artifact: spec` entry は処理しない（spec-save の対象）
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-req-file-manager`: REQ ファイル操作の判定ロジック、採番ルール、3フェーズ分離詳細、決定的スクリプト呼出契約（CREATE/APPEND/UPDATE 候補、SPLIT 候補、REQ 再構成候補はサブエージェントが返し、親エージェントがファイル保存）
+- `agentdev-decision-file-manager`: Decision ファイル作成、採番ルール（max+1、欠番埋め禁止）
+- `agentdev-artifact-validation`: 公開検証契約（check-frontmatter-consistency、check-entry-existence、check-change-impact、決定的採番）
+- `agentdev-quality-gates`: QG-{N}（適用結果の整合性検証）
+- `agentdev-conventional-commits`: commit message 生成
+- `agentdev-git-worktree`: 並列実行安全ステージングプロシージャ（明示パスステージ、`git commit -- <paths>`）
+- `agentdev-workflow-orchestration`: capture 境界（deviation capture の委譲）
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+- integrity checker skill（AG-{NNN} detector、repo 固有）: check_changed_docs.ts（targeted docs guard）
+
+## internal Workflow Extension 読込
+
+本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-req-save.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、req-save command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+
+## 共通制約
+
+- **工程分岐**: `work_type` 固定分岐ではなく `artifact_actions` の有無で判定する（判定基準の詳細は `agentdev-workflow-lifecycle` 参照）
+- **Issue 作成禁止**: req-save は Issue を作成しない（case-open の責任範囲）
+- **capture 非関与**: intake/learning capture は原則行わない。例外は REQ 再構成 intake（`.agentdev/intake/inbox/req-restructure/**`）のみ生成可。deviation capture は Skill（`agentdev-learning-capture` または `agentdev-intake-pipeline`）への委譲で実施する
+- **内容品質の再検証なし**: req-save の QG-{N} は適用結果の整合性のみ検証し、内容の品質は req-define の QG-{N} の責務
+- **成果物本文 verbatim**: 成果物本文は verbatim で返す。判定結果、調査過程、中間ログは要約・圧縮して返す
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **`<workflows/step-reference-contract>` SPEC**: STEP reference 構造、resume point
+- **`docs/decisions/DEC-{N}.md`**: Command / Workflow Skill / Capability Skill 責務3層分化と1:N分割原則
+- **`docs/decisions/DEC-{N}.md`**: STEP resume point と会話記憶非依存
+- **req-save command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）

--- a/src/opencode/skills/agentdev-workflow-req-save/references/indexes-and-persistence.md
+++ b/src/opencode/skills/agentdev-workflow-req-save/references/indexes-and-persistence.md
@@ -1,0 +1,340 @@
+# STEP-5〜12: インデックス・整合性検証・永続化・報告（indexes-and-persistence）
+
+> 本 reference は `agentdev-workflow-req-save` SKILL.md の STEP-5〜STEP-12 詳細である。インデックス・ハブ更新、Decision ファイル作成、docs 変更整合性検証、README 索引影響確認、変更範囲検証、ドラフト status 更新、コミット・プッシュ、完了報告を提供する。
+
+## 目次
+
+- STEP-5: インデックス・ハブ更新
+- STEP-6: Decision ファイル作成
+- STEP-7: docs 変更整合性検証
+- STEP-8: README 索引影響確認
+- STEP-9: 変更範囲検証・リモート同期
+- STEP-10: ドラフト status 更新
+- STEP-11: コミット・プッシュ
+- STEP-12: 完了報告
+
+## STEP-5: インデックス・ハブ更新
+
+### Purpose
+
+REQ インデックスとドキュメントハブへ新規エントリを登録する。
+
+### Input Resolution
+
+1. SSoT 再構成: `docs/requirements/README.md`、`docs/README.md`
+2. identifier 保持: REQ番号
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-4 の REQ ファイル操作が完了している
+
+### Procedure
+
+詳細は `agentdev-req-file-manager` を参照。委譲接続点: 親エージェントのみが `docs/` ファイルを更新する。**エントリ存在確認のスクリプト呼出（REQ、AG-{NNN}、AG-{NNN}）**: README へのエントリ追加後に `agentdev-artifact-validation` の公開検証契約（RU-{NNNNNNNN}-01 合意、`check-entry-existence`）で登録を検証する。具体的な CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照。
+
+### Result
+
+- README エントリ登録済み（check-entry-existence 検証合格）
+
+### Evidence
+
+- 更新後 README、check-entry-existence の JSON 結果
+
+### Completion Verification
+
+- 新規 REQ のエントリが README 索引に存在すること
+
+### Resume-Idempotency
+
+- エントリ存在確認で登録済みを検出した場合は再追加しない
+
+## STEP-6: Decision ファイル作成
+
+### Purpose
+
+`artifact: decision` entry から Decision ファイルを作成する。
+
+### Input Resolution
+
+1. SSoT 再構成: `docs/decisions/` 既存ファイル（採番 max+1）
+2. identifier 保持: `new:{topic-slug}` → 確定 DEC-NNN
+3. 最小 scalar: なし
+4. runtime artifact: ドラフト内 Decision 参照
+
+### Preconditions
+
+- `artifact_actions` に `artifact: decision` の entry が含まれる場合のみ実行
+
+### Procedure
+
+`agentdev-decision-file-manager` に従って Decision ファイルを作成する。作成後、`docs/README.md` にDecisionセクションが存在しない場合は追加し、Decisionエントリを記載する。**Decision妥当性再検証ゲート**（保存の直前）: Decisionが技術判断（アーキテクチャ上の決定）を含むか確認、REQ/SPEC相当の内容のみの場合は保存を停止し理由を報告、`agentdev-decision-guidelines` の判定結果を前提として検証、`agentdev-decision-file-manager` の採番ルール（max+1、欠番埋め禁止）で確定した番号を振る、draft 内の全 Decision 参照（`new:{topic-slug}` 形式）を当該確定番号で置換する。
+
+### Result
+
+- Decision ファイル作成済み、ハブ追記済み、draft 内参照置換済み
+
+### Evidence
+
+- 作成ファイルパス、採番根拠（既存最大番号）
+
+### Completion Verification
+
+- 採番が max+1 であり、draft 内参照置換が完了していること
+
+### Resume-Idempotency
+
+- Decision ファイルの存在（durable state）で再実行を判定する。作成済みの場合は再作成しない
+
+## STEP-7: docs 変更整合性検証
+
+### Purpose
+
+REQ番号の連続性と frontmatter id↔ファイル名一致を検証する。
+
+### Input Resolution
+
+1. SSoT 再構成: `docs/requirements/**`、`docs/decisions/**`
+2. identifier 保持: REQ番号、DEC番号
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-4〜6 のファイル操作が完了している
+
+### Procedure
+
+REQ番号の連続性確認、frontmatter の `id` とファイル名の一致を確認する。frontmatter id↔ファイル名整合性確認は `agentdev-artifact-validation` の公開検証契約で決定的スクリプトを実行する（REQ/Decision 保存時）。CLI 形式は同 SKILL.md を参照。
+
+### Result
+
+- 連続性・整合性検証結果
+
+### Evidence
+
+- 検証スクリプトの JSON 結果
+
+### Completion Verification
+
+- 違反0件であること（違反時は STEP-4 へ戻して修正）
+
+### Resume-Idempotency
+
+- 読取検査であり再実行可能
+
+## STEP-8: README 索引影響確認
+
+### Purpose
+
+REQ/Decision/SPEC 操作が各 README 索引へ影響するか確認し、targeted docs guard を実行する。
+
+### Input Resolution
+
+1. SSoT 再構成: `docs/README.md`、各 README、`.agentdev/extensions/**`
+2. identifier 保持: REQ番号、DEC番号
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-7 の整合性検証が完了している
+
+### Procedure
+
+REQ/Decision/SPEC操作が `docs/README.md`、各 README（`docs/requirements/README.md`、`docs/decisions/README.md`、`docs/specs/README.md`）の索引に影響するか確認する。影響がある場合は更新、ない場合は「README 索引更新なし」とする。README 索引更新は導線の更新であり、要件、判断、仕様の更新ではない。
+
+- **targeted docs guard（REQ）**: 変更 REQ ファイルと連動ファイル（`docs/requirements/README.md`、`docs/README.md`、`AGENTS.md`）に対し `check_changed_docs.ts --workflow req-save --files <changed REQ files> --json` を実行する。`failures` に strict severity を含む場合は修正して再実行する。`full_docs_check_recommended` true 時は全体監査（self-hosting リポジトリ限定の自己監査コマンド）の実行をユーザーに提案する
+- **extension 更新要否（REQ）**: REQ/Decision 追加/移動/削除が `.agentdev/extensions/**` へ影響するか確認する。該当 REQ/Decision を context に列挙している extension がある場合、paths も更新対象。必要時はユーザーへ指示を仰ぐ（直接編集しない）
+- **エントリ存在確認（REQ、AG-{NNN}）**: `agentdev-artifact-validation` の公開検証契約（`check-entry-existence`）で REQ/Decision エントリの README 索引への存在を確認する
+
+### Result
+
+- 索引更新結果、targeted docs guard 結果、extension 更新要否
+
+### Evidence
+
+- check_changed_docs.ts の JSON 結果、索引更新の有無
+
+### Completion Verification
+
+- targeted docs guard の failures に strict severity を含まないこと
+
+### Resume-Idempotency
+
+- 読取と guard 実行であり再実行可能
+
+## STEP-9: 変更範囲検証・リモート同期
+
+### Purpose
+
+変更ファイルが許可パスリスト内であることを検証し、リモート同期と hash 一致を確認する。
+
+### Input Resolution
+
+1. SSoT 再構成: `git diff --name-only`、`git pull` 後の HEAD
+2. identifier 保持: 読込時 commit hash（STEP-2 記録）
+3. 最小 scalar: pull 後 commit hash
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-8 の索引確認が完了している
+
+### Procedure
+
+- **決定的処理のスクリプト呼出（REQ、AG-{NNN}）**: `git diff --name-only` で変更ファイル一覧を取得し、許可パスリスト（G02）との照合を `agentdev-artifact-validation` の公開検証契約（`check-change-impact`、RU-{NNNNNNNN}-01 合意）で実行する。許可範囲外の変更を検出したらエラー内容をユーザーに報告して指示を待つ（自動破棄しない）。`violations` が空でない場合は G02 違反として報告し指示を待つ
+- **リモート同期と hash 検証**: `git pull --ff-only` 後、読込時 hash と pull 後 hash の一致検証を必須とする。一致しない場合は評価、承認をやり直す。**RU パス保存禁止**の詳細、委譲接続点は `agentdev-req-file-manager` を参照
+
+### Result
+
+- 変更範囲検証結果、hash 一致検証結果
+
+### Evidence
+
+- check-change-impact の JSON 結果、読込時/pull 後 hash
+
+### Completion Verification
+
+- violations 0件、hash 一致であること（不一致時は中止）
+
+### Resume-Idempotency
+
+- 検証は読取であり再実行可能。external Git failure（pull 失敗等）時はエラー報告し、同一状態からリトライする
+
+## STEP-10: ドラフト status 更新
+
+### Purpose
+
+ドラフトの `status` を `saved` へ更新し、commit 対象に含める。
+
+### Input Resolution
+
+1. SSoT 再構成: ドラフト frontmatter
+2. identifier 保持: topic-slug
+3. 最小 scalar: `status: saved`
+4. runtime artifact: ドラフトファイル
+
+### Preconditions
+
+- STEP-9 の変更範囲検証が合格している
+
+### Procedure
+
+ドラフト `draft-data` の `status`（frontmatter）を `saved` に更新する。commit/push より前に更新し commit 対象に含める（push 後の status 更新は永続化されないため禁止、G07）。
+
+### Result
+
+- `status: saved` 更新済み
+
+### Evidence
+
+- 更新後 frontmatter
+
+### Completion Verification
+
+- `status: saved` が commit 対象に含まれていること
+
+### Resume-Idempotency
+
+- `status: saved` の存在（durable state）で commit 済み否かを再構成できる。二重更新は冪等
+
+## STEP-11: コミット・プッシュ
+
+### Purpose
+
+変更を明示パスでコミットし、main ブランチへ push する。
+
+### Input Resolution
+
+1. SSoT 再構成: `git status`、変更ファイル一覧
+2. identifier 保持: REQ番号、DEC番号
+3. 最小 scalar: なし
+4. runtime artifact: OU 結果書き戻し（`operation_units` の `result`）
+
+### Preconditions
+
+- STEP-10 の status 更新が完了している
+
+### Procedure
+
+`agentdev-conventional-commits` に従ってコミットメッセージを生成し、main ブランチに push する。STEP-10 の status 変更を commit 対象に含める。並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、`git add <path>` で明示パスステージし、`git commit -- <paths>`（--only pathspec 形式）でコミットする。スイープ操作（`git add -A`/ `git add .` 等）は禁止する。
+
+- **REQ/Decision artifact_actions 処理結果の保存（ドラフトに複数 entry がある場合）**: (a) 保存したREQドキュメントのリスト（REQ番号含む）(b) 各 artifact_action から保存したREQドキュメントへのマッピング (c) ソースRUからREQ操作へのマッピング (d) case-open で消費可能な形式での保存結果
+- **OU 結果の書き戻し**: ドラフトに `operation_units` セクションがある場合、各 OU の `result` に (a) 保存したREQドキュメント一覧 (b) OU 操作と保存先REQ doc の対応 (c) source RUとOU操作の対応 (d) case-open が入力として扱える保存結果を書き戻す
+- **Issue作成の責任分離**: req-save はREQドキュメントの保存中に Issue を作成しない（case-open の責任範囲）
+
+### Result
+
+- commit・push 完了、OU 結果書き戻し済み
+
+### Evidence
+
+- commit hash、push 結果、commit 対象パス一覧
+
+### Completion Verification
+
+- 変更が全てコミット済みであり、push が成功していること
+
+### Resume-Idempotency
+
+- commit 前中断時は `git status` から未コミット変更を再検出して再実行する。push 拒絶（external Git failure）時はエラー報告し、同一 commit からリトライする
+
+## STEP-12: 完了報告
+
+### Purpose
+
+実行結果に応じた種別の完了報告を出力する。
+
+### Input Resolution
+
+1. SSoT 再構成: STEP-11 の結果、保存済み REQ/Decision 一覧
+2. identifier 保持: REQ番号、DEC番号
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-11 の push が完了している（no-op 時は STEP-1 判定直後）
+
+### Procedure
+
+完了報告 template に従って出力する。実行結果に応じて `templates/req-save/` 配下の種別（`split-detected.md` / `epic.md` / `standard.md`）を選択する。
+
+### Result
+
+- 完了報告出力
+
+### Evidence
+
+- 完了報告本文（種別、保存結果）
+
+### Completion Verification
+
+- 選択種別が実行結果（SPLIT 検出有無、Epic 規模）と一致していること
+
+### Resume-Idempotency
+
+- 報告のみで副作用を持たない
+
+## 関連 STEP
+
+- 前: STEP-4（precheck-and-req-ops.md）
+- 次: なし（workflow 終了。後続は spec-save / case-open）
+
+## 関連 Capability Skill
+
+- `agentdev-decision-file-manager`: Decision ファイル作成、採番
+- `agentdev-artifact-validation`: check-entry-existence、check-change-impact
+- `agentdev-conventional-commits`: commit message 生成
+- `agentdev-git-worktree`: 並列実行安全ステージング
+- integrity checker skill（AG-{NNN} detector、repo 固有）: check_changed_docs.ts（--workflow req-save）
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G07（status 更新は commit/push 前に実施し commit 対象に含める）
+- G08（pull 後の読込時 hash と pull 後 hash の一致検証必須）
+- G10（成果物本文 verbatim、過程は圧縮）
+- G11（Issue 作成禁止）
+- G12（capture 原則非関与、例外は REQ 再構成 intake のみ）

--- a/src/opencode/skills/agentdev-workflow-req-save/references/precheck-and-req-ops.md
+++ b/src/opencode/skills/agentdev-workflow-req-save/references/precheck-and-req-ops.md
@@ -1,0 +1,183 @@
+# STEP-1〜4: 事前チェック・読込・検証・REQ ファイル操作（precheck-and-req-ops）
+
+> 本 reference は `agentdev-workflow-req-save` SKILL.md の STEP-1〜STEP-4 詳細である。事前チェック（no-op 判定）、ドラフト読込、ドラフト検証、REQ ファイル操作を提供する。
+
+## 目次
+
+- STEP-1: 事前チェック
+- STEP-2: ドラフト読込
+- STEP-3: ドラフト検証・処理対象確定
+- STEP-4: REQ ファイル操作
+
+## STEP-1: 事前チェック
+
+### Purpose
+
+`draft-data` の `artifact_actions` から処理要否を判定する（no-op 判定）。
+
+### Input Resolution
+
+1. SSoT 再構成: `.agentdev/drafts/req-draft-*.md` の `# draft-data` block
+2. identifier 保持: topic-slug
+3. 最小 scalar: なし
+4. runtime artifact: ドラフトファイル
+
+### Preconditions
+
+- req-save command が起動している
+
+### Procedure
+
+`draft-data` の `artifact_actions` を確認し、`artifact: req` または `artifact: decision` の entry が含まれるか判定する。REQ/Decision 対象 artifact_actions がない場合は no-op 完了とする（後続の case-open へ進むよう完了報告で案内）。`work_type` による停止は廃止する。旧形式 draft（`artifact_actions` フィールドなし）の場合は従来どおり全 req-operation を処理する（後方互換）。
+
+### Result
+
+- 処理要否判定（no-op or 継続）
+
+### Evidence
+
+- `artifact_actions` の entry 種別一覧
+
+### Completion Verification
+
+- no-op 判定時に REQ/Decision entry が実際に0件であること
+
+### Resume-Idempotency
+
+- 読取のみで副作用を持たない。再実行時は同一判定になる
+
+## STEP-2: ドラフト読込
+
+### Purpose
+
+対象ドラフトを特定し、読込時点の commit hash を記録する。
+
+### Input Resolution
+
+1. SSoT 再構成: `.agentdev/drafts/req-draft-*.md`（最新の1件を対象）
+2. identifier 保持: topic-slug
+3. 最小 scalar: 読込時 commit hash
+4. runtime artifact: ドラフトファイル
+
+### Preconditions
+
+- STEP-1 で処理対象ありと判定されている
+
+### Procedure
+
+`.agentdev/drafts/req-draft-*.md` を読み込み、最新の1件を対象とする。見つからない場合はエラーで中止する（先に `/agentdev/req-define` を実行するよう案内）。**読込時 hash 記録**: `git rev-parse HEAD` で読込時点の commit hash を記録する。
+
+### Result
+
+- ドラフト読込済み、読込時 commit hash 記録済み
+
+### Evidence
+
+- 対象ドラフトパス、読込時 commit hash
+
+### Completion Verification
+
+- 対象ドラフトが一意に特定され、hash が記録されていること
+
+### Resume-Idempotency
+
+- 読取のみで副作用を持たない。再実行時は最新ドラフトと最新 hash を再取得する
+
+## STEP-3: ドラフト検証・処理対象確定
+
+### Purpose
+
+draft-data の必須フィールドを検証し、処理対象 entry を確定する。
+
+### Input Resolution
+
+1. SSoT 再構成: draft-data
+2. identifier 保持: OU ID（指定時）
+3. 最小 scalar: なし
+4. runtime artifact: ドラフトファイル
+
+### Preconditions
+
+- STEP-2 でドラフトが読み込まれている
+
+### Procedure
+
+`draft-data` の必須フィールド（artifact_actions、operation_units、topic_slug）が存在することを確認する。欠損時はエラーで中止する。
+
+- **分類ゲート検査**: CREATE 対象 REQ の要件テーブル検査。**文書分類適合確認**: REQ/Decision 保存前のドキュメント種別確認。詳細、委譲接続点は `agentdev-req-file-manager` を参照
+- **REQ/Decision artifact_actions 処理ゲート**: ドラフトの `artifact_actions` から `artifact: req`/ `artifact: decision` の entry を処理対象とする（draft 全体を処理し、OU ごとに分割しない）。`artifact_actions` に REQ/Decision entry がない場合は no-op 完了とする。`operation_units` 存在時は OU ID 指定があれば当該 OU 配下のみ、未指定時は draft 全体を処理対象とする。`artifact_actions` フィールドがない（旧形式 draft）の場合は従来どおり全 req-operation を処理する（後方互換）。`artifact: spec` の entry は spec-save コマンドの対象であり処理しない
+
+### Result
+
+- 必須フィールド検証結果、処理対象 entry 一覧
+
+### Evidence
+
+- 検証結果、処理対象 entry の種別と target
+
+### Completion Verification
+
+- 必須フィールドが全て存在すること。処理対象に `artifact: spec` を含まないこと
+
+### Resume-Idempotency
+
+- 検証は読取のみで副作用を持たない
+
+## STEP-4: REQ ファイル操作
+
+### Purpose
+
+処理対象 entry を REQ/Decision ファイルへ保存する（決定的スクリプト適用、QG-{N} 相当検証込み）。
+
+### Input Resolution
+
+1. SSoT 再構成: `docs/requirements/**`、`docs/decisions/**` の既存ファイル
+2. identifier 保持: REQ番号、要件行ID、Decision番号
+3. 最小 scalar: なし
+4. runtime artifact: ドラフト、`requirements-review-finding` 検出事項（SPLIT 検出時）
+
+### Preconditions
+
+- STEP-3 で処理対象が確定している
+
+### Procedure
+
+`agentdev-req-file-manager` の判定ロジックと採番ルールに従って実行する。STEP-3 で処理対象とした `artifact_actions`（`artifact: req`/ `artifact: decision`）の全 entry を処理する（draft 全体を処理し、OU ごとの消費は行わない）。`artifact_actions` フィールドがない場合は従来どおり全 req-operation を処理する（後方互換）。委譲接続点: サブエージェントは CREATE/APPEND/UPDATE 候補、SPLIT 候補、REQ 再構成候補を返し、親エージェントがファイル保存を行う（詳細は `agentdev-req-file-manager` 参照）。
+
+- **決定的処理のスクリプト呼出（REQ、AG-{NNN}）**: REQ番号採番、要件行ID採番、frontmatter id↔ファイル名整合性確認は `agentdev-artifact-validation` の公開検証契約（RU-{NNNNNNNN}-01 合意）および `agentdev-req-file-manager` SKILL.md「Scripts（決定的処理）」で規定する決定的スクリプトを bash 経由で呼び出して実行する。LLM 推論で代替しない。具体的な CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照
+- **QG-{N}（適用結果の整合性検証、REQ/082、AG-{NNN}）**: REQ/Decision ファイル保存前に `agentdev-quality-gates` の QG-{N} を実行する。採番結果、マージ結果、インデックス、変更範囲の妥当性を決定的スクリプトの JSON 結果で機械的に確認する。fail 時は保存を停止し req-define へ差り戻す。req-save の QG-{N} は内容の品質を再検証せず、それは req-define の QG-{N} の責務である
+- **語彙・責務・runtime境界矛盾の防止**: STEP-4 完了後に既知の矛盾を検出可能な範囲で防止する。**Catalog entry 確認（APPEND 時）**: 関連 integrity-rule-catalog SPEC（extension 経由）の catalog entry 有無を確認、未記載時はユーザーへ追記を促す（`docs/specs/` 配下は直接編集しない G02）。**複数 REQ/Decision ファイルの3フェーズ分離**: 採番バッチ[直列] / ファイル作成[並列・最大5件] / インデックス更新[直列]。各詳細は `agentdev-req-file-manager` を参照
+
+### Result
+
+- REQ/Decision ファイル保存済み（QG-{N} 検証合格）
+
+### Evidence
+
+- 保存ファイルパス群、決定的スクリプトの JSON 結果、QG-{N} 判定
+
+### Completion Verification
+
+- 処理対象 entry 全てが保存済みであり、QG-{N} が合格であること
+
+### Resume-Idempotency
+
+- 保存済み REQ ファイルの存在（durable state）で再開点を判定する。再実行時は既存採番・既存ファイルを検出し、未保存分のみ処理する（rerun idempotency）。partial failure 時は保存済みファイルを残したまま未完了分を再処理する
+
+## 関連 STEP
+
+- 前: なし（workflow 開始）
+- 次: STEP-5（indexes-and-persistence.md）
+
+## 関連 Capability Skill
+
+- `agentdev-req-file-manager`: 判定ロジック、採番ルール、3フェーズ分離
+- `agentdev-artifact-validation`: 決定的スクリプト、公開検証契約
+- `agentdev-quality-gates`: QG-{N} 適用結果整合性検証
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G01（REQ/Decision 対象 artifact_actions がない場合は no-op 完了）
+- G02/G03（ファイル編集スコープ）
+- G05（REQ番号は連番・一意、空き番号再利用禁止）
+- G06（要件doc構造は doc_requirement.md テンプレート厳密準拠）

--- a/src/opencode/skills/agentdev-workflow-spec-save/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-spec-save/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: agentdev-workflow-spec-save
+description: "spec-save command の workflow 実装本体。req-define で分離された SPEC 保存対象（artifact: spec entry）を docs/specs/ へ保存・確定する制御を所有する。事前チェック（no-op 判定）、配置先解決（search-target-area.ts）、SPEC 分離基準の最終確認、SPEC ファイル操作（target_area セクション置換、並列化、SPEC 宣言付与）、インデックス整合、targeted docs guard、ドラフト status 更新、変更範囲検証、コミット・プッシュを提供する。USE FOR: spec-save command 実行時の workflow 制御（normal create/update・no-op・validation failure・partial failure・rerun idempotency・commit 前中断・external Git failure 各シナリオ）。DO NOT USE FOR: 要件doc 作成（req-define）、REQ/Decision 保存（req-save）、Issue 作成（case-open）、SPEC ファイル管理・配置判断・target_area マッチング規則の定義（agentdev-spec-file-manager）、決定的検証スクリプトの所有（agentdev-artifact-validation）、SPEC status 昇格 draft→accepted（case-close の責務）、gh CLI I/O 手続き（agentdev-gh-cli）、git worktree 操作（agentdev-git-worktree）、直接起動（Workflow Skill。対応する /agentdev/* command の工程経由で利用し、単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制）。"
+---
+
+# spec-save workflow スキル
+
+spec-save command の workflow 実装本体。req-define で分離された SPEC 保存対象（`draft-data` の `artifact_actions` 内 `artifact: spec` entry）を `docs/specs/<**/*>.md` に保存、確定する制御構造を所有する。req-save の次、case-open の前に実行する。req-save の G02（SPEC 編集禁止）を緩和するものではなく、SPEC 保存を独立責務として切り出す。全 work_type 対象であり、`work_type` による判定は廃止する。
+
+spec-save command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜004）。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md（control plane）と `references/` 配下（各 STEP 詳細）が担う。
+Workflow Skill 固有契約は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-spec-save.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と spec-save command の公開契約のみを前提とする。SPEC ディレクトリの内部構成は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない `docs/specs/**` 内部パスを固定知識として読みに行かない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## USE FOR
+
+- spec-save command の実行時 workflow 制御（全 STEP）
+- 事前チェック（`artifact: spec` entry 有無判定、no-op 完了、旧形式 draft 後方互換）
+- 配置先解決（既存パス vs `new:{slug}` / `target_spec` 構造化、決定的スクリプト呼出）
+- SPEC 分離基準の最終確認（安定契約例外の除外と follow-up 明示）
+- SPEC ファイル操作（create: frontmatter 付き新規作成、update: target_area セクション置換 / 後方互換追記、複数 action 並列化、SPEC 宣言付与）
+- インデックス整合（新規 SPEC の README 一覧登録、check-entry-existence 検証）
+- SPEC 一覧整合確認（targeted docs guard、extension 更新要否確認）
+- ドラフト status 更新（SPEC 消費済みフラグ）、変更範囲検証、コミット・プッシュ
+
+## DO NOT USE FOR
+
+- 要件doc 作成、壁打ち（`/agentdev/req-define`）
+- REQ/Decision ファイル保存（`/agentdev/req-save`）
+- Issue 作成（`/agentdev/case-open`。spec-save は Issue を作成しない）
+- SPEC ファイル管理・配置判断・target_area マッチング規則の定義（`agentdev-spec-file-manager`）
+- 決定的検証スクリプトの所有（`agentdev-artifact-validation`）
+- SPEC status 昇格（draft → accepted）の判定（case-close の責務。spec-save は accepted を付与しない）
+- SPEC 内容品質の再検証（req-define の QG-{N} の責務）
+- commit message 規約の定義（`agentdev-conventional-commits`）
+- 並列実行安全ステージングの定義（`agentdev-git-worktree`）
+
+## 入力
+
+- `.agentdev/drafts/req-draft-{topic-slug}.md`（req-define が生成し req-save が REQ 保存済みのドラフト。`draft-data` の `artifact_actions` に `artifact: spec` entry を含む）
+
+## 出力
+
+- `docs/specs/<**/*>.md`（既存 SPEC への追記 or 新規 SPEC 作成）
+- `.agentdev/drafts/req-draft-{topic-slug}.md`（SPEC artifact_actions 消費済みフラグの status 更新）
+
+## 副作用
+
+- `docs/specs/**` と `.agentdev/drafts/**` のみ作成・編集（G02。`docs/specs/README.md` は SPEC 操作に付随する更新のみ）
+- main ブランチへの commit・push（明示パスステージ、`agentdev-git-worktree` プロシージャ準拠）
+- Issue は作成しない（G12、case-open の責任範囲）
+
+## Control Plane（STEP 一覧）
+
+spec-save workflow は次の11 STEP で構成する。各 STEP は resume point を持つ（DEC-{N}、`docs/specs/<workflows/step-reference-contract>.md`）。会話コンテキストに依存せず、durable state（draft の SPEC 消費済みフラグ、SPEC ファイルの存在と frontmatter `status`、`docs/specs/README.md` エントリ、git 状態）から再開点を再構成する。
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-1 | 事前チェック | spec-save 起動 | 処理要否判定（no-op or 継続） | [references/placement-and-save.md](references/placement-and-save.md) |
+| STEP-2 | SPEC artifact_actions 読込 | 処理対象あり | 処理対象 entry（target、operation、content）確定 | [references/placement-and-save.md](references/placement-and-save.md) |
+| STEP-3 | 配置先解決 | entry 確定 | 配置先 SPEC（既存 or 新規）解決、target_area 判定 | [references/placement-and-save.md](references/placement-and-save.md) |
+| STEP-4 | SPEC 分離基準の最終確認 | 配置先解決済み | 適合判定（安定契約例外は除外し follow-up 明示） | [references/placement-and-save.md](references/placement-and-save.md) |
+| STEP-5 | SPEC ファイル操作 | 適合判定済み | SPEC create / update 実行（並列化、宣言付与） | [references/placement-and-save.md](references/placement-and-save.md) |
+| STEP-6 | インデックス整合 | ファイル操作完了 | 新規 SPEC の README 一覧登録（check-entry-existence 検証） | [references/verification-and-persistence.md](references/verification-and-persistence.md) |
+| STEP-7 | SPEC 一覧整合確認 | インデックス整合完了 | targeted docs guard、extension 更新要否確認 | [references/verification-and-persistence.md](references/verification-and-persistence.md) |
+| STEP-8 | ドラフト status 更新 | 一覧整合確認完了 | SPEC 消費済みフラグ（commit 対象に含む） | [references/verification-and-persistence.md](references/verification-and-persistence.md) |
+| STEP-9 | 変更範囲検証 | status 更新済み | check-change-impact 検証 | [references/verification-and-persistence.md](references/verification-and-persistence.md) |
+| STEP-10 | コミット・プッシュ | 変更範囲検証合格 | 明示パス commit、push | [references/verification-and-persistence.md](references/verification-and-persistence.md) |
+| STEP-11 | 完了報告 | push 完了 | 保存した SPEC 一覧、スキップ、follow-up 報告 | [references/verification-and-persistence.md](references/verification-and-persistence.md) |
+
+### STEP 間の依存と分岐
+
+- **標準経路**: STEP-1 → STEP-2 → STEP-3 → STEP-4 → STEP-5 → STEP-6 → STEP-7 → STEP-8 → STEP-9 → STEP-10 → STEP-11
+- **no-op 経路**: STEP-1 で `artifact: spec` entry がない場合（旧形式 draft 含む）、no-op で完了
+- **部分スキップ**: STEP-3 で配置先 SPEC 特定不能な候補は当該候補をスキップし follow-up 明示（全体中止しない）。STEP-4 で安定契約例外相当は除外し follow-up に明示
+- **並列化**: 異なる `target` パスの SPEC create/update は並列化可能（最大5件）。同一 SPEC ファイルへの複数 action は順序依存のため直列サブセットとして分離する
+
+### resume protocol
+
+- 再開点は durable state から再構成する: draft の SPEC 消費済みフラグ、SPEC ファイルの存在と frontmatter（`status`、`updated`）、`docs/specs/README.md` のエントリ、`git status`
+- commit 前中断時は `git diff --name-only` で変更ファイルを再検出し、未実行 STEP から再開する。SPEC 消費済みフラグの更新は commit/push より前に実施し commit 対象に含める
+- partial failure 時は保存済み SPEC（durable state）を残したまま未完了 action のみ再処理する（rerun idempotency）。external Git failure 時はエラー報告し、同一状態からリトライ可能な STEP を明示する
+
+### termination
+
+- 正常終了: STEP-11 の完了報告出力まで（no-op 時は STEP-1 の no-op 完了）
+- 停止終了: ドラフト不存在（エラーで中止、req-define を案内）、`artifact_actions` 形式不正（エラーで中止し req-define 差し戻し推奨）、変更範囲検証違反（ユーザーへ報告し指示待ち、自動破棄禁止）
+- SPEC status は新規作成時 `draft` のみ付与し、既存追記時は変更しない。`accepted` 昇格は case-close の責務
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する（REQ-{NNNN}-{NNN}）。
+
+- `agentdev-spec-file-manager`: SPEC ファイル操作、配置判断、target_area マッチング規則、SPEC ライフサイクル適用、決定的スクリプト呼出契約（search-target-area.ts）、複数 action 並列化
+- `agentdev-artifact-validation`: 公開検証契約（check-entry-existence、check-change-impact）
+- `agentdev-conventional-commits`: commit message 生成
+- `agentdev-git-worktree`: 並列実行安全ステージングプロシージャ（明示パスステージ、`git commit -- <paths>`）
+- `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+- integrity checker skill（AG-{NNN} detector、repo 固有）: check_changed_docs.ts（--workflow spec-save）
+
+## internal Workflow Extension 読込
+
+本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-spec-save.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、spec-save command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+
+## 共通制約
+
+- **工程分岐**: `artifact: spec` entry の有無で判定する（全 work_type 対象、`work_type` による判定は廃止）
+- **SPEC ライフサイクル**: 新規作成時 `status: draft`、既存追記時 `status` 変更なし。遷移契機の詳細は `agentdev-spec-file-manager` の spec-lifecycle-application が正とする
+- **再分類禁止**: SPEC artifact_actions の分離根拠、配置先判定は req-define（`agentdev-req-analysis`）の結果を尊重し、spec-save で再分類しない
+- **実行時非依存**: SPEC ファイルは実行時コマンドが依存する記述にしない（G09）
+- **Issue 作成禁止**: spec-save は Issue を作成しない（case-open の責任範囲）
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **`<workflows/step-reference-contract>` SPEC**: STEP reference 構造、resume point
+- **`docs/decisions/DEC-{N}.md`**: Command / Workflow Skill / Capability Skill 責務3層分化と1:N分割原則
+- **`docs/decisions/DEC-{N}.md`**: STEP resume point と会話記憶非依存
+- **spec-save command**: 本スキルの呼出元（公開 interface・ガードレール・dispatch を所有）

--- a/src/opencode/skills/agentdev-workflow-spec-save/references/placement-and-save.md
+++ b/src/opencode/skills/agentdev-workflow-spec-save/references/placement-and-save.md
@@ -1,0 +1,221 @@
+# STEP-1〜5: 事前チェック・配置先解決・SPEC ファイル操作（placement-and-save）
+
+> 本 reference は `agentdev-workflow-spec-save` SKILL.md の STEP-1〜STEP-5 詳細である。事前チェック、SPEC artifact_actions 読込、配置先解決、SPEC 分離基準の最終確認、SPEC ファイル操作を提供する。
+
+## 目次
+
+- STEP-1: 事前チェック
+- STEP-2: SPEC artifact_actions 読込
+- STEP-3: 配置先解決
+- STEP-4: SPEC 分離基準の最終確認
+- STEP-5: SPEC ファイル操作
+
+## STEP-1: 事前チェック
+
+### Purpose
+
+ドラフトの `artifact: spec` entry 有無を判定する（no-op 判定）。
+
+### Input Resolution
+
+1. SSoT 再構成: `.agentdev/drafts/req-draft-{topic-slug}.md` の `# draft-data` block
+2. identifier 保持: topic-slug
+3. 最小 scalar: なし
+4. runtime artifact: ドラフトファイル
+
+### Preconditions
+
+- spec-save command が起動している
+
+### Procedure
+
+ドラフトの `draft-data` の `artifact_actions` から `artifact: spec` entry の有無を確認する（全 work_type 対象、`work_type` による判定は廃止）。SPEC 対象 artifact_actions がない場合は no-op で完了する。ドラフトが存在しない場合はエラーで中止する（先に `/agentdev/req-define` を実行するよう案内）。
+
+### Result
+
+- 処理要否判定（no-op or 継続）
+
+### Evidence
+
+- `artifact_actions` の entry 種別一覧
+
+### Completion Verification
+
+- no-op 判定時に `artifact: spec` entry が実際に0件であること
+
+### Resume-Idempotency
+
+- 読取のみで副作用を持たない。再実行時は同一判定になる
+
+## STEP-2: SPEC artifact_actions 読込
+
+### Purpose
+
+処理対象となる SPEC action 群を読み込む。
+
+### Input Resolution
+
+1. SSoT 再構成: draft-data の `artifact_actions`
+2. identifier 保持: なし
+3. 最小 scalar: なし
+4. runtime artifact: ドラフトファイル
+
+### Preconditions
+
+- STEP-1 で処理対象ありと判定されている
+
+### Procedure
+
+ドラフトの `draft-data` の `artifact_actions` から `artifact: spec` の entry を読み込む。`artifact_actions` フィールドが存在しない（旧形式 draft）場合は SPEC 保存対象なしと判定し、no-op で完了する（後方互換）。`artifact: spec` entry が空の場合も no-op で完了する。各 action の `target`（file path または `new:{slug}`）、`operation`（create/update）、`content` を処理対象とする。
+
+### Result
+
+- 処理対象 entry 一覧（target、operation、content）
+
+### Evidence
+
+- entry ごとの target と operation
+
+### Completion Verification
+
+- 処理対象 entry の必須項目（target、operation、content）が読み取れていること（形式不正時はエラーで中止し req-define 差し戻し推奨）
+
+### Resume-Idempotency
+
+- 読取のみで副作用を持たない
+
+## STEP-3: 配置先解決
+
+### Purpose
+
+各 SPEC action の配置先 SPEC を解決する。
+
+### Input Resolution
+
+1. SSoT 再構成: `docs/specs/` 配下の既存 SPEC パス
+2. identifier 保持: `target_spec: {operation, domain, slug}` 構造化指定
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-2 で処理対象 entry が確定している
+
+### Procedure
+
+各 SPEC action の `target`（または `target_spec: {operation, domain, slug}` 構造化）から配置先 SPEC を解決する。既存 SPEC パス（例: `docs/specs/{domain}/<existing-spec>.md`、または `target_spec: {operation: update, domain, slug}`）は当該 SPEC へ追記（`update` 操作）とする。`target_spec: {operation: create, domain, slug}` は新規 SPEC 作成（`create` 操作、ファイル名 `docs/specs/{domain}/{slug}.md`）とする。同一 `target` の action は1つの SPEC へ集約する。
+
+**決定的処理のスクリプト呼出（REQ、AG-{NNN}）**: 配置先 SPEC が既存か新規か、`target_area` が存在するかの判定は `agentdev-spec-file-manager` SKILL.md「Scripts（決定的処理）」が規定する決定的スクリプト（`search-target-area.ts`）を bash 経由で呼び出して実行する（LLM 推論で代替しない）。CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照。
+
+### Result
+
+- 配置先 SPEC 解決済み（既存 or 新規）、target_area 判定結果（matches）
+
+### Evidence
+
+- search-target-area.ts の JSON 結果（matches）
+
+### Completion Verification
+
+- 全 action の配置先が解決済みであること（特定不能な候補はスキップし follow-up 記録、全体中止しない）
+
+### Resume-Idempotency
+
+- 読取とスクリプト実行のみで副作用を持たない
+
+## STEP-4: SPEC 分離基準の最終確認
+
+### Purpose
+
+各 SPEC action が SPEC に置くべき内容の基準に適合するか再確認する。
+
+### Input Resolution
+
+1. SSoT 再構成: SPEC 分離基準（`agentdev-req-analysis` の結果を尊重）
+2. identifier 保持: なし
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-3 で配置先が解決されている
+
+### Procedure
+
+各 SPEC action が SPEC に置くべき内容の基準に適合するか再確認する。安定契約例外相当の内容は REQ 側に残すべきものとして除外し、完了報告の follow-up に明示する。
+
+### Result
+
+- 適合判定（除外候補と follow-up 一覧）
+
+### Evidence
+
+- 判定根拠（分離基準照合結果）
+
+### Completion Verification
+
+- 不適合 action が follow-up へ退避済みであること
+
+### Resume-Idempotency
+
+- 判定は読取であり副作用を持たない
+
+## STEP-5: SPEC ファイル操作
+
+### Purpose
+
+処理対象 entry に対する SPEC create / update を実行する。
+
+### Input Resolution
+
+1. SSoT 再構成: 配置先 SPEC ファイル、`docs/specs/README.md`
+2. identifier 保持: target、target_area
+3. 最小 scalar: なし
+4. runtime artifact: ドラフトの `spec_logical_division`、`canonical_owner` 宣言
+
+### Preconditions
+
+- STEP-4 の適合判定が完了している
+
+### Procedure
+
+`draft-data` の `artifact_actions`（`artifact: spec`）の全 entry を処理する:
+
+- **create**: 新規 SPEC ファイルを frontmatter（`title`、`status: draft`、`created`、`updated`）付きで作成し、action の `content` をセクションとして記載する
+- **update**: `target_area` 指定時（operation が `update`/`spec-update`）は `agentdev-spec-file-manager` のセクション置換ロジック（target-area-matching）で対象セクションを `content` で置換する。`target_area` 未指定時は既存 SPEC ファイルの該当セクションへ `content` を追記する（後方互換）。frontmatter `updated` を更新し、`status` は変更しない
+- **target_area 見出し検索のスクリプト呼出（REQ、AG-{NNN}）**: `update` 操作における `target_area` 見出し検索は `search-target-area.ts` で実行する。STEP-3 の結果（`matches`）を用いてセクション範囲を特定し `content` で置換する。`matches` 空 → スキップし follow-up 記録（operation を spec-create 推奨）、複数マッチ → G09 に従い置換拒否
+- **複数 SPEC action の並列化**: 異なる `target` パスの SPEC create/update は並列化可能（最大5件）。同一 SPEC ファイルへの複数 action は順序依存のため直列サブセットとして分離する。直列集約対象（index 更新、draft 更新、commit、push）は並列委譲の完了を待ってから実行する
+- **SPEC 宣言付与（CREATE/UPDATE）**: req-define が各 entry へ出力した `spec_logical_division` と `canonical_owner` を読み取り、SPEC frontmatter または冒頭宣言節へ宣言として付与する。CREATE で宣言なしで完了することを禁止する。UPDATE で宣言未宣言かつ分類値が `unknown` 以外に確定の場合は宣言を補完、`unknown` または欠落の場合は警告して処理を継続する（soft-contract、宣言欠落だけで保存拒否しない）。既存 SPEC の一括更新は行わず、未変更 SPEC へ遡及的に宣言を付与しない（段階適用）
+
+### Result
+
+- SPEC create / update 実行済み
+
+### Evidence
+
+- 作成・更新ファイルパス、search-target-area.ts の JSON 結果、宣言付与結果
+
+### Completion Verification
+
+- 新規 SPEC に frontmatter（`title`、`status: draft`、`created`、`updated`）があること。CREATE で宣言が付与されていること。既存追記で `status` が不変であること
+
+### Resume-Idempotency
+
+- SPEC ファイルの存在（durable state）で再開点を判定する。保存済み action は再処理しない。partial failure 時は保存済み SPEC を残したまま未完了 action のみ再処理する
+
+## 関連 STEP
+
+- 前: なし（workflow 開始）
+- 次: STEP-6（verification-and-persistence.md）
+
+## 関連 Capability Skill
+
+- `agentdev-spec-file-manager`: 配置判断、target_area マッチング規則、セクション置換ロジック、並列化詳細、SPEC ライフサイクル適用
+- `agentdev-req-analysis`: SPEC 分離基準（req-define の結果を尊重）
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G01（`artifact: spec` 有無での判定、`work_type` 判定廃止）
+- G02/G03/G04（ファイル編集スコープ、SPEC 対象なし時の編集禁止）
+- G05/G06/G07（SPEC ライフサイクル制約）
+- G08/G09（SPEC 分離基準適合、実行時非依存）

--- a/src/opencode/skills/agentdev-workflow-spec-save/references/verification-and-persistence.md
+++ b/src/opencode/skills/agentdev-workflow-spec-save/references/verification-and-persistence.md
@@ -1,0 +1,264 @@
+# STEP-6〜11: 整合確認・永続化・報告（verification-and-persistence）
+
+> 本 reference は `agentdev-workflow-spec-save` SKILL.md の STEP-6〜STEP-11 詳細である。インデックス整合、SPEC 一覧整合確認、ドラフト status 更新、変更範囲検証、コミット・プッシュ、完了報告を提供する。
+
+## 目次
+
+- STEP-6: インデックス整合
+- STEP-7: SPEC 一覧整合確認
+- STEP-8: ドラフト status 更新
+- STEP-9: 変更範囲検証
+- STEP-10: コミット・プッシュ
+- STEP-11: 完了報告
+
+## STEP-6: インデックス整合
+
+### Purpose
+
+新規 SPEC を `docs/specs/README.md` の SPEC 一覧へ登録する。
+
+### Input Resolution
+
+1. SSoT 再構成: `docs/specs/README.md`、新規 SPEC ファイル
+2. identifier 保持: SPEC パス、domain
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-5 で新規 SPEC が作成されている（既存追記時は本 STEP をスキップ可）
+
+### Procedure
+
+新規 SPEC 作成時は `docs/specs/README.md`（SPEC 一覧）に追加する。既存 SPEC 追記時は README 更新不要とする。新規 SPEC 作成後に `agentdev-artifact-validation` の公開検証契約（`check-entry-existence`、RU-{NNNNNNNN}-01 合意）で登録を検証する。CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照。
+
+### Result
+
+- README 一覧登録済み（check-entry-existence 検証合格）
+
+### Evidence
+
+- 更新後 README、check-entry-existence の JSON 結果
+
+### Completion Verification
+
+- 新規 SPEC のエントリが SPEC 一覧表に存在すること
+
+### Resume-Idempotency
+
+- エントリ存在確認で登録済みを検出した場合は再追加しない
+
+## STEP-7: SPEC 一覧整合確認
+
+### Purpose
+
+SPEC 一覧表の整合を確認し、targeted docs guard と extension 更新要否確認を実施する。
+
+### Input Resolution
+
+1. SSoT 再構成: `docs/specs/README.md`、`.agentdev/extensions/**`
+2. identifier 保持: SPEC パス
+3. 最小 scalar: なし
+4. runtime artifact: 変更 SPEC ファイル一覧
+
+### Preconditions
+
+- STEP-6 のインデックス整合が完了している
+
+### Procedure
+
+SPEC 新規作成時は `docs/specs/README.md` の SPEC 一覧表に追加済みであることを確認する（STEP-6 で実施済みの場合は重複確認）。SPEC 一覧表の整合は SPEC 探索導線の維持に必要な更新のみを対象とし、要件、判断、仕様の更新は含まない。
+
+- **extension 更新要否の確認（REQ）**: SPEC の追加、移動、分割が `.agentdev/extensions/**` に影響するか確認する。移動または分割により extension 参照先 SPEC パスが変わる場合、当該 extension の context paths を更新する。extension 参照先 SPEC を移動した場合はエラーとし、spec-save 自身は移動を完了させずユーザー判断を仰ぐ（IR-{NNN} check #5 strict 違反を防止）。SPEC 新規作成で既存 command/skill の実行時参照が増える場合、対応 extension の `context` への追加をユーザーに提案する（直接編集しない）
+- **targeted docs guard（REQ）**: 変更 SPEC ファイルと連動ファイル（`docs/specs/README.md`）に対し `check_changed_docs.ts --workflow spec-save --files <changed SPEC files> --json` を実行する。`failures` に strict severity を含む場合は保存工程を継続せず修正して再実行する。`spec_readme_update_required` が true の場合は STEP-6 の更新要否判定に反映する。`full_docs_check_recommended` が true の場合は全体監査（self-hosting リポジトリ限定の自己監査コマンド）の実行をユーザーに提案する
+
+### Result
+
+- 一覧整合確認結果、targeted docs guard 結果、extension 更新要否
+
+### Evidence
+
+- check_changed_docs.ts の JSON 結果
+
+### Completion Verification
+
+- targeted docs guard の failures に strict severity を含まないこと
+
+### Resume-Idempotency
+
+- 読取と guard 実行であり再実行可能
+
+## STEP-8: ドラフト status 更新
+
+### Purpose
+
+ドラフトへ SPEC 消費済みフラグを記録する。
+
+### Input Resolution
+
+1. SSoT 再構成: ドラフト frontmatter
+2. identifier 保持: topic-slug
+3. 最小 scalar: SPEC 消費済みフラグ
+4. runtime artifact: ドラフトファイル
+
+### Preconditions
+
+- STEP-7 の一覧整合確認が完了している
+
+### Procedure
+
+ドラフトの SPEC artifact_actions 消費状態を記録する（`draft-data` に SPEC 消費済みフラグを付与）。commit/push より前に更新し、commit 対象に含める。
+
+### Result
+
+- SPEC 消費済みフラグ記録済み
+
+### Evidence
+
+- 更新後 draft-data
+
+### Completion Verification
+
+- フラグが commit 対象に含まれていること
+
+### Resume-Idempotency
+
+- フラグの存在（durable state）で消費済み否かを再構成できる。二重更新は冪等
+
+## STEP-9: 変更範囲検証
+
+### Purpose
+
+変更ファイルが許可パスリスト内であることを検証する。
+
+### Input Resolution
+
+1. SSoT 再構成: `git diff --name-only`
+2. identifier 保持: なし
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-8 の status 更新が完了している
+
+### Procedure
+
+**決定的処理のスクリプト呼出（REQ、AG-{NNN}）**: `git diff --name-only` で変更ファイル一覧を取得し、許可パスリスト（G02）との照合を `agentdev-artifact-validation` の公開検証契約（`check-change-impact`、RU-{NNNNNNNN}-01 合意）で実行する。許可範囲外の変更を検出したらエラーを報告し指示を待つ（自動破棄しない）。`violations` が空でない場合は G02 違反として報告し指示を待つ。CLI 形式、stdin JSON 入力、stdout schema は同 SKILL.md を参照。
+
+### Result
+
+- 変更範囲検証結果
+
+### Evidence
+
+- check-change-impact の JSON 結果
+
+### Completion Verification
+
+- violations 0件であること
+
+### Resume-Idempotency
+
+- 読取検査であり再実行可能
+
+## STEP-10: コミット・プッシュ
+
+### Purpose
+
+変更を明示パスでコミットし、main ブランチへ push する。
+
+### Input Resolution
+
+1. SSoT 再構成: `git status`、変更ファイル一覧
+2. identifier 保持: SPEC パス
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-9 の変更範囲検証が合格している
+
+### Procedure
+
+`agentdev-conventional-commits` に従い main ブランチに push する。STEP-8 の status 変更を commit 対象に含める。並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、`git add <path>` で明示パスステージし、`git commit -- <paths>`（--only pathspec 形式）でコミットする。スイープ操作は禁止する。最終的な commit/push は明示パス指定で一括実行する（複数 SPEC action の並列委譲時も直列集約対象）。
+
+### Result
+
+- commit・push 完了
+
+### Evidence
+
+- commit hash、push 結果、commit 対象パス一覧
+
+### Completion Verification
+
+- 変更が全てコミット済みであり、push が成功していること
+
+### Resume-Idempotency
+
+- commit 前中断時は `git status` から未コミット変更を再検出して再実行する。push 拒絶（external Git failure）時はエラー報告し、同一 commit からリトライする
+
+## STEP-11: 完了報告
+
+### Purpose
+
+保存結果を報告する。
+
+### Input Resolution
+
+1. SSoT 再構成: STEP-10 の結果、保存済み SPEC 一覧
+2. identifier 保持: SPEC パス群
+3. 最小 scalar: なし
+4. runtime artifact: follow-up 一覧
+
+### Preconditions
+
+- STEP-10 の push が完了している（no-op 時は STEP-1 判定直後）
+
+### Procedure
+
+完了報告 template に従い、保存した SPEC 一覧（新規/追記別）、スキップ有無、follow-up（安定契約例外で除外した候補）を出力する。
+
+### Result
+
+- 完了報告出力
+
+### Evidence
+
+- 完了報告本文
+
+### Completion Verification
+
+- 保存・スキップ・follow-up の全数が報告されていること
+
+### Resume-Idempotency
+
+- 報告のみで副作用を持たない
+
+## 関連 STEP
+
+- 前: STEP-5（placement-and-save.md）
+- 次: なし（workflow 終了。後続は case-open）
+
+## 関連 Capability Skill
+
+- `agentdev-artifact-validation`: check-entry-existence、check-change-impact
+- `agentdev-conventional-commits`: commit message 生成
+- `agentdev-git-worktree`: 並列実行安全ステージング
+- integrity checker skill（AG-{NNN} detector、repo 固有）: check_changed_docs.ts（--workflow spec-save）
+
+## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
+
+- G10（分離根拠・配置先判定の再分類禁止）
+- G11（SPEC status 昇格は case-close の責務）
+- G12（Issue 作成禁止）
+
+## 検証観点（品質ゲート: 適用結果の整合性検証）
+
+- `target_area` 置換結果の整合性（STEP-5 の `search-target-area.ts` 結果と置換後本体の一致）
+- SPEC status の整合性（新規作成時 `status: draft`、既存追記時 `status` 変更なし）
+- インデックスの整合性（`docs/specs/README.md` エントリと新規 SPEC の一致、STEP-6 の `check-entry-existence.ts` 結果）
+- 変更範囲の妥当性（STEP-9 の `check-change-impact.ts` 結果）
+- 宣言付与の整合性（CREATE で `spec_logical_division` と `canonical_owner` が frontmatter または冒頭宣言節へ付与、UPDATE で `unknown` 以外確定時に補完）
+- 内容の品質（SPEC 分離基準適合性等）は再検証しない（req-define の QG-{N} の責務。STEP-4 の最終確認は分離基準の最終チェックであり内容品質の再審査ではない）


### PR DESCRIPTION
Refs: #2102

## 概要

Epic #2099 Wave 2 / Issue #2102（OU-002）: req/case core 8 Command（req-define / req-save / spec-save / case-run / case-update / case-open / case-close / case-auto）の Workflow Skill 移行と thin Command 化。case-run は single workflow と epic-wave workflow の 1:N 分離を含む。既存3 Workflow Skill（case-open / case-close / case-auto）は Command 本文残存 workflow 実装の移管と STEP 8要素化により完全化した。

## 実装内容

1. **Workflow Skill 新設 5件**（SKILL.md + references、各 STEP は Purpose / Input Resolution / Preconditions / Procedure / Result / Evidence / Completion Verification / Resume-Idempotency の8要素を所有）:
   - `agentdev-workflow-req-define`（11 STEP、対話型。draft-data 下書きを durable state とする resume 設計、経路A）
   - `agentdev-workflow-req-save`（12 STEP、3フェーズ並列委譲モデル、読込時 hash 記録）
   - `agentdev-workflow-spec-save`（11 STEP、target_area セクション置換、SPEC 宣言付与）
   - `agentdev-workflow-case-update`（4 STEP、--body / --comment / --req / --review-ng 4分岐）
   - `agentdev-workflow-case-run`（1:N 分離: single workflow STEP-S1〜S6 + epic-wave workflow STEP-W1〜W5 + 共通委譲・result 処理 reference。実行契約差異表で target cardinality / parallelism / fan-out・fan-in / child task recovery / partial result / Wave-level completion の6軸を明示）
2. **既存3 Workflow Skill の完全化**: 14 reference 計61 STEP セクションを8要素構造へ retrofit、SKILL.md に resume protocol / termination 節を明示追加、case-auto SKILL.md に「下位 Workflow Skill 連携（上位 orchestrator）」節を追加（req-save / spec-save / case-open / case-run / case-close の各 Workflow Skill を名レベル参照、下位契約の複製なし）
3. **core 8 Command の thin Command 化**: 各 Command 本文は public interface（入出力・ガードレール）と Workflow Skill dispatch（### Step N 形式の STEP 一覧 + 名レベル参照）のみを所有。frontmatter description は全件変更なし（Public IF 維持）
4. **soft guard 付与（REQ-027-002 相当、OpenCode 1.18.15 向け）**: core 8 Command の workflow 節に soft guard 宣言を追加、8 Workflow Skill の description DO NOT USE FOR に「単独の skill 起動は REQ-{NNNN}-{NNN} soft guard で抑制」トリガーを付与
5. **IR-055 baseline 再生成**: 移設（command から skill への参照移動）に伴う delta を正規 CLI（`--update-ir055-baseline`）で登録。エントリは 98 -> 61 に純減（thin 化により command 側参照が減少）

## 完了条件

- [x] core 8 Command 本文が public interface / guardrails / Workflow Skill dispatch のみを所有し、workflow 実装本体を複製していないこと（AC-02、AC-03、AG-004）。検証: 8 Command の行数は 47〜73 行（旧 req-define 152行 / case-run 180行等から縮小）、手順本文は各 Workflow Skill 側へ移管、description frontmatter の diff 0件
- [x] 8 Command の Workflow Skill が存在し、purpose / input / output / global invariants / STEP list / transition / resume protocol / termination を持ち、独立実行可能であること（AC-01、TS-001）。検証: 8 skill とも SKILL.md に入力・出力・副作用・Control Plane（STEP 一覧）・STEP 間の依存と分岐（transition）・resume protocol・termination・共通制約（global invariants）が存在、STEP 8要素は機械検査 61/61 セクション合格
- [x] agentdev-workflow-case-run が single workflow と epic-wave workflow を分離し、実行契約差異（target cardinality / parallelism / fan-out・fan-in / child task recovery / partial result / Wave-level completion）を明示的に扱っていること（AG-003、TS-001 subcheck）。検証: SKILL.md「Workflow 構成（1:N 分離、DEC-010）」節 + 6軸の実行契約差異表 + references/single.md・references/epic-wave.md・references/delegation-and-result.md の3 reference 構成
- [x] case-auto が下位 workflow の契約を複製しない上位 orchestrator として再設計されていること（AG-004、REQ-006-072/073 の適用状態）。検証: command 本文の「下位 workflow の権威情報源」節と skill の「下位 Workflow Skill 連携」節で5下位 Workflow Skill を名レベル参照、工程固有手順の再実装なし（check_delegation_contract_residual.ts IR-032/033 違反 0）
- [x] core 8 Command に soft guard（OpenCode 1.18.15 向け）が付与されていること。検証: 8 Command すべての workflow 節に soft guard 宣言、8 Skill description に DO NOT USE FOR トリガー（grep で 8/8 + 8/8 確認）
- [x] 全 Workflow Skill について STEP reference / resume model / durable state / Input Resolution 契約が成立し、conversation memory のみを resume source とする Workflow Skill が存在しないこと（AC-04、TS-002）。検証: 61 STEP 全てが8要素を持ち、各 resume protocol は GitHub Issue/PR・.agentdev/・draft status frontmatter 等 durable state から再開点を再構成（機械検査スクリプト結果: issues 0）
- [x] 対象 Command 本文から Capability Skill 内部 reference（references/* 等の内部パス）への直接依存が存在しないこと（名レベル参照であること、AG-003）。検証: 8 Command に対する agentdev スキル内部 references パターンの grep 0件。workflow dispatch 先の「当該 Workflow Skill の references/ 配下を参照」表現は対応 Workflow Skill 自身への参照（Stage 0 確立形式）
- [x] Public IF（name / primary input / primary output / user-visible workflow meaning）に意図しない変更がないこと。検証: frontmatter description 8件とも元の文言を保持、入出力セクション・ガードレール番号（G01〜）を維持、検査ツール系スクリプトのパス表現は placeholder 形式（<integrity-detector-skill>）で維持

## テスト結果

- **TS-001（core 8 検証）**: 合格。8 Command の thin 化・Workflow Skill 存在・8要素・soft guard・Capability 境界（名レベル参照）を個別検証（上記完了条件の検証記録）
- **TS-002（STEP/resume 契約）**: 合格。全8 skill の61 STEP セクションについて8要素存在を機械検査（スクリプトによる分割検査、issues 0）。各 resume protocol は durable state 優先順位に基づき会話記憶非依存
- **TS-006（代表シナリオ、設計検証）**: 合格（durable-state 追跡表による設計検証として実施。実ランタイム実行は OU-008a の最終検証対象）。

### TS-006 durable-state 追跡表（シナリオ × STEP × durable state × 期待結果）

| シナリオ | 到達 STEP | durable state | 期待結果 | 判定 |
|---|---|---|---|---|
| case-run single 正常系 | S1→S6 | worktree+PR 存在、PR URL | completed-pr、最終 gate 合格、L2 内訳付き完了報告 | pass |
| case-run Epic Wave 正常系 | W1→W5 | Epic Issue 本文テーブル、子Issue PR 群 | 全子 completed-pr、1 Wave で return | pass |
| child partial blocked | W3→W4 | blocked 子の Issue コメント（SSoT） | 完了子の PR は有効保持、blocked 子は次 Wave 対象外 | pass |
| child failed | W3→W4 | failed 子の Issue コメント（SSoT） | 当該子のみ停止、他子は継続 | pass |
| fan-out 後 compaction recovery | W2〜W4 再開 | worktree・PR の存在、Epic テーブル、子 task 状態（Harness 復元） | 完了済み子を再委譲せず未確定子のみ再開 | pass |
| fan-in state reconstruction | W4 | PR・Issue コメントからの子 task 状態再構成 | 全子が4状態に分類され partial result 保持 | pass |
| req-define 対話開始 | STEP-1〜2 | 入力ファイル・RU | 入力ソース確定、壁打ち開始 | pass |
| req-define HITL | STEP-2 | draft-data 下書き（合意内容反映） | 承認済み項目を再質問しない | pass |
| req-define blocked | STEP-4/8 | ブロッカー、unresolved 判断事項（draft 下書き） | STEP-9 に進まず停止 | pass |
| req-define resume | STEP-2〜11 再開 | draft-data 下書き、status frontmatter | 未解決項目のみ再対話 | pass |
| req-define draft 生成 | STEP-6〜10 | req-draft ファイル、auto_gate | draft-data 形式で保存、QG 検証 | pass |
| req-save normal create/update | STEP-1〜12 | REQ ファイル、README、status: saved、commit | QG 合格、明示パス commit+push | pass |
| req-save no-op | STEP-1 | artifact_actions に req/decision なし | no-op 完了、case-open 案内 | pass |
| req-save validation failure | STEP-3 | 必須フィールド欠損検出 | エラー中止、req-define 差し戻し | pass |
| req-save partial failure | STEP-4 再開 | 保存済み REQ ファイル | 未保存分のみ再処理 | pass |
| req-save rerun idempotency | STEP-4/6 | 既存採番・既存 Decision ファイル | 再作成せず未完了分のみ処理 | pass |
| req-save commit 前中断 | STEP-10〜11 再開 | git status、status: saved 未 commit | 未コミット変更再検出、status を commit 対象に含め再実行 | pass |
| req-save external Git failure | STEP-9/11 | pull/push エラー時の HEAD | エラー報告、同一状態からリトライ可能 STEP 明示 | pass |
| spec-save normal create/update | STEP-1〜11 | SPEC frontmatter（status: draft）、README 一覧、消費済みフラグ | 宣言付与、check-entry-existence 合格、commit+push | pass |
| spec-save no-op / validation failure / partial failure / rerun idempotency / commit 前中断 / external Git failure | STEP-1〜10 | artifact_actions、SPEC ファイル存在、target_area matches、git status | req-save と対称の停止・再開・冪等挙動（各 resume protocol に明記） | pass |

- **TS-102（Skill/Command 品質査読）**: 合格（未解決違反 0件）。agentdev-skill-authoring の5評価軸（明確性・完全性・トリガー精度・スコープ範囲・アンチパターン）で全新設・変更ファイルを査読: frontmatter は name/description のみ、description は3人称 + USE FOR / DO NOT USE FOR 必須トリガー付き、参照深度1階層、100行超 reference に目次、実行時パス遵守。agentdev-command-authoring の品質基準: Steps 5〜12個、行数 47〜73行（150行上限内）、詳細判定表の Skill 移管、決定的処理の Script 委譲維持、パスは実行時パス

### gates

- `check_distribution_boundary.ts --profile source --json`: **pass**（ok=true、282 files、hits 0、rules ok。DEC-014 決定5 準拠）
- `check_extensions.ts --json`: **pass**（ok=true、failures 0、public_skills 40 = 35 + 新設5）
- `check_command_format.ts --json`: **pass**（ok=true、violations 0）
- `lint_skills.ts --json`: 自ファイルの ng 0件（repo-agentdev-integrity 自身の See Also ng 4件は base から既存）
- `check_executor_notation.ts` / `check_delegation_contract_residual.ts` / `check_retired_artifact_residual.ts`: **pass**（違反 0）
- repo-integrity test suite（bun test）: **1875 pass / 4 fail**。4 fail は全て base ブランチ由来の既知事象（check_templates --dry-run 系3件は環境依存、ADR README.md 存在検査1件は DEC-009 移行後の stale 期待値）。本 PR で base 由来の失敗7件を解消（case-open/close Steps 構造・templates 参照・case-close 検証・番号 Step 参照）
- `check_changed_docs.ts --workflow case-run`: docs/** 変更なしのためスキップ（本 Issue 対象外）
- `check_extensions.ts` 相当の worktree 制約: 本 worktree は source パス基準の実装のため src/opencode/ から直接実行可能であり制約なし

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 完了条件達成数 | 8/8 | 8/8 | 合格 |
| STEP 8要素機械検査 | 61/61 セクション、issues 0 | 全 STEP 8要素 | 合格 |
| 配布依存境界 最終 gate | ok=true、hits 0 | 違反 0 | 合格 |
| repo-integrity tests | 1875 pass / 4 fail（全て base 既存） | 新規失敗 0 | 合格 |
| soft guard 付与 | Command 8/8、Skill 8/8 | 16/16（core 8 分） | 合格 |
| thin Command 行数 | 47〜73 行 | 150 行以内 | 合格 |
| Public IF（description）変更 | 0 件 | 0 件 | 合格 |

## Findings / Capture候補

### intake

- 発見元: 本 PR の検証作業。内容: `commands_e2e.test.ts` の「ADR README.md exists」が `docs/adr/README.md` の存在を要求するが、DEC-009（ADR から Decision への移行）以降 同パスは不存在で base から失敗している。テスト期待値の更新（`docs/decisions/README.md` へ）または当該検査の意義再評価が必要。分類: intake
- 発見元: 本 PR の検証作業。内容: case-open / case-auto の SKILL.md・references は STEP 識別子がマスク形式（`STEP-{N}`）で、case-close は実番号（STEP-1 等）と不統一（Stage 0 の配布物 ID 衛生適用差）。新設5 skill は実番号（STEP-N / STEP-S / STEP-W）を採用。既存2 skill の識別子統一は横断是正候補。分類: intake
- 発見元: 本 PR の検証作業。内容: `check_templates.ts` の --dry-run 系テスト3件が base から失敗（環境依存の模様。worktree 配置の templates 参照解決）。分類: intake

### learning

- 発見元: 本 PR の IR-055 対応。内容: workflow 実装を command から skill へ移設すると、同一文言の参照でも移設先ファイルが baseline 未登録のため delta 違反になる。正規 CLI（`check_integrity.ts --update-ir055-baseline`）での再生成が移設作業の標準手順として機能する（今回 98 から 61 entries に純減し、ratchet として健全）。分類: learning

## SPEC確定候補

- thin Command の workflow 節標準構造: 「### Step N: 名称 + 1行要約」見出し群 + Workflow Skill 名レベル dispatch 宣言 + soft guard 宣言（REQ-027-002 相当）の3要素構成。command-file-format SPEC（OU-005 同期対象）への反映候補
- case-run 1:N 分離の実行契約差異表（target cardinality / parallelism / fan-out・fan-in / child task recovery / partial result / Wave-level completion の6軸）は workflow-skill-model SPEC「1:N 分割基準」の適用実例として記録可能
- soft guard の二層様式: Command 側は workflow 節の宣言文（grep 可能な `soft guard` マーカー）、Skill 側は description の DO NOT USE FOR トリガー。全16 Command への展開は OU-003 / OU-004 が、完結確認は OU-008a が担当
- Workflow Skill の STEP 8要素見出し形式（`### Purpose` から `### Resume-Idempotency` まで）は step-reference-contract SPEC の機械検査可能な標準見出し群として確定候補（本 PR の検証スクリプトで 61/61 準拠確認済み）
