### PR TITLE
feat(scripts): check スクリプトの git リポジトリ性判定を情報報告へ格下げし導入文書を新前提へ更新 (#2129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,37 +72,65 @@ AgentDevFlow プラグインの設定を管理するリポジトリ。AI エー�
 
 AgentDevFlow を外部プロジェクトに導入する手順。
 
+### 前提: provisioning と install は別軸
+
+導入は2つの独立した軸で構成する。
+
+- **provisioning（チェックアウトの取得）**: 利用者の責務。git clone または GitHub ソース ZIP の展開のいずれかで、`.agentdev-plugin/` に agent-dev-flow のチェックアウトを用意する
+- **install（実行時の接続）**: install スクリプトが `.opencode/` 配下を junction で `.agentdev-plugin/src/opencode/` へ接続する（link mode）
+
+install スクリプトは provisioning（clone、fetch、reset）も network access も行わない。どちらの provisioning 形態でも install 手段は link mode に限られ、ZIP 展開による provisioning は配布成果物の実体コピーを伴わない。
+
+> 「source ZIP によるチェックアウト供給」と「release archive projection」（REQ-029 が別途定義する配布と検証の投影）は別の概念である（DEC-014）。本導入手順の ZIP 展開は前者であり、後者を扱わない。
+
 ### インストール
 
 通常版（GitHub 版 OpenCode を利用する環境）のインストール。
 
 ```powershell
-# 1. scripts/ を適用先リポジトリにコピー
-# 2. インストールを実行（clone + ジャンクション 作成）
-./scripts/install-consumer-opencode.ps1 -Mode apply
+# 1. provisioning: .agentdev-plugin/ にチェックアウトを用意する（どちらか）
+git clone https://github.com/yogata/agent-dev-flow.git .agentdev-plugin
+# または: GitHub リポジトリの [Code] → [Download ZIP] でソース ZIP を取得し、
+# 展開した中身（src/、scripts/ 等）を .agentdev-plugin/ 直下に配置
+
+# 2. install: 導入先リポジトリのルートで実行（junction を作成）
+./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode apply
 ```
 
 ローカル版（ローカル版 OpenCode を利用する環境）のインストール。`-LocalMode` を付けると `agentdev-gh-cli` だけが `src/opencode-local/agentdev-gh-cli/` へ接続され、それ以外の command/skill は通常版と同じ `src/opencode/` 配下へ接続される（REQ-009、DEC-004）。
 
 ```powershell
-./scripts/install-consumer-opencode.ps1 -Mode apply -LocalMode
+./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode apply -LocalMode
 ```
+
+> ZIP 展開チェックアウト（`.git` なし）は正規の provisioning 形態だが、サポート対象外の環境である（不具合報告の受け付け対象外）。版の確認など git を前提とする運用には git clone を使う。
+>
+> スクリプトを `./scripts/` として導入先リポジトリに置く場合は、`.agentdev-plugin/` と同一のチェックアウトからコピーする（スクリプトとチェックアウトの版不一致を防ぐため）。
 
 ### 状態確認
 
 ```powershell
 # インストール状態を確認（リンクモードを自動検出して報告）
-./scripts/check-consumer-opencode.ps1
+./.agentdev-plugin/scripts/check-consumer-opencode.ps1
 ```
+
+チェックアウトの git リポジトリ性は乖離ではなく情報として報告される。版（commit/branch）は `.git` が存在する場合のみ表示され、ZIP 展開環境では unknown と表示される。
 
 ### 更新
 
+更新手順は provisioning 形式に従う。install の apply は冪等であり、再実行で junction 構成を変化させない。
+
 ```powershell
-# agent-dev-flow の最新を取得して再同期
+# git clone 環境: チェックアウトを更新して再同期
 cd .agentdev-plugin && git pull && cd ..
-./scripts/install-consumer-opencode.ps1 -Mode apply
+./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode apply
+
+# ZIP 展開環境: ソース ZIP を再取得して .agentdev-plugin/ を差し替えた後、
+# 必要に応じて install を再実行する（再実行の要否は利用者の判断）
+# ./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode apply
+
 # ローカル版環境の場合は -LocalMode を付けて再実行
-# ./scripts/install-consumer-opencode.ps1 -Mode apply -LocalMode
+# ./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode apply -LocalMode
 ```
 
 ### 推奨 .gitignore 設定

--- a/docs/guides/consumer-project-setup.md
+++ b/docs/guides/consumer-project-setup.md
@@ -35,22 +35,21 @@ scripts/
 ### 適用プロジェクト（consumer-with-agentdev）
 
 ```
-.agentdev-plugin/                → agent-dev-flow の git clone 先（適用プロジェクト専用）
+.agentdev-plugin/                → agent-dev-flow のチェックアウト配置先（git clone またはソース ZIP 展開）
   src/opencode/                  → 原本
+  scripts/install-consumer-opencode.ps1 → 適用プロジェクト用インストールスクリプト
+  scripts/check-consumer-opencode.ps1   → 適用プロジェクト用状態確認スクリプト
 .opencode/
   commands/agentdev/              → ジャンクション → .agentdev-plugin/src/opencode/commands/agentdev/
   commands/{local}/               → プロジェクト独自コマンド（実ディレクトリ）
   skills/agentdev-*/              → ジャンクション → .agentdev-plugin/src/opencode/skills/agentdev-*/
   skills/{local}-*/               → プロジェクト独自スキル（実ディレクトリ）
-scripts/
-  install-consumer-opencode.ps1   → 適用プロジェクト用インストールスクリプト
-  check-consumer-opencode.ps1     → 適用プロジェクト用状態確認スクリプト
 ```
 
-- `.agentdev-plugin/` に agent-dev-flow を clone する（`.agentdev/` ではない）
+- `.agentdev-plugin/` に agent-dev-flow のチェックアウトを配置する（git clone またはソース ZIP 展開、`.agentdev/` ではない）
 - `.agentdev/` は AgentDevFlow のドメイン状態用（Intake, Learning, Backlog 等）として予約
 - `.opencode/` は AgentDevFlow 提供 command/skill とプロジェクト独自設定の混在場所
-- AgentDevFlow 提供ファイルは ジャンクション（更新時に clone を pull すれば自動反映）
+- AgentDevFlow 提供ファイルは ジャンクション（更新時にチェックアウトを更新すれば自動反映）
 - プロジェクト独自ファイルは直接管理する
 
 ### 非 AgentDevFlow プロジェクト（consumer-local）
@@ -71,7 +70,7 @@ GitHub Issue/PR を使わない個人利用環境向けのリポジトリ種別�
 詳細な接続フロー、link target 確認は SPEC [実行時パッケージ境界](../specs/local/runtime-package-boundary.md) を参照。
 
 ```
-.agentdev-plugin/                → agent-dev-flow の git clone 先（link 元の取得元）
+.agentdev-plugin/                → agent-dev-flow のチェックアウト配置先（git clone またはソース ZIP 展開）
   src/opencode/                  → GitHub 版 AgentDevFlow の原本（agentdev-gh-cli 以外の接続先）
   src/opencode-local/            → ローカル版 link 先原本領域（agentdev-gh-cli のみ）
     README.md                    → ローカル版 link 設定の実行手順
@@ -94,20 +93,22 @@ GitHub Issue/PR を使わない個人利用環境向けのリポジトリ種別�
 
 #### ローカル版セットアップ手順
 
-1. agent-dev-flow リポジトリを `.agentdev-plugin/` に clone する
-2. `./scripts/install-consumer-opencode.ps1 -Mode apply -LocalMode` を実行し、link 設定を行う（`agentdev-gh-cli` のみ `src/opencode-local/agentdev-gh-cli/` へ接続、それ以外は `src/opencode/` 配下へ接続）
-3. 各 link が意図した target へ解決されることを `./scripts/check-consumer-opencode.ps1` で確認する
+1. `.agentdev-plugin/` に agent-dev-flow のチェックアウトを用意する（git clone またはソース ZIP 展開）
+2. `./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode apply -LocalMode` を実行し、link 設定を行う（`agentdev-gh-cli` のみ `src/opencode-local/agentdev-gh-cli/` へ接続、それ以外は `src/opencode/` 配下へ接続）
+3. 各 link が意図した target へ解決されることを `./.agentdev-plugin/scripts/check-consumer-opencode.ps1` で確認する
 4. `.agentdev/cases/` ディレクトリが存在することを確認する（ローカル Case ファイル用）
 5. `.gitignore` に link 先（`.opencode/commands/agentdev/`, `.opencode/skills/agentdev-*/`）を追加する
 
 #### ローカル版の更新手順
 
 ```powershell
-# agent-dev-flow の最新を取得
+# git clone 環境: agent-dev-flow の最新を取得
 cd .agentdev-plugin && git pull && cd ..
 
+# ZIP 展開環境: ソース ZIP を再取得し、.agentdev-plugin/ を差し替える
+
 # unlink / relink により link を張り直す（全削除して作り直す方式は採らない）
-./scripts/install-consumer-opencode.ps1 -Mode apply -LocalMode
+./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode apply -LocalMode
 ```
 
 > 詳細な実行手順、制約、link target 確認は `src/opencode-local/README.md`（link 設定の実行エントリポイント）と SPEC [実行時パッケージ境界](../specs/local/runtime-package-boundary.md)、[ローカル Case ファイル](../specs/local/local-case-file.md) を参照。
@@ -119,7 +120,7 @@ cd .agentdev-plugin && git pull && cd ..
 | `agentdev` | コマンド名前空間 | `self-hosting`, `consumer-with-agentdev`, `consumer-generated` |
 | `agentdev-*` | スキルプレフィックス | `self-hosting`, `consumer-with-agentdev`, `consumer-generated` |
 | `.agentdev/` | ドメイン状態ディレクトリ | `self-hosting`, `consumer-with-agentdev`, `consumer-generated` |
-| `.agentdev-plugin/` | 適用プロジェクトの clone 先 | `consumer-with-agentdev`, `consumer-generated` |
+| `.agentdev-plugin/` | 適用プロジェクトのチェックアウト配置先 | `consumer-with-agentdev`, `consumer-generated` |
 
 **禁止事項**:
 - consumer-local での `agentdev` 名前空間の使用（v2:ADR-011-056）
@@ -133,50 +134,82 @@ docs-check は `repo-agentdev-integrity`（配布対象外スキル）として 
 
 ## インストール方式の方針
 
+provisioning（チェックアウトの取得）と install 手段（link mode による接続）は別軸である（REQ-009）。どちらの provisioning 形態でも install 手段は link mode に限られる。導入方式ポリシーの正規な定義は SPEC [実行時パッケージ境界](../specs/local/runtime-package-boundary.md) を参照。
+
+### provisioning 形式（チェックアウトの取得）
+
+provisioning は利用者の責務である。install スクリプトは provisioning（clone、fetch、reset）も network access も行わない。
+
+| 形式 | 対応 | 推奨 | 備考 |
+|--------|------|------|------|
+| git clone（`.agentdev-plugin/`） | ✅ | **推奨** | git pull で更新できる。check スクリプトの版報告も機能する |
+| ソース ZIP 展開（`.agentdev-plugin/`） | ✅ | git clone を優先 | 正規の provisioning 形態だがサポート対象外環境（REQ-009-048）。版は unknown として報告される |
+
+### install 手段
+
 | 方式 | 対応 | 推奨 | 備考 |
 |--------|------|------|------|
-| ジャンクション + clone（`.agentdev-plugin/`） | ✅ | **推奨** | 更新が自動反映、原本が単一 |
+| ジャンクション + チェックアウト（`.agentdev-plugin/`） | ✅ | **推奨** | 更新が自動反映、原本が単一 |
 | 直接コピー | ⚠️ | 非推奨 | 手動更新が必要、乖離のリスク |
 | Git サブモジュール | ⚠️ | 検討可能 | 複雑性が増す |
 | プラグイン/npm/package | ❌ | 将来対応 | v2:ADR-011-064 で将来の選択肢扱い |
 
-### ジャンクションと clone によるインストール（推奨）
+> 「source ZIP によるチェックアウト供給」と「release archive projection」（REQ-029 が別途定義する配布と検証の投影）は別の概念である（DEC-014）。ZIP 展開による provisioning は手動 copy インストールに該当せず、install 手段は link mode に限定される。
 
-agent-dev-flow を `.agentdev-plugin/` に clone し、ジャンクションで実行時の配置先を作成する。
+### ジャンクションによるインストール（推奨）
+
+`.agentdev-plugin/` にチェックアウトを配置し、ジャンクションで実行時の配置先を作成する。スクリプトはチェックアウト配下のものを導入先リポジトリのルートから実行する。
 
 ```powershell
-# 1. インストール（clone + ジャンクション作成を一括実行）
-./scripts/install-consumer-opencode.ps1 -Mode apply
+# 1. provisioning: .agentdev-plugin/ にチェックアウトを用意する（どちらか）
+git clone https://github.com/yogata/agent-dev-flow.git .agentdev-plugin
+# または: GitHub リポジトリの [Code] → [Download ZIP] でソース ZIP を取得し、
+# 展開した中身（src/、scripts/ 等）を .agentdev-plugin/ 直下に配置
+# （ZIP 展開で生じる agent-dev-flow-<ref>/ の一段ネストを避け、
+#   .agentdev-plugin/src/opencode/ となる配置にする）
 
-# 2. 状態確認
-./scripts/check-consumer-opencode.ps1
+# 2. インストール（ジャンクション作成）
+./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode apply
 
-# 3. ドライラン（変更確認）
-./scripts/install-consumer-opencode.ps1 -Mode dry-run
+# 3. 状態確認
+./.agentdev-plugin/scripts/check-consumer-opencode.ps1
+
+# 4. ドライラン（変更確認）
+./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode dry-run
 ```
+
+> ZIP 展開チェックアウト（`.git` なし）は正規の provisioning 形態だが、サポート対象外の環境である（不具合報告の受け付け対象外、REQ-009-048）。
+>
+> スクリプトを `./scripts/` として導入先リポジトリに置く場合は、`.agentdev-plugin/` と同一のチェックアウトからコピーする（スクリプトとチェックアウトの版不一致を防ぐため）。
 
 ### 更新手順
 
+更新は provisioning 形式に従う（REQ-009-049）。install の apply は冪等であり、再実行で junction 構成を変化させない。
+
 ```powershell
-# agent-dev-flow の最新を取得
+# git clone 環境: agent-dev-flow の最新を取得
 cd .agentdev-plugin && git pull && cd ..
 
+# ZIP 展開環境: ソース ZIP を再取得し、.agentdev-plugin/ を差し替える
+# （install 再実行の要否は利用者の判断）
+
 # ジャンクションを再同期（新しい skill/command が追加された場合）
-./scripts/install-consumer-opencode.ps1 -Mode apply
+./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode apply
 ```
 
 ### 直接コピーによるインストール（非推奨）
 
 - 初回は手動コピーで動作するが、AgentDevFlow 更新時に再コピーが必要
 - docs-check で乖離を検出可能（IR-016）
+- ソース ZIP 展開による provisioning はこの方式に該当しない（install 手段は link mode に限定される）
 
 ## スクリプトの適用範囲
 
 | スクリプト | 対象リポジトリ種別 | 役割 |
 |--------|---------------|------|
 | `scripts/sync-self-opencode.ps1` | `self-hosting` | `src/opencode/` ↔ `.opencode/` の同期 |
-| `scripts/install-consumer-opencode.ps1` | `consumer-with-agentdev` | `.agentdev-plugin/` clone + ジャンクション作成 |
-| `scripts/check-consumer-opencode.ps1` | `consumer-with-agentdev` | インストール状態の検証 |
+| `scripts/install-consumer-opencode.ps1` | `consumer-with-agentdev` | チェックアウト済み `.agentdev-plugin/` を前提としたジャンクション作成 |
+| `scripts/check-consumer-opencode.ps1` | `consumer-with-agentdev` | インストール状態の検証（git リポジトリ性は情報報告、版報告は `.git` 存在時のみ） |
 | （link 設定スクリプト: `-LocalMode`） | `consumer-generated` | `install-consumer-opencode.ps1 -Mode apply -LocalMode` が `agentdev-gh-cli` のみ `src/opencode-local/agentdev-gh-cli/` へ接続し、それ以外を `src/opencode/` 配下へ接続する（v2:ADR-011-032, v2:ADR-009）。決定的な変換ロジックを実装したスクリプトは使用しない |
 
 ### 本体リポジトリ（self-hosting）での同期
@@ -190,10 +223,10 @@ cd .agentdev-plugin && git pull && cd ..
 ### 適用プロジェクト（consumer-with-agentdev）でのインストール/確認
 
 ```powershell
-./scripts/install-consumer-opencode.ps1 -Mode apply   # clone + ジャンクション作成
-./scripts/install-consumer-opencode.ps1 -Mode check   # 乖離の検出
-./scripts/install-consumer-opencode.ps1 -Mode dry-run # 変更予測
-./scripts/check-consumer-opencode.ps1                  # 状態確認（check のみ）
+./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode apply   # ジャンクション作成（チェックアウト前提）
+./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode check   # 乖離の検出
+./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode dry-run # 変更予測
+./.agentdev-plugin/scripts/check-consumer-opencode.ps1                  # 状態確認（check のみ）
 ```
 
 ## プロジェクト独自の命名ルール
@@ -216,7 +249,7 @@ cd .agentdev-plugin && git pull && cd ..
 適用プロジェクトリポジトリで推奨される `.gitignore` 設定:
 
 ```gitignore
-# AgentDevFlow の clone 先
+# AgentDevFlow のチェックアウト配置先
 .agentdev-plugin/
 
 # AgentDevFlow がジャンクション管理するディレクトリ（インストールスクリプトが自動作成）
@@ -231,9 +264,9 @@ cd .agentdev-plugin && git pull && cd ..
 
 ### 新規適用プロジェクトの導入手順
 
-1. 適用プロジェクトリポジトリに `scripts/` ディレクトリをコピー（または agent-dev-flow から取得）
-2. `./scripts/install-consumer-opencode.ps1 -Mode apply` を実行
-3. `./scripts/check-consumer-opencode.ps1` で動作確認
+1. `.agentdev-plugin/` に agent-dev-flow のチェックアウトを用意する（git clone またはソース ZIP 展開）
+2. `./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode apply` を実行
+3. `./.agentdev-plugin/scripts/check-consumer-opencode.ps1` で動作確認
 4. `.agentdev/` ディレクトリが存在することを確認（Intake/Learning 用）
 5. `.gitignore` に推奨エントリを追加
 
@@ -241,6 +274,7 @@ cd .agentdev-plugin && git pull && cd ..
 
 1. 既存の `.opencode/` 内容を確認
 2. `agentdev` 名前空間との衝突がないことを確認
-3. `./scripts/install-consumer-opencode.ps1 -Mode apply` でインストール
-4. `./scripts/check-consumer-opencode.ps1` で整合性確認
-5. `.gitignore` を更新
+3. `.agentdev-plugin/` に agent-dev-flow のチェックアウトを用意する（git clone またはソース ZIP 展開）
+4. `./.agentdev-plugin/scripts/install-consumer-opencode.ps1 -Mode apply` でインストール
+5. `./.agentdev-plugin/scripts/check-consumer-opencode.ps1` で整合性確認
+6. `.gitignore` を更新

--- a/scripts/check-consumer-opencode.ps1
+++ b/scripts/check-consumer-opencode.ps1
@@ -3,26 +3,27 @@
     Check consumer repository AgentDevFlow installation status.
 
 .DESCRIPTION
-    導入先リポジトリの AgentDevFlow インストール状態を確認する。clone しない軽量確認
-    （検証のみ、ファイル変更なし）。既存の .agentdev-plugin/ と junction を検証し、
-    乖離を報告する。
+    導入先リポジトリの AgentDevFlow インストール状態を確認する。軽量確認
+    （検証のみ、ファイル変更なし、provisioning なし）。既存の .agentdev-plugin/ と
+    junction を検証し、乖離を報告する（REQ-009-046、DEC-016）。
 
     関連3モードの技術的差（参考）:
-    - check（当スクリプト / install -Mode check）: clone せず既存状態を検証
-    - install -Mode check                      : clone して検証（ファイル変更なし）
-    - install -Mode dry-run                    : clone して予測（ファイル変更なし）
-    - install -Mode apply                      : clone して実行（ファイル変更あり）
+    - check（当スクリプト / install -Mode check）: チェックアウトを前提に既存状態を検証（ファイル変更なし）
+    - install -Mode dry-run                    : チェックアウトを前提に予測（ファイル変更なし）
+    - install -Mode apply                      : チェックアウトを前提に junction 設定を実行（ファイル変更あり）
 
     当スクリプトと install -Mode check の使い分け:
-    - 当スクリプト（check-consumer-opencode.ps1）: clone しない軽量確認。.agentdev-plugin/
-      が未インストールや破損時でも速く確認できる。orphan 検出を含む。
-    - install -Mode check: clone（または更新）した上で検証する。初回導入時や、原本側の最新を
-      取り込んでから検証したい場合に使う。
+    - 当スクリプト（check-consumer-opencode.ps1）: 軽量確認。orphan 検出を含む。
+    - install -Mode check: 同様にチェックアウトを前提に検証する。orphan 検出は含まない。
 
     Verifies that the consumer repository's AgentDevFlow installation is healthy:
-    - .agentdev-plugin/ exists and is a git repository
+    - .agentdev-plugin/ has a usable checkout (src/opencode/ exists; .git is not required)
     - All expected junctions exist and point to correct targets
     - Reports divergences
+
+    チェックアウトの git リポジトリ性は乖離（DIVERGENCE）ではなく情報として報告する。
+    版（commit/branch）報告は .git が存在する場合のみ行い、ZIP 展開チェックアウト（.git なし）
+    の版は unknown とする（AG-003/REQ-009-048）。version manifest ファイルは導入しない。
 
     Auto-detects link mode from the agentdev-gh-cli junction target:
     - Normal mode: agentdev-gh-cli -> src/opencode/skills/agentdev-gh-cli/
@@ -32,7 +33,7 @@
 
 .PARAMETER PluginDir
     Directory name for the agent-dev-flow checkout (default: .agentdev-plugin).
-    上級者向け: clone 先ディレクトリ名を変更した環境でのみ指定。通常は既定値を使用する。
+    上級者向け: チェックアウト配置先ディレクトリ名を変更した環境でのみ指定。通常は既定値を使用する。
 
 .EXAMPLE
     ./scripts/check-consumer-opencode.ps1
@@ -68,9 +69,9 @@ function Assert-ValidConsumerCwd {
     #>
     $cwd = $PWD.Path
 
-    # 1. .agentdev-plugin/ 配下（clone 先）
+    # 1. .agentdev-plugin/ 配下（チェックアウト配置先）
     if ($cwd -match '[\\/]\.agentdev-plugin([\\/]|$)') {
-        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow の clone 先です。1つ上のフォルダへ移動してください。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow のチェックアウト配置先です。1つ上のフォルダへ移動してください。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
         exit 1
     }
 
@@ -122,6 +123,37 @@ function Get-TargetSourcePath {
     return Join-Path $SourceDir $RelPath
 }
 
+# --- Checkout Guidance (AG-003/REQ-009-047) ---
+
+# 案内表示用の既定値（当スクリプトは provisioning を行わないため、案内以外では使用しない）
+$DefaultRepoUrl = 'https://github.com/yogata/agent-dev-flow.git'
+$DefaultBranch = 'main'
+
+function Show-PluginCheckoutGuidance {
+    <#
+    .SYNOPSIS
+        チェックアウト未検出時の案内。provisioning（clone、fetch、reset）も network access も
+        代行実行しない（AG-001/REQ-009-046、DEC-016）。チェックアウトの取得は利用者の責務。
+    #>
+    $repoWebUrl = $DefaultRepoUrl -replace '\.git$', ''
+    Write-Host "[ERROR] 利用可能なチェックアウトが見つかりません。usable checkout 判定（$PluginDir/src/opencode/ の存在）に失敗しました。"
+    Write-Host ''
+    Write-Host 'このスクリプトは provisioning（clone、fetch、reset）と network access を行いません（REQ-009-046、DEC-016）。'
+    Write-Host '以下のいずれかで agent-dev-flow のチェックアウトを用意してから再実行してください。'
+    Write-Host ''
+    Write-Host '方法1: git clone でチェックアウトを用意する'
+    Write-Host "  git clone --branch $DefaultBranch $DefaultRepoUrl $PluginDir"
+    Write-Host ''
+    Write-Host '方法2: ソース ZIP を取得して展開する'
+    Write-Host "  1. $repoWebUrl を開く"
+    Write-Host '  2. [Code] ボタン → [Download ZIP] でソース ZIP をダウンロード'
+    Write-Host "  3. ZIP を展開し、中身（src/、scripts/ 等）を $PluginDir/ 直下に配置"
+    Write-Host "     （$PluginDir/src/opencode/ が存在すればよく、.git のない ZIP 展開チェックアウトも正規の配置形態）"
+    Write-Host ''
+    Write-Host "期待される状態: $SourceDir が存在すること"
+    exit 1
+}
+
 # --- Main ---
 
 # cwd 安全化（REQ-{NNNN}-{NNN}）
@@ -130,36 +162,34 @@ Assert-ValidConsumerCwd
 Write-Host '=== Consumer Install Status Check ==='
 $divergences = 0
 
-# 1. Plugin checkout
-if (-not (Test-Path -LiteralPath $PluginPath)) {
-    Write-Host "[DIVERGENCE] $PluginDir does not exist (run install-consumer-opencode.ps1 -Mode apply)"
-    $divergences++
-} elseif (-not (Test-Path -LiteralPath (Join-Path $PluginPath '.git'))) {
-    Write-Host "[DIVERGENCE] $PluginDir exists but is not a git repository"
-    $divergences++
-} else {
-    Write-Host "[OK] $PluginDir is a git repository"
-    # Show current commit
-    Push-Location -LiteralPath $PluginPath
-    try {
-        $commit = git rev-parse --short HEAD 2>$null
-        $branch = git rev-parse --abbrev-ref HEAD 2>$null
-        Write-Host "[INFO] Checkout: $branch ($commit)"
-    }
-    finally {
-        Pop-Location
-    }
-}
-
-# 2. Source directory
+# 1. Plugin checkout (usable checkout 判定)
+# .git の有無ではなく src/opencode/ の存在で判定する（AG-003/REQ-009-047、REQ-009-048）。
+# ZIP 展開チェックアウト（.git なし）も正規の配置形態とする。チェックアウト未検出時は
+# エラー停止して clone とソース ZIP の手順を案内する（provisioning の代行はしない）。
 if (-not (Test-Path -LiteralPath $SourceDir)) {
-    Write-Host "[DIVERGENCE] Source directory not found: $PluginDir/src/opencode/"
-    $divergences++
+    Show-PluginCheckoutGuidance
 } else {
-    Write-Host "[OK] Source directory exists: $PluginDir/src/opencode/"
+    Write-Host "[OK] Usable checkout exists: $PluginDir/src/opencode/"
+    # git リポジトリ性は乖離ではなく情報として報告する（AG-003/REQ-009-048）。
+    # 版（commit/branch）報告は .git が存在する場合のみ行い、ZIP 展開環境では unknown とする。
+    if (Test-Path -LiteralPath (Join-Path $PluginPath '.git')) {
+        Write-Host "[INFO] $PluginDir is a git repository"
+        Push-Location -LiteralPath $PluginPath
+        try {
+            $commit = git rev-parse --short HEAD 2>$null
+            $branch = git rev-parse --abbrev-ref HEAD 2>$null
+            Write-Host "[INFO] Checkout: $branch ($commit)"
+        }
+        finally {
+            Pop-Location
+        }
+    } else {
+        Write-Host "[INFO] $PluginDir is not a git repository (possibly a ZIP-expanded checkout; informational, not a divergence)"
+        Write-Host '[INFO] Checkout: unknown'
+    }
 }
 
-# 3. Link mode detection (agentdev-gh-cli junction target)
+# 2. Link mode detection (agentdev-gh-cli junction target)
 # Local mode: agentdev-gh-cli -> src/opencode-local/agentdev-gh-cli/ (consumer-generated)
 # Normal mode: agentdev-gh-cli -> src/opencode/skills/agentdev-gh-cli/ (consumer-with-agentdev)
 $DetectedLocalMode = $false
@@ -179,7 +209,7 @@ if ($DetectedLocalMode) {
     Write-Host '[INFO] Link mode: normal (consumer-with-agentdev) — agentdev-gh-cli -> src/opencode/'
 }
 
-# 3b. Local redirect source (local mode only)
+# 2b. Local redirect source (local mode only)
 if ($DetectedLocalMode) {
     if (-not (Test-Path -LiteralPath $ghCliLocalSource)) {
         Write-Host "[DIVERGENCE] Local redirect source not found: $PluginDir/src/opencode-local/$LocalModeRedirectSkill/"
@@ -189,7 +219,7 @@ if ($DetectedLocalMode) {
     }
 }
 
-# 4. .opencode/ status
+# 3. .opencode/ status
 if (-not (Test-Path -LiteralPath $ProjectionDir)) {
     Write-Host '[DIVERGENCE] .opencode/ does not exist'
     $divergences++
@@ -200,7 +230,7 @@ if (-not (Test-Path -LiteralPath $ProjectionDir)) {
     Write-Host '[OK] .opencode/ is a real directory'
 }
 
-# 5. Parent directories
+# 4. Parent directories
 if (Test-Path -LiteralPath $ProjectionDir) {
     foreach ($parentRel in @('commands', 'skills')) {
         $parentPath = Join-Path $ProjectionDir $parentRel
@@ -216,7 +246,7 @@ if (Test-Path -LiteralPath $ProjectionDir) {
     }
 }
 
-# 6. Junction checks
+# 5. Junction checks
 if (Test-Path -LiteralPath $SourceDir) {
     # Enumerate expected targets from source
     $targets = [System.Collections.Generic.List[string]]::new()
@@ -259,7 +289,7 @@ if (Test-Path -LiteralPath $SourceDir) {
         }
     }
 
-    # 7. Orphan detection (agentdev-* junctions that don't match source)
+    # 6. Orphan detection (agentdev-* junctions that don't match source)
     Write-Host ''
     Write-Host '--- Orphan junctions ---'
     $orphansFound = $false


### PR DESCRIPTION
# feat: check スクリプトの判定変更と導入文書の新前提導線更新（OU-002）

Refs: #2129

## 概要

OU-002（Issue #2129）。チェックアウト済み前提（provisioning 2 形式: git clone / GitHub ソース ZIP 展開）に対応する check スクリプトの判定変更と、README.md・導入ガイドの導線更新。

## 変更内容

### scripts/check-consumer-opencode.ps1

- usable checkout 判定を `.git` の有無ではなく `src/opencode/` の存在で行う（AG-003、REQ-009-047）
- チェックアウト未検出時は clone コマンド例とソース ZIP 取得手順を案内表示してエラー停止（provisioning 代行なし、DEC-016 整合）
- `.agentdev-plugin/` の git リポジトリ性を DIVERGENCE から情報報告（`[INFO]`）へ格下げ（AG-003、CR-003、REQ-009-048）
- 版（commit/branch）報告は `.git` が存在する場合のみ。ZIP 展開環境では `[INFO] Checkout: unknown` と表示（REQ-009-048）
- version manifest ファイルは導入せず（AG-003）
- comment-based help の install モード説明をチェックアウト済み前提の文言へ更新。cwd 停止メッセージの「clone 先」を「チェックアウト配置先」へ修正（install-script-usability SPEC 整合）

### README.md

- 導入セクションを「git clone または ZIP 展開で `.agentdev-plugin/` を用意し、install スクリプト（`./.agentdev-plugin/scripts/install-consumer-opencode.ps1`）を実行する」導線へ書き換え。「scripts/ を適用先リポジトリにコピー」前提は削除（AG-006）
- 更新手順を provisioning 形式別（git pull / ZIP 再取得・ディレクトリ差し替え）へ整理（AG-006、AG-004、REQ-009-049）
- provisioning（チェックアウト取得）と install（link mode）が別軸である旨と、「source ZIP によるチェックアウト供給」と「release archive projection」の非混同（DEC-014）を記載（AG-007）
- 状態確認セクションに git リポジトリ性の情報報告化と版表示仕様（`.git` 存在時のみ、ZIP 環境は unknown）を追記

### docs/guides/consumer-project-setup.md

- consumer-with-agentdev / consumer-generated の図と手順を新前提（チェックアウト配置先）へ更新
- インストール方式の方針を provisioning 形式と install 手段の 2 表へ分離し、別軸である旨を明記
- ZIP 展開環境がサポート対象外である旨の注記と、scripts/ のコピー元を `.agentdev-plugin/` と同一チェックアウトとする推奨を追加（AG-006）
- 移行ガイド（新規・既存プロジェクト）を新前提の手順へ更新

### 定義層（検証のみ・本 PR では未編集）

- `docs/specs/local/runtime-package-boundary.md`（導入方式ポリシー、link mode 接続手順技術詳細、チェックアウト検証、更新運用）は spec-save commit bb34aa4f で保存済みであることを確認

## テスト証拠

### TS-003 (AG-003): ZIP 展開チェックアウトでの apply + check — 合格

サンドボックス（`C:\WINDOWS\TEMP\opencode\ts2129\consumer-zip`。git 管理の consumer リポジトリ + ソースツリー展開による `.git` なし `.agentdev-plugin/`）:

- `install-consumer-opencode.ps1 -Mode apply` → exit 0（junction 48 本作成）
- `check-consumer-opencode.ps1` → exit 0。`[OK] Usable checkout exists: .agentdev-plugin/src/opencode/`、`[INFO] .agentdev-plugin is not a git repository (possibly a ZIP-expanded checkout; informational, not a divergence)`、`[INFO] Checkout: unknown`、DIVERGENCE 0 件
- 版報告の `.git` 依存の対照検証（consumer-git: `.agentdev-plugin/` を git リポジトリ化）: `[INFO] .agentdev-plugin is a git repository` + `[INFO] Checkout: main (2b192bf)` と表示、exit 0
- チェックアウト未検出時（`-PluginDir .no-such-plugin`）: clone コマンド例とソース ZIP 手順の案内を表示して exit 1
- version manifest ファイルの生成なし（`*version*` ファイル 0 件）

### TS-004 (AG-006): 文書手順を ZIP 環境で実行 — 合格

README.md の導入手順と docs/guides/consumer-project-setup.md の手順（provisioning → install apply → check → dry-run）を ZIP 展開相当環境で文書記載の通りに実行し、全工程が完了:

- 文書の前提（`.agentdev-plugin/src/opencode/` の配置、導入先リポジトリのルートで実行）とスクリプトが要求する前提が一致
- ガイドの ZIP ネスト注意（`agent-dev-flow-<ref>/` の一段ネストを避け、`.agentdev-plugin/src/opencode/` となる配置）とスクリプトの usable checkout 判定が一致
- `install -Mode dry-run` → exit 0、変更なし

### TS-005 (AG-007): /repo/docs-check — 合格

docs-check の検査スクリプト群（bun、source profile）を実施:

- `check_integrity.ts`: README.md、docs/guides/consumer-project-setup.md、scripts/ への指摘 0 件。初回実行で検出された DEC-016（proposed）引用の WARNING 2 件は DEC-016 引用を本文から除去して解消（制約の正規参照は SPEC 側が保持）。残る NG 36 件はすべて本変更が触れていないファイルの既存指摘
- `check_command_format.ts`: OK
- `check_extensions.ts`: failures 0
- `check_distribution_boundary.ts`: failures 0
- `check_autogen_freshness.ts`: EXIT 1 — 既存の AUTOGEN 陳腐化（integrity-rule-catalog の IR-005、rule-ownership、req-health-metrics、spec-health-metrics、DOC-MAP.md 欠落）。本変更が触れていないファイル群の既存指摘（intake 候補に記載）

### TS-008 (AG-006): 文書品質査読 — 合格

変更後の README.md 導入セクションと docs/guides/consumer-project-setup.md に agentdev-doc-writing の基準を適用:

- japanese-tech-writing 規範: 中黒並列（「配布・検証」→「配布と検証」）を修正。em-dash なし、一文一行、LLM 表現なし
- 文書種別責務: ガイドの導入方式方針に SPEC（実行時パッケージ境界）への導線を明記。案内層として規範の再定義を行わない
- 実行主体分類: install/check は「スクリプト」として記述（command/skill 誤認なし）
- Decision 引用ポリシー: proposed な DEC-016 の本文引用を除去（SSoT は runtime-package-boundary SPEC 側）

## targeted docs guard

```
bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref origin/main --json
```

exit 0、failures 0、warnings 0（files_checked: README.md, docs/guides/consumer-project-setup.md / coupled: docs/README.md）

## Findings / Capture候補

### docs-integrity

- targeted docs guard: PASS（strict failure なし）

### intake

（docs-check 実行時に検出した既存指摘。本 PR では `.agentdev/` への書き込み禁止により intake item として未保存）

- AUTOGEN ブロック陳腐化: `docs/specs/integrity/integrity-rule-catalog.md`（IR-005 の ADR→Decision 表記ずれ）、`docs/specs/integrity/rule-ownership.md`、`docs/specs/quality/req-health-metrics.md`、`docs/specs/quality/spec-health-metrics.md`。`generate_indexes.ts` の再生成で解消可能
- `docs/DOC-MAP.md` 欠落による `check_autogen_freshness.ts` EXIT 1（block_id=docmap-inventory）
- 既存の broken reference 群（REQ-021 の ADR-006 参照、vocabulary-registry の REQ-0145 参照、integrity/audits 配下の壊れた相対リンク等）
- check スクリプトと install スクリプトでチェックアウト未検出時の案内文言・既定 URL 定数が重複実装（将来的な共有化の検討候補）

### learning

- なし（本 Issue の実行で再発防止知見に値する逸脱は発生しなかった）

## SPEC確定候補

- なし（導入方式ポリシーと link mode 接続手順の技術詳細は spec-save（bb34aa4f）で `docs/specs/local/runtime-package-boundary.md` に保存済み）