### PR TITLE
feat(scripts): install スクリプトのオプション整理と案内文言をチェックアウト済み前提へ更新

### DIFF
--- a/scripts/install-consumer-opencode.ps1
+++ b/scripts/install-consumer-opencode.ps1
@@ -3,10 +3,13 @@
     Install AgentDevFlow runtime artifacts into a consumer repository.
 
 .DESCRIPTION
-    導入系スクリプト。3つのモードの技術的差は以下の通り:
-    - check   : clone しない軽量確認（検証のみ、ファイル変更なし）
-    - dry-run : clone して予測（ファイル変更なし）
-    - apply   : clone して実行（ファイル変更あり）
+    導入系スクリプト。3つのモードの技術的差は以下の通り（REQ-009-042）:
+    - check   : 検証のみ（ファイル変更なし）
+    - dry-run : 変更予測（ファイル変更なし）
+    - apply   : 実行（ファイル変更あり）
+
+    いずれのモードも provisioning（clone、fetch、reset）と network access を行わず、
+    チェックアウト済みの .agentdev-plugin/ を前提に動作する（REQ-009-046、DEC-016）。
 
     Creates junctions for public runtime artifacts ONLY:
     - .opencode/commands/agentdev/  = junction -> .agentdev-plugin/src/opencode/commands/agentdev/
@@ -36,16 +39,8 @@
 
 .PARAMETER PluginDir
     Directory name for the agent-dev-flow checkout (default: .agentdev-plugin).
