### PR TITLE
feat(agentdev): 旧責務残存の分類・除去と preventive checker 7項目の導入（OU-007、Refs #2107）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/SKILL.md
+++ b/.opencode/skills/repo-agentdev-integrity/SKILL.md
@@ -82,6 +82,7 @@ agent-dev-flow リポジトリ（self-hosting repo）の artifact 整合性検�
 | Obsolete spec path | `check_integrity.ts` | `obsolete-path-map.yaml` に基づく旧SPEC直下パス参照検出、直接生成方式語彙検出（IR-057, REQ-0158-002） |
 | Distribution reference boundary | `check_distribution_boundary.ts` | 配布 command/skill 本文（`src/opencode/commands/agentdev/**/*.md`, `src/opencode/skills/agentdev-*/**/*.md`）に含まれる具体ID（`ADR-NNNN`, `REQ-NNNN`）、具体パス（`docs/(adr\|requirements\specs)/<file>.md`、但し README.md とテンプレート表記は除外）、固定URL（blob/raw）を検出。project extensions 機構（配布物参照境界）の持続的検査を担う |
 | Targeted docs guard | `check_changed_docs.ts` | 変更ファイル限定の整合性検査。req-save / spec-save / case-close / docs-check の各 workflow で実行（REQ-0158-003） |
