### PR TITLE
refactor(agentdev): doc-diagnostics 旧手順番号参照の Workflow Skill 工程参照への置換（OU-008、Refs: #2142）

### DIFF
--- a/src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-categories.md
+++ b/src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-categories.md
@@ -138,7 +138,11 @@ docs-spec-rebuild-integrity SPEC が定義する5パターンを配布物整合�
 
 ### ルーティング先
 
-判定ロジック、検出手順、問題候補出力スキーマ（7フィールド）は `agentdev-req-structure-diagnostics` が所有する。本スキルは配布物統合性を inspect-docs Step 11、inspect-skills Step 3 でルーティングし、検出事項を共通 finding 出力契約（`finding-output-contract.md`）へ正規化する。
+判定ロジック、検出手順、問題候補出力スキーマ（7フィールド）は `agentdev-req-structure-diagnostics` が所有する。
+本スキルは配布物統合性を次の Workflow Skill の工程・手順節でルーティングし、検出事項を共通 finding 出力契約（`finding-output-contract.md`）へ正規化する。
+
+- `agentdev-workflow-inspect-docs`: 「配布物整合性検査・route 判定」工程（手順節「配布物整合性検査」、`references/distribution-check-and-output.md`）
+- `agentdev-workflow-inspect-skills`: 「診断観点の評価・分類・route 提示」工程（手順節「配布物構文健全性、責務整合診断」、`references/skill-structure-diagnostics.md`）
 
 ## 安定契約例外の総合判定
 

--- a/src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-routing.md
+++ b/src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-routing.md
@@ -47,23 +47,31 @@ inspect-docs command が実行する docs 横断診断のうち、専門診断�
 専門 skill から返却された検出事項（finding）は、本スキルが定める共通 finding 出力契約（`finding-output-contract.md`）へ適合させて統合する。
 severity、confidence、NG 分類は本スキルの共通契約へ正規化する。
 
-## ルーティング表と inspect-docs Step の対応
+## ルーティング表と inspect-docs workflow 工程の対応
 
-inspect-docs command の各 Step は次のように本スキルと専門 skill を組み合わせる。
+inspect-docs Workflow Skill（`agentdev-workflow-inspect-docs`）の各工程は、次のように本スキルと専門 skill を組み合わせる。
+工程名は同 Skill の SKILL.md Control Plane（工程一覧）に、診断観点は各工程 reference の手順節名に対応する。
 
-| inspect-docs Step | 本スキルの役割 | ルーティング先 |
-|--------------------|----------------|----------------|
-| Step 2: REQ 参照 ID 整合性確認 | 横断スキャンで対象特定 | `agentdev-req-structure-diagnostics` |
-| Step 3: 第一参照導線確認 | 横断スキャンで対象特定 | `agentdev-req-structure-diagnostics` |
-| Step 4: 現行/廃止/世代境界確認 | 横断スキャンで対象特定 | `agentdev-req-structure-diagnostics` |
-| Step 5: SPEC 意味診断 | 横断契約矛盾の抽出（本スキル直接判定） | `agentdev-req-structure-diagnostics`（詳細は委譲） |
-| Step 6: ADR 意味診断 | 横断契約矛盾の抽出（本スキル直接判定） | `agentdev-req-structure-diagnostics`（詳細は委譲） |
-| Step 7: guides 意味診断 | 横断契約矛盾の抽出（本スキル直接判定） | `agentdev-doc-writing`（文意品質） |
-| Step 8: README 索引診断 | 索引の範囲超過の抽出（本スキル直接判定） | 該当なし（本スキル直接判定） |
-| Step 9: REQ structure review（6観点） | 横断比較でシグナル抽出 | `agentdev-req-structure-diagnostics` |
-| Step 10: 文書分類一貫性検査 | 横断スキャンで SPEC 分離基準違反シグナル抽出 | `agentdev-req-structure-diagnostics`（MOVE 観点） |
-| Step 11: 配布物整合性検査 | 対象範囲特定、ルーティング | `agentdev-req-structure-diagnostics` |
-| Step 13: 未処理 artifact 確認 | 横断スキャン（本スキル直接判定） | 該当なし |
+### 「REQ 体系・文書種別別意味診断」工程（`agentdev-workflow-inspect-docs/references/scan-and-doc-diagnostics.md`）
+
+| 診断観点（手順節名） | 本スキルの役割 | ルーティング先 |
+|----------------------|----------------|----------------|
+| REQ 参照ID整合性確認 | 横断スキャンで対象特定 | `agentdev-req-structure-diagnostics` |
+| 第一参照導線確認 | 横断スキャンで対象特定 | `agentdev-req-structure-diagnostics` |
+| 現行/廃止/世代境界確認 | 横断スキャンで対象特定 | `agentdev-req-structure-diagnostics` |
+| SPEC 意味診断 | 横断契約矛盾の抽出（本スキル直接判定） | `agentdev-req-structure-diagnostics`（詳細は委譲） |
+| Decision 意味診断 | 横断契約矛盾の抽出（本スキル直接判定） | `agentdev-req-structure-diagnostics`（詳細は委譲） |
+| guides 意味診断 | 横断契約矛盾の抽出（本スキル直接判定） | `agentdev-doc-writing`（文意品質） |
+| README 索引診断 | 索引の範囲超過の抽出（本スキル直接判定） | 該当なし（本スキル直接判定） |
+| REQ structure review（6観点） | 横断比較でシグナル抽出 | `agentdev-req-structure-diagnostics` |
+| 文書分類一貫性検査 | 横断スキャンで SPEC 分離基準違反シグナル抽出 | `agentdev-req-structure-diagnostics`（MOVE 観点） |
+
+### 「配布物整合性検査・route 判定」工程（`agentdev-workflow-inspect-docs/references/distribution-check-and-output.md`）
+
+| 診断観点（手順節名） | 本スキルの役割 | ルーティング先 |
+|----------------------|----------------|----------------|
+| 配布物整合性検査 | 対象範囲特定、ルーティング | `agentdev-req-structure-diagnostics` |
+| 未処理 artifact 確認 | 横断スキャン（本スキル直接判定） | 該当なし |
 
 ## 責務重複なしの保証（AC-{NNN}）
 


