### PR TITLE
test(integrity): ADR README 期待値を decisions README へ更新

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/commands_error_cases.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/commands_error_cases.test.ts
@@ -361,9 +361,15 @@ describe("REQ-0030-011: Real repo error case validation", () => {
       expect(fs.existsSync(docsReadmePath)).toBe(true);
     });
 
-    it("ADR README.md exists (referenced by case-open, integrity-check)", () => {
-      const adrReadmePath = path.join(REPO_ROOT, "docs", "adr", "README.md");
-      expect(fs.existsSync(adrReadmePath)).toBe(true);
+    it("Decision README.md exists (docs/decisions/README.md, DEC-009 AG-014)", () => {
+      // DEC-009 AG-014 の正規索引。旧 docs/adr/README.md からの期待値更新（索引存在検証として存続）。
+      const decisionsReadmePath = path.join(
+        REPO_ROOT,
+        "docs",
+        "decisions",
+        "README.md",
+      );
+      expect(fs.existsSync(decisionsReadmePath)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## 概要

Issue #2137（OU-003、RU-0002 実装順序4〜5）の実装。e2e 期待値更新と pre-existing failure 是正。

- `commands_error_cases.test.ts` の「ADR README.md exists」検査の期待値を `docs/decisions/README.md`（DEC-009 AG-014 の正規索引）へ更新した。検査は廃止せず、Decision 索引の存在検証として存続する（テスト名: `Decision README.md exists (docs/decisions/README.md, DEC-009 AG-014)`）。
- REQ-0030-009/010/011 起因の3クラスタを双方環境で検証した（後述）。本 PR 時点で実失敗は上記1件のみであり、他2クラスタ（Steps section 構造・template skill coverage、case-close body numbered step）は thin Command モデル移行に伴うテスト側 regex 更新（`**STEP-N**` / `**工程-N**` 受容）により本 PR 以前に両環境で pass 済みとなっていた。本 PR で pass 状態を確認した。

### 実装位置に関する補記

Issue 本文（および由来 intake item）は当該検査を `commands_e2e.test.ts` と記載するが、「ADR README.md exists」検査の実装箇所は `commands_error_cases.test.ts`（REQ-0030-011 クラスタ、Issue 完了条件2の「full validation・ADR README.md 存在性」と同一クラスタ）である。このため実装箇所で期待値を更新した（検査廃止ではなく索引存在検証として存続という完了条件1の実質は満たす）。

## 検証（TS-002）

worktree（`.worktrees/2137-feature/`、base a1a9964b、src fallback モード）:

- `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts ./.opencode/skills/repo-agentdev-integrity/scripts/command_fixtures.test.ts ./.opencode/skills/repo-agentdev-integrity/scripts/commands_error_cases.test.ts`
  → 214 pass / 0 fail（Steps section 構造・template skill coverage、case-close body numbered step、full validation、Decision README 索引存在を含む）
- `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/commands_error_cases.test.ts -t "Decision README"` → 1 pass / 0 fail
- full suite `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/` → 1964 pass / 4 fail。fail は修正前から同一の worktree 環境依存（check_templates の --dry-run / --json 計3件。Epic 課題(3) = OU-004 #2138 所管）に加え、単発の負荷起因 flake（launcher.test.ts、単独再実行で 10 pass / 0 fail）。本差分起因の失敗なし。

main baseline（main repo は read-only 実行、同 commit a1a9964b）:

- 修正前 full suite: 1977 pass / 3 fail。fail 内訳は TS-009 エンコーディング（main 作業ディレクトリのみ。後述 Findings）、ADR README.md exists（本 PR の修正対象）、skills_structure の See Also 参照（main のみ。後述 Findings）。
- 3クラスタは main baseline では ADR README 1件のみ失敗（Steps section 構造・template skill coverage、case-close body numbered step、full validation は pass）。
- 修正後の当該アサーションは `existsSync(REPO_ROOT/docs/decisions/README.md)` のみで経路解決モード（projection / src fallback）非依存であり、main 側の `docs/decisions/README.md` 存在（Test-Path で True を確認済み）から main baseline でも pass する。

## Findings / Capture候補

### intake

1. TS-009（commands_e2e.test.ts「実配布物: src/opencode 配下の Markdown に BOM と CRLF/LF 混在は存在しない」）が main 作業ディレクトリのみ失敗する。原因: `src/opencode/skills/*/scripts/node_modules/@types/bun/README.md`（4件、git 管理外）が CRLF/LF 混在で、再帰スキャンが node_modules を除外していない。worktree（node_modules 未配置）では発生しない。checker 実行契約系 SPEC でのスキャン除外規定の候補。
2. skills_structure.test.ts「See Also reference "agentdev-adr-guidelines" points to existing skill directory」が main（projection モード）のみ失敗する。`.opencode/skills/repo-agentdev-integrity/SKILL.md`（24、27、202行目）が DEC-009 AG-013 で改名済みの `agentdev-adr-guidelines`（現 `agentdev-decision-guidelines`）を参照残留しているため。worktree は src fallback で repo-agentdev-integrity が列挙対象外になるため pass する。既存 broken reference 一掃（OU-002 #2136）または陳腐化参照是正（OU-009 #2143）の管轄と思われる。

### learning

(none)

## SPEC確定候補

(none)

Refs: #2137