+| Workflow preventive checks | `check_workflow_preventive.ts` | AG-008 旧責務残存の予防検査7項目（全公開 Command の Workflow Skill dispatch 存在、dispatch 先 Skill 存在、Workflow Skill の soft guard 存在、旧 extension kind・runtime path 残存禁止、Command から Skill 内部 reference 直接依存禁止、Workflow/Capability 分類と Extension kind 整合、command-format rules と thin Command モデル無矛盾）。false positive 対策の exemption は script 本体に構造化 |
 
 ### Finding レベル（REQ-0108-100~105）
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for check_workflow_preventive.ts (AG-008 preventive checks).
+ *
+ * Integration target is the parent repo: after the OU-007 cleanup all 7
+ * preventive items must pass (ok=true). Fixture-based tests verify each
+ * item's detection logic and the structured exemptions.
+ */
+
+import { expect, test, describe, beforeAll, afterAll } from "bun:test";
+import { checkWorkflowPreventive } from "./check_workflow_preventive.ts";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+
+// Resolve to the worktree root (4 levels up from .opencode/skills/repo-agentdev-integrity/scripts).
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..", "..");
+
+describe("checkWorkflowPreventive (integration against real repo)", () => {
+  test("all 7 preventive items pass (ok=true)", () => {
+    const report = checkWorkflowPreventive(REPO_ROOT);
+    expect(report.ok).toBe(true);
+    expect(report.checks.length).toBe(7);
+    for (const c of report.checks) {
+      expect(c.pass).toBe(true);
+    }
+    expect(report.failures.filter((f) => f.severity === "strict").length).toBe(0);
+    expect(report.stats.public_commands).toBe(16);
+    expect(report.stats.legacy_kind_files).toBe(0);
+    expect(report.stats.legacy_commands_dir_files).toBe(0);
+  });
+
+  test("exemptions are structured and recorded", () => {
+    const report = checkWorkflowPreventive(REPO_ROOT);
+    const areas = report.exemptions.map((e) => e.area);
+    expect(areas).toContain("check-4 legacy-path detection fixtures");
+    expect(areas).toContain("check-4 abolition declarations");
+    expect(areas).toContain("check-5 generic directory declarations");
+  });
+});
+
+interface FixtureOptions {
+  commandBody?: string;
+  skillBody?: string;
+  skillExists?: boolean;
+  extensionYaml?: string | null;
+  legacyCommandsDirFile?: boolean;
+  extraDistributionFile?: { rel: string; content: string } | null;
+  rulesYaml?: string;
+}
+
+const DEFAULT_COMMAND_BODY = `---
+description: fixture command
+---
+
+# demo
+
+本コマンドは workflow 実装本体を \`agentdev-workflow-demo\` スキルへ委譲する（DEC-010、REQ-002-016）。
+
+各 STEP の詳細は \`agentdev-workflow-demo\` スキルの \`references/\` 配下を参照。本コマンドは同スキルを名レベルで参照し、内部構造（STEP ID、reference パス）へ直接依存しない。
+
+**soft guard（REQ-002-017）**: 同 Workflow Skill は本コマンドの工程経由でのみ利用し、単独起動を行わない。
+`;
+
+const DEFAULT_SKILL_BODY = `---
+name: agentdev-workflow-demo
+description: fixture workflow skill
+---
+
+# agentdev-workflow-demo
+
+本スキルは case-run workflow を所有する。
+
+**soft guard**: 本スキルは \`/agentdev/demo\` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わない。
+`;
+
+const DEFAULT_EXTENSION_YAML = `version: 1
+kind: workflow-extension
+id: agentdev-workflow-demo
+
+context: []
+rules: []
+checks: []
+acceptance_gates: []
+must_not: []
+`;
+
+const DEFAULT_RULES_YAML = `schema_version: 1
+top_level_step_rules:
+  scan_dirs:
+    - src/opencode/commands/agentdev
+  heading_regex: "^###\\\\s+Step\\\\s+(\\\\d+)(?:[〜-](\\\\d+))?\\\\s*:"
+  forbidden_heading_regex: "^###\\\\s+Step\\\\s+[A-Za-z]"
+`;
+
+function buildFixture(dir: string, opts: FixtureOptions = {}): string {
+  const root = fs.mkdtempSync(path.join(dir, "wf-prev-"));
+  const commandDir = path.join(root, "src/opencode/commands/agentdev");
+  fs.mkdirSync(commandDir, { recursive: true });
+  fs.writeFileSync(path.join(commandDir, "demo.md"), opts.commandBody ?? DEFAULT_COMMAND_BODY, "utf-8");
+
+  if (opts.skillExists !== false) {
+    const skillDir = path.join(root, "src/opencode/skills/agentdev-workflow-demo");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, "SKILL.md"), opts.skillBody ?? DEFAULT_SKILL_BODY, "utf-8");
+  }
+
+  if (opts.extensionYaml !== null) {
+    const extDir = path.join(root, ".agentdev/extensions/skills");
+    fs.mkdirSync(extDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(extDir, "agentdev-workflow-demo.yaml"),
+      opts.extensionYaml ?? DEFAULT_EXTENSION_YAML,
+      "utf-8",
+    );
+  }
+
+  if (opts.legacyCommandsDirFile) {
+    const legacyDir = path.join(root, ".agentdev/extensions/commands");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, "demo.yaml"), "kind: command-extension\n", "utf-8");
+  }
+
+  if (opts.extraDistributionFile) {
+    const abs = path.join(root, opts.extraDistributionFile.rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, opts.extraDistributionFile.content, "utf-8");
+  }
+
+  const rulesPath = path.join(root, ".opencode/skills/repo-agentdev-integrity/data");
+  fs.mkdirSync(rulesPath, { recursive: true });
+  fs.writeFileSync(
+    path.join(rulesPath, "command-format-rules.yaml"),
+    opts.rulesYaml ?? DEFAULT_RULES_YAML,
+    "utf-8",
+  );
+  return root;
+}
+
+let tmpBase: string;
+
+beforeAll(() => {
+  tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "agentdev-wf-prev-test-"));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpBase, { recursive: true, force: true });
+});
+
+describe("fixture: valid repository passes", () => {
+  test("ok=true with all checks passing", () => {
+    const root = buildFixture(tmpBase);
+    const report = checkWorkflowPreventive(root);
+    expect(report.ok).toBe(true);
+    expect(report.checks.every((c) => c.pass)).toBe(true);
+  });
+});
+
+describe("check 1: workflow-dispatch-presence", () => {
+  test("command without a dispatch mention fails", () => {
+    const root = buildFixture(tmpBase, {
+      commandBody: DEFAULT_COMMAND_BODY.replace(/agentdev-workflow-demo/g, "agentdev-somewhere-else"),
+    });
+    const report = checkWorkflowPreventive(root);
+    expect(report.ok).toBe(false);
+    expect(report.checks.find((c) => c.item === 1)?.pass).toBe(false);
+    expect(report.failures.some((f) => f.check === 1 && f.check_name === "workflow-dispatch-presence")).toBe(true);
+  });
+});
+
+describe("check 2: dispatch-target-existence", () => {
+  test("missing Workflow Skill directory fails", () => {
+    const root = buildFixture(tmpBase, { skillExists: false });
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 2)?.pass).toBe(false);
+  });
+});
+
+describe("check 3: workflow-soft-guard", () => {
+  test("Workflow Skill without a soft guard declaration fails", () => {
+    const root = buildFixture(tmpBase, {
+      skillBody: DEFAULT_SKILL_BODY.replace(/\*\*soft guard\*\*.*\n/, ""),
+    });
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 3)?.pass).toBe(false);
+    expect(report.failures.some((f) => f.check === 3)).toBe(true);
+  });
+});
+
+describe("check 4: legacy-extension-residual", () => {
+  test("legacy extension kind fails", () => {
+    const root = buildFixture(tmpBase, {
+      extensionYaml: DEFAULT_EXTENSION_YAML.replace("kind: workflow-extension", "kind: skill-extension"),
+    });
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 4)?.pass).toBe(false);
+    expect(report.stats.legacy_kind_files).toBe(1);
+  });
+
+  test("legacy commands extension directory residual fails", () => {
+    const root = buildFixture(tmpBase, { legacyCommandsDirFile: true });
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 4)?.pass).toBe(false);
+    expect(report.stats.legacy_commands_dir_files).toBe(1);
+  });
+
+  test("legacy runtime path reference in a command body fails", () => {
+    const root = buildFixture(tmpBase, {
+      commandBody:
+        DEFAULT_COMMAND_BODY +
+        "\n本コマンドは `.agentdev/extensions/commands/demo.yaml` を読み込む。\n",
+    });
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 4)?.pass).toBe(false);
+    expect(
+      report.failures.some((f) => f.check === 4 && f.message.includes("abolished extension runtime path")),
+    ).toBe(true);
+  });
+
+  test("abolition-declaration line is exempted", () => {
+    const root = buildFixture(tmpBase, {
+      extraDistributionFile: {
+        rel: "src/opencode/skills/agentdev-project-extensions/SKILL.md",
+        content:
+          "# project extensions\n\n旧配置 `.agentdev/extensions/commands/**` は廃止済みである。runtime は旧配置を後方互換で読まない。\n",
+      },
+    });
+    const report = checkWorkflowPreventive(root);
+    expect(report.ok).toBe(true);
+    expect(report.stats.legacy_path_exempted_lines).toBe(1);
+  });
+
+  test("detection fixture (*.test.ts) building the legacy path is exempted", () => {
+    const root = buildFixture(tmpBase, {
+      extraDistributionFile: {
+        rel: "src/opencode/skills/agentdev-artifact-graph/scripts/tests/containment.test.ts",
+        content:
+          "test(\"containment\", () => {\n  const dir = join(root, \".agentdev/extensions/commands\");\n});\n",
+      },
+    });
+    const report = checkWorkflowPreventive(root);
+    expect(report.ok).toBe(true);
+  });
+});
+
+describe("check 5: internal-reference-direct-dep", () => {
+  test("specific reference file mention fails", () => {
+    const root = buildFixture(tmpBase, {
+      commandBody:
+        DEFAULT_COMMAND_BODY +
+        "\n手続きの詳細は `agentdev-workflow-demo` スキル（references/delegation-and-result.md の STEP-S5）を参照する。\n",
+    });
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 5)?.pass).toBe(false);
+    expect(report.failures.some((f) => f.check === 5 && f.file?.endsWith("demo.md"))).toBe(true);
+  });
+
+  test("generic `references/` 配下 declaration without a filename is exempted", () => {
+    const root = buildFixture(tmpBase);
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 5)?.pass).toBe(true);
+  });
+});
+
+describe("check 6: classification-kind-consistency", () => {
+  test("workflow-extension targeting a non-Workflow Skill fails", () => {
+    const root = buildFixture(tmpBase, {
+      extensionYaml: DEFAULT_EXTENSION_YAML.replace(
+        "id: agentdev-workflow-demo",
+        "id: agentdev-cap-thing",
+      ),
+    });
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 6)?.pass).toBe(false);
+    expect(
+      report.failures.some((f) => f.check === 6 && f.message.includes("is not a Workflow Skill")),
+    ).toBe(true);
+  });
+
+  test("capability-skill-extension targeting a Workflow Skill fails", () => {
+    const root = buildFixture(tmpBase, {
+      extensionYaml: DEFAULT_EXTENSION_YAML.replace(
+        "kind: workflow-extension",
+        "kind: capability-skill-extension",
+      ),
+    });
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 6)?.pass).toBe(false);
+    expect(
+      report.failures.some((f) => f.check === 6 && f.message.includes("is not a Capability Skill")),
+    ).toBe(true);
+  });
+});
+
+describe("check 7: command-format-thin-consistency", () => {
+  test("mandatory procedure-section directive fails", () => {
+    const root = buildFixture(tmpBase, {
+      rulesYaml: DEFAULT_RULES_YAML + 'required_sections:\n  - "## 手順"\n',
+    });
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 7)?.pass).toBe(false);
+    expect(report.failures.some((f) => f.check === 7 && f.message.includes("mandatory-content"))).toBe(true);
+  });
+
+  test("forbidden pattern rejecting the thin dispatch heading fails", () => {
+    const root = buildFixture(tmpBase, {
+      rulesYaml:
+        'schema_version: 1\nforbidden_heading_rules:\n  forbidden_primary_headings:\n    - "^##\\\\s+workflow\\\\s*$"\n',
+    });
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 7)?.pass).toBe(false);
+    expect(
+      report.failures.some((f) => f.check === 7 && f.message.includes("must not forbid the thin model")),
+    ).toBe(true);
+  });
+
+  test("missing rules file fails", () => {
+    const root = buildFixture(tmpBase);
+    fs.rmSync(path.join(root, ".opencode/skills/repo-agentdev-integrity/data/command-format-rules.yaml"));
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 7)?.pass).toBe(false);
+    expect(report.failures.some((f) => f.check === 7 && f.message.includes("rules file is missing"))).toBe(true);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.ts
@@ -1,0 +1,624 @@
+/**
+ * Workflow preventive checker (AG-008, OU-007 / Issue #2107).
+ *
+ * 7 machine-checkable preventive items guarding the thin Command model
+ * (DEC-010) and the 3-kind extension era (DEC-012):
+ *
+ *   1. workflow-dispatch-presence       every public command references its
+ *                                       dedicated Workflow Skill by name
+ *   2. dispatch-target-existence        the dedicated Workflow Skill exists
+ *   3. workflow-soft-guard              each command-bound Workflow Skill
+ *                                       SKILL.md declares the soft guard
+ *   4. legacy-extension-residual        legacy kinds and the legacy runtime
+ *                                       path must not remain (extension tree
+ *                                       + distribution bodies under src/)
+ *   5. internal-reference-direct-dep    command bodies must not reference
+ *                                       specific skill-internal reference files
+ *   6. classification-kind-consistency  extension kinds align with the
+ *                                       deterministic Workflow/Capability
+ *                                       classification
+ *   7. command-format-thin-consistency  command-format rules must not mandate
+ *                                       procedure sections or forbid the
+ *                                       workflow dispatch structure
+ *
+ * Semantic duplication detection stays with /agentdev/inspect-skills and the
+ * command-file-format SPEC "thin Command モデル検査" scope note: this checker
+ * only enforces structurally decidable invariants (AG-008).
+ *
+ * Structured exemptions (AG-008 false-positive records, kept here so future
+ * checker false positives are self-documenting):
+ *   - check 4: *.test.ts fixtures that intentionally build the legacy path to
+ *     validate containment detection (agentdev-artifact-graph containment
+ *     tests)
+ *   - check 4: abolition-declaration lines (lines mentioning the legacy path
+ *     together with 廃止 / 後方互換で読まない / migration-required declare the
+ *     abolition itself; agentdev-project-extensions SKILL.md)
+ *   - check 5: generic "`references/` 配下を参照" declarations that name no
+ *     specific file (they assert name-level non-dependence, REQ-002-017)
+ *   - scan scope: docs/** historical records (superseded SPECs, DEC-005,
+ *     IR-056 detection-scope declarations) are intentionally not scanned;
+ *     docs semantics stay with inspect-docs / inspect-skills
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { deriveSkillClassification } from "./check_extensions.ts";
+
+export interface PreventiveFailure {
+  check: number;
+  check_name: string;
+  severity: "strict" | "warning";
+  classification: "existence" | "consistency" | "residual" | "format";
+  file?: string;
+  line?: number;
+  message: string;
+}
+
+export interface PreventiveCheckSummary {
+  item: number;
+  name: string;
+  pass: boolean;
+}
+
+export interface PreventiveExemption {
+  area: string;
+  description: string;
+}
+
+export interface PreventiveReport {
+  ok: boolean;
+  checks: PreventiveCheckSummary[];
+  failures: PreventiveFailure[];
+  exemptions: PreventiveExemption[];
+  stats: {
+    public_commands: number;
+    workflow_skills: number;
+    capability_skills: number;
+    extensions_checked: number;
+    legacy_kind_files: number;
+    legacy_commands_dir_files: number;
+    legacy_path_scanned_files: number;
+    legacy_path_exempted_lines: number;
+  };
+}
+
+const PUBLIC_COMMAND_DIR = "src/opencode/commands/agentdev";
+const DISTRIBUTION_SCAN_DIRS = ["src/opencode", "src/opencode-local"];
+const SKILLS_DIR = "src/opencode/skills";
+const EXTENSIONS_SKILLS_DIR = ".agentdev/extensions/skills";
+const EXTENSIONS_COMMANDS_DIR = ".agentdev/extensions/commands";
+const COMMAND_FORMAT_RULES_PATH = path.join(
+  ".opencode",
+  "skills",
+  "repo-agentdev-integrity",
+  "data",
+  "command-format-rules.yaml",
+);
+
+const LEGACY_EXTENSION_KINDS = ["command-extension", "skill-extension"];
+const LEGACY_EXTENSIONS_PATH = ".agentdev/extensions/commands";
+const SOFT_GUARD_MARKER = "soft guard";
+
+// check 5: a specific internal reference file (references/<file>.md|.ts).
+// The generic "`references/` 配下を参照" declaration names no file and is the
+// documented non-dependence statement, so it does not match.
+const INTERNAL_REFERENCE_FILE = /references\/[A-Za-z0-9_-]+\.(?:md|ts)\b/;
+
+// check 4 exemptions:
+//  - detection fixtures (*.test.ts) legitimately build the legacy path
+//  - abolition declarations mention the legacy path only to forbid reading it
+const ABOLITION_DECLARATION = /廃止|後方互換で読まない|migration-required/;
+
+export const PREVENTIVE_EXEMPTIONS: PreventiveExemption[] = [
+  {
+    area: "check-4 legacy-path detection fixtures",
+    description:
+      "*.test.ts files may build .agentdev/extensions/commands fixtures to validate containment detection",
+  },
+  {
+    area: "check-4 abolition declarations",
+    description:
+      "lines mentioning the legacy path together with 廃止 / 後方互換で読まない / migration-required declare the abolition itself",
+  },
+  {
+    area: "check-5 generic directory declarations",
+    description:
+      "`references/` 配下を参照 lines that name no specific file assert name-level non-dependence (REQ-002-017)",
+  },
+  {
+    area: "scan scope",
+    description:
+      "docs/** historical records (superseded SPECs, DEC-005, IR-056 detection-scope declarations) are not scanned; docs semantics stay with inspect-docs / inspect-skills",
+  },
+];
+
+const CHECK_NAMES: Record<number, string> = {
+  1: "workflow-dispatch-presence",
+  2: "dispatch-target-existence",
+  3: "workflow-soft-guard",
+  4: "legacy-extension-residual",
+  5: "internal-reference-direct-dep",
+  6: "classification-kind-consistency",
+  7: "command-format-thin-consistency",
+};
+
+function dirExists(p: string): boolean {
+  try {
+    return fs.existsSync(p) && fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function readText(p: string): string | null {
+  try {
+    return fs.readFileSync(p, "utf-8") as string;
+  } catch {
+    return null;
+  }
+}
+
+function listMarkdownFiles(dirPath: string): string[] {
+  const result: string[] = [];
+  if (!dirExists(dirPath)) return result;
+  for (const ent of fs.readdirSync(dirPath, { withFileTypes: true }) as any[]) {
+    if (ent.isFile() && ent.name.endsWith(".md") && ent.name !== "README.md") {
+      result.push(path.join(dirPath, ent.name).replace(/\\/g, "/"));
+    }
+  }
+  return result.sort();
+}
+
+function listFilesRecursive(dirPath: string, extensions?: string[]): string[] {
+  const result: string[] = [];
+  if (!dirExists(dirPath)) return result;
+  for (const ent of fs.readdirSync(dirPath, { withFileTypes: true }) as any[]) {
+    const full = path.join(dirPath, ent.name);
+    if (ent.isDirectory()) {
+      result.push(...listFilesRecursive(full, extensions));
+    } else if (ent.isFile()) {
+      if (!extensions || extensions.some((e) => ent.name.endsWith(e))) {
+        result.push(full.replace(/\\/g, "/"));
+      }
+    }
+  }
+  return result.sort();
+}
+
+function extractYamlField(text: string, field: string): string | null {
+  const m = text.match(new RegExp(`^${field}:\\s*(\\S+)\\s*$`, "m"));
+  return m ? m[1] : null;
+}
+
+/**
+ * Collect `forbidden*` regex values from the command-format rules YAML.
+ * Double-quoted YAML scalars use JSON-compatible escapes; both the
+ * `forbidden_key: "pattern"` and `forbidden_key:` + `- "pattern"` list forms
+ * are handled.
+ */
+function collectForbiddenRegexes(yamlText: string): { key: string; value: string }[] {
+  const result: { key: string; value: string }[] = [];
+  const lines = yamlText.split(/\r?\n/);
+  let currentListKey: string | null = null;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (line === "" || /^#/.test(line)) {
+      currentListKey = null;
+      continue;
+    }
+    const kv = line.match(/^([A-Za-z_][A-Za-z0-9_]*):\s*"(.*)"\s*$/);
+    if (kv) {
+      currentListKey = kv[1].startsWith("forbidden") ? kv[1] : null;
+      if (currentListKey) {
+        try {
+          result.push({ key: currentListKey, value: JSON.parse(`"${kv[2]}"`) });
+        } catch {
+          // malformed scalar: reported by the caller via compile failure
+          result.push({ key: currentListKey, value: kv[2] });
+        }
+      }
+      continue;
+    }
+    const bareKey = line.match(/^([A-Za-z_][A-Za-z0-9_]*):\s*$/);
+    if (bareKey) {
+      currentListKey = bareKey[1].startsWith("forbidden") ? bareKey[1] : null;
+      continue;
+    }
+    const item = line.match(/^-\s*"(.*)"\s*$/);
+    if (item && currentListKey) {
+      try {
+        result.push({ key: currentListKey, value: JSON.parse(`"${item[1]}"`) });
+      } catch {
+        result.push({ key: currentListKey, value: item[1] });
+      }
+    }
+  }
+  return result;
+}
+
+// Key names that would intrinsically mandate content presence in the scanned
+// command files. `required_primary_heading` (IR-031, PR-body heading shape)
+// is intentionally NOT in this set: it constrains PR bodies, not command
+// files, so it does not contradict the thin Command model.
+const MANDATORY_CONTENT_KEYS = new Set([
+  "required_sections",
+  "required_headings",
+  "mandatory_sections",
+  "must_contain",
+  "must_contain_sections",
+]);
+
+export function checkWorkflowPreventive(repoRoot: string): PreventiveReport {
+  const failures: PreventiveFailure[] = [];
+  const origCwd = process.cwd();
+  process.chdir(repoRoot);
+  try {
+    const classification = deriveSkillClassification();
+    const commandFiles = listMarkdownFiles(PUBLIC_COMMAND_DIR);
+
+    const stats = {
+      public_commands: commandFiles.length,
+      workflow_skills: classification.workflowSkills.size,
+      capability_skills: classification.capabilitySkills.size,
+      extensions_checked: 0,
+      legacy_kind_files: 0,
+      legacy_commands_dir_files: 0,
+      legacy_path_scanned_files: 0,
+      legacy_path_exempted_lines: 0,
+    };
+
+    if (commandFiles.length === 0) {
+      failures.push({
+        check: 1,
+        check_name: CHECK_NAMES[1],
+        severity: "strict",
+        classification: "existence",
+        file: PUBLIC_COMMAND_DIR,
+        message: `public command directory has no command files (${PUBLIC_COMMAND_DIR})`,
+      });
+    }
+
+    // Checks 1-3 + 5: per-command structural invariants
+    for (const cf of commandFiles) {
+      const base = path.basename(cf).replace(/\.md$/, "");
+      const workflowSkill = `agentdev-workflow-${base}`;
+      const text = readText(cf) ?? "";
+
+      // Check 1: dispatch presence (name-level reference to the dedicated Workflow Skill)
+      if (!new RegExp(`\\b${workflowSkill}\\b`).test(text)) {
+        failures.push({
+          check: 1,
+          check_name: CHECK_NAMES[1],
+          severity: "strict",
+          classification: "consistency",
+          file: cf,
+          message: `command does not reference its dedicated Workflow Skill '${workflowSkill}' (thin Command model requires a name-level dispatch)`,
+        });
+      }
+
+      // Check 2: dispatch target existence
+      const skillMd = path.join(SKILLS_DIR, workflowSkill, "SKILL.md");
+      if (!readText(skillMd)) {
+        failures.push({
+          check: 2,
+          check_name: CHECK_NAMES[2],
+          severity: "strict",
+          classification: "existence",
+          file: skillMd,
+          message: `dispatch target Workflow Skill '${workflowSkill}' does not exist (expected ${skillMd})`,
+        });
+      } else {
+        // Check 3: soft guard declaration in the Workflow Skill
+        const skillText = readText(skillMd) ?? "";
+        if (!skillText.includes(SOFT_GUARD_MARKER)) {
+          failures.push({
+            check: 3,
+            check_name: CHECK_NAMES[3],
+            severity: "strict",
+            classification: "consistency",
+            file: skillMd,
+            message: `Workflow Skill '${workflowSkill}' does not declare the soft guard (standalone skill launch suppression)`,
+          });
+        }
+      }
+
+      // Check 5: no direct dependency on skill-internal reference files
+      const lines = text.split(/\r?\n/);
+      for (let i = 0; i < lines.length; i++) {
+        const m = lines[i].match(INTERNAL_REFERENCE_FILE);
+        if (m) {
+          failures.push({
+            check: 5,
+            check_name: CHECK_NAMES[5],
+            severity: "strict",
+            classification: "residual",
+            file: cf,
+            line: i + 1,
+            message: `command references a skill-internal reference file '${m[0]}' (workflow references must stay Workflow-Skill name level, REQ-002-017)`,
+          });
+        }
+      }
+    }
+
+    // Check 4a: legacy kinds under the extension tree
+    const extensionFiles = listFilesRecursive(EXTENSIONS_SKILLS_DIR, [".yaml", ".yml"]);
+    stats.extensions_checked = extensionFiles.length;
+    for (const ef of extensionFiles) {
+      const text = readText(ef) ?? "";
+      const kind = extractYamlField(text, "kind");
+      if (kind && LEGACY_EXTENSION_KINDS.includes(kind)) {
+        stats.legacy_kind_files++;
+        failures.push({
+          check: 4,
+          check_name: CHECK_NAMES[4],
+          severity: "strict",
+          classification: "residual",
+          file: ef,
+          message: `legacy extension kind '${kind}' detected (fully abolished; migrate to workflow-extension / internal-workflow-extension / capability-skill-extension)`,
+        });
+      }
+    }
+
+    // Check 4b: legacy commands extension directory residual
+    const commandsDirFiles = listFilesRecursive(EXTENSIONS_COMMANDS_DIR);
+    stats.legacy_commands_dir_files = commandsDirFiles.length;
+    if (commandsDirFiles.length > 0) {
+      failures.push({
+        check: 4,
+        check_name: CHECK_NAMES[4],
+        severity: "strict",
+        classification: "residual",
+        file: EXTENSIONS_COMMANDS_DIR,
+        message: `${EXTENSIONS_COMMANDS_DIR}/** still contains ${commandsDirFiles.length} file(s); the directory is abolished`,
+      });
+    }
+
+    // Check 4c: legacy runtime path references in distribution bodies
+    for (const scanDir of DISTRIBUTION_SCAN_DIRS) {
+      const textFiles = listFilesRecursive(scanDir, [".md", ".ts"]);
+      for (const tf of textFiles) {
+        const text = readText(tf);
+        if (!text || !text.includes(LEGACY_EXTENSIONS_PATH)) continue;
+        stats.legacy_path_scanned_files++;
+        const lines = text.split(/\r?\n/);
+        for (let i = 0; i < lines.length; i++) {
+          if (!lines[i].includes(LEGACY_EXTENSIONS_PATH)) continue;
+          const relPath = tf.replace(/\\/g, "/");
+          const isFixture = /\.test\.ts$/.test(relPath);
+          const isAbolitionDeclaration = ABOLITION_DECLARATION.test(lines[i]);
+          if (isFixture || isAbolitionDeclaration) {
+            stats.legacy_path_exempted_lines++;
+            continue;
+          }
+          failures.push({
+            check: 4,
+            check_name: CHECK_NAMES[4],
+            severity: "strict",
+            classification: "residual",
+            file: relPath,
+            line: i + 1,
+            message: `distribution body references the abolished extension runtime path '${LEGACY_EXTENSIONS_PATH}' (extensions live under ${EXTENSIONS_SKILLS_DIR}/)`,
+          });
+        }
+      }
+    }
+
+    // Check 6: extension kind vs deterministic Workflow/Capability classification
+    for (const ef of extensionFiles) {
+      const text = readText(ef) ?? "";
+      const kind = extractYamlField(text, "kind");
+      const id = extractYamlField(text, "id");
+      if (!kind || LEGACY_EXTENSION_KINDS.includes(kind)) continue; // legacy handled by check 4
+      const relPath = path.relative(EXTENSIONS_SKILLS_DIR, ef).replace(/\\/g, "/");
+      const segments = relPath.split("/");
+      const fileBase = (segments[segments.length - 1] ?? "").replace(/\.ya?ml$/, "");
+
+      if (kind === "workflow-extension") {
+        if (segments.length !== 1) {
+          failures.push({
+            check: 6,
+            check_name: CHECK_NAMES[6],
+            severity: "strict",
+            classification: "consistency",
+            file: ef,
+            message: `workflow-extension must be placed flat at ${EXTENSIONS_SKILLS_DIR}/{workflow-skill-name}.yaml (got: ${relPath})`,
+          });
+        }
+        if (id && !classification.workflowSkills.has(id)) {
+          failures.push({
+            check: 6,
+            check_name: CHECK_NAMES[6],
+            severity: "strict",
+            classification: "consistency",
+            file: ef,
+            message: `workflow-extension target '${id}' is not a Workflow Skill (Workflow Skill = agentdev-workflow-{command} with an existing command)`,
+          });
+        }
+        if (id && id !== fileBase) {
+          failures.push({
+            check: 6,
+            check_name: CHECK_NAMES[6],
+            severity: "strict",
+            classification: "consistency",
+            file: ef,
+            message: `workflow-extension 'id' (${id}) must match the target skill name derived from the filename (${fileBase})`,
+          });
+        }
+      } else if (kind === "capability-skill-extension") {
+        if (segments.length !== 1) {
+          failures.push({
+            check: 6,
+            check_name: CHECK_NAMES[6],
+            severity: "strict",
+            classification: "consistency",
+            file: ef,
+            message: `capability-skill-extension must be placed flat at ${EXTENSIONS_SKILLS_DIR}/{capability-skill-name}.yaml (got: ${relPath})`,
+          });
+        }
+        if (id && !classification.capabilitySkills.has(id)) {
+          failures.push({
+            check: 6,
+            check_name: CHECK_NAMES[6],
+            severity: "strict",
+            classification: "consistency",
+            file: ef,
+            message: `capability-skill-extension target '${id}' is not a Capability Skill (Capability Skill = an agentdev-* skill directory without a corresponding command)`,
+          });
+        }
+        if (id && id !== fileBase) {
+          failures.push({
+            check: 6,
+            check_name: CHECK_NAMES[6],
+            severity: "strict",
+            classification: "consistency",
+            file: ef,
+            message: `capability-skill-extension 'id' (${id}) must match the target skill name derived from the filename (${fileBase})`,
+          });
+        }
+      } else if (kind === "internal-workflow-extension") {
+        const parent = segments[0] ?? "";
+        if (segments.length !== 2 || !/^internal\.ya?ml$/.test(segments[1] ?? "")) {
+          failures.push({
+            check: 6,
+            check_name: CHECK_NAMES[6],
+            severity: "strict",
+            classification: "consistency",
+            file: ef,
+            message: `internal-workflow-extension must be placed at ${EXTENSIONS_SKILLS_DIR}/{workflow-skill-name}/internal.yaml (got: ${relPath})`,
+          });
+        }
+        if (id && id !== parent) {
+          failures.push({
+            check: 6,
+            check_name: CHECK_NAMES[6],
+            severity: "strict",
+            classification: "consistency",
+            file: ef,
+            message: `internal-workflow-extension 'id' (${id}) must match the parent directory Workflow Skill name (${parent})`,
+          });
+        }
+        if (id && !classification.workflowSkills.has(id)) {
+          failures.push({
+            check: 6,
+            check_name: CHECK_NAMES[6],
+            severity: "strict",
+            classification: "consistency",
+            file: ef,
+            message: `internal-workflow-extension parent '${id}' is not a Workflow Skill`,
+          });
+        }
+      }
+    }
+
+    // Check 7: command-format rules must not contradict the thin Command model
+    const rulesText = readText(COMMAND_FORMAT_RULES_PATH);
+    if (!rulesText) {
+      failures.push({
+        check: 7,
+        check_name: CHECK_NAMES[7],
+        severity: "strict",
+        classification: "existence",
+        file: COMMAND_FORMAT_RULES_PATH,
+        message: `command-format rules file is missing (${COMMAND_FORMAT_RULES_PATH})`,
+      });
+    } else {
+      // (i) no mandatory-content directives (e.g. a required ## 手順 section)
+      const ruleLines = rulesText.split(/\r?\n/);
+      for (let i = 0; i < ruleLines.length; i++) {
+        const keyMatch = ruleLines[i].match(/^\s*([A-Za-z_][A-Za-z0-9_]*):\s*/);
+        if (keyMatch && MANDATORY_CONTENT_KEYS.has(keyMatch[1].toLowerCase())) {
+          failures.push({
+            check: 7,
+            check_name: CHECK_NAMES[7],
+            severity: "strict",
+            classification: "format",
+            file: COMMAND_FORMAT_RULES_PATH,
+            line: i + 1,
+            message: `command-format rules define a mandatory-content directive ('${ruleLines[i].trim()}'); the thin Command model must not require a procedure section in public commands`,
+          });
+        }
+      }
+      // (ii) forbidden patterns must not reject the thin dispatch structure
+      const thinSamples = [
+        "## workflow",
+        "本コマンドは workflow 実装本体を `agentdev-workflow-demo` スキルへ委譲する（DEC-010、REQ-002-016）。",
+        "### Step 1: 入力解決",
+      ];
+      for (const { key, value } of collectForbiddenRegexes(rulesText)) {
+        let re: RegExp | null = null;
+        try {
+          re = new RegExp(value);
+        } catch {
+          failures.push({
+            check: 7,
+            check_name: CHECK_NAMES[7],
+            severity: "strict",
+            classification: "format",
+            file: COMMAND_FORMAT_RULES_PATH,
+            message: `command-format rule '${key}' holds an invalid regex: ${value}`,
+          });
+          continue;
+        }
+        for (const sample of thinSamples) {
+          if (re!.test(sample)) {
+            failures.push({
+              check: 7,
+              check_name: CHECK_NAMES[7],
+              severity: "strict",
+              classification: "format",
+              file: COMMAND_FORMAT_RULES_PATH,
+              message: `command-format rule '${key}' (${value}) matches the thin Command dispatch structure sample '${sample}'; format rules must not forbid the thin model`,
+            });
+          }
+        }
+      }
+    }
+
+    const checks: PreventiveCheckSummary[] = [];
+    for (let item = 1; item <= 7; item++) {
+      checks.push({
+        item,
+        name: CHECK_NAMES[item],
+        pass: !failures.some((f) => f.check === item && f.severity === "strict"),
+      });
+    }
+    const strictFailures = failures.filter((f) => f.severity === "strict");
+    return {
+      ok: strictFailures.length === 0,
+      checks,
+      failures,
+      exemptions: PREVENTIVE_EXEMPTIONS,
+      stats,
+    };
+  } finally {
+    process.chdir(origCwd);
+  }
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const json = args.includes("--json");
+  const positional = args.filter((a) => !a.startsWith("--"));
+  const repoRoot = positional[0] || process.cwd();
+  const report = checkWorkflowPreventive(repoRoot);
+  if (json) {
+    process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+  } else {
+    process.stdout.write(`check_workflow_preventive.ts - AG-008 preventive checks (7 items)\n`);
+    process.stdout.write(`===============================================================\n`);
+    process.stdout.write(`repoRoot: ${repoRoot}\n`);
+    process.stdout.write(`ok: ${report.ok}\n`);
+    process.stdout.write(`checks:\n`);
+    for (const c of report.checks) {
+      process.stdout.write(`  [${c.pass ? "PASS" : "FAIL"}] #${c.item} ${c.name}\n`);
+    }
+    process.stdout.write(`stats: ${JSON.stringify(report.stats, null, 2)}\n`);
+    process.stdout.write(`failures (${report.failures.length}):\n`);
+    for (const f of report.failures) {
+      process.stdout.write(
+        `  [${f.severity}/${f.classification}] check #${f.check} ${f.check_name}${f.file ? ` (${f.file}${f.line ? `:${f.line}` : ""})` : ""}: ${f.message}\n`,
+      );
+    }
+  }
+  process.exit(report.ok ? 0 : 1);
+}

