### PR TITLE
docs(agentdev): 16 Command SPEC を Workflow Skill 構成と同期（OU-005）

### DIFF
--- a/docs/specs/commands/backlog-review.md
+++ b/docs/specs/commands/backlog-review.md
@@ -2,7 +2,7 @@
 title: backlog-review SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # backlog-review SPEC
@@ -41,7 +41,8 @@ updated: 2026-08-14
 
 ## 現在の動作
 
-処理段階（外部から意味のある順序）。各段階の詳細手順は Workflow Skill（`agentdev-workflow-backlog-review`）が権威情報源である。
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-backlog-review`）が正規情報源である。
 
 - 実行前同期（`git pull --ff-only`）
 - 成果物検出（引数有無切り替え（引数あり: 指定ファイルのみ / 引数なし: `promoted/` 全件））
@@ -52,6 +53,13 @@ updated: 2026-08-14
 - 成果物削除（RU 生成失敗成果物は削除しない（G06））
 - Git 永続化
 - 完了報告
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/backlog-review.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（工程構成、内部手順、reference 構成）は Workflow Skill（`agentdev-workflow-backlog-review`）が所有し、本 SPEC はこれらを複製しない。
+- Workflow Skill の単独起動防止（soft guard）は Workflow Skill description の DO NOT USE FOR トリガーにより実効する（command 定義本文に soft guard 宣言節を持たない構成である）。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## Artifact Graph 利用
 
@@ -138,10 +146,18 @@ backlog-review が `tentative_classification` に7値以外の値を付与しよ
 backlog-review は全 RU frontmatter に `tentative_classification` を付与すること。
 フィールド欠落の RU は生成しないこと。
 
+## 停止状態
+
+- 矛盾検出時の追加判断をユーザーから得られない場合（REQ-003-009。矛盾する artifact の RU 化を保留し、判断を待つ）。
+- adversarial-review 審議で unresolved な本質的争点またはユーザー判断事項が残る場合（RU 生成、採用済み成果物削除、Git 永続化等の後続不可逆処理へ進まない、REQ-014-009）。
+- RU frontmatter `tentative_classification` へ7値以外の値を付与しようとした場合（RU 生成を停止し、訂正を求める）。
+- 実行前同期（`git pull --ff-only`）失敗時（エラーを報告して停止する）。
+
 ## See Also
 
 - [intake-promote.md](intake-promote.md), [learning-promote.md](learning-promote.md), [inspect-promote.md](inspect-promote.md)（前段コマンド）
 - [req-define.md](req-define.md)（後続コマンド（RU を入力として要件定義））
+- `agentdev-workflow-backlog-review` skill（workflow 実装本体）
 - `agentdev-backlog-integration` skill（分析基準、統合分割判定、depends_on 依存解決、矛盾検出、RU 生成ルール）
 - REQ-008（RU lifecycle）
 - REQ-010（Backlog-review）

--- a/docs/specs/commands/case-auto.md
+++ b/docs/specs/commands/case-auto.md
@@ -2,7 +2,7 @@
 title: case-auto SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # case-auto SPEC
@@ -11,6 +11,11 @@ updated: 2026-08-14
 
 要件doc から req-save → spec-save → case-open → case-run → case-close を順次自走実行する最大自走モード。
 ユーザーが明示的に指定した場合のみ使用する追加入口であり、標準ワークフローを置き換えない。
+
+## 承認・HITL 境界
+
+- ユーザーが case-auto の実行を明示的に指定した場合のみ使用する追加入口である（起動自体が唯一の事前判断）。
+- 自走中に新規の承認点を追加しない。blocked / failed、停止条件検出時は自走を停止し、ユーザー判断を待つ（bounded parent decision resolution による decision_context の限定的親判断を除く）。
 
 ## 入力
 
@@ -31,7 +36,8 @@ updated: 2026-08-14
 
 ## 現在の動作
 
-処理段階（外部から意味のある順序）。各段階の詳細手順は Workflow Skill（`agentdev-workflow-case-auto`）が権威情報源である。
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-case-auto`）が正規情報源である。
 
 - 入力解決
   - 実行開始時刻の記録（REQ-006-082）（JST、人間が読みやすい形式で case_auto_started_at 変数に保持）
@@ -45,7 +51,7 @@ updated: 2026-08-14
   - auto_gate preflight（auto_gate.auto_ready が false または未解決 item 残る場合は停止）
 - 各工程の実行
   - 委譲工程（req-save / spec-save / case-open / case-close）: 実行担当サブエージェントとして起動（v2:ADR-0127, REQ-006-006/084/085）。req-save / spec-save 統合委譲で順次実行、case-open / case-close は各コマンド委譲契約に従い起動。委譲起動不能時に delegation-unavailable 報告（REQ-002-003/004）
-  - case-run（インライン実行）: case-auto が case-run の Workflow Skill（`agentdev-workflow-case-run`）を権威情報源として読み込み、準備/クリーンアップフェーズを自ら実行。実行担当サブエージェント委譲フェーズでは case-auto から直接実行担当サブエージェントへ委譲（委譲起点の折りたたみ/002）。adapter skill（agentdev-case-run-execution-adapter）を case-auto が読み込む
+  - case-run（インライン実行）: case-auto が case-run の Workflow Skill（`agentdev-workflow-case-run`）を正規情報源として読み込み、準備/クリーンアップフェーズを自ら実行。実行担当サブエージェント委譲フェーズでは case-auto から直接実行担当サブエージェントへ委譲（委譲起点の折りたたみ/002）。adapter skill（agentdev-case-run-execution-adapter）を case-auto が読み込む
   - 結果状態の4次元集約（REQ-006-110）: 各工程の output_contract から (1) 工程結果 pass/warn/fail、(2) artifact_action 適用結果 applied/skipped/failed/no-op、(3) 定義適用工程完了状態、(4) OU ライフサイクル完了状態を収集し混同なく保持する。集約規則の詳細は後述「結果状態の4次元集約（REQ-006-110）」セクション
 - Wave 反復制御（Epic Issue 指定時）
   - case-auto が Epic Issue 番号を記録。Epic Issue 本文から Wave 構成、各子Issue ステータスを読み取る（読み取りのみ、Epic Issue 本文の書き込みは case-close の責務）
@@ -69,6 +75,14 @@ genuine blocker（実装上の問題、スコープ外操作、コンフリク�
 context 管理:
 - case-run インライン実行時のコンテキスト管理は harness の責務（REQ-002-002）
 - REQ-006-073（親コンテキスト非累積）は case-run インライン実行時の例外として取り扱う
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/case-auto.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（orchestration stage モデル、Wave 反復制御、停止理由分類、reference 構成）は Workflow Skill（`agentdev-workflow-case-auto`）が所有し、本 SPEC はこれらを複製しない。各工程の output_contract（工程別契約表）も Workflow Skill が所有する。
+- case-run（インライン実行）の workflow 実装本体は case-run の Workflow Skill（`agentdev-workflow-case-run`）が所有する（single workflow、epic-wave workflow の分離を含む）。
+- Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## 参照する横断 SPEC
 
@@ -305,9 +319,21 @@ Phase 0 の枝PR に含まれるコミット構成運用を規定する。原則
 
 **commit 分割手順**: 実行担当サブエージェントは成果物変更を先にコミットする。ドメイン state に触れる必要がある場合は別コミットへ分離するが、前述の通り case-run 委譲内では原則として `.agentdev/` 配下を編集せず、PR 本文経由で case-close へ引き継ぐ。
 
+## 停止状態
+
+停止状態の詳細（停止理由分類、伝播契約）は「adversarial-review 由来の停止伝播（経路H）」「bounded parent decision resolution」節、および Workflow Skill（`agentdev-workflow-case-auto`）の停止条件分類が正規所有する。
+主要な停止状態は次のとおり。
+
+- 委譲工程の result が blocked / failed の場合（当該工程で自走停止、ユーザー判断待ち）。
+- 委譲起動不能時（delegation-unavailable 報告、当該工程を停止）。
+- auto_gate preflight の未解決 item 残存時（`auto_gate.auto_ready` が false または未解決 item が残る場合は停止）。
+- 停止条件（10項目の停止条件いずれか）検出時（実行停止、停止時タイミング情報を追記）。
+- user-decision-required（上位合意矛盾、新規ユーザー判断事項）検出時（自走を停止しユーザーへ判断を求める）。
+
 ## See Also
 
 - [req-save.md](req-save.md), [spec-save.md](spec-save.md), [case-open.md](case-open.md), [case-run.md](case-run.md), [case-close.md](case-close.md)（構成工程）
+- `agentdev-workflow-case-auto` skill（workflow 実装本体（orchestration stage モデル、Wave 反復制御、停止理由分類））
 - `agentdev-quality-gates` skill（QG-1〜QG-4（各工程で適用））
 - `agentdev-case-run-execution-adapter` skill（case-run 外部実行委譲）
 - `agentdev-git-worktree` skill（並列実行安全 git 操作）

--- a/docs/specs/commands/case-close.md
+++ b/docs/specs/commands/case-close.md
@@ -2,7 +2,7 @@
 title: case-close SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # case-close SPEC
@@ -20,6 +20,11 @@ case-run / 実行担当サブエージェント / 外部実行バックエンド
 
 **責務境界（REQ-003-007）**: 完了処理 + マージ時コンフリクトの機械的解消（rebase のみ、解消不能時は即エスカレーション、実装変更は行わない）。
 コンフリクト解消の実装変更、オーケストレーション級判断（マージ順序変更、blocked 単位の隔離）は case-auto の責務（`docs/specs/commands/case-auto.md` コンフリクト解消モデル Level 2/3 参照）。