-    This directory is created relative to the consumer repo root.
-    上級者向け: clone 先ディレクトリ名を変更する場合のみ指定。通常は既定値を使用する。
-
-.PARAMETER RepoUrl
-    Git remote URL for agent-dev-flow (default: https://github.com/yogata/agent-dev-flow.git)
-    上級者向け: clone 元リポジトリ URL を変更する場合（フォーク等）のみ指定。通常は既定値を使用する。
-
-.PARAMETER Branch
-    Branch to checkout from agent-dev-flow (default: main)
-    上級者向け: clone 元ブランチを変更する場合のみ指定。通常は既定値を使用する。
+    Expected location of the checkout, relative to the consumer repo root.
+    上級者向け: チェックアウト配置先を変更する場合のみ指定。通常は既定値を使用する（REQ-009-043）。
 
 .EXAMPLE
     ./scripts/install-consumer-opencode.ps1
@@ -67,11 +62,7 @@ param(
 
     [switch]$LocalMode,
 
-    [string]$PluginDir = '.agentdev-plugin',
-
-    [string]$RepoUrl = 'https://github.com/yogata/agent-dev-flow.git',
-
-    [string]$Branch = 'main'
+    [string]$PluginDir = '.agentdev-plugin'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -101,9 +92,9 @@ function Assert-ValidConsumerCwd {
     #>
     $cwd = $PWD.Path
 
-    # 1. .agentdev-plugin/ 配下（clone 先）
+    # 1. .agentdev-plugin/ 配下（チェックアウト配置先、REQ-009-041）
     if ($cwd -match '[\\/]\.agentdev-plugin([\\/]|$)') {
-        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow の clone 先です。1つ上のフォルダへ移動してください。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow のチェックアウト配置先です。1つ上のフォルダへ移動してください。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
         exit 1
     }
 
@@ -134,10 +125,10 @@ function Invoke-InstallWizard {
     Write-Host '=== AgentDevFlow 導入ウィザード ==='
     Write-Host ''
     Write-Host 'Q1. 目的を選んでください（番号を入力）:'
-    Write-Host '  1) 新規インストール（apply: clone して実行）'
-    Write-Host '  2) 更新・再同期（apply: clone して実行）'
-    Write-Host '  3) 状態確認（check: clone しない軽量確認、ファイル変更なし）'
-    Write-Host '  4) 変更予測（dry-run: clone するがファイル変更なし）'
+    Write-Host '  1) 新規インストール（apply: 実行、ファイル変更あり）'
+    Write-Host '  2) 更新・再同期（apply: 実行、ファイル変更あり）'
+    Write-Host '  3) 状態確認（check: 検証のみ、ファイル変更なし）'
+    Write-Host '  4) 変更予測（dry-run: 変更予測のみ、ファイル変更なし）'
     $modeChoice = Read-Host '番号'
     switch ($modeChoice) {
         '1' { $script:Mode = 'apply' }
@@ -233,20 +224,23 @@ function Show-PluginCheckoutGuidance {
         チェックアウト未検出時の案内。provisioning（clone、fetch、reset）も network access も
         代行実行しない（AG-001/REQ-009-046、DEC-016）。チェックアウトの取得は利用者の責務。
     #>
-    $repoWebUrl = $RepoUrl -replace '\.git$', ''
+    $repoUrl = 'https://github.com/yogata/agent-dev-flow.git'
+    $repoWebUrl = $repoUrl -replace '\.git$', ''
     Write-Host "[ERROR] 利用可能なチェックアウトが見つかりません。usable checkout 判定（$PluginDir/src/opencode/ の存在）に失敗しました。"
     Write-Host ''
     Write-Host 'このスクリプトは provisioning（clone、fetch、reset）と network access を行いません（REQ-009-046、DEC-016）。'
     Write-Host '以下のいずれかで agent-dev-flow のチェックアウトを用意してから再実行してください。'
     Write-Host ''
     Write-Host '方法1: git clone でチェックアウトを用意する'
-    Write-Host "  git clone --branch $Branch $RepoUrl $PluginDir"
+    Write-Host "  git clone $repoUrl $PluginDir"
     Write-Host ''
     Write-Host '方法2: ソース ZIP を取得して展開する'
     Write-Host "  1. $repoWebUrl を開く"
     Write-Host '  2. [Code] ボタン → [Download ZIP] でソース ZIP をダウンロード'
     Write-Host "  3. ZIP を展開し、中身（src/、scripts/ 等）を $PluginDir/ 直下に配置"
-    Write-Host "     （$PluginDir/src/opencode/ が存在すればよく、.git のない ZIP 展開チェックアウトも正規の配置形態）"
+    Write-Host "     注意: ZIP 展開直後の agent-dev-flow-<ref>/ の一段ネストを避け、$PluginDir/src/opencode/ となる配置にすること"
+    Write-Host "     （.git のない ZIP 展開チェックアウトも正規の配置形態）"
+    Write-Host "  4. scripts/ は $PluginDir/ と同一チェックアウトからコピーすること（スクリプトとチェックアウトの版不一致の防止）"
     Write-Host ''
     Write-Host "期待される状態: $SourceDir が存在すること"
     exit 1


### PR DESCRIPTION
## 概要

OU-003。install スクリプト（scripts/install-consumer-opencode.ps1）のオプション整理と対話ウィザード・ヘルプ文言をチェックアウト済み前提へ更新する（AG-005）。

Refs: #2130

## 変更内容

- -RepoUrl と -Branch を廃止（provisioning を行わないモデルのため）。指定時は PowerShell のパラメータバインドエラー（A parameter cannot be found that matches parameter name 'RepoUrl'/'Branch'.）で拒否される（AG-005）
- -PluginDir を「チェックアウト配置先を変更する上級者向けオプション」として存続（REQ-009-043）
- 対話ウィザード Q1 の文言を「apply: 実行、ファイル変更あり」「check: 検証のみ、ファイル変更なし」「dry-run: 変更予測のみ、ファイル変更なし」へ更新し、「clone して実行」系の表現を除去（AG-005、ACT-SPEC-003）
- チェックアウト未検出時のエラー案内に、ZIP 展開時のディレクトリ配置に関する注意（agent-dev-flow-<ref>/ の一段ネストを避け .agentdev-plugin/src/opencode/ となる配置指示）と、scripts/ を .agentdev-plugin/ と同一チェックアウトからコピーする案内を追加（AG-002、REQ-009-047）
- ヘルプの3モード説明を「検証のみ（check）/変更予測（dry-run）/実行（apply）」へ更新し、いずれのモードも provisioning・network access を行わずチェックアウト済み前提で動作する旨を明記（REQ-009-042、ACT-SPEC-004）
- cwd 安全化の停止理由文言を「agent-dev-flow の clone 先」から「agent-dev-flow のチェックアウト配置先」へ更新。停止条件の実体（.agentdev-plugin/ 配下での停止）は不変（REQ-009-041、ACT-SPEC-006）
- -LocalMode の接続先切替は従来どおり維持（DEC-004）。provisioning・network access は行わないまま維持（DEC-016）

## 定義層検証（検証のみ）

docs/specs/local/install-script-usability.md（spec-save commit bb34aa4f）の対象4節（対話ウィザード、dry-run/check/apply の技術的差、cwd 安全化、上級者向けオプション）が保存済みであることを確認した。本 PR では定義層を編集していない。

## テスト evidence（TS-007、AG-005）

サンドボックス（C:\WINDOWS\TEMP\opencode\2130-ts007\consumer1、git init 済み consumer リポジトリに scripts/ をコピー）で実施:

| # | 検証 | 結果 |
|---|---|---|
| A | -RepoUrl https://example.com/x.git -Mode check | exit=1。A parameter cannot be found that matches parameter name 'RepoUrl'. で拒否 |
| B | -Branch dev -Mode check | exit=1。同一形式のパラメータエラーで拒否 |
| C | -Mode check（チェックアウト未配置） | exit=1。案内に clone コマンド例（git clone https://github.com/yogata/agent-dev-flow.git .agentdev-plugin）、Download ZIP 手順、agent-dev-flow-<ref>/ の一段ネスト回避の注意、scripts/ を .agentdev-plugin/ と同一チェックアウトからコピーする案内がすべて含まれる |
| D | 別名ディレクトリ（adf-zip-checkout、.git なし ZIP 展開想定）を -PluginDir に指定して -Mode apply | exit=0。commands/agentdev、skills/agentdev-gh-cli、skills/agentdev-doc-writing、skills/japanese-tech-writing の4 junction を当該ディレクトリ配下へ作成（ReparsePoint=True、接続先検証済み） |
| E | 引数なし起動（ウィザード、stdin パイプで 3→1 を入力） | Q1 に新文言（実行、ファイル変更あり / 検証のみ、ファイル変更なし / 変更予測のみ、ファイル変更なし）を表示。出力全体に「clone して」「clone しない」「clone する」表現なし |
| F | .agentdev-plugin/ 配下で -Mode check | exit=1。「agent-dev-flow のチェックアウト配置先です。1つ上のフォルダへ移動してください。」で停止。停止条件の実体は不変 |
| G | Get-Help -Detailed | 3モード説明が検証のみ/変更予測/実行（ファイル変更あり）。パラメータ署名は Mode/LocalMode/PluginDir のみ（RepoUrl/Branch なし） |

TS-007 判定: 合格（全項目 pass、on_failure 発動なし）

## Findings / Capture候補

### intake
- agentdev-gh-cli の WRITE 標準手続きが一時ファイル配置先を .agentdev/tmp/（workspace-local）に定めているのに対し、case-run 委譲の MUST NOT は .agentdev/** 全域を触らないと定義しており、両者が衝突している。今回の委譲では MUST NOT を優先し一時ファイルをリポジトリ外の TEMP に配置した。手続き文書のいずれか側を明確化する検討候補。

### learning
（該当なし）

## SPEC確定候補

（本 Issue の実装で install-script-usability.md に追記すべき SPEC レベルの詳細は発見されず。保存済み記述と実装の乖離もなし）