--- a/docs/specs/responsibilities/artifact-responsibilities.md
+++ b/docs/specs/responsibilities/artifact-responsibilities.md
@@ -127,7 +127,7 @@ REQ-003-034（同一契約再定義抑止）との両立関係を運用面で明
 
 ### 適用パターン1: project extensions boilerplate
 
-15 の agentdev command で同一4行の extension 宣言（project extensions boilerplate）が
+16 の agentdev command で同一4行の extension 宣言（project extensions boilerplate）が
 重複定義される場合、下記の分離フローを適用する。
 
 #### 公開契約宣言 vs 詳細契約 の分離フロー

--- a/docs/specs/skills/agentdev-project-extensions.md
+++ b/docs/specs/skills/agentdev-project-extensions.md
@@ -16,7 +16,7 @@ updated: 2026-07-27
 ### USE FOR
 
 - command/skill が自分に対応する extension を読み込む際の探索、読み取り契約
-- extension 不在時、破損時の標準的な扱い
+- extension 不在時、破損時、旧 kind・未知 kind 検出時の標準的な扱い
 - context/rules/checks/acceptance_gates/must_not の5セクション読み取り
 - extension が追加・拡張であり上書きでないことの扱い
 - rules/checks から project-local skill 委譲対象の抽出
@@ -32,9 +32,11 @@ updated: 2026-07-27
 
 | 判断・操作 | 内容 |
 |---|---|