+
+## 承認・HITL 境界
+
+- QG-4 合格後の squash merge、Issue close、Capture 回収は自動実行する（case-close 自身の承認点を持たない）。
+- QG-4 不合格、mergeable CONFLICTING の解消不能時はマージせず停止し、ユーザー判断を求める（実装変更による解消は case-auto レベルの判断）。
 
 ## 入力
 
@@ -61,7 +66,8 @@ worktree を削除する前に、未追跡ファイルだけを対象とする c
 
 ## 現在の動作
 
-処理段階（外部から意味のある順序）。各段階の詳細手順は Workflow Skill（`agentdev-workflow-case-close`）が権威情報源である。
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-case-close`）が正規情報源である。
 
 ### 入力判定
 
@@ -128,6 +134,13 @@ Epic status table 更新の後、最終 Wave 判定の前に実施する。Epic 
 - 学びの検知、抽出（`agentdev-learning-capture`、ユーザーに学び有無を問わない（G13）、Capture 回収（PR 本文から intake/learning を分離））
 - ドメイン状態永続化（`.agentdev/` 配下を commit/push（learning と intake を同一 commit））
 - 完了報告（結果状態の分離報告（GitHub側、`.agentdev`、ブランチ削除））
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/case-close.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（単一 Issue クローズと Epic Wave クローズの STEP 構成、内部手順、reference 構成）は Workflow Skill（`agentdev-workflow-case-close`）が所有し、本 SPEC はこれらを複製しない。
+- Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## Artifact Graph 利用
 
@@ -245,10 +258,19 @@ verification-only 判定基準3項目を満たさない files_checked 空（例:
 - 出力制約: 成果物本文（PR本文、commit message）は verbatim で返す（G10/G18、別途成果物パス、根拠、親判断事項は圧縮）
 - 結果状態分離報告: GitHub側、`.agentdev` 永続化、ブランチ削除状態を独立して報告（G19）
 
+## 停止状態
+
+- QG-4 前提確認で完了条件チェックボックスの未完了（`- [ ]` 残存）を検出した場合（評価エラーで停止する。部分的なチェック済み化は行わない）。
+- mergeable UNKNOWN ポーリング上限超過時（マージ中止、構造化エラー停止）。
+- squash merge のコンフリクトが rebase で解消不能な場合（実装変更を伴う解消は行わず、case-auto レベル判断へエスカレーションして停止）。
+- 最終 Wave で完了条件が残る場合（Epic クローズせずエラー停止、残 Wave 通知へ整理）。
+- worktree、ブランチ削除のリトライ上限超過時（`prune` と復元を実施し、削除失敗を報告して停止）。
+
 ## See Also
 
 - [case-run.md](case-run.md)（前段コマンド）
 - [case-auto.md](case-auto.md)（自走モード）
+- `agentdev-workflow-case-close` skill（workflow 実装本体（単一 Issue クローズ、Epic Wave クローズ））
 - `agentdev-quality-gates` skill（QG-4）
 - `agentdev-git-worktree` skill（worktree、ブランチ削除）
 - `agentdev-epic-tracker` skill（ステータス追跡テーブル）

--- a/docs/specs/commands/case-open.md
+++ b/docs/specs/commands/case-open.md
@@ -2,7 +2,7 @@
 title: case-open SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # case-open SPEC
@@ -12,6 +12,11 @@ updated: 2026-08-14
 要件定義（req-define）の結果をもとに GitHub Issue を作成する。
 壁打ち→構造的実行フェーズの境界。
 Epic + 子 Issue 一括作成に対応する。
+
+## 承認・HITL 境界
+
+- case-open 自身の承認点を持たない（req-define で壁打ち合意済みの要件 doc を入力とし、Issue 作成を自動実行する）。
+- OU 選択ゲートで処理対象 OU を決定できない場合（OU ID 指定 / 自動選択 / 一覧表示停止のいずれにも該当しないとき）は、一覧を表示してユーザー判断を求める。
 
 ## 入力
 
@@ -41,7 +46,8 @@ Epic + 子 Issue 一括作成に対応する。
 
 ## 現在の動作
 
-処理段階（外部から意味のある順序）。各段階の詳細手順は Workflow Skill（`agentdev-workflow-case-open`）が権威情報源である。
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-case-open`）が正規情報源である。
 
 - 前工程からの引き継ぎ停止判定（`agentdev_handoff: true` 含まれる場合は Issue 作成せず停止）
 - OU 選択ゲート（`operation_units` セクションがある場合、処理対象 OU を決定（OU ID 指定 / 自動選択 / 一覧表示停止））
@@ -69,6 +75,13 @@ Epic + 子 Issue 一括作成に対応する。
   - draft / RU 削除残存検証（`git status --porcelain` で残存検出）
   - draft/RU 削除 commit 後の即時 push（REQ-003-003）（削除コミット後に `git push` を即時実行する）。case-run 引き継ぎ時の `git pull --ff-only` 失敗防止のため
   - 完了報告（Standard / 単一REQ Epic / マルチREQ Epic テンプレート）
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/case-open.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（STEP 構成、Standard flow / Epic flow の内部手順、reference 構成）は Workflow Skill（`agentdev-workflow-case-open`）が所有し、本 SPEC はこれらを複製しない。
+- Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## 構成生成事前検証（preflight）
 
@@ -316,12 +329,21 @@ case-open SPEC 内の REQ-006-089、REQ-006-093 参照行と正規定義（REQ-0
 
 原本ドラフトが挙げていた L239-240 は近似行であり、実施時に正確な行を再特定する。
 
+## 停止状態
+
+- 前工程からの引き継ぎ停止判定（`agentdev_handoff: true`）検出時（Issue 作成せず停止する）。
+- `auto_gate.auto_ready` が false、未解決質問、未解決衝突、repo外操作、停止理由が残る場合（REQ-008-013）。
+- preflight 検証失敗時（Issue 作成呼び出しを実行せず停止する、REQ-006-028）。
+- review_dispositions の evidence 失効検出時（Issue 作成を中止する。`covered` のまま失効した disposition は再利用しない）。
+- adversarial-review 審議で unresolved なユーザー判断事項が残る場合（最初の GitHub Issue 作成へ進まない）。
+
 ## See Also
 
 - [req-define.md](req-define.md)（前段コマンド）
 - [req-save.md](req-save.md)（前段コマンド（REQ/Decision 保存））
 - [spec-save.md](spec-save.md)（前段コマンド（SPEC 保存））
 - [case-run.md](case-run.md)（後続コマンド（実装））
+- `agentdev-workflow-case-open` skill（workflow 実装本体（STEP 構成、resume protocol））
 - `agentdev-issue-management` skill（Issue 本文生成、テンプレート充足）
 - `agentdev-workflow-templates` skill（テンプレート選定）
 - `agentdev-workflow-lifecycle` skill（work_type、scale 判定、ラベル付与）

--- a/docs/specs/commands/case-run.md
+++ b/docs/specs/commands/case-run.md
@@ -2,7 +2,7 @@
 title: case-run SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # case-run SPEC
@@ -24,6 +24,12 @@ case-run から実行担当サブエージェントへの委譲契約を以下�
 - **実行主体分類**: 委譲 prompt 内で実行される command は skill ではなく command である。`load_skills` には command 名を指定せず、adapter skill 名を指定する。
 - **test strategy 項目の test-fix ループ（REQ-006-029/030）**: Issue 本文のテスト戦略セクションに test strategy 項目（3要素構造: verification / pass_criteria / on_failure）が含まれる場合、委譲契約は各項目の検証、不合格時の処置（実装修正して再検証、または Findings 記録）、全項目処理までの反復を実行担当サブエージェントに要求する。詳細な責務は adapter skill（`agentdev-case-run-execution-adapter`）が定義する。
 
+## 承認・HITL 境界
+
+- case-run 本体の承認点を持たない（Issue に確定済みの execution contract を再判断せず消費する）。
+- result が blocked / failed の場合はユーザー判断待ちとして扱い、Issue 更新は case-update へ委譲する（自律補完、スコープ拡大をしない）。
+- クリーンアップフェーズで未コミット変更を検出した場合は報告してユーザーの指示に従う（自動的な破棄、コミットを行わない）。
+
 ## 入力
 
 - Issue番号またはURL（要件doc埋め込み済み）（単一 Issue 実行モード）
@@ -44,7 +50,9 @@ case-run から実行担当サブエージェントへの委譲契約を以下�
 
 ## 現在の動作
 
