### PR TITLE
install スクリプトから provisioning を削除しチェックアウト済み前提へ変更（OU-001）

### DIFF
--- a/scripts/install-consumer-opencode.ps1
+++ b/scripts/install-consumer-opencode.ps1
@@ -225,36 +225,31 @@ function Get-TargetSourcePath {
     return Join-Path $SourceDir $RelPath
 }
 
-# --- Clone / Update ---
+# --- Checkout Guidance (AG-002/REQ-009-047) ---
 
-function Initialize-PluginCheckout {
+function Show-PluginCheckoutGuidance {
     <#
     .SYNOPSIS
-        Clone or update the agent-dev-flow repo into $PluginPath.
+        チェックアウト未検出時の案内。provisioning（clone、fetch、reset）も network access も
+        代行実行しない（AG-001/REQ-009-046、DEC-016）。チェックアウトの取得は利用者の責務。
     #>
-    if (Test-Path -LiteralPath (Join-Path $PluginPath '.git')) {
-        Write-Host "[ACTION] Updating existing checkout: $PluginDir"
-        Push-Location -LiteralPath $PluginPath
-        try {
-            git fetch origin
-            git checkout $Branch
-            git reset --hard "origin/$Branch"
-        }
-        finally {
-            Pop-Location
-        }
-    } else {
-        if (Test-Path -LiteralPath $PluginPath) {
-            Write-Error "[ERROR] $PluginDir exists but is not a git repository. Remove it manually and retry."
-            exit 1
-        }
-        Write-Host "[ACTION] Cloning agent-dev-flow into $PluginDir"
-        git clone --branch $Branch --depth 1 $RepoUrl $PluginPath
-        if ($LASTEXITCODE -ne 0) {
-            Write-Error "[ERROR] Failed to clone agent-dev-flow"
-            exit 1
-        }
-    }
+    $repoWebUrl = $RepoUrl -replace '\.git$', ''
+    Write-Host "[ERROR] 利用可能なチェックアウトが見つかりません。usable checkout 判定（$PluginDir/src/opencode/ の存在）に失敗しました。"
+    Write-Host ''
+    Write-Host 'このスクリプトは provisioning（clone、fetch、reset）と network access を行いません（REQ-009-046、DEC-016）。'
+    Write-Host '以下のいずれかで agent-dev-flow のチェックアウトを用意してから再実行してください。'
+    Write-Host ''
+    Write-Host '方法1: git clone でチェックアウトを用意する'
+    Write-Host "  git clone --branch $Branch $RepoUrl $PluginDir"
+    Write-Host ''
+    Write-Host '方法2: ソース ZIP を取得して展開する'
+    Write-Host "  1. $repoWebUrl を開く"
+    Write-Host '  2. [Code] ボタン → [Download ZIP] でソース ZIP をダウンロード'
+    Write-Host "  3. ZIP を展開し、中身（src/、scripts/ 等）を $PluginDir/ 直下に配置"
+    Write-Host "     （$PluginDir/src/opencode/ が存在すればよく、.git のない ZIP 展開チェックアウトも正規の配置形態）"
+    Write-Host ''
+    Write-Host "期待される状態: $SourceDir が存在すること"
+    exit 1
 }
 
 # --- Main ---
@@ -267,14 +262,11 @@ if (-not $Mode) {
     Invoke-InstallWizard
 }
 
-# Clone/update first for all modes (need source to enumerate targets)
-if ($Mode -ne 'check') {
-    Initialize-PluginCheckout
-}
-
+# usable checkout 判定（AG-002/REQ-009-047）: .git の有無ではなく src/opencode/ の存在で判定する。
+# 全モード（check、dry-run、apply）共通の前提であり、provisioning は行わない（AG-001/REQ-009-046、DEC-016）。
+# ZIP 展開チェックアウト（.git なし）も正規の配置形態として扱う（AG-003/REQ-009-048）。
 if (-not (Test-Path -LiteralPath $SourceDir)) {
-    Write-Error "[ERROR] Source directory not found: $SourceDir. Ensure $PluginDir contains agent-dev-flow checkout."
-    exit 1
+    Show-PluginCheckoutGuidance
 }
 
 # LocalMode requires the local source redirect target to exist
@@ -299,20 +291,20 @@ if ($Mode -eq 'check') {
     }
     $divergences = 0
 
-    # 1. Plugin checkout
-    if (-not (Test-Path -LiteralPath (Join-Path $PluginPath '.git'))) {
-        Write-Host "[DIVERGENCE] $PluginDir is not a git repository (clone required)"
+    # 1. Plugin checkout directory
+    if (-not (Test-Path -LiteralPath $PluginPath)) {
+        Write-Host "[DIVERGENCE] $PluginDir not found (git clone またはソース ZIP 展開が必要)"
         $divergences++
     } else {
-        Write-Host "[OK] $PluginDir is a git repository"
+        Write-Host "[OK] $PluginDir exists"
     }
 
-    # 2. Source directory
+    # 2. Source directory (usable checkout 判定: .git の有無ではなく src/opencode/ の存在。ZIP 展開チェックアウトも正規の配置形態、AG-003/REQ-009-048)
     if (-not (Test-Path -LiteralPath $SourceDir)) {
-        Write-Host "[DIVERGENCE] Source directory not found: $SourceDir"
+        Write-Host "[DIVERGENCE] Usable checkout not found: $PluginDir/src/opencode/ (git clone またはソース ZIP 展開が必要)"
         $divergences++
     } else {
-        Write-Host "[OK] Source directory exists: $PluginDir/src/opencode/"
+        Write-Host "[OK] Usable checkout exists: $PluginDir/src/opencode/"
     }
 
     # 2b. Local redirect source (LocalMode only)


### PR DESCRIPTION
## 概要

OU-001。REQ-009（配布基盤と導入モデル）の導入前提変更の中核を実装する。install スクリプト（scripts/install-consumer-opencode.ps1）から provisioning（clone、fetch、checkout、reset）を削除して network access を排除し、利用者がチェックアウト済みの .agentdev-plugin/（git clone または GitHub ソース ZIP 展開）を前提とする（AG-001〜AG-004、REQ-009-046〜049、DEC-016）。

Refs: #2128

## 変更内容

scripts/install-consumer-opencode.ps1 のみ（+32 / -40 行）。

- provisioning 処理（Initialize-PluginCheckout 相当の clone、fetch、checkout、reset）を削除（REQ-009-046、DEC-016）
- チェックアウト検出を .git の有無ではなく src/opencode/ の存在（usable checkout 判定）へ変更。全モード（check、dry-run、apply）共通ゲート（REQ-009-047）
- チェックアウト未検出時（.agentdev-plugin/ 不在、src/opencode/ 不在）は exit 1 でエラー停止し、clone コマンド例とソース ZIP 取得手順の案内（Show-PluginCheckoutGuidance）を表示。provisioning を代行実行しない
- check モードの検出も usable checkout 判定へ変更（.git 必須の divergence 判定を撤廃し、ZIP 展開チェックアウト（.git なし）を正規の配置形態として扱う、REQ-009-048）
- -Mode apply の冪等性（REQ-009-049）と -LocalMode の接続先切替（DEC-004）は従来どおり維持
- -RepoUrl/-Branch パラメータとウィザード・コメントヘルプ文言は本 Issue の対象外（OU-003 が担当）。-RepoUrl/-Branch は案内文言の clone コマンド例表示にのみ使用

## テスト戦略の結果

### TS-001 (AG-001): チェックアウト済み環境で provisioning/network 系コマンド不実行 — 合格

- 手段: git ありチェックアウト（worktree からのローカル clone）を用意した consumer リポジトリで `-Mode apply` を実行
- 実行時証明: PATH 先頭に呼び出し記録型のダミー git.cmd を配置した状態で実行し、git 呼び出しログが空（GIT_INVOCATIONS=NONE）であることを確認。clone、fetch、reset、その他 network access が一切起動されないことを証明
- コード検査: git clone/fetch/reset/pull/push/remote、Invoke-WebRequest/Invoke-RestMethod/curl/wget の実行箇所が 0 件（マッチは案内文言・コメントのみ）
- 結果: exit 0、junction 49 本（commands\agentdev + agentdev-* skills + japanese-tech-writing）が既存 src/opencode/ へ作成

### TS-002 (AG-002): チェックアウト不在でエラー停止・案内表示・副作用なし — 合格

- 手段: .agentdev-plugin/ を持たない consumer リポジトリ（.opencode/ にマーカーファイル付き repo-local ディレクトリを事前配置）で `-Mode apply` を実行
- 結果: exit 1 でエラー停止。clone コマンド例（`git clone --branch main https://github.com/yogata/agent-dev-flow.git .agentdev-plugin`）とソース ZIP 取得手順（[Code] → [Download ZIP] → 展開 → 配置）を含む案内を表示
- 副作用: .opencode/ 配下のスナップショット比較（パス・サイズ・更新時刻）で変更なし（OPENCODE_UNCHANGED=True）。.agentdev-plugin/ 未作成。ダミー git により provisioning 代行なしも確認

### TS-006 (AG-004): apply 連続実行の冪等性 — 合格

- 手段: チェックアウト済み consumer リポジトリで `-Mode apply` を 2 回連続実行し、junction 構成（パス→ターゲットの完全マップ）を比較
- 結果: 両回 exit 0、junction 50 本の構成が完全同一（MAP_IDENTICAL=True）。2 回目の出力は [ACTION] 0 行・全 junction が Already junctioned

### AG-003 基本検証（REQ-009-048、完了条件の基本確認）

- 手段: git archive で生成したソース ZIP を展開した .git なしチェックアウト（src/opencode/ 存在）で `-Mode apply` を実行
- 結果: exit 0、junction 50 本作成。続けて `-Mode check` も exit 0（[OK] Usable checkout exists を報告）
- 注記: ZIP 展開時の apply 完了の統合検証は TS-003（OU-002 Issue）が担当

## 定義層の検証（検証のみ、本 PR では変更なし）

- docs/requirements/REQ-009.md: REQ-009-009/010/041/043 の UPDATE、REQ-009-046〜049 の APPEND を確認
- docs/decisions/DEC-016.md: 新設（proposed、導入系スクリプトの副作用ゼロ原則）を確認
- req-save commit 87970bfc で保存済みであることを確認

## Findings / Capture候補

### intake

- ウィザード（Invoke-InstallWizard Q1）とコメントヘルプ DESCRIPTION が「apply: clone して実行」等の旧前提文言のまま。本 Issue では対象外（OU-003 がウィザード・ヘルプ文言と -RepoUrl/-Branch 廃止を担当）
- README.md「適用プロジェクトへの導入」と docs/guides/consumer-project-setup.md の clone 前提導線が未更新（OU-002 対象）

### learning

- Windows 環境でスクリプトの network 系コマンド不使用を実行時証明する手法: PATH 先頭に呼び出し記録型のダミー git.cmd を配置してスクリプトを実行し、呼び出しログ空＋exit 0 を確認する手法が有効（コード検査のみより強い証拠になる）

## SPEC確定候補

- なし（本変更は script 実装のみ。usable checkout 判定、ZIP 許容、冪等性の定義は REQ-009-046〜049、DEC-016 が既に正規所有）