-| extension 探索 | command は `.agentdev/extensions/commands/<command>.yaml`、skill は `.agentdev/extensions/skills/<skill>.yaml` を対応 extension として特定する |
+| extension 探索 | Workflow Skill は `.agentdev/extensions/skills/<workflow-skill-name>.yaml`（workflow-extension）と必要に応じて `.agentdev/extensions/skills/<workflow-skill-name>/internal.yaml`（internal-workflow-extension）、Capability Skill は `.agentdev/extensions/skills/<capability-skill-name>.yaml`（capability-skill-extension）を対応 extension として特定する |
 | 不在時の扱い | 対応 extension が存在しない場合は空 extension として扱い、標準動作で続行する |
-| 破損時の扱い | 対応 extension が破損している場合はエラーを表示し、当該 extension を無視して標準動作で続行する |
+| 破損時の扱い | 対応 extension が破損している場合（YAML 構文エラー、必須 field 欠落等）はエラーを表示し、当該 extension を無視して標準動作で続行する（fail-open） |
+| 旧 kind 検出時の扱い | `kind: command-extension` / `kind: skill-extension` を検出した場合は migration-required として停止する（silent ignore しない） |
+| 未知 kind 検出時の扱い | 構文上有効だが `kind` が公式3値以外の場合は schema violation として停止する（fail-open しない） |
 | 5セクション読み取り | context, rules, checks, acceptance_gates, must_not を読み取る |
 | 追加・拡張の扱い | extension の内容は配布 command/skill 本文の動作に追加され、既存動作を置き換えない |
 | 委譲対象抽出 | rules/checks の `skill:` フィールドから project-local skill 委譲対象を抽出する |