-処理段階（外部から意味のある順序）。各段階の詳細手順は Workflow Skill（`agentdev-workflow-case-run`）が権威情報源である。
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-case-run`）が正規情報源である。
+Workflow Skill は単一 Issue 実行（single workflow）と Epic Wave 実行（epic-wave workflow）の2 workflow に分離される（後述「所有関係と委譲」）。
 
 ### フェーズ判定（再開ポイント検出、実行モード分岐）
 
@@ -103,6 +111,14 @@ v2:ADR-0128 Decision #3 に基づく。
 - worktree クリーンアップ確認 + 完了報告
   - 未コミット変更あり: 報告してユーザーの指示に従う。自動的な破棄、コミットは行わない
   - 未コミット変更なし: 完了報告へ。runtime workspace のクリーンアップは harness の責務であり、case-run は関与しない（REQ-002-002）
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/case-run.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体は Workflow Skill（`agentdev-workflow-case-run`）が所有し、本 SPEC は内部手順、STEP 構成、reference 構成を複製しない。
+- case-run の Workflow Skill は、単一 Issue 実行（single workflow）と Epic Wave 実行（epic-wave workflow）の2 workflow 構成に分離される（DEC-010 の 1:N 分割基準の適用。operation 差ではなく制御構造の実質差異による分割）。両 workflow の実行契約差異（target cardinality、parallelism、fan-out・fan-in、child task recovery、partial result、Wave-level completion の6軸）は Workflow Skill が所有する。
+- Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。case-auto が case-run をインライン実行する場合も同一の Workflow Skill を正規情報源として読み込む。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## QG-3 前置 staleness check 手順（新規セクション）
 
@@ -337,11 +353,21 @@ case-run 委譲内で作成する commit の構成運用を規定する。原則
 
 **commit 分割手順**: 実行担当サブエージェントは成果物変更を先にコミットする。ドメイン state に触れる必要がある場合は別コミットへ分離するが、前述の通り case-run 委譲内では原則として `.agentdev/` 配下を編集せず、PR 本文経由で case-close へ引き継ぐ。
 
+## 停止状態
+
+- result が blocked の場合（回答可能な blocker。詳細は Issue コメント SSoT。ユーザー判断待ちとして case-update 連携）。
+- result が failed の場合（repository context で回答不能な blocker。詳細は Issue コメント SSoT）。
+- result が delegation-unavailable の場合（実行未試行のため Issue を `pending` に戻す、REQ-002-004）。
+- 前工程からの引き継ぎ停止判定（`agentdev_handoff: true`）検出時（実装開始せず停止する）。
+- worktree precondition gate 失敗時（worktree、ブランチ未作成なら実行担当サブエージェントを起動しない、G30）。
+- 完了条件の不足、曖昧さ、矛盾、実現不能の検出時（自律補完せず blocked とする。execution contract 消費境界参照）。
+
 ## See Also
 
 - [case-open.md](case-open.md)（前段コマンド（Issue 作成））
 - [case-close.md](case-close.md)（後続コマンド（PR マージ、Issue クローズ））
 - [case-auto.md](case-auto.md)（自走モード）
+- `agentdev-workflow-case-run` skill（workflow 実装本体（single workflow、epic-wave workflow、6軸実行契約差異））
 - `agentdev-workflow-orchestration` skill（フェーズ判定、エラー処理）
 - `agentdev-case-run-execution-adapter` skill（委譲統合、result 契約）
 - `agentdev-git-worktree` skill（worktree 作成、precondition gate）

--- a/docs/specs/commands/case-update.md
+++ b/docs/specs/commands/case-update.md
@@ -2,7 +2,7 @@
 title: case-update SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # case-update SPEC
@@ -11,6 +11,11 @@ updated: 2026-08-14
 
 既存 Case（Issue）の本文更新、コメント追加、または REQ ファイル更新を行う。
 レビュー NG コメント対応を含む。
+
+## 承認・HITL 境界
+
+- ユーザー指示完結型であり、コマンド自身の承認点を持たない（更新対象、更新内容はユーザー指示による）。
+- レビュー NG コメント（`--review-ng`）は QG-3 乖離検出結果（既に提示済みの判断材料）を引用するものであり、新規の HITL を発生させない。
 
 ## 入力
 
@@ -30,7 +35,8 @@ updated: 2026-08-14
 
 ## 現在の動作
 
-処理段階（外部から意味のある順序）。各段階の詳細手順は Workflow Skill（`agentdev-workflow-case-update`）が権威情報源である。
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-case-update`）が正規情報源である。
 
 - Issue番号解決: ユーザー入力またはセッション内会話から取得。`gh issue list` / `gh issue status` 等は禁止（G03）
 - 現在状態取得: Issue 状態を取得し、フェーズ判定（`agentdev-workflow-routing`、`agentdev-workflow-lifecycle`）
@@ -40,6 +46,13 @@ updated: 2026-08-14
   - `--req`（REQ ファイル更新（APPEND/UPDATE 対応）、git commit/push）
   - `--review-ng`（レビュー NG コメント）。**必ず QG-3 の乖離検出結果を引用**（G05）
 - 完了報告
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/case-update.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（制御構造、STEP 遷移、内部手順、reference 構成）は Workflow Skill（`agentdev-workflow-case-update`）が所有し、本 SPEC はこれらを複製しない。
+- Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## 参照する横断 SPEC
 
@@ -64,9 +77,16 @@ updated: 2026-08-14
 - フェーズ維持（G01）: 現在のフェーズを変更しない
 - 出力制約（G11）: 成果物本文（Issue 本文、コメント、commit message）は verbatim で返す
 
+## 停止状態
+
+- Issue番号が解決できない場合（G03 の範囲外の手段は使用せず、エラーとして報告して停止する）。
+- テンプレート必須セクションの欠落を検出した場合（G06、G07。投稿前に停止し補完を求める）。
+- gh CLI / git 操作の失敗時（`agentdev-gh-cli` のエラー取扱いに従い、自動リトライ範囲を超えたら停止して報告する）。
+
 ## See Also
 
 - [case-run.md](case-run.md), [case-close.md](case-close.md)（関連コマンド）
+- `agentdev-workflow-case-update` skill（workflow 実装本体）
 - `agentdev-workflow-routing` skill（フェーズ判定、次コマンド推論）
 - `agentdev-workflow-lifecycle` skill（work_type 分岐判定）
 - `agentdev-gh-cli` skill（gh CLI 安全使用）

--- a/docs/specs/commands/inspect-docs.md
+++ b/docs/specs/commands/inspect-docs.md
@@ -2,7 +2,7 @@
 title: inspect-docs SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # inspect-docs SPEC
@@ -12,6 +12,10 @@ updated: 2026-08-14
 docs 全体（REQ/Decision/SPEC/guides）の意味整合性を診断し、検出事項を `.agentdev/inspect/inbox/` へ出力する。
 検査対象を直接修正しない診断専用コマンド。
 REQ structure review（SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）に加えて SPEC、Decision、guides、README の意味診断を含む。
+
+## 承認・HITL 境界
+
+- 承認点を持たない（診断と検出事項出力のみ。採用、分類の判断は `/agentdev/inspect-promote` が担う）。
 
 ## 入力
 
@@ -34,7 +38,8 @@ REQ structure review（SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）に加えて SP
 
 ## 現在の動作
 
-処理段階（外部から意味のある順序）。各段階の詳細手順は Workflow Skill（`agentdev-workflow-inspect-docs`）が権威情報源である（read-only-diagnostic 型、REQ-027-003 により STEP model 対象外）。
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-inspect-docs`）が正規情報源である（read-only-diagnostic 型、REQ-027-003 により STEP model 対象外）。
 
 - スキャン対象の収集（`docs/requirements/`, `docs/decisions/`, `docs/specs/`, `docs/guides/`, `README.md`, `.opencode/`）
 - REQ 参照 ID 整合性確認（`agentdev-req-structure-diagnostics`）
@@ -53,6 +58,13 @@ REQ structure review（SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）に加えて SP
 - 実行前同期（`git pull --ff-only`、失敗時は git-error-messages template で停止）
 - `.agentdev/inspect/` 変更の commit と push（変更なし時は commit/push せず「変更なし」報告、変更あり時は `.agentdev/inspect/` のみ `git add`、commit、push、push 失敗時は停止）
 - 完了報告
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/inspect-docs.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（工程構成、各診断観点の実行手順、reference 構成）は Workflow Skill（`agentdev-workflow-inspect-docs`）が所有し、本 SPEC はこれらを複製しない。本 workflow は read-only-diagnostic 型であり、STEP model の対象外である（REQ-027-003）。resume point、export、import を持たず、工程一覧のラベルは順序ラベルである。中断時は先頭から再実行する。
+- Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## Artifact Graph 利用
 
@@ -89,10 +101,17 @@ consumer 環境に対応 node type または relation type が存在しない場
 | スキャン対象ディレクトリが存在しない | 該当カテゴリを空として扱い、警告を出力 |
 | ファイル読込失敗 | 該当ファイルをスキップし、警告を出力 |
 
+## 停止状態
+
+- 実行前同期（`git pull --ff-only`）失敗時（エラーを報告して停止する）。
+- `.agentdev/inspect/` 変更の push 失敗時（停止して報告する）。
+- スキャン対象ディレクトリ不存在、ファイル読込失敗は停止条件としない（「エラー処理」のとおり空扱い、スキップ継続）。
+
 ## See Also
 
 - [inspect-skills.md](inspect-skills.md)（Command/Skill 参照妥当性検出）
 - [inspect-promote.md](inspect-promote.md)（検出事項分類、昇格）
+- `agentdev-workflow-inspect-docs` skill（workflow 実装本体（工程構成、冪等性、終了条件））
 - `agentdev-req-structure-diagnostics` skill（REQ 構造検査ロジック）
 - REQ-010（inspect-docs / REQ 再構成運用）
 - REQ-010（inspect-* 検出コマンド群）

--- a/docs/specs/commands/inspect-promote.md
+++ b/docs/specs/commands/inspect-promote.md
@@ -2,7 +2,7 @@
 title: inspect-promote SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # inspect-promote SPEC
@@ -11,6 +11,11 @@ updated: 2026-08-14
 
 `.agentdev/inspect/inbox/` の検出事項を分類、採用し、採用済み成果物として `.agentdev/inspect/promoted/` へ出力する。
 `--auto` オプションで高確信度検出事項の自動 promote を有効化する。
+
+## 承認・HITL 境界
+
+- 手動分類対象の分類確定（HITL 確定）が主要 HITL である（G01。promote / defer / reject のユーザー明示承認必須）。
+- `--auto` による fast path（高確信度検出事項の自動 promote）は HITL を経由しない（G06 の明示 opt-in により有効化）。
 
 ## 入力
 
@@ -33,6 +38,9 @@ updated: 2026-08-14
 
 ## 現在の動作
 
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-inspect-promote`）が正規情報源である。
+
 - 実行前同期（`git pull --ff-only`）
 - inbox スキャン
 - 検出事項分類（promote / defer / reject）