### PR DESCRIPTION
## 概要

agentdev-doc-diagnostics の references に残存していた旧 Command 手順番号直参照（inspect-docs Step 2〜13 表、「inspect-docs Step 11」「inspect-skills Step 3」）を、agentdev-workflow-inspect-docs / agentdev-workflow-inspect-skills の工程名・手順節名参照へ置換した（RU-0011 実質残存課題、DEC-010 準拠）。

Refs: #2142
Parent: #2134

## 変更内容

### `src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-routing.md`

- 「ルーティング表と inspect-docs Step の対応」節（Step 2〜Step 13 の表行）を廃止し、Workflow Skill の工程単位の2表へ再構成した
  - 「REQ 体系・文書種別別意味診断」工程（`agentdev-workflow-inspect-docs/references/scan-and-doc-diagnostics.md`）: 9 診断観点（REQ 参照ID整合性確認、第一参照導線確認、現行/廃止/世代境界確認、SPEC 意味診断、Decision 意味診断、guides 意味診断、README 索引診断、REQ structure review（6観点）、文書分類一貫性検査）
  - 「配布物整合性検査・route 判定」工程（`agentdev-workflow-inspect-docs/references/distribution-check-and-output.md`）: 2 診断観点（配布物整合性検査、未処理 artifact 確認）
- 工程名は inspect-docs SKILL.md Control Plane（工程一覧）の名称列、診断観点は各工程 reference の手順節名に対応させる。手順番号には依存しないため、OU-010（STEP 識別子実番号化）の影響を受けない
- 旧表の「ADR 意味診断」は参照先の実在節名「Decision 意味診断」へ用語を合わせた

### `src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-categories.md`

- 配布物統合性のルーティング先記述「inspect-docs Step 11、inspect-skills Step 3」を、工程名・手順節名参照のリストへ置換した
  - `agentdev-workflow-inspect-docs`: 「配布物整合性検査・route 判定」工程（手順節「配布物整合性検査」）
  - `agentdev-workflow-inspect-skills`: 「診断観点の評価・分類・route 提示」工程（手順節「配布物構文健全性、責務整合診断」）

対象 Workflow Skill（agentdev-workflow-inspect-docs / agentdev-workflow-inspect-skills）のファイルは編集していない（read-only 参照先）。

## 検証結果（TS-OU008-1）

### 旧手順番号直参照の残存確認（grep）

| パターン | 対象ファイル | 置換前 | 置換後 |
|---|---|---|---|
| `Step\s*\d` | diagnostic-routing.md | 11 件 | 0 件 |
| `Step\s*\d` | diagnostic-categories.md | 2 件 | 0 件 |
| `(inspect-docs\|inspect-skills)\s+Step` | diagnostic-routing.md | 2 件 | 0 件 |
| `(inspect-docs\|inspect-skills)\s+Step` | diagnostic-categories.md | 2 件 | 0 件 |

置換前の内訳: diagnostic-routing.md は表の Step 2〜11、13 行（11件）と節見出し・表ヘッダの「inspect-docs Step」表記（2件）、diagnostic-categories.md は「inspect-docs Step 11、inspect-skills Step 3」行。

### 参照解決確認（置換後参照 → 参照先実ファイル）

15 の工程名・手順節名参照と 3 つの reference ファイルパス、計 18/18 が解決することを確認した。

| 参照先ファイル | 解決確認した工程名・節名 |
|---|---|
| agentdev-workflow-inspect-docs/SKILL.md | 「REQ 体系・文書種別別意味診断」「配布物整合性検査・route 判定」（Control Plane 工程一覧） |
| agentdev-workflow-inspect-docs/references/scan-and-doc-diagnostics.md | REQ 参照ID整合性確認 / 第一参照導線確認 / 現行/廃止/世代境界確認 / SPEC 意味診断 / Decision 意味診断 / guides 意味診断 / README 索引診断 / REQ structure review（6観点）/ 文書分類一貫性検査 |
| agentdev-workflow-inspect-docs/references/distribution-check-and-output.md | 配布物整合性検査 / 未処理 artifact 確認 |
| agentdev-workflow-inspect-skills/SKILL.md | 「診断観点の評価・分類・route 提示」（Control Plane 工程一覧） |
| agentdev-workflow-inspect-skills/references/skill-structure-diagnostics.md | 「配布物構文健全性、責務整合診断」 |

### その他の確認

- 旧節見出し「ルーティング表と inspect-docs Step の対応」への外部参照なし（git grep 0 件）
- 編集後ファイルは BOM なし UTF-8 を保持（バイト先頭確認）
- `docs/requirements/**`、`docs/decisions/**`、`docs/specs/**` は未編集

## Findings / Capture候補

### intake

(none)

### learning

(none)

## SPEC確定候補

- agentdev-workflow-inspect-docs の各 reference の手順節ヘッダは旧 Command 手順の通し番号（scan-and-doc-diagnostics.md が Step 1〜10、distribution-check-and-output.md が Step 11〜17）をファイル分割で引き継いでいる。Workflow Skill 工程単位の採番へ再整理する候補（OU-010 の STEP 識別子実番号化と並行する検討対象）。本 PR の参照は節名ベースのため、再採番の影響を受けない