@@ -47,7 +49,7 @@ updated: 2026-07-27
 
 - extension は標準 command/skill の上書きではなく、追加・拡張のみ（G01）
 - 自分に対応する extension（1件）のみを読み、他 command/skill の extension は読まない（G02）
-- 破損 extension で処理全体を停止しない（G03）
+- 破損 extension（malformed）で処理全体を停止しない。旧 kind は migration-required、未知 kind は schema violation として停止する（G03）
 - 委譲先 project-local skill の中身には関与しない（G04）
 - rules/checks の初期契約では `action`, `required`, `fail_on` を採用しない。呼び出された skill は extension entry の `id`, `when`, `skill` および周辺文脈をもとに判断する
 - 配布 command/skill 本文にプロジェクト固有文書の具体参照を持たせない（G05）。プロジェクト固有参照は extension 経由でのみ与える
@@ -61,7 +63,7 @@ updated: 2026-07-27
 
 ## 検証観点
 
-- SKILL.md が存在し、6つの責務（extension 探索、不在時空 extension 扱い、破損時エラー表示と無視、5セクション読み取り、上書きでないことの扱い、委譲対象抽出）が全て定義されていること
+- SKILL.md が存在し、7つの責務（extension 探索、不在時空 extension 扱い、破損時エラー表示と無視、旧 kind・未知 kind 検出時の停止、5セクション読み取り、上書きでないことの扱い、委譲対象抽出）が全て定義されていること
 - 配布物参照境界（SKILL.md 本文にプロジェクト固有文書の具体ID、具体パス、固定URLを持たない）が遵守されていること
 
 ## See Also

--- a/docs/specs/workflows/workflow-contracts.md
+++ b/docs/specs/workflows/workflow-contracts.md
@@ -174,7 +174,7 @@ AgentDevFlow は case-auto と case-run の2階層委譲構造で大規模自走
 
 ### case-auto 構成工程委譲
 
-case-auto は構成工程（req-save、spec-save、case-open、case-close）を各コマンド定義を権威情報源として読み込む委譲起動で実行する。
+case-auto は構成工程（req-save、spec-save、case-open、case-close）を各工程の Workflow Skill を権威情報源とする委譲起動で実行する。
 case-auto 本体は薄いオーケストレータに専念し、入力解決、工程分岐、工程間状態引き継ぎ、停止条件検出、完了報告、OU と子Issue ループ制御、クリーンアップ検証ゲートのみを保持し、工程内部ロジックを実行しない。
 
 case-run は case-auto 内でインライン実行する（構成工程委譲の対象外）。