@@ -47,6 +55,13 @@ updated: 2026-08-14
 - defer 処理: `.agentdev/inspect/inbox/` に残す
 - 完了報告
 - `.agentdev/` 変更の commit と push
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/inspect-promote.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（STEP 構成、resume protocol、reference 構成）は Workflow Skill（`agentdev-workflow-inspect-promote`）が所有し、本 SPEC はこれらを複製しない。検出事項ごとの分類確定状態の再構成規則（durable state からの復元）は backlog-artifact-lifecycle SPEC「inspect-promote 自動 promote」節が正規所有する。
+- Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## 参照する横断 SPEC
 
@@ -73,10 +88,18 @@ updated: 2026-08-14
 - 自動 promote 対象外の手動分類回し: 命名、分類の意味判断、ADR 要否判断
 - 実行ログ記録の完備（G08）
 
+## 停止状態
+
+- 実行前同期（`git pull --ff-only`）失敗時（エラーを報告して停止する。自動解消しない）。
+- adversarial-review 審議で unresolved な本質的争点が残る場合（HITL 確定へ進まず、ユーザー判断事項として停止する）。
+- `.agentdev/` 変更の push 失敗時（停止して報告する）。
+- inbox 空は停止ではなく終了条件（「対象なし」と報告して完了する）。
+
 ## See Also
 
 - [inspect-docs.md](inspect-docs.md), [inspect-skills.md](inspect-skills.md)（前段コマンド（検出事項生成））
 - [backlog-review.md](backlog-review.md)（後続コマンド（RU 生成））
+- `agentdev-workflow-inspect-promote` skill（workflow 実装本体（STEP 構成、resume protocol））
 - REQ-010（inspect-promote / 検出事項分類、昇格）
 - REQ-001（inspect-promote 自動 promote（REQ-001-016））
 

--- a/docs/specs/commands/inspect-skills.md
+++ b/docs/specs/commands/inspect-skills.md
@@ -2,7 +2,7 @@
 title: inspect-skills SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-10
+updated: 2026-08-15
 ---
 
 # inspect-skills SPEC
@@ -11,6 +11,10 @@ updated: 2026-08-10
 
 Command→Skill 参照妥当性と Skill 構造を、検査対象を直接修正せずに診断するコマンド。
 検出事項を `.agentdev/inspect/inbox/` へ出力する。
+
+## 承認・HITL 境界
+
+- 承認点を持たない（診断と検出事項出力のみ。採用、分類の判断は `/agentdev/inspect-promote` が担う）。
 
 ## 入力
 
@@ -37,6 +41,9 @@ Command→Skill 参照妥当性と Skill 構造を、検査対象を直接修正
 
 ## 現在の動作
 
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-inspect-skills`）が正規情報源である（read-only-diagnostic 型、REQ-027-003 により STEP model 対象外）。
+
 - 診断対象の読込（Command、Skill 群）
 - 各診断観点の評価（`agentdev-inspect-skills`）:
  - Command 参照の妥当性診断
@@ -51,6 +58,13 @@ Command→Skill 参照妥当性と Skill 構造を、検査対象を直接修正
 - 実行前同期（`git pull --ff-only`）
 - `.agentdev/inspect/` 変更の commit と push
 - 完了報告
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/inspect-skills.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（工程構成、各診断観点の詳細手順、reference 構成）は Workflow Skill（`agentdev-workflow-inspect-skills`）が所有し、本 SPEC はこれらを複製しない。本 workflow は read-only-diagnostic 型であり、STEP model の対象外である（REQ-027-003）。resume point、export、import を持たず、工程一覧のラベルは順序ラベルである。中断時は先頭から再実行する。
+- Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## Artifact Graph 利用
 
@@ -79,10 +93,17 @@ consumer 環境に対応 node type または relation type が存在しない場
 - commit/push スコープ: `.agentdev/inspect/` 配下のみ（G04）
 - 自動修正禁止（G05）
 
+## 停止状態
+
+- 実行前同期（`git pull --ff-only`）失敗時（エラーを報告して停止する。自動解消しない）。
+- `.agentdev/inspect/` 変更の push 失敗時（停止して報告する）。
+- 検査対象ファイルの読込失敗は停止条件としない（該当対象をスキップし警告を出力する）。
+
 ## See Also
 
 - [inspect-docs.md](inspect-docs.md)（docs 全体の意味整合レビュー）
 - [inspect-promote.md](inspect-promote.md)（検出事項分類、昇格）
+- `agentdev-workflow-inspect-skills` skill（workflow 実装本体（工程構成、冪等性、終了条件））
 - `agentdev-inspect-skills` skill（詳細手順、finding 形式、推奨 route）
 - REQ-010（inspect-skills / Command/Skill 参照妥当性検出）
 

--- a/docs/specs/commands/intake-capture.md
+++ b/docs/specs/commands/intake-capture.md
@@ -2,7 +2,7 @@
 title: intake-capture SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # intake-capture SPEC
@@ -11,6 +11,10 @@ updated: 2026-08-14
 
 未分類の変更候補を手動入力から intake item として保存する。
 保存専用コマンドであり、GitHub Issue 作成、採用可否判断は行わない。
+
+## 承認・HITL 境界
+
+- 承認点を持たない（入力の受領と保存のみ。採用可否の判断は `/agentdev/intake-promote` が担う）。
 
 ## 入力
 
@@ -30,7 +34,8 @@ updated: 2026-08-14
 
 ## 現在の動作
 
-処理段階（外部から意味のある順序）。各段階の詳細手順は Workflow Skill（`agentdev-workflow-intake-capture`）が権威情報源である（capture-only 型、REQ-027-003 により STEP model 対象外）。
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-intake-capture`）が正規情報源である（capture-only 型、REQ-027-003 により STEP model 対象外）。
 
 - 入力受領
 - intake item 生成（推奨標準形に整理、ユーザー未指定セクションは省略（G13: 過度補完禁止、G11: 過度解釈禁止））
@@ -39,6 +44,13 @@ updated: 2026-08-14
 - 保存（`.agentdev/intake/inbox/`）。同名時は連番付与
 - commit/push（`.agentdev/intake/` 配下変更のみ）
 - 完了報告
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/intake-capture.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（工程構成、intake item 推奨標準形への整形手順、reference 構成）は Workflow Skill（`agentdev-workflow-intake-capture`）が所有し、本 SPEC はこれらを複製しない。本 workflow は capture-only 型であり、STEP model の対象外である（REQ-027-003）。resume point、export、import を持たず、工程は逐次実行、中断時は先頭から再実行する。
+- Workflow Skill の単独起動防止（soft guard）は Workflow Skill description の DO NOT USE FOR トリガーにより実効する（command 定義本文に soft guard 宣言節を持たない構成である）。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## 参照する横断 SPEC
 
@@ -65,10 +77,16 @@ updated: 2026-08-14
 - 同名時連番付与
 - git 操作スコープ: `.agentdev/intake/` 配下のみ
 
+## 停止状態
+
+- 実行前同期（`git pull --ff-only`）失敗時（エラーを報告して停止する）。
+- 保存先の書き込み失敗時（commit/push を実行せず、エラーを報告して停止する）。
+
 ## See Also
 
 - [intake-promote.md](intake-promote.md)（後続コマンド（採用判断））
 - [intake-from-github.md](intake-from-github.md)（GitHub からの自動抽出）
+- `agentdev-workflow-intake-capture` skill（workflow 実装本体）
 - `agentdev-intake-pipeline` skill（共通手順）
 - REQ-010（Intake command群）
 

--- a/docs/specs/commands/intake-from-github.md
+++ b/docs/specs/commands/intake-from-github.md
@@ -2,7 +2,7 @@
 title: intake-from-github SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # intake-from-github SPEC
@@ -11,6 +11,10 @@ updated: 2026-08-14
 
 クローズ済み GitHub Issue/PR から未回収の変更候補を抽出し、intake item として保存する。
 保存専用コマンド。
+
+## 承認・HITL 境界
+
+- 承認点を持たない（抽出と保存のみ。採用可否の判断は `/agentdev/intake-promote` が担う）。
 
 ## 入力
 
@@ -32,7 +36,8 @@ updated: 2026-08-14
 
 ## 現在の動作
 
-処理段階（外部から意味のある順序）。各段階の詳細手順は Workflow Skill（`agentdev-workflow-intake-from-github`）が権威情報源である（capture-only 型、REQ-027-003 により STEP model 対象外）。
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-intake-from-github`）が正規情報源である（capture-only 型、REQ-027-003 により STEP model 対象外）。
 
 - 期間解釈（`agentdev-intake-pipeline`）
 - データ取得（`agentdev-intake-pipeline`）（クローズ済み Issue/PR のみ対象（G10））
@@ -44,6 +49,13 @@ updated: 2026-08-14
 - commit/push（`.agentdev/intake/` 配下変更のみ）
 - サマリーレポート提示
 - 完了報告
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/intake-from-github.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（抽出アルゴリズムの実行手順、工程構成、reference 構成）は Workflow Skill（`agentdev-workflow-intake-from-github`）が所有し、本 SPEC はこれらを複製しない。本 workflow は capture-only 型であり、STEP model の対象外である（REQ-027-003）。resume point、export、import を持たず、工程は逐次実行、中断時は先頭から再実行する。
+- Workflow Skill の単独起動防止（soft guard）は Workflow Skill description の DO NOT USE FOR トリガーにより実効する（command 定義本文に soft guard 宣言節を持たない構成である）。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## 参照する横断 SPEC
 
@@ -68,10 +80,16 @@ updated: 2026-08-14
 - 出力制約（G13）: 成果物本文 verbatim、判定結果、調査過程は圧縮
 - 抽出ロジック精度: `agentdev-intake-pipeline` 参照
 
+## 停止状態
+
+- 実行前同期（`git pull --ff-only`）失敗時、GitHub データ取得失敗時（エラーを報告して停止する。自動解消しない）。
+- 保存先の書き込み失敗時（commit/push を実行せず、エラーを報告して停止する）。
+
 ## See Also
 
 - [intake-capture.md](intake-capture.md)（手動 capture）
 - [intake-promote.md](intake-promote.md)（後続コマンド（採用判断））
+- `agentdev-workflow-intake-from-github` skill（workflow 実装本体）
 - `agentdev-intake-pipeline` skill（抽出アルゴリズム）
 - REQ-010（Intake command群）
 

--- a/docs/specs/commands/intake-promote.md
+++ b/docs/specs/commands/intake-promote.md
@@ -2,7 +2,7 @@
 title: intake-promote SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # intake-promote SPEC
@@ -63,7 +63,8 @@ intake-promote は change_nature と併せて、observed_evidence（根拠とな
 
 ## 現在の動作
 
-5 フェーズ構成。各フェーズの詳細手順は Workflow Skill（`agentdev-workflow-intake-promote`）が権威情報源である。
+5 フェーズ構成。
+各フェーズの詳細手順は Workflow Skill（`agentdev-workflow-intake-promote`）が正規情報源である。
 
 - フェーズ1 inbox スキャン: inbox 確認、item 読込
 - フェーズ2 内部レビュー: レビュー評価、暫定分類の生成と提示
@@ -73,6 +74,13 @@ intake-promote は change_nature と併せて、observed_evidence（根拠とな
 
 **自動実行の前提**（REQ-003-008）: フェーズ3 で分類が確定（採用/保留/却下のいずれか）している場合のみ、フェーズ4、5 を自動実行する。
 分類未確定、修正中は進まない。
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/intake-promote.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（フェーズ構成、内部手順、reference 構成）は Workflow Skill（`agentdev-workflow-intake-promote`）が所有し、本 SPEC はこれらを複製しない。
+- Workflow Skill の単独起動防止（soft guard）は Workflow Skill description の DO NOT USE FOR トリガーにより実効する（command 定義本文に soft guard 宣言節を持たない構成である）。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## 参照する横断 SPEC
 
@@ -103,10 +111,17 @@ intake-promote は change_nature と併せて、observed_evidence（根拠とな
 - 保存先が `.agentdev/intake/promoted/` 直下のみであること（G16）
 - 採用 item 元ファイルの inbox 削除（`archive/promoted/` への移動を廃止）（G17）
 
+## 停止状態
+
+- 分類未確定、修正中のまま自動進行しない（REQ-003-003。フェーズ3 の HITL 確定を待つ）。
+- adversarial-review 審議で unresolved な本質的争点が残る場合（HITL 確定へ進まず、ユーザー判断事項として停止する）。
+- 実行前同期（`git pull --ff-only`）失敗時、push 失敗時（エラーを報告して停止する）。
+
 ## See Also
 
 - [intake-capture.md](intake-capture.md), [intake-from-github.md](intake-from-github.md)（前段コマンド）
 - [backlog-review.md](backlog-review.md)（後続コマンド（RU 生成））
+- `agentdev-workflow-intake-promote` skill（workflow 実装本体）
 - `agentdev-intake-pipeline` skill（inbox スキャン、レビュー評価、分類提示、整形保存）
 - REQ-010（Intake command群）
 

--- a/docs/specs/commands/learning-promote.md
+++ b/docs/specs/commands/learning-promote.md
@@ -2,7 +2,7 @@
 title: learning-promote SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # learning-promote SPEC
@@ -69,7 +69,8 @@ learning-promote は change_nature と併せて、observed_evidence（根拠と�
 
 ## 現在の動作
 
-6 フェーズ構成。各フェーズの詳細手順は Workflow Skill（`agentdev-workflow-learning-promote`）が権威情報源である。
+6 フェーズ構成。
+各フェーズの詳細手順は Workflow Skill（`agentdev-workflow-learning-promote`）が正規情報源である。
 
 - フェーズ1 inbox スキャン: inbox.md 読込、deferred.md 読込
 - フェーズ2-5 Normalize→Classify→Evaluate→Dispose→HITL:
@@ -89,6 +90,13 @@ learning-promote は change_nature と併せて、observed_evidence（根拠と�
   - commit/push
   - 完了報告
 
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/learning-promote.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（フェーズ構成、内部手順、reference 構成）は Workflow Skill（`agentdev-workflow-learning-promote`）が所有し、本 SPEC はこれらを複製しない。
+- Workflow Skill の単独起動防止（soft guard）は Workflow Skill description の DO NOT USE FOR トリガーにより実効する（command 定義本文に soft guard 宣言節を持たない構成である）。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
+
 ## 参照する横断 SPEC
 
 - [workflows/capture-boundaries.md](../workflows/capture-boundaries.md)（Capture 境界）
@@ -107,9 +115,16 @@ learning-promote は change_nature と併せて、observed_evidence（根拠と�
 - 既存対策優先（G05）: 新規 X 化より既存 X へ反映
 - ユーザー承認必須（G06）: 判定、prune
 
+## 停止状態
+
+- ユーザー承認（判定、prune）を得るまで実行フェーズへ進まない（G06）。
+- adversarial-review 審議で unresolved な本質的争点が残る場合（ユーザー承認、deferred 移動、prune 等の不可逆処理へ進まず停止する、REQ-014-009）。
+- 実行前同期（`git pull --ff-only`）失敗時、push 失敗時（エラーを報告して停止する）。
+
 ## See Also
 
 - [backlog-review.md](backlog-review.md)（後続コマンド（RU 生成））
+- `agentdev-workflow-learning-promote` skill（workflow 実装本体）
 - `agentdev-learning-pipeline` skill（全判定基準、スコアリングルール、提示形式、承認フロー）
 - `agentdev-learning-capture` skill（capture 層（独立スキル））
 - REQ-010（Learning-promote）

--- a/docs/specs/commands/req-define.md
+++ b/docs/specs/commands/req-define.md
@@ -2,7 +2,7 @@
 title: req-define SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # req-define SPEC
@@ -11,6 +11,12 @@ updated: 2026-08-14
 
 機能追加またはバグ修正の要件を壁打ちにより整理、定義し、構造化 `draft-data` 形式の要件 doc（`.agentdev/drafts/req-draft-{topic-slug}.md`）を生成する。
 壁打ちフェーズで使用。
+
+## 承認・HITL 境界
+
+- 壁打ち対話そのものが主要 HITL である（要件の深掘り、合意形成をユーザーとの対話で行う、REQ-004）。
+- auto_gate の未解決 item 解消方策は壁打ちで合意する（解消時は `auto_ready: true` へ更新。ユーザーが明示的に false を選択した場合は `conflict_resolutions` に記録して継続する）。
+- 生成した要件doc は提示のみとし、承認は求めない（後続の req-save / case-open へそのまま渡す）。
 
 ## 入力
 
@@ -32,9 +38,10 @@ updated: 2026-08-14
 - git 操作: 実行しない（G08）
 - Issue 作成: 行わない（後続 case-open 責務）
 
-## 現在の動作（oracle/explore 抽象化後）
+## 現在の動作
 
-処理段階（外部から意味のある順序）。各段階の詳細手順は Workflow Skill（`agentdev-workflow-req-define`）が権威情報源である。
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-req-define`）が正規情報源である。
 
 - セッションコンテキスト検知（引数なし単体実行時のみ）（当該セッション履歴、現在コンテキストを Requirement Source 候補として評価）
 - 明示入力ファイル読込（指定時）（RU 自動検出を含む）
@@ -393,6 +400,13 @@ auto_gate:
 
 抑止により `auto_ready: false` となった場合、auto_gate完了ゲートの既存手順に従い `stop_reasons` をユーザーへ提示し、壁打ち対話で解消方策を合意する。合意により未確定事項が解消され、(A)(B) いずれの検査も該当しなくなった場合に限り `auto_ready: true` へ更新する。ユーザーが「`auto_ready: false` のまま標準フローで手動実行する」と明示的に選択した場合は `conflict_resolutions` へ記録して継続する（REQ-004-048）。
 
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/req-define.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（STEP 構成、resume protocol、reference 構成）は Workflow Skill（`agentdev-workflow-req-define`）が所有し、本 SPEC はこれらを複製しない。
+- Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
+
 ## Artifact Graph 利用
 
 req-define は既存 REQ、関連 Decision と SPEC、canonical owner、構造的所有者重複、downstream 変更影響候補の探索に Artifact Graph を利用できる。Graph は候補提供者であり、CREATE, APPEND, UPDATE, SPLIT, MERGE, 意味的重複, canonical owner の最終判断は正規成果物本文と独立探索手段（`glob`, `grep`, `rg` 等）での確認後に下す。共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「利用上の防護」を参照。
@@ -408,7 +422,7 @@ Graph 不在、stale、consumer 環境に対応 node type または relation typ
 - [quality-gates.md](../quality/quality-gates.md)（QG-1）
 - [document-type-responsibilities.md](../responsibilities/document-type-responsibilities.md)（draft body 品質検査）
 
-## 対象外（G18 抽象化後）
+## 対象外
 
 - 実装コードの作成、編集（G01: 壁打ちフェーズのみ）
 - 関連ドキュメントの個別ファイル列挙をユーザーに求める（G02）