--- a/src/opencode/commands/agentdev/backlog-review.md
+++ b/src/opencode/commands/agentdev/backlog-review.md
@@ -24,7 +24,7 @@ description: 採用済み成果物を分析、統合し、ユーザー承認後�
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/backlog-review.yaml`）を読み込む（ADR）。
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-backlog-review`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-backlog-review.yaml`、kind: workflow-extension）を読み込む（ADR）。
 
 - extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
 - extension が存在しない場合は標準動作で続行する

--- a/src/opencode/commands/agentdev/case-auto.md
+++ b/src/opencode/commands/agentdev/case-auto.md
@@ -14,7 +14,7 @@ description: req-save→spec-save→case-open→case-run→case-closeを順次�
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-auto.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-case-auto`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-case-auto.yaml`、kind: workflow-extension）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
 ## 入力
 

--- a/src/opencode/commands/agentdev/case-close.md
+++ b/src/opencode/commands/agentdev/case-close.md
@@ -19,7 +19,7 @@ last-write-wins 競合防止は case-close の単一書き手で維持される�
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-close.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-case-close`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-case-close.yaml`、kind: workflow-extension）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
 ## 入力
 

--- a/src/opencode/commands/agentdev/case-open.md
+++ b/src/opencode/commands/agentdev/case-open.md
@@ -18,7 +18,7 @@ description: 要件定義をもとにGitHub Issueを作成する
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-open.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-case-open`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-case-open.yaml`、kind: workflow-extension）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
 ## workflow
 

--- a/src/opencode/commands/agentdev/case-run.md
+++ b/src/opencode/commands/agentdev/case-run.md
@@ -10,7 +10,7 @@ Case に対して実装実行を実行担当サブエージェント経由で委
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-run.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-case-run`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-case-run.yaml`、kind: workflow-extension）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
 ## 入力
 
@@ -52,14 +52,10 @@ Case に対して実装実行を実行担当サブエージェント経由で委
 
 ### Step 7-1: 配布依存境界の最終変更経路 gate（実装後）
 
-result が `completed-pr` の場合、worktree クリーンアップに進む前に、実装後の実際の worktree HEAD に対して配布依存境界の最終 gate を行う（実装担当サブエージェントが追加した変更も含めて検査する）。
+result が `completed-pr` かつ PR 対象ファイルに `src/opencode/{commands,skills}/**` 変更を含む場合、worktree クリーンアップの前に実装後の worktree HEAD へ最終 gate を適用する（実行担当サブエージェントが追加した変更も含む。当該変更を含まない PR ではスキップする）。
 
-- **実行条件**: result が `completed-pr` であり、PR 対象ファイルに `src/opencode/{commands,skills}/**` 変更を含む場合。当該変更を含まない PR（docs のみ等）ではスキップする
-- **実行コマンド**: `bun run .opencode/skills/<integrity-detector-skill>/scripts/check_distribution_boundary.ts --profile source --json`。現在の worktree（実装後 HEAD）の配布物ソースツリーを検査する
-- **検出結果の分類**: 検査エラー（読込不能、未分類エントリ、adapter 起動失敗）は全て gate-not-passed として扱う。clean として通過させない
-- **違反検出時の停止契約**（adapter result `blocked` とは区別）: 違反検出時は PR 本文の `## Findings / Capture候補` セクションに `### distribution-boundary` 小見出しで記録し、クリーンアップへ進まず case-run を停止する。adapter result は `completed-pr` のまま変更せず、adapter result 契約の `blocked`（Issue コメント SSoT を伴う blocker）へ上書きしない。next action は同一 Issue で case-run を再実行し違反を修正する（worktree+ブランチ存活時は委譲 STEP から再開、べき等）。case-close へは進めない（case-close 側で同一 gate が停止するため前段で停止する）
-
-手続きの詳細は `agentdev-workflow-case-run` スキル（references/delegation-and-result.md の STEP-S5）を参照する。
+- 実行コマンド: `bun run .opencode/skills/<integrity-detector-skill>/scripts/check_distribution_boundary.ts --profile source --json`
+- 違反検出時は PR 本文の `### distribution-boundary` 小見出しに記録して case-run を停止する。adapter result は `completed-pr` のまま `blocked` へ上書きしない。検出結果の分類、停止契約の詳細は `agentdev-workflow-case-run` スキルを参照
 
 **soft guard（REQ-{NNNN}-{NNN}、OpenCode 1.18.15 向け）**: 本コマンドの workflow 実装本体は `agentdev-workflow-case-run` が所有する。同 Workflow Skill は `/agentdev/case-run` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わないこと。OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため、本宣言を soft guard として機能させる。
 

--- a/src/opencode/commands/agentdev/case-update.md
+++ b/src/opencode/commands/agentdev/case-update.md
@@ -9,7 +9,7 @@ description: 既存Caseの本文更新、コメント追加、またはREQファ
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/case-update.yaml`）を読み込む（ADR）。
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-case-update`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-case-update.yaml`、kind: workflow-extension）を読み込む（ADR）。
 
 - extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
 - extension が存在しない場合は標準動作で続行する

--- a/src/opencode/commands/agentdev/inspect-docs.md
+++ b/src/opencode/commands/agentdev/inspect-docs.md
@@ -44,7 +44,7 @@ routing は実行コマンド選択の目安であり、各コマンドの検出
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/inspect-docs.yaml`）を読み込む（ADR）。
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-inspect-docs`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-inspect-docs.yaml`、kind: workflow-extension）を読み込む（ADR）。
 
 - extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
 - extension が存在しない場合は標準動作で続行する

--- a/src/opencode/commands/agentdev/inspect-promote.md
+++ b/src/opencode/commands/agentdev/inspect-promote.md
@@ -27,7 +27,7 @@ description: 検出事項を分類、採用し、採用済み成果物として 
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/inspect-promote.yaml`）を読み込む（ADR）。
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-inspect-promote`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-inspect-promote.yaml`、kind: workflow-extension）を読み込む（ADR）。
 
 - extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
 - extension が存在しない場合は標準動作で続行する

--- a/src/opencode/commands/agentdev/inspect-skills.md
+++ b/src/opencode/commands/agentdev/inspect-skills.md
@@ -46,7 +46,7 @@ routing は実行コマンド選択の目安であり、各コマンドの検出
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/inspect-skills.yaml`）を読み込む（ADR）。
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-inspect-skills`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-inspect-skills.yaml`、kind: workflow-extension）を読み込む（ADR）。
 
 - extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
 - extension が存在しない場合は標準動作で続行する

--- a/src/opencode/commands/agentdev/intake-capture.md
+++ b/src/opencode/commands/agentdev/intake-capture.md
@@ -12,7 +12,7 @@ description: 未分類の変更候補を手動入力から intake item として
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/intake-capture.yaml`）を読み込む（ADR）。
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-intake-capture`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-intake-capture.yaml`、kind: workflow-extension）を読み込む（ADR）。
 
 - extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
 - extension が存在しない場合は標準動作で続行する

--- a/src/opencode/commands/agentdev/intake-from-github.md
+++ b/src/opencode/commands/agentdev/intake-from-github.md
@@ -13,7 +13,7 @@ description: クローズ済み GitHub Issue/PR から未回収の変更候補�
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/intake-from-github.yaml`）を読み込む（ADR）。
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-intake-from-github`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-intake-from-github.yaml`、kind: workflow-extension）を読み込む（ADR）。
 
 - extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
 - extension が存在しない場合は標準動作で続行する

--- a/src/opencode/commands/agentdev/intake-promote.md
+++ b/src/opencode/commands/agentdev/intake-promote.md
@@ -12,7 +12,7 @@ description: inbox 内の intake item をレビュー、分類し、採用 item 
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/intake-promote.yaml`）を読み込む（ADR）。
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-intake-promote`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-intake-promote.yaml`、kind: workflow-extension）を読み込む（ADR）。
 
 - extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
 - extension が存在しない場合は標準動作で続行する

--- a/src/opencode/commands/agentdev/learning-promote.md
+++ b/src/opencode/commands/agentdev/learning-promote.md
@@ -12,7 +12,7 @@ description: inbox.mdから正規化、分類、8軸評価、HITL確定を経て
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/learning-promote.yaml`）を読み込む（ADR）。
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-learning-promote`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-learning-promote.yaml`、kind: workflow-extension）を読み込む（ADR）。
 
 - extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
 - extension が存在しない場合は標準動作で続行する

--- a/src/opencode/commands/agentdev/req-define.md
+++ b/src/opencode/commands/agentdev/req-define.md
@@ -25,7 +25,7 @@ description: 要件を整理、定義する（機能追加、バグ修正共通�
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/req-define.yaml`）を読み込む（ADR）。
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-req-define`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-req-define.yaml`、kind: workflow-extension）を読み込む（ADR）。
 
 - extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
 - extension が存在しない場合は標準動作で続行する

--- a/src/opencode/commands/agentdev/req-save.md
+++ b/src/opencode/commands/agentdev/req-save.md
@@ -23,7 +23,7 @@ req-defineで生成された壁打ち成果物をREQ/Decisionファイルとし�
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/req-save.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-req-save`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-req-save.yaml`、kind: workflow-extension）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
 ## workflow
 

--- a/src/opencode/commands/agentdev/spec-save.md
+++ b/src/opencode/commands/agentdev/spec-save.md
@@ -20,7 +20,7 @@ req-save の G02（SPEC 編集禁止）を緩和するものではなく、SPEC 
 
 ## project extensions
 
-本コマンドは実行時に自分に対応する project extension（`.agentdev/extensions/commands/spec-save.yaml`）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。extension に列挙されていない `docs/specs/**` 内部パスを固定知識として読みに行かない。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-spec-save`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-spec-save.yaml`、kind: workflow-extension）を読み込む（ADR）。extension の5セクション（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）は標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行し、破損時はエラー表示して当該 extension を無視し標準動作で続行する。extension に列挙されていない `docs/specs/**` 内部パスを固定知識として読みに行かない。詳細な読み込み契約は `agentdev-project-extensions` skill 参照
 
 ## workflow
 

--- a/src/opencode/skills/agentdev-doc-diagnostics/SKILL.md
+++ b/src/opencode/skills/agentdev-doc-diagnostics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentdev-doc-diagnostics
-description: docs 横断診断カテゴリ、共通証拠構造、共通 finding 出力契約、文書種別別診断へのルーティングを提供する診断判断 skill。USE FOR: inspect-docs command の診断カテゴリ定義、docs 横断の診断判定規則、共通証拠構造（finding schema、severity、信頼度）、診断結果（finding）の出力契約、診断に必要な reference または script の選択、文書種別別診断（REQ 固有、文意品質、探索順）へのルーティング。DO NOT USE FOR: 診断対象の修正、promote 判断（inspect-promote 担当）、REQ/SPEC/RU 保存（各保存 command 担当）、commit/push（command 担当）、Issue/PR 操作（case-* 担当）、REQ 固有の SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT 診断（agentdev-req-structure-diagnostics 担当）、文意品質診断（agentdev-doc-writing 担当）、探索順（agentdev-doc-map 担当）。
+description: docs 横断診断カテゴリ、共通証拠構造、共通 finding 出力契約、文書種別別診断へのルーティングを提供する診断判断 skill。USE FOR: inspect-docs command の診断カテゴリ定義、docs 横断の診断判定規則、共通証拠構造（finding schema、severity、信頼度）、診断結果（finding）の出力契約、診断に必要な reference または script の選択、文書種別別診断（REQ 固有、文意品質）へのルーティング。DO NOT USE FOR: 診断対象の修正、promote 判断（inspect-promote 担当）、REQ/SPEC/RU 保存（各保存 command 担当）、commit/push（command 担当）、Issue/PR 操作（case-* 担当）、REQ 固有の SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT 診断（agentdev-req-structure-diagnostics 担当）、文意品質診断（agentdev-doc-writing 担当）。
 ---
 
 # docs 横断診断知識ベース（doc-diagnostics）

--- a/src/opencode/skills/agentdev-doc-diagnostics/references/finding-output-contract.md
+++ b/src/opencode/skills/agentdev-doc-diagnostics/references/finding-output-contract.md
@@ -11,7 +11,6 @@ REQ 固有診断、文意品質診断等の専門診断からルーティング�
 |------------|--------------|------------------|
 | `agentdev-req-structure-diagnostics` | 問題候補出力スキーマ7フィールド（観点、対象、根拠、シグナル数、確信度、推奨アクション、req-define入力案） | 観点→category、対象→target、根拠→evidence、シグナル数→notes、確信度→confidence、推奨アクション→recommended_route、req-define入力案→notes へマッピング。severity、source_of_truth、ng_classification は本スキルが横断的に付与 |
 | `agentdev-doc-writing` | 査読出力形式（`references/review-output.md`） | 本契約の target、evidence、recommended_route へ正規化 |
-| `agentdev-doc-map` | 影響確認フロー結果 | 本契約の target、evidence、recommended_route へ正規化 |
 
 ## finding schema（共通証拠構造）
 

--- a/src/opencode/skills/agentdev-project-extensions/SKILL.md
+++ b/src/opencode/skills/agentdev-project-extensions/SKILL.md
@@ -173,24 +173,24 @@ extension 原本は各プロジェクトが所有する。AgentDevFlow 本体は
 
 ## 公開契約宣言と詳細契約の分離
 
-15の agentdev command は、実行時に対応する project extension を読み込む旨の同一宣言を持つ。
+16の agentdev command は、対応する project extension を Workflow Skill が読み込む旨の同一宣言を持つ。
 この宣言は「公開契約宣言」（command 公開契約の宣言部分）と「詳細契約」（extension の context/rules/checks 等の中身）に分離できる。
 分離の判断基準は artifact-responsibilities SPEC「重複許容基準 適用例集」適用パターン1（project extensions boilerplate）に準拠する。
 
 ### 公開契約宣言
 
-command が対応 extension を読み込む旨を宣言する部分。
+対応 extension を Workflow Skill が読み込む旨を宣言する部分。
 配布 command 本文に直接記載を許容する。
 許容範囲は宣言文（1行）とそれに続く boilerplate 4行（リスト形式）で構成される。
 
-- 宣言文: command が対応 extension を読み込む旨の1行
+- 宣言文: 対応 extension を Workflow Skill が読み込む旨の1行
 - boilerplate 行1: extension の5セクション名（`context` / `rules` / `checks` / `acceptance_gates` / `must_not`）と追加・拡張であること（上書きでないこと）の宣言
 - boilerplate 行2: extension が存在しない場合の標準動作継続宣言
 - boilerplate 行3: extension が破損している場合のエラー表示・無視・標準動作継続宣言
 - boilerplate 行4: 詳細な読み込み契約は本 SKILL 参照との宣言
 
 「4行上限」は boilerplate リスト部分の4行を指す（SPEC 適用パターン1「上限: 宣言4行まで」）。
-本範囲は15 command の公開契約（extension 読込宣言）の一部として許容判定された事例に該当する。
+本範囲は16 command の公開契約（extension 読込宣言）の一部として許容判定された事例に該当する。
 
 ### 詳細契約
 
@@ -210,7 +210,7 @@ inspect-skills が複数 command 間で同一文言の重複を検出した場�
 
 | 重複内容 | 公開契約宣言の範囲 | 判定 | 根拠 |
 |---|---|---|---|
-| command が対応 extension を読み込む旨の宣言 | 範囲内 | 許容 | 重複許容基準 適用パターン1 |
+| 対応 extension を Workflow Skill が読み込む旨の宣言 | 範囲内 | 許容 | 重複許容基準 適用パターン1 |
 | 5セクション名の列挙と追加・拡張の宣言 | 範囲内 | 許容 | 重複許容基準 適用パターン1 |
 | 不在時・破損時の標準動作継続宣言 | 範囲内 | 許容 | 重複許容基準 適用パターン1 |
 | 詳細は skill 参照の宣言 | 範囲内 | 許容 | 重複許容基準 適用パターン1 |

--- a/src/opencode/skills/agentdev-workflow-case-auto/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-auto/SKILL.md
@@ -128,9 +128,9 @@ case-auto workflow は次の8 STEP で構成する。各 STEP は resume point �
 - `agentdev-adversarial-review`: 経路H で停止伝播のみ受領（case-auto は直接起動しない）
 - 各工程の Capability Skill を継承（req-save/spec-save/case-open/case-run/case-close の依存スキル群）
 
-## internal Workflow Extension 読込
+## Workflow Extension 読込
 
-本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-case-auto.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、case-auto command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-case-auto.yaml`、`kind: workflow-extension`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-case-auto/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、case-auto command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
 
 ## 共通制約
 

--- a/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
@@ -120,9 +120,9 @@ case-close workflow は次の STEP で構成する。Epic Wave クローズは S
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
 - integrity checker skill（repo-local）: check_changed_docs.ts（targeted docs guard）、check_extensions.ts（IR-{NNN}）
 
-## internal Workflow Extension 読込
+## Workflow Extension 読込
 
-本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-case-close.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、case-close command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-case-close.yaml`、`kind: workflow-extension`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-case-close/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、case-close command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
 
 ## 共通制約
 

--- a/src/opencode/skills/agentdev-workflow-case-open/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/SKILL.md
@@ -111,9 +111,9 @@ case-open workflow は次の6 STEP で構成する。各 STEP は resume point �
 - `agentdev-adversarial-review`: 経路F review 呼出
 - `agentdev-learning-capture` / `agentdev-intake-pipeline`: deviation capture 委譲（STEP-{N}/5 で実観測時）
 
-## internal Workflow Extension 読込
+## Workflow Extension 読込
 
-本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-case-open.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、case-open command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-case-open.yaml`、`kind: workflow-extension`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-case-open/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、case-open command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
 
 ## 共通制約
 

--- a/src/opencode/skills/agentdev-workflow-case-run/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/SKILL.md
@@ -145,9 +145,9 @@ workflow 選択は STEP-S1 の実行モード分岐で確定する（引数が E
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
 - integrity checker skill（repo-local）: check_changed_docs.ts（targeted docs guard）、check_extensions.ts（IR-{NNN}）、check_distribution_boundary.ts（配布依存境界）
 
-## internal Workflow Extension 読込
+## Workflow Extension 読込
 
-本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-case-run.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、case-run command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-case-run.yaml`、`kind: workflow-extension`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-case-run/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、case-run command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
 
 ## 共通制約
 

--- a/src/opencode/skills/agentdev-workflow-case-update/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-update/SKILL.md
@@ -100,9 +100,9 @@ case-update workflow は次の4 STEP で構成する。各 STEP は resume point
 - `agentdev-git-worktree`: `--req` 時の並列実行安全ステージング
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
 
-## internal Workflow Extension 読込
+## Workflow Extension 読込
 
-本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-case-update.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、case-update command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-case-update.yaml`、`kind: workflow-extension`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-case-update/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、case-update command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
 
 ## 共通制約
 

--- a/src/opencode/skills/agentdev-workflow-req-define/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-req-define/SKILL.md
@@ -113,9 +113,9 @@ req-define workflow は次の11 STEP で構成する。各 STEP は resume point
 - `agentdev-adversarial-review`: 経路A review 呼出
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
 
-## internal Workflow Extension 読込
+## Workflow Extension 読込
 
-本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-req-define.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、req-define command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-req-define.yaml`、`kind: workflow-extension`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-req-define/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、req-define command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
 
 ## 共通制約
 

--- a/src/opencode/skills/agentdev-workflow-req-save/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-req-save/SKILL.md
@@ -118,9 +118,9 @@ req-save workflow は次の12 STEP で構成する。各 STEP は resume point �
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
 - integrity checker skill（AG-{NNN} detector、repo 固有）: check_changed_docs.ts（targeted docs guard）
 
-## internal Workflow Extension 読込
+## Workflow Extension 読込
 
-本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-req-save.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、req-save command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-req-save.yaml`、`kind: workflow-extension`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-req-save/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、req-save command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
 
 ## 共通制約
 

--- a/src/opencode/skills/agentdev-workflow-spec-save/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-spec-save/SKILL.md
@@ -110,9 +110,9 @@ spec-save workflow は次の11 STEP で構成する。各 STEP は resume point 
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
 - integrity checker skill（AG-{NNN} detector、repo 固有）: check_changed_docs.ts（--workflow spec-save）
 
-## internal Workflow Extension 読込
+## Workflow Extension 読込
 
-本スキルは internal Workflow Extension（`.agentdev/extensions/skills/agentdev-workflow-spec-save.yaml`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。Workflow Skill のみが読み、spec-save command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-spec-save.yaml`、`kind: workflow-extension`）を読み込む場合がある（REQ-{NNNN}-{NNN}、DEC-{N}）。必要に応じて internal workflow extension（`.agentdev/extensions/skills/agentdev-workflow-spec-save/internal.yaml`、`kind: internal-workflow-extension`）を追加で読む。いずれも Workflow Skill のみが読み、spec-save command は直接読まない。標準動作に追加・拡張される（上書きではない）。存在しない場合は標準動作で続行する。
 
 ## 共通制約
 


### PR DESCRIPTION
## 概要

Issue #2107（OU-007 / AG-008）: 全リポジトリ検索による旧責務残存6分類の検出・分類・除去（実違反を 0 へ）と、preventive checker 7項目の導入。

## 実装内容

### 1. 6分類リポジトリ検索と実違反是正（実違反 20 件 → 0）

検索対象: `src/opencode/**`、`src/opencode-local/**`、`docs/**`、`.opencode/skills/repo-agentdev-integrity/**`、`.agentdev/extensions/**`。baseline（Issue #2100 コメント、63件）から Waves 1-4 で大半是正済みのため、現 HEAD の残存を再検索して確定した。

| 分類 | 実違反 | 是正内容 |
|---|---|---|
| (a) Command workflow Step 所有記述 | 1 | case-run 定義「Step 7-1」の手続本体（実行条件/実行コマンド/検出結果の分類/違反検出時の停止契約）を summary（導入文 + 2行）へ圧縮。全情報を委譲先 `agentdev-workflow-case-run` の STEP-S5 が所有することを確認済み。detector entrypoint（check_distribution_boundary.ts）と `--profile source` は `distribution_boundary_routing_contract.test.ts` が固定する公開契約として保持 |
| (b) Command definition 権威記述 | 1 | workflow-contracts SPEC の case-auto 構成工程委譲における「各コマンド定義を権威情報源として読み込む」を「各工程の Workflow Skill を権威情報源とする」へ更新 |
| (c) 旧 extension runtime path 参照 | 17 | 16 Command 本文の `.agentdev/extensions/commands/{name}.yaml` 宣言を「本コマンドの workflow 実装本体を所有する Workflow Skill（agentdev-workflow-{name}）が `.agentdev/extensions/skills/agentdev-workflow-{name}.yaml`（kind: workflow-extension）を読み込む」へ更新。project-extensions skill SPEC の旧探索契約を新3種 kind 配置へ、旧状態分類（不在/破損のみ）を5状態分類（missing/malformed fail-open/旧 kind migration-required/未知 kind schema violation/有効）へ更新 |
| (d) old kind 残存 | 0 | OU-006 で移行済み（`kind:` 値の anchored grep 0 件、`.agentdev/extensions/commands/` ディレクトリ消滅を確認） |
| (e) Workflow Skill 内部 reference 直接依存 | 1 | case-run 定義の当該 reference ファイル直接言及（delegation-and-result.md の STEP-S5）をスキル名レベル参照へ変更 |
| (f) 同一 workflow implementation の Command/Skill 重複 | 1 | case-run Step 7-1 と Workflow Skill STEP-S5 の重複（(a) と同一インスタンス。(a) 是正で解消） |

false positive 14件は exemption として checker 本体（`PREVENTIVE_EXEMPTIONS` + check 4 の行単位 exemption 規則）に構造化記録した:

- `containment.test.ts`（旧 path を意図的に作成する検出 fixture、*.test.ts 除外）
- `agentdev-project-extensions` SKILL.md の廃止宣言行 ×2（廃止/後方互換で読まない/migration-required を含む行を除外）
- superseded 文書群（DEC-005、inspect-extensions SPEC、artifact-graph SPEC と references、IR-056 の検査対象宣言 affected_artifacts）
- 各 Command の「`references/` 配下を参照」非依存宣言（ファイル名を伴わない汎用言及）
- `docs/specs/foundations/system.md:103`（旧表現の使用禁止を宣言する文）
- 他15 Command の thin な Step 名レベル列挙（委譲宣言 + 1行 summary のみ）

### 2. preventive checker 7項目の新規追加

`.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.ts`（新規、+ `check_workflow_preventive.test.ts` 18 test）。実行結果: **ok=true、7項目すべて PASS、failures 0**。

1. workflow-dispatch-presence — 全公開 Command（16/16）が専用 Workflow Skill を名レベル参照
2. dispatch-target-existence — 専用 Workflow Skill（16）が実在
3. workflow-soft-guard — command 紐付き Workflow Skill（16）が soft guard 宣言を保有
4. legacy-extension-residual — 旧 kind 0 件、`.agentdev/extensions/commands/` 残存 0、配布物本文（src/opencode、src/opencode-local）の旧 runtime path 参照 0（exemption 4行: containment fixture ×2、廃止宣言 ×2）
5. internal-reference-direct-dep — Command からの内部 reference ファイル（references/<file>.md|ts）直接依存 0 件
6. classification-kind-consistency — 29 extension の kind・配置・id が決定的 Workflow/Capability 分類（check_extensions.ts `deriveSkillClassification` 共有）と整合
7. command-format-thin-consistency — command-format-rules.yaml が mandatory-content directive（required_sections 等）を持たず、forbidden pattern が thin 構造（`## workflow`、委譲文、`### Step N:`）を拒否しない

repo-agentdev-integrity SKILL.md の補助検査スクリプト表に登録行を追加した。

### 3. Wave 4 intake 指摘（OU-007 候補として指摘済み）の消費

- ① 16 Command 本文の旧 extension パス prose → 実違反 (c) として是正
- ② project-extensions skill SPEC の旧契約 → 実違反 (c) として是正（上記表参照）
- ③ doc-diagnostics の削除済み agentdev-doc-map 言及 → SKILL.md description と `references/finding-output-contract.md` 表行から除去
- ④ 「15 command」計数 → 16 へ更新（project-extensions SKILL.md 2箇所 + artifact-responsibilities SPEC 1箇所の両側同一コミットで同期）
- ⑤ 8 Workflow Skill の "internal Workflow Extension" 呼称 → 既に正規形を使用する 5 skill（backlog-review、intake-*、learning-promote）+ inspect 系 3 skill と同一の正規文面（`## Workflow Extension 読込`）へ統一

関数削除は本 PR に存在しない（削除したのは doc-map 表行と手続本文テキストのみのため、使用箇所 grep 証拠は不要）。

## 完了条件

- [x] 旧責務残存の実違反が 0 件であること（TS-005 subchecks 1-6。修正後再検索で (a)=0、(b)=0、(c) src 配下は exemption のみ、(d)=0、(e)=0、(f)=0）
- [x] false positive と実違反が正当に区別され、false positive は exemption として記録されていること（AG-008、TS-005。checker 本体の PREVENTIVE_EXEMPTIONS と行単位規則に構造化）
- [x] preventive checker 7項目が実装され pass すること（AC-17、TS-005。ok=true、7/7 PASS）
- [x] Command 本文の workflow 手順残存判定が機械判定可能な構造のみで構成され、semantic 重複が inspect-skills 管轄として扱われていること（AG-008。checker header に管轄分離を明記、semantic 判定は checker 化せず）
- [x] full integrity / targeted checker が pass すること（AC-17。distribution boundary ok=true、targeted docs guard failures 0、preventive checker pass。full suite の 29 fail は全て pre-existing、下記証跡）

## テスト結果

- `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.ts` → ok=true（7項目 PASS、failures 0、exempted_lines=4）
- `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.test.ts` → 18 pass / 0 fail
- `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts --profile source --json` → ok=true、exit 0（scanned_files 313）
- targeted docs guard: `check_changed_docs.ts --workflow case-run --files <docs 変更3ファイル>` → failures []（`--base-ref` は未コミット差分を検出できないため `--files` 明示。docs 変更3ファイル + coupled 2ファイル検査）
- `bun test ./.opencode/skills/repo-agentdev-integrity/` → 1939 pass / 29 fail / 1968 tests。29 fail は全て pre-existing（`git stash` で本変更を除外した同一テスト実行で同一失敗・同一件数、IR-055 delta も変更前後とも +2 で不変であることを確認。内訳: REQ-0030 e2e/fixtures/error_cases 25、check_templates --dry-run 3、IR-055 1。いずれも intake inbox 既知項目）
- TS-005 subchecks 1-6: 実違反 0（上記是正後の再 grep で確認）
- TS-107 doc-writing 査読: 修正対象ドキュメント（docs 3ファイル、Command/Skill prose）について一文一行・実行主体分類（Workflow Skill が読み取り主体）・具体 ID 参照なし・LLM 的表現なしを確認。未解決 0

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 旧責務残存 実違反（6分類合計） | 20件検出 → 0件 | 0件 | ✅ |
| preventive checker 7項目 | 7/7 PASS（ok=true） | 7/7 pass | ✅ |
| false positive exemption 記録 | checker 内 4 area + 行単位規則（exempted 4行） | 構造化記録 | ✅ |
| check_workflow_preventive.test.ts | 18/18 pass | 全 pass | ✅ |
| distribution boundary（--profile source） | ok=true、exit 0 | pass | ✅ |
| targeted docs guard（docs 3ファイル） | failures 0 | 0 | ✅ |
| full test suite（本変更起因の新規失敗） | 0（29 fail は pre-existing、stash 比較で同一） | 0 | ✅ |

## Findings / Capture候補

### intake

1. **doc-diagnostics の「探索順」カテゴリ残余曖昧さ**: 本 PR で agentdev-doc-map への直接言及（description、finding-output-contract.md 表行）は除去したが、SKILL.md 本文（L10/L47/L85）に「探索順」を専門 skill への委譲先として挙げる記述が残る。L60 は「README 索引の整合性は本スキルが、探索順序の詳細は README 群が担う」と再定義しており、委譲先表記との間に残余曖昧さがある。発見元: 本 Issue の intake ③ 対応時の読み合わせ。分類: intake

### learning

1. **thin 化圧縮時のテスト固定トークン確認**: case-run Step 7-1 の手続本体圧縮時に、`distribution_boundary_routing_contract.test.ts` が detector entrypoint（check_distribution_boundary.ts）と `--profile source` を Step 7-1 節の公開契約として固定していることを踏まえず、一時的に同テスト 4件を失敗させた（圧縮版から当該トークンを復元して解決、最終 24/24 pass）。Command 本文の thin 化・圧縮を行う場合は、本文の特定セクションを固定する契約テスト（routing contract 系）の存在を先に確認する必要がある。発見元: 本 Issue 実装（test-fix ループ）。分類: learning

## SPEC確定候補

1. **Workflow/Capability 機械分類規則の workflow-skill-model SPEC 明文化**: preventive checker 項目 6 は `deriveSkillClassification`（check_extensions.ts と共有）の決定的分類規則「Workflow Skill = agentdev-workflow-{X}（src/opencode/commands/agentdev/{X}.md が存在）／他の agentdev-* は Capability Skill（横断 agentdev-workflow-* 含む）」に依存する。同規則の SPEC 明文化は PR 2116 から見送り済み（intake inbox 2026-08-15 spec-candidate item）。本 checker は当該規則を2 checker で実装検証する構成となったため、SPEC 側の分類表明文化の優先度が相対的に上がった。対応は spec-save（UPDATE）または backlog-review の判断。

## 決定事項

- Command 本文の extension 宣言の読み取り主体は foundations/project-extensions SPEC の実行時読込契約（Workflow Skill が読む、command は直接読まない）に基づき Workflow Skill 主体の文面とした（委譲時指示の「Command は対応 Workflow Extension を読む」はかかる正規契約への更新指示と解釈）
- checker の旧 path 走査範囲は src/opencode・src/opencode-local とし、docs/** は superseded・検査対象宣言を exemption とする意味領域としてスコープ外（inspect-docs / inspect-skills 管轄）。checker header に明記

## 関連Issue

Closes #2107