@@ -432,11 +446,19 @@ Graph 不在、stale、consumer 環境に対応 node type または relation typ
 - artifact_actions 構成: REQ/Decision/SPEC 別 action が適切に統合されているか
 - OU 構造検証: 要件doc確認工程で ou_id、operation、target_req/target_spec、depends_on、result 整合性
 
-## See Also（oracle 抽象化後）
+## 停止状態
+
+- auto_gate 完了ゲートで未解決 item が残る場合（stop_reasons を提示して解消方策を壁打ちで合意する。未解決のままの場合は壁打ちへ差し戻し、要件doc を確定させない）。
+- tentative_classification の最終確定バリデーションで7値違反、フィールド欠落を検出した場合（確定を停止し、理由を提示、または backlog-review への差し戻しを提示する）。
+- 前工程からの引き継ぎ判定（`agentdev_handoff: true`）検出時（要件展開を開始せず停止する）。
+- adversarial-review 審議で unresolved な本質的争点が残る場合（最初の副作用（要件doc 保存）へ進まず停止する）。
+
+## See Also
 
 - [req-save.md](req-save.md)（後続コマンド（REQ/Decision 保存））
 - [spec-save.md](spec-save.md)（後続コマンド（SPEC 保存））
 - [case-open.md](case-open.md)（後続コマンド（Issue 作成））
+- `agentdev-workflow-req-define` skill（workflow 実装本体（STEP 構成、resume protocol））
 - `agentdev-req-analysis` skill（要件分析手法）
 - `agentdev-req-file-manager` skill（REQ ファイル管理、照合）
 - `agentdev-decision-guidelines` skill（Decision 判断基準）

--- a/docs/specs/commands/req-save.md
+++ b/docs/specs/commands/req-save.md
@@ -2,7 +2,7 @@
 title: req-save SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # req-save SPEC
@@ -11,6 +11,11 @@ updated: 2026-08-14
 
 req-define で壁打ちした成果物を REQ/Decision ファイルとして docs/ に保存し、コミット、プッシュする。
 壁打ちフェーズで使用（REQ/Decision 対象 artifact_actions がある場合）。
+
+## 承認・HITL 境界
+
+- req-save 自身の承認点を持たない（req-define で壁打ち合意済みの draft を入力として保存する）。
+- Decision 保存直前の妥当性再検証で REQ/SPEC 相当の内容のみと判定した場合は、保存せず停止してユーザー判断を求める。
 
 ## 入力
 
@@ -41,7 +46,8 @@ req-define で壁打ちした成果物を REQ/Decision ファイルとして doc
 
 ## 現在の動作
 
-処理段階（外部から意味のある順序）。各段階の詳細手順は Workflow Skill（`agentdev-workflow-req-save`）が権威情報源である。
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-req-save`）が正規情報源である。
 
 - 事前チェック: draft-data の `artifact_actions` に REQ/Decision 対象 action があるか確認する。存在しない場合は no-op として完了する
 - 読込と検証: draft を読み、必須フィールドと入力 hash を記録する。draft 構造、文書分類、許可範囲を検証する
@@ -52,6 +58,14 @@ req-define で壁打ちした成果物を REQ/Decision ファイルとして doc
 - 検証: changed-docs 検査、README 索引影響確認、許可パスとリモート同期を検証する
 - 永続化: draft の保存状態と OU result を更新し、commit、push する
 - 報告: 保存結果と次工程を報告する
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/req-save.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（STEP 構成、resume protocol、reference 構成）は Workflow Skill（`agentdev-workflow-req-save`）が所有し、本 SPEC はこれらを複製しない。
+- Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
+
 ## 参照する横断 SPEC
 
 - [workflows/workflow-contracts.md](../workflows/workflow-contracts.md)（フェーズ定義、コマンド分類）
@@ -115,11 +129,19 @@ req-save は複数 REQ/Decision ファイルの変更案作成、検査を並列
 
 G07（commit 前 status 更新）は フェーズ3 で維持。
 
+## 停止状態
+
+- ドラフトファイル不存在時（G04。エラー中止する）。
+- 読込時 hash とリモート同期後 hash の不一致検出時（G08。保存処理を中止し、差異を報告する）。
+- Decision 妥当性再検証で REQ/SPEC 相当と判定した場合（保存せず停止し、ユーザー判断を求める）。
+- targeted docs guard の検査失敗時（検査対象文書を修正して再実行するまで永続化しない）。
+
 ## See Also
 
 - [req-define.md](req-define.md)（前段コマンド）
 - [spec-save.md](spec-save.md)（後続コマンド（SPEC 候補がある場合））
 - [case-open.md](case-open.md)（後続コマンド（Issue 作成））
+- `agentdev-workflow-req-save` skill（workflow 実装本体（STEP 構成、resume protocol））
 - `agentdev-req-file-manager` skill（REQ ファイル管理、採番）
 - `agentdev-decision-file-manager` skill（Decision ファイル管理、採番）
 - `agentdev-artifact-validation` skill（README エントリ存在確認）

--- a/docs/specs/commands/spec-save.md
+++ b/docs/specs/commands/spec-save.md
@@ -2,7 +2,7 @@
 title: spec-save SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-14
+updated: 2026-08-15
 ---
 
 # spec-save SPEC
@@ -12,6 +12,11 @@ updated: 2026-08-14
 req-define で分離された SPEC 保存対象（`draft-data` の `artifact_actions` 内 `artifact: spec` entry）を `docs/specs/**/*.md` に保存、確定する。
 req-save の次、case-open の前に実行する。
 全 work_type 対象であり、`work_type` による判定は廃止する（REQ-008-009）。
+
+## 承認・HITL 境界
+
+- spec-save 自身の承認点を持たない（req-define で分離済みの SPEC 保存対象を入力として保存する）。
+- 配置一貫性検証の保存拒否、SPEC 分離基準の最終確認で REQ 残留と判定した場合は、保存せず停止してユーザー判断を求める。
 
 ## 入力
 
@@ -35,7 +40,8 @@ req-save の次、case-open の前に実行する。
 
 ## 現在の動作
 
-処理段階（外部から意味のある順序）。各段階の詳細手順は Workflow Skill（`agentdev-workflow-spec-save`）が権威情報源である。
+処理段階（外部から意味のある順序）。
+各段階の詳細手順は Workflow Skill（`agentdev-workflow-spec-save`）が正規情報源である。
 
 - 事前チェック: `draft-data` の `artifact_actions` から `artifact: spec` entry の有無を確認。なければ no-op 完了。ドラフト不存在時はエラー中止
 - SPEC artifact_actions 読込（`artifact: spec` entry を読込）。`artifact_actions` フィールド不存在（旧形式 draft）の場合は SPEC 保存対象なしと判定し no-op 完了（後方互換）。各 action の `target`（file path または `new:{slug}`）、`operation`（公式 enum: create/update、非正規 alias: spec-create/spec-update/spec-append、REQ-008-058）、`content` を処理対象とする
@@ -52,6 +58,13 @@ req-save の次、case-open の前に実行する。
 - 変更範囲検証（許可パス照合は `agentdev-req-file-manager/scripts/` の決定的スクリプトで実行。`git diff --name-only` で `docs/specs/**` と `.agentdev/drafts/**` 以外の変更を検出したらエラー報告、指示待ち（自動破棄しない））
 - コミット、プッシュ（`agentdev-conventional-commits` + `agentdev-git-worktree` 並列実行安全ステージング）
 - 完了報告（保存した SPEC 一覧（新規/追記別）、スキップ有無、follow-up（安定契約例外で除外した候補））
+
+## 所有関係と委譲
+
+- public contract（公開目的、入力、出力、副作用、安全境界、承認・HITL 境界、停止状態、外部から意味のある順序）の正規文書は本 SPEC であり、command 定義（`src/opencode/commands/agentdev/spec-save.md`）はその実行時投影である（DEC-010）。
+- workflow 実装本体（STEP 構成、resume protocol、reference 構成）は Workflow Skill（`agentdev-workflow-spec-save`）が所有し、本 SPEC はこれらを複製しない。
+- Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
+- Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
 ## 配置一貫性検証
 
@@ -257,11 +270,19 @@ spec-save は複数 SPEC ファイルの変更案作成、検査を並列化で�
 同一 SPEC ファイルへの複数 action のみ順序依存のため直列サブセットとして分離。
 最終的な commit/push は v2:REQ-0137 の明示パス指定で一括実行。
 
+## 停止状態
+
+- ドラフトファイル不存在時（エラー中止する）。
+- 配置一貫性検証による保存拒否時（対象 action を保存せず停止する）。
+- 変更範囲検証で許可パス外の変更を検出した場合（自動破棄せずエラー報告、指示待ちで停止する）。
+- 実行前同期（`git pull --ff-only`）失敗時、push 失敗時（エラーを報告して停止する）。
+
 ## See Also
 
 - [req-define.md](req-define.md)（前段コマンド（SPEC 候補分離））
 - [req-save.md](req-save.md)（前段コマンド（REQ/Decision 保存））
 - [case-open.md](case-open.md)（後続コマンド（Issue 作成））
+- `agentdev-workflow-spec-save` skill（workflow 実装本体（STEP 構成、resume protocol））
 - `agentdev-artifact-validation` skill（README エントリ存在確認）
 - `agentdev-conventional-commits` skill（コミットメッセージ規約）
 - `agentdev-git-worktree` skill（並列実行安全 git 操作）

--- a/docs/specs/workflows/backlog-artifact-lifecycle.md
+++ b/docs/specs/workflows/backlog-artifact-lifecycle.md
@@ -2,7 +2,7 @@
 title: RU / 採用済み成果物 / draft ライフサイクル
 status: accepted
 created: 2026-06-21
-updated: 2026-07-26
+updated: 2026-08-15
 ---
 
 # RU / 採用済み成果物 / draft ライフサイクル
@@ -171,6 +171,23 @@ revoke は人間の判断により行う。
 3. 当該ファイルが backlog-review により既に RU 化済みの場合: 生成された RU を `.agentdev/backlog/req-units/` から削除し、要件化されていないことを確認する。要件化（REQ/Issue 化）が既に進行している場合はユーザーに停止を依頼する
 4. `auto-promote-log.md` の該当エントリに `status: revoked` と revoke 理由を追記する
 5. 同種の誤検知が再発しないよう、誤検知となった判定根拠を docs-check rule / IR の false positive 抑制へフィードバックする候補として記録する（intake 経由または PR 本文の Findings セクション）
+
+### 分類確定状態の再構成規則（durable state からの復元）
+
+inspect-promote は会話コンテキストに依存せず、durable state から検出事項ごとの分類確定状態を再構成する。
+再構成規則は次のとおり。
+
+| durable state の観測 | 分類確定状態 | 再開時の取扱い |
+|---|---|---|
+| `.agentdev/inspect/inbox/` に残存 | 未確定 | 暫定分類（STEP-3 相当）から再開する |
+| `.agentdev/inspect/promoted/` に保存済み | promote 確定 | 再保存しない |
+| auto-promote-log に記載済みかつ `.agentdev/intake/promoted/inspect-auto-*.md` が存在 | 自動 promote 確定 | 再投入しない |
+| inbox から削除済み | reject 確定 | 復元しない |
+| inbox 残置かつ処理実行済みの報告がある | defer 確定 | 再分類しない |
+
+HITL 承認状態は処理実行（promote / reject / defer の実行 STEP）の完了状態から逆算して再構成する。
+処理実行が済んでいない検出事項は承認未了と扱い、HITL 確定から再開する。
+自然言語の前 STEP result のみに依存した再開を行わない。
 
 ## REQ ファイル整合性検査（横断）
 

--- a/docs/specs/workflows/step-reference-contract.md
+++ b/docs/specs/workflows/step-reference-contract.md
@@ -2,7 +2,7 @@
 title: STEP Reference Contract
 status: draft
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-15
 spec_logical_division: cross_cutting_contract
 canonical_owner: step-reference-contract
 ---
@@ -26,6 +26,22 @@ DEC-011（STEP resume point と会話記憶非依存）の実装詳細を正規�
 - Evidence: 実行証拠
 - Completion Verification: 完了確認基準
 - Resume-Idempotency: 再開時のべき等性保証
+
+### 標準見出し形式（機械検査可能な標準見出し群）
+
+8要素は機械検査可能な標準見出し群として確定する。
+新規作成する STEP reference の標準形式は `### Purpose`、`### Input Resolution`、`### Preconditions`、`### Procedure`、`### Result`、`### Evidence`、`### Completion Verification`、`### Resume-Idempotency` の8見出しである（見出し文言を固定し、翻訳、alias を持たない）。
+
+現行実装には次の表現変種が存在し、いずれも8要素を含む点で等価である。
+
+| 変種 | 形式 | 該当例 |
+|---|---|---|
+| h3 見出し形式（標準） | `### Purpose` 〜 `### Resume-Idempotency` | Wave 2 移行の Workflow Skill（req-define、req-save、spec-save、case-run、case-update、case-auto、intake-promote、learning-promote、backlog-review 等） |
+| h2 見出し形式 | `## Purpose` 〜 `## Resume-Idempotency` | Wave 1 移行の case-open、case-close の一部 reference |
+| STEP 見出し + リスト形式 | `## STEP-N` 見出し配下に `- **Purpose**:` 等のリスト | inspect-promote |
+
+既存変種から標準形式への移行は必須としない（要素群の等価性をもって準拠とみなす）。
+STEP model 対象外型（capture-only 型、read-only-diagnostic 型）の工程一覧は resume point を持たないため、本形式の適用対象外である。
 
 ## STEP transition
 

--- a/docs/specs/workflows/workflow-skill-model.md
+++ b/docs/specs/workflows/workflow-skill-model.md
@@ -2,7 +2,7 @@
 title: Workflow Skill Model
 status: draft
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-15
 spec_logical_division: cross_cutting_contract
 canonical_owner: workflow-skill-model
 ---
@@ -21,6 +21,17 @@ DEC-010（責務3層分化と1:N分割原則）の実装詳細を正規所有す
 
 公開interface（入出力契約・ガードレール）、workflow dispatch。workflow 実装本体は所有しない。
 
+### thin Command の workflow 節標準構造
+
+thin Command の workflow 節は次の3要素で構成する。
+
+1. Workflow Skill 名レベルの dispatch 宣言（委譲先 Workflow Skill 名と委譲範囲の宣言。内部構造（STEP ID、reference パス）への直接依存を持たない）
+2. 公開順序の要約（順序ラベル付きの見出し群。Workflow Skill 内部手順の複製ではなく、公開interface としての順序提示）
+3. soft guard 宣言（Workflow Skill の単独起動防止宣言。後述「soft guard の二層様式」）
+
+順序ラベルは現行実装に `### Step N`、`STEP-N`、`工程-N` の3様式が存在する。
+様式の統一基準、記述量の基準といった執筆詳細は `authoring/command-file-format.md` が正規所有し、本節は workflows 側の構成契約のみを記録する。
+
 ## Workflow Skill 責務
 
 workflow 実装本体。SKILL.md = control plane（STEP transition・STEP間参照）、STEP = resume point 単位。
@@ -28,6 +39,39 @@ workflow 実装本体。SKILL.md = control plane（STEP transition・STEP間参�
 operation 差だけの不必要分割は回避。
 
 Workflow Skill は workflow STEP を所有し、特定 Command の制御構造を持つ（REQ-002-001、REQ-002-002）。
+
+### Workflow 型分類と標準構成（STEP model 対象型と対象外型）
+
+Workflow Skill は STEP model の適用有無により次の3型に分類される（REQ-027-003）。
+
+| 型 | 対象 | STEP model | resume point / export / import |
+|---|---|---|---|
+| 標準型 | req-define、req-save、spec-save、case-open、case-run、case-update、case-close、case-auto、intake-promote、learning-promote、backlog-review、inspect-promote | 対象 | 持つ（DEC-011） |
+| capture-only 型 | intake-capture、intake-from-github | 対象外 | 持たない。工程は逐次実行し、中断時は先頭から再実行する |
+| read-only-diagnostic 型 | inspect-docs、inspect-skills | 対象外 | 持たない。工程一覧のラベルは順序ラベルであり、中断時は先頭から再実行する |
+
+read-only-diagnostic 型の SKILL.md は次の標準セクション構成を持つ。
+
+1. 型判定節（read-only-diagnostic 型である旨と、STEP model 対象外である旨の宣言）
+2. 工程一覧（STEP ラベルは順序ラベルであり resume point ではない旨の宣言を伴う）
+3. 冪等性の根拠（診断が読み取りと検出事項ファイル生成のみの副作用であり、中断時は先頭から再実行できる根拠）
+4. 終了条件（termination）
+
+capture-only 型も同様に型判定節と工程一覧を持ち、保存専用 workflow であることを宣言する。
+
+### 1:N 分割基準の適用実例（case-run）
+
+case-run は単一 Issue 実行と Epic Wave 実行で制御構造に実質差異があるため、Workflow Skill を single workflow と epic-wave workflow の2 workflow に分離する。
+両 workflow の実行契約差異は次の6軸で定義され、Workflow Skill（`agentdev-workflow-case-run`）が所有する。
+
+| 契約軸 | single workflow | epic-wave workflow |
+|---|---|---|
+| target cardinality | 1 Issue | 現在 ready な Wave の子Issue 群（1 Wave 分、最大5件） |
+| parallelism | 委譲1件（並列なし） | 子Issue 並列委譲（最大5件） |
+| fan-out / fan-in | fan-out なし。委譲1件の result を直接処理 | fan-out（子Issue ごとの worktree と委譲起動）→ fan-in（全委譲完了待機・結果収集） |
+| child task recovery | 対象外 | 委譲異常終了時の子タスク単位の回復 |
+| partial result | 対象外 | 一部子Issue の blocked / failed と他の completed-pr の混在保持 |
+| Wave-level completion | 対象外 | 1 Wave の完了判定と次 Wave へのべき等遷移（Wave 境界のマージは case-close 責務） |
 
 ## Capability Skill 責務
 
@@ -142,6 +186,19 @@ DEC-010 Inventory が挙げる新規 Capability Skill 候補。本 SPEC は候�
 Command → Workflow Skill（名レベル参照）→ STEP reference（references/ 配下）。
 Workflow Skill → Capability Skill（名レベル参照）。循環依存禁止。
 Capability Skill → Capability Skill（名レベル参照、循環依存禁止）。
+
+## soft guard の二層様式
+
+Workflow Skill の単独起動防止（soft guard）は OpenCode 1.18.15 が skill 直接起動を機械的に防止できないため、宣言による様式で担保する。
+実効層は次の2層である。
+
+| 層 | 実装 | 全 Workflow Skill での実装有無 |
+|---|---|---|
+| Skill 層 | Workflow Skill description の DO NOT USE FOR トリガー（「単独起動を行わない」旨） | 全16 Workflow Skill で実装（実効の主層） |
+| Command 層 | command 定義本文 workflow 節の soft guard 宣言節（grep 可能な `soft guard` マーカー） | core 8 Command（req-define、req-save、spec-save、case-open、case-run、case-update、case-close、case-auto）と inspect 3 Command（inspect-docs、inspect-skills、inspect-promote）で実装。intake / learning / backlog 5 Command（intake-capture、intake-from-github、intake-promote、learning-promote、backlog-review）は command 定義本文に宣言節を持たず、Skill 層のみで実効する |
+
+command 定義本文に宣言節を持たない構成でも Skill 層の DO NOT USE FOR トリガーにより soft guard は実効する。
+Command SPEC の delegated responsibility 記述は、当該 command の実効層構成（二層または Skill 層のみ）を反映する。
 
 ## artifact-contracts.md からの委譲
 


### PR DESCRIPTION
## 概要

Refs: #2105

Issue #2105（OU-005、Epic #2099 Wave 3）として、docs/specs/commands/ 全16件の Command SPEC を Wave 2 実装（OU-002 / OU-003 / OU-004: 16 Workflow Skill、thin Command 化、soft guard、case-run 1:N 分離、capture-only型 / read-only-diagnostic型の STEP model 除外）と同期した。
各 SPEC は public purpose / input / output / side effects / safety boundary / approval・HITL boundary / stop states / externally significant ordering / delegated Workflow・Capability responsibility のみを保持する構成へ整理した。

## 実装内容

16 Command SPEC（docs/specs/commands/ 全16件）:

- 9 public contract 項目の整備: 各 SPEC に「承認・HITL 境界」「所有関係と委譲」「停止状態」を追加した。backlog-review / intake-promote / learning-promote の承認・HITL 境界は既存「HITL 境界、自動実行ルール（REQ-003-xxx）」節が正規保持するため見出し新設しない
- 所有関係の統一: 「権威情報源」表現を「正規情報源」へ置換し、public contract の正規文書は Command SPEC、command 定義は実行時投影（DEC-010）との記述を全 SPEC で統一
- delegated responsibility の実装一致記述: case-run の single workflow / epic-wave workflow 分離（6軸実行契約差異は Workflow Skill 所有）、capture-only 型（intake-capture / intake-from-github）と read-only-diagnostic 型（inspect-docs / inspect-skills）の STEP model 対象外（REQ-027-003）、soft guard 実効層の二層 / Skill 層のみの区別、intake-promote 5 フェーズ構成、inspect-promote の分類確定状態再構成規則の backlog-artifact-lifecycle 参照
- See Also への各 Workflow Skill 追記（16件）、見出し接尾語（「（oracle/explore 抽象化後）」等）の除去

横断 SPEC 3件（Wave 2 PR の SPEC確定候補反映）:

- docs/specs/workflows/workflow-skill-model.md: thin Command の workflow 節標準構造、Workflow 型分類と標準構成（3型）、1:N 分割基準の適用実例（case-run 6軸）、soft guard の二層様式
- docs/specs/workflows/step-reference-contract.md: STEP 8要素の標準見出し形式（機械検査可能な標準見出し群、既存3変種の等価性）
- docs/specs/workflows/backlog-artifact-lifecycle.md: inspect-promote 分類確定状態の再構成規則（durable state からの復元）

TS-105 機械判定是正:

- 変更行の一文一行分割 25 行、req-save.md の見出し直前空行補完

## 完了条件

- [x] 全16件の Command SPEC に Step 番号複製および Workflow Skill 内部手順複製が存在しないこと（AC-05、TS-003、AG-005）
  - 検証: grep `Step \d+[:：]`、`STEP-\d`、`agentdev-workflow-[a-z-]+/references` の各系統で 16 SPEC 0 件。「現在の動作」は処理段階（外部から意味のある順序）のみを保持
- [x] 全16件から「Command definition is authority」系表現、「Command 側の workflow procedure」系表現、Workflow Skill 内部 reference path 直接参照、旧 extension path / kind 表現（command-extension / skill-extension / .agentdev/extensions/commands/）が 0 件であること（TS-003、ACT-SPEC-004）
  - 検証: 上記5系統の grep で 16 SPEC 0 件。docs/specs/commands/ 全域での旧 extension 表現の残存は inspect-extensions.md（superseded、OU-006 対象）のみで本 Issue 対象範囲外
- [x] 全 SPEC が public contract 9項目を保持すること
  - 検証: 16 SPEC すべてに 目的 / 承認・HITL 境界（または同等の正規保持節）/ 入力 / 出力 / 副作用 / 現在の動作（外部から意味のある順序）/ 所有関係と委譲 / 停止状態 が存在
- [x] 同期先の SPEC が実装された Workflow Skill 構成と一致すること
  - 検証: case-run の references/single.md と references/epic-wave.md（1:N 分離）、capture-only 型・read-only-diagnostic 型の SKILL.md 型判定節、soft guard マーカーの command 定義 grep（core 8 + inspect 3 の11件に存在、intake / learning / backlog 5件は Skill 層のみ）が SPEC 記述と一致
- [x] 既存3移行済み Command（case-open / case-close / case-auto）も再検証が完全であること（AG-005）
  - 検証: 3 SPEC とも同期編集を適用し、残渣 grep 0 件、frontmatter status: accepted / updated: 2026-08-15 を確認

## テスト結果

- TS-003（AG-001、AG-005）: PASS。全16 Command SPEC の残渣 grep 0 件、public contract のみ保持を確認
- TS-105（agentdev-doc-writing 査読）: PASS（指摘解決済み）。機械判定で変更行の一文一行違反 25 行と req-save.md 見出し直前空行欠落を検出し、fix-and-reverify で全件解決、再査読で未解決 0 件。em-dash、LLM 表現の機械判定は追加行 0 件。「承認・HITL 境界」「Workflow・Capability responsibility」の中黒は Issue 本文由来の契約項目名（固定複合名詞）として許容判定
- Gate: `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref origin/remediation/staging --json` → failures 0 / warnings 0（変更19ファイル + coupled 2ファイル検査）
- 既知の pre-existing 欠陥（generate_indexes.ts が docs/adr/README.md を要求し exit 2）は既に intake 済みのため本 PR では再記録しない

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 残渣 grep（5系統、16 Command SPEC） | 0 件 | 0 件 | PASS |
| check_changed_docs.ts（case-run、strict） | failures 0 / warnings 0 | strict fail なし | PASS |
| 変更行 一文一行機械判定（是正後再実行） | 是正対象 0 件 | 0 件 | PASS |
| frontmatter（16 Command SPEC） | status: accepted / updated: 2026-08-15 | status・日付維持 | PASS |
| worktree 隔離 | git rev-parse --show-toplevel = .worktrees/2105-feature | worktree 内完結 | PASS |

## Findings / Capture候補

### intake

- thin Command の workflow 節における順序ラベル様式（`### Step N` / `STEP-N` / `工程-N`）の統一基準、記述量基準といった執筆詳細の docs/specs/authoring/command-file-format.md（authoring ドメイン）への反映。本 Issue の対象範囲は docs/specs/commands/ 全16件と workflows 横断 SPEC のみのため見送り、後続 issue 候補として記録する（発見元: PR #2114 SPEC確定候補のうち workflows 側構成契約のみを反映した残）
- 変更範囲外の既存行に一文一行機械判定違反、テーブルセル `| — |` N/A プレースホルダ（inspect-promote.md、docs/specs/workflows/ 配下の未変更ファイル等）が残存する。機械横断是正（独立 OU）での対応候補

### learning

- check_changed_docs.ts の --base-ref モードは `git diff <base>...HEAD`（コミット済み範囲）のみを対象とするため、コミット前の worktree では files_checked が空になり「対象ファイルが検出されませんでした」warning となる。case-run の gate 実行はコミット後が前提であり、コミット前に実行して空結果を pass と誤認しない運用知見
- ハーネスの Write ツールからリポジトリ外 temp（C:\WINDOWS\TEMP\opencode）へのスクリプト作成が distribution-boundary-guard でブロックされる事象を確認した。機械一括是正が必要な場合は edit ツールによる逐次実行、または .git 配下への作業ファイル配置で回避できる

## SPEC確定候補

Wave 2 PR（#2112、#2114。#2113 は該当なし）の SPEC確定候補6件の処置。

| # | 候補 | 出典 | 処置 | 反映先 / 根拠 |
|---|---|---|---|---|
| 1 | read-only-diagnostic 型 Workflow Skill の標準セクション構成 | #2112 | 反映 | workflow-skill-model.md「Workflow 型分類と標準構成」（型判定節、工程一覧、冪等性根拠、終了条件の4構成） |
| 2 | inspect-promote の分類確定状態再構成規則（durable state からの復元） | #2112 | 反映 | backlog-artifact-lifecycle.md「分類確定状態の再構成規則（durable state からの復元）」（5観測→確定状態の表と HITL 承認逆算規則） |
| 3 | thin Command の workflow 節標準構造（3要素） | #2114 | 一部反映 | 構成契約を workflow-skill-model.md「thin Command の workflow 節標準構造」へ反映。執筆詳細の authoring/command-file-format.md への反映は本 Issue 対象範囲外のため見送り（Findings の intake 候補として記録） |
| 4 | case-run 1:N 分離の実行契約差異表（6軸） | #2114 | 反映 | workflow-skill-model.md「1:N 分割基準の適用実例（case-run）」 |
| 5 | soft guard の二層様式 | #2114 | 反映 | workflow-skill-model.md「soft guard の二層様式」（Command 層11件 / Skill 層のみ5件の実測と一致） |
| 6 | STEP 8要素見出し形式（機械検査可能な標準見出し群） | #2114 | 反映 | step-reference-contract.md「標準見出し形式」（8見出し固定、既存3変種の等価性、移行非必須、対象外型の除外） |
