### PR TITLE
refactor(agentdev): 導入系スクリプト定数共有化と Workflow Skill 順序ラベル統一（RU-0014/RU-0015、Refs: #2144）

### DIFF
--- a/scripts/check-consumer-opencode.ps1
+++ b/scripts/check-consumer-opencode.ps1
@@ -48,6 +48,9 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# 共有定義（URL・ブランチ定数、cwd 安全化、チェックアウト案内。RU-0014、AG-020）
+. (Join-Path $PSScriptRoot 'consumer-opencode-common.ps1')
+
 $RepoRoot = $PWD.Path
 $PluginPath = Join-Path $RepoRoot $PluginDir
 $SourceDir = Join-Path $PluginPath 'src\opencode'
@@ -60,39 +63,6 @@ $SkillsDir = Join-Path $ProjectionDir 'skills'
 $LocalModeRedirectSkill = 'agentdev-gh-cli'
 
 # --- Helper Functions ---
-
-function Assert-ValidConsumerCwd {
-    <#
-    .SYNOPSIS
-        実行ディレクトリが AgentDevFlow 導入先として適切か検査する。
-        想定外ディレクトリの場合、即座に停止する（REQ-{NNNN}-{NNN}）。
-    #>
-    $cwd = $PWD.Path
-
-    # 1. .agentdev-plugin/ 配下（チェックアウト配置先）
-    if ($cwd -match '[\\/]\.agentdev-plugin([\\/]|$)') {
-        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow のチェックアウト配置先です。1つ上のフォルダへ移動してください。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
-        exit 1
-    }
-
-    # 2. src/opencode/ 配下（原本領域）
-    if ($cwd -match '[\\/]src[\\/]opencode([\\/]|$)') {
-        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow の原本領域です。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
-        exit 1
-    }
-
-    # 3. .opencode/ 配下（実行時領域）
-    if ($cwd -match '[\\/]\.opencode([\\/]|$)') {
-        Write-Host "現在のフォルダ: $cwd。このフォルダは OpenCode の実行時領域です。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
-        exit 1
-    }
-
-    # 4. .git 無し（Git リポジトリでない）
-    if (-not (Test-Path -LiteralPath (Join-Path $cwd '.git'))) {
-        Write-Host "現在のフォルダ: $cwd。このフォルダは Git リポジトリではありません。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
-        exit 1
-    }
-}
 
 function Test-Junction {
     param([string]$Path)
@@ -125,34 +95,9 @@ function Get-TargetSourcePath {
 
 # --- Checkout Guidance (AG-003/REQ-009-047) ---
 
-# 案内表示用の既定値（当スクリプトは provisioning を行わないため、案内以外では使用しない）
-$DefaultRepoUrl = 'https://github.com/yogata/agent-dev-flow.git'
-$DefaultBranch = 'main'
-
-function Show-PluginCheckoutGuidance {
-    <#
-    .SYNOPSIS
-        チェックアウト未検出時の案内。provisioning（clone、fetch、reset）も network access も
-        代行実行しない（AG-001/REQ-009-046、DEC-016）。チェックアウトの取得は利用者の責務。
-    #>
-    $repoWebUrl = $DefaultRepoUrl -replace '\.git$', ''
-    Write-Host "[ERROR] 利用可能なチェックアウトが見つかりません。usable checkout 判定（$PluginDir/src/opencode/ の存在）に失敗しました。"
-    Write-Host ''
-    Write-Host 'このスクリプトは provisioning（clone、fetch、reset）と network access を行いません（REQ-009-046、DEC-016）。'
-    Write-Host '以下のいずれかで agent-dev-flow のチェックアウトを用意してから再実行してください。'
-    Write-Host ''
-    Write-Host '方法1: git clone でチェックアウトを用意する'
-    Write-Host "  git clone --branch $DefaultBranch $DefaultRepoUrl $PluginDir"
-    Write-Host ''
-    Write-Host '方法2: ソース ZIP を取得して展開する'
-    Write-Host "  1. $repoWebUrl を開く"
-    Write-Host '  2. [Code] ボタン → [Download ZIP] でソース ZIP をダウンロード'
-    Write-Host "  3. ZIP を展開し、中身（src/、scripts/ 等）を $PluginDir/ 直下に配置"
-    Write-Host "     （$PluginDir/src/opencode/ が存在すればよく、.git のない ZIP 展開チェックアウトも正規の配置形態）"
-    Write-Host ''
-    Write-Host "期待される状態: $SourceDir が存在すること"
-    exit 1
-}
+# 案内文言・既定 URL 定数は consumer-opencode-common.ps1 の共有定義を使用する（RU-0014、AG-020）。
+# 当スクリプトは provisioning を行わないため、案内以外では使用しない。
+# clone コマンドは既定ブランチ付き、ZIP 配置の補足は当スクリプトの案内文言を維持する。
 
 # --- Main ---
 
@@ -167,7 +112,9 @@ $divergences = 0
 # ZIP 展開チェックアウト（.git なし）も正規の配置形態とする。チェックアウト未検出時は
 # エラー停止して clone とソース ZIP の手順を案内する（provisioning の代行はしない）。
 if (-not (Test-Path -LiteralPath $SourceDir)) {
-    Show-PluginCheckoutGuidance
+    Show-ConsumerCheckoutGuidance -PluginDir $PluginDir -SourceDir $SourceDir `
+        -CloneCommandLine "git clone --branch $ConsumerDefaultBranch $ConsumerRepoUrl $PluginDir" `
+        -ZipNoteLines @("   （$PluginDir/src/opencode/ が存在すればよく、.git のない ZIP 展開チェックアウトも正規の配置形態）")
 } else {
     Write-Host "[OK] Usable checkout exists: $PluginDir/src/opencode/"
     # git リポジトリ性は乖離ではなく情報として報告する（AG-003/REQ-009-048）。

--- a/scripts/consumer-opencode-common.ps1
+++ b/scripts/consumer-opencode-common.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    check-consumer-opencode.ps1 / install-consumer-opencode.ps1 共有定義モジュール。
+
+.DESCRIPTION
+    導入系スクリプト2本の共通定義（既定リポジトリ URL・ブランチ定数、cwd 安全化、
+    チェックアウト未検出時の案内文言）を単一定義として所有する（RU-0014、AG-020）。
+    両スクリプトから dot-source され、二重管理を解消する。本モジュール単体では
+    実行しない。利用者可視挙動の変更を伴わない内部再構成である（DEC-016）。
+
+    スクリプトを `./scripts/` として導入先リポジトリに置く場合は本ファイルも
+    同一チェックアウトからコピーすること（スクリプト群の版不一致防止）。
+#>
+
+#Requires -Version 7.0
+
+# 既定の provisioning 先（案内表示用。当モジュールを読むスクリプトは provisioning を行わない）
+$ConsumerRepoUrl = 'https://github.com/yogata/agent-dev-flow.git'
+$ConsumerDefaultBranch = 'main'
+
+function Assert-ValidConsumerCwd {
+    <#
+    .SYNOPSIS
+        実行ディレクトリが AgentDevFlow 導入先として適切か検査する。
+        想定外ディレクトリの場合、即座に停止する（REQ-{NNNN}-{NNN}）。
+    #>
+    $cwd = $PWD.Path
+
+    # 1. .agentdev-plugin/ 配下（チェックアウト配置先、REQ-009-041）
+    if ($cwd -match '[\\/]\.agentdev-plugin([\\/]|$)') {
+        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow のチェックアウト配置先です。1つ上のフォルダへ移動してください。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        exit 1
+    }
+
+    # 2. src/opencode/ 配下（原本領域）
+    if ($cwd -match '[\\/]src[\\/]opencode([\\/]|$)') {
+        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow の原本領域です。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        exit 1
+    }
+
+    # 3. .opencode/ 配下（実行時領域）
+    if ($cwd -match '[\\/]\.opencode([\\/]|$)') {
+        Write-Host "現在のフォルダ: $cwd。このフォルダは OpenCode の実行時領域です。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        exit 1
+    }
+
+    # 4. .git 無し（Git リポジトリでない）
+    if (-not (Test-Path -LiteralPath (Join-Path $cwd '.git'))) {
+        Write-Host "現在のフォルダ: $cwd。このフォルダは Git リポジトリではありません。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
+        exit 1
+    }
+}
+
+function Show-ConsumerCheckoutGuidance {
+    <#
+    .SYNOPSIS
+        チェックアウト未検出時の案内。provisioning（clone、fetch、reset）も network access も
+        代行実行しない（AG-001/REQ-009-046、DEC-016）。チェックアウトの取得は利用者の責務。
+
+    .PARAMETER PluginDir
+        チェックアウト配置先ディレクトリ名。
+
+    .PARAMETER SourceDir
+        期待される src/opencode/ の絶対パス（期待される状態行の表示用）。
+
+    .PARAMETER CloneCommandLine
+        方法1 に表示する git clone コマンド行（呼び出し元スクリプトで組み立てる）。
+
+    .PARAMETER ZipNoteLines
+        方法2 の ZIP 配置手順に続く補足行群（先頭インデント込み、呼び出し元スクリプト固有の行）。
+    #>
+    param(
+        [string]$PluginDir,
+        [string]$SourceDir,
+        [string]$CloneCommandLine,
+        [string[]]$ZipNoteLines = @()
+    )
+    $repoWebUrl = $ConsumerRepoUrl -replace '\.git$', ''
+    Write-Host "[ERROR] 利用可能なチェックアウトが見つかりません。usable checkout 判定（$PluginDir/src/opencode/ の存在）に失敗しました。"
+    Write-Host ''
+    Write-Host 'このスクリプトは provisioning（clone、fetch、reset）と network access を行いません（REQ-009-046、DEC-016）。'
+    Write-Host '以下のいずれかで agent-dev-flow のチェックアウトを用意してから再実行してください。'
+    Write-Host ''
+    Write-Host '方法1: git clone でチェックアウトを用意する'
+    Write-Host "  $CloneCommandLine"
+    Write-Host ''
+    Write-Host '方法2: ソース ZIP を取得して展開する'
+    Write-Host "  1. $repoWebUrl を開く"
+    Write-Host '  2. [Code] ボタン → [Download ZIP] でソース ZIP をダウンロード'
+    Write-Host "  3. ZIP を展開し、中身（src/、scripts/ 等）を $PluginDir/ 直下に配置"
+    foreach ($noteLine in $ZipNoteLines) {
+        Write-Host "  $noteLine"
+    }
+    Write-Host ''
+    Write-Host "期待される状態: $SourceDir が存在すること"
+    exit 1
+}

--- a/scripts/install-consumer-opencode.ps1
+++ b/scripts/install-consumer-opencode.ps1
@@ -67,6 +67,9 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# 共有定義（URL・ブランチ定数、cwd 安全化、チェックアウト案内。RU-0014、AG-020）
+. (Join-Path $PSScriptRoot 'consumer-opencode-common.ps1')
+
 $RepoRoot = $PWD.Path
 $PluginPath = Join-Path $RepoRoot $PluginDir
 $SourceDir = Join-Path $PluginPath 'src\opencode'
@@ -83,39 +86,6 @@ $RepoLocalSkillPrefix = 'repo-'
 $LocalModeRedirectSkill = 'agentdev-gh-cli'
 
 # --- Helper Functions ---
-
-function Assert-ValidConsumerCwd {
-    <#
-    .SYNOPSIS
-        実行ディレクトリが AgentDevFlow 導入先として適切か検査する。
-        想定外ディレクトリの場合、即座に停止する（REQ-{NNNN}-{NNN}）。
-    #>
-    $cwd = $PWD.Path
-
-    # 1. .agentdev-plugin/ 配下（チェックアウト配置先、REQ-009-041）
-    if ($cwd -match '[\\/]\.agentdev-plugin([\\/]|$)') {
-        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow のチェックアウト配置先です。1つ上のフォルダへ移動してください。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
-        exit 1
-    }
-
-    # 2. src/opencode/ 配下（原本領域）
-    if ($cwd -match '[\\/]src[\\/]opencode([\\/]|$)') {
-        Write-Host "現在のフォルダ: $cwd。このフォルダは agent-dev-flow の原本領域です。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
-        exit 1
-    }
-
-    # 3. .opencode/ 配下（実行時領域）
-    if ($cwd -match '[\\/]\.opencode([\\/]|$)') {
-        Write-Host "現在のフォルダ: $cwd。このフォルダは OpenCode の実行時領域です。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
-        exit 1
-    }
-
-    # 4. .git 無し（Git リポジトリでない）
-    if (-not (Test-Path -LiteralPath (Join-Path $cwd '.git'))) {
-        Write-Host "現在のフォルダ: $cwd。このフォルダは Git リポジトリではありません。AgentDevFlow をインストールしたいリポジトリの一番上のフォルダ（.git がある場所）で実行してください。"
-        exit 1
-    }
-}
 
 function Invoke-InstallWizard {
     <#
@@ -218,32 +188,17 @@ function Get-TargetSourcePath {
 
 # --- Checkout Guidance (AG-002/REQ-009-047) ---
 
-function Show-PluginCheckoutGuidance {
-    <#
-    .SYNOPSIS
-        チェックアウト未検出時の案内。provisioning（clone、fetch、reset）も network access も
-        代行実行しない（AG-001/REQ-009-046、DEC-016）。チェックアウトの取得は利用者の責務。
-    #>
-    $repoUrl = 'https://github.com/yogata/agent-dev-flow.git'
-    $repoWebUrl = $repoUrl -replace '\.git$', ''
-    Write-Host "[ERROR] 利用可能なチェックアウトが見つかりません。usable checkout 判定（$PluginDir/src/opencode/ の存在）に失敗しました。"
-    Write-Host ''
-    Write-Host 'このスクリプトは provisioning（clone、fetch、reset）と network access を行いません（REQ-009-046、DEC-016）。'
-    Write-Host '以下のいずれかで agent-dev-flow のチェックアウトを用意してから再実行してください。'
-    Write-Host ''
-    Write-Host '方法1: git clone でチェックアウトを用意する'
-    Write-Host "  git clone $repoUrl $PluginDir"
-    Write-Host ''
-    Write-Host '方法2: ソース ZIP を取得して展開する'
-    Write-Host "  1. $repoWebUrl を開く"
-    Write-Host '  2. [Code] ボタン → [Download ZIP] でソース ZIP をダウンロード'
-    Write-Host "  3. ZIP を展開し、中身（src/、scripts/ 等）を $PluginDir/ 直下に配置"
-    Write-Host "     注意: ZIP 展開直後の agent-dev-flow-<ref>/ の一段ネストを避け、$PluginDir/src/opencode/ となる配置にすること"
-    Write-Host "     （.git のない ZIP 展開チェックアウトも正規の配置形態）"
-    Write-Host "  4. scripts/ は $PluginDir/ と同一チェックアウトからコピーすること（スクリプトとチェックアウトの版不一致の防止）"
-    Write-Host ''
-    Write-Host "期待される状態: $SourceDir が存在すること"
-    exit 1
+# 案内文言・既定 URL 定数は consumer-opencode-common.ps1 の共有定義を使用する（RU-0014、AG-020）。
+# clone コマンドはブランチ指定なし、ZIP 配置の補足（ネスト回避、scripts/ 同一チェックアウトコピー）は
+# 当スクリプトの案内文言を維持する。
+function Invoke-PluginCheckoutGuidance {
+    Show-ConsumerCheckoutGuidance -PluginDir $PluginDir -SourceDir $SourceDir `
+        -CloneCommandLine "git clone $ConsumerRepoUrl $PluginDir" `
+        -ZipNoteLines @(
+            "   注意: ZIP 展開直後の agent-dev-flow-<ref>/ の一段ネストを避け、$PluginDir/src/opencode/ となる配置にすること",
+            "   （.git のない ZIP 展開チェックアウトも正規の配置形態）",
+            "4. scripts/ は $PluginDir/ と同一チェックアウトからコピーすること（スクリプトとチェックアウトの版不一致の防止）"
+        )
 }
 
 # --- Main ---
@@ -260,7 +215,7 @@ if (-not $Mode) {
 # 全モード（check、dry-run、apply）共通の前提であり、provisioning は行わない（AG-001/REQ-009-046、DEC-016）。
 # ZIP 展開チェックアウト（.git なし）も正規の配置形態として扱う（AG-003/REQ-009-048）。
 if (-not (Test-Path -LiteralPath $SourceDir)) {
-    Show-PluginCheckoutGuidance
+    Invoke-PluginCheckoutGuidance
 }
 
 # LocalMode requires the local source redirect target to exist

--- a/src/opencode/skills/agentdev-workflow-case-auto/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-auto/SKILL.md
@@ -76,22 +76,22 @@ case-auto workflow は次の8 STEP で構成する。各 STEP は resume point �
 
 | STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
 |---|---|---|---|---|
-| STEP-{N} | 入力解決・開始時刻記録 | case-auto 起動 | 入力モード確定、`case_auto_started_at` 記録 | [references/input-resolution-and-orchestration.md](references/input-resolution-and-orchestration.md) |
-| STEP-{N} | work_type 読取・工程分岐 | 入力解決完了 | 工程順序確定（artifact_actions ベース、auto_gate preflight） | [references/input-resolution-and-orchestration.md](references/input-resolution-and-orchestration.md) |
-| STEP-{N} | orchestration 実行 | 工程順序確定 | 各工程の実行結果、stage モデル適用、Wave 反復、bg task 状態管理 | [references/input-resolution-and-orchestration.md](references/input-resolution-and-orchestration.md) |
-| STEP-{N} | 停止条件検出・停止理由分類 | 各工程の結果受領 | 停止判定（11項目）、停止理由分類（7軸＋上位合意矛盾/新規ユーザー判断） | [references/stop-and-decision-resolution.md](references/stop-and-decision-resolution.md) |
-| STEP-{N} | adversarial-review 経路H 停止伝播 | user-decision-required + decision_context 受領 | 当該 execution_unit の自走停止、ユーザー判断待機 | [references/stop-and-decision-resolution.md](references/stop-and-decision-resolution.md) |
-| STEP-{N} | bounded parent decision resolution | decision_context 受領 | 自律解決 / 作業仮定 / 上位合意矛盾停止 / 新規ユーザー判断停止 | [references/stop-and-decision-resolution.md](references/stop-and-decision-resolution.md) |
-| STEP-{N} | コンフリクト解消 Level 2/3 | case-close から Level 1 失敗エスカレーション受領 | インライン case-run 再実行（最大2回）、オーケストレーション級判断、解消 or 停止 | [references/conflict-resolution-and-reporting.md](references/conflict-resolution-and-reporting.md) |
-| STEP-{N} | 完了報告 | 全工程完了 or 停止 | L1 タイムスタンプ、4次元集約、OU処理ループ、結果状態の分離報告 | [references/conflict-resolution-and-reporting.md](references/conflict-resolution-and-reporting.md) |
+| STEP-1 | 入力解決・開始時刻記録 | case-auto 起動 | 入力モード確定、`case_auto_started_at` 記録 | [references/input-resolution-and-orchestration.md](references/input-resolution-and-orchestration.md) |
+| STEP-2 | work_type 読取・工程分岐 | 入力解決完了 | 工程順序確定（artifact_actions ベース、auto_gate preflight） | [references/input-resolution-and-orchestration.md](references/input-resolution-and-orchestration.md) |
+| STEP-3 | orchestration 実行 | 工程順序確定 | 各工程の実行結果、stage モデル適用、Wave 反復、bg task 状態管理 | [references/input-resolution-and-orchestration.md](references/input-resolution-and-orchestration.md) |
+| STEP-4 | 停止条件検出・停止理由分類 | 各工程の結果受領 | 停止判定（11項目）、停止理由分類（7軸＋上位合意矛盾/新規ユーザー判断） | [references/stop-and-decision-resolution.md](references/stop-and-decision-resolution.md) |
+| STEP-5 | adversarial-review 経路H 停止伝播 | user-decision-required + decision_context 受領 | 当該 execution_unit の自走停止、ユーザー判断待機 | [references/stop-and-decision-resolution.md](references/stop-and-decision-resolution.md) |
+| STEP-6 | bounded parent decision resolution | decision_context 受領 | 自律解決 / 作業仮定 / 上位合意矛盾停止 / 新規ユーザー判断停止 | [references/stop-and-decision-resolution.md](references/stop-and-decision-resolution.md) |
+| STEP-7 | コンフリクト解消 Level 2/3 | case-close から Level 1 失敗エスカレーション受領 | インライン case-run 再実行（最大2回）、オーケストレーション級判断、解消 or 停止 | [references/conflict-resolution-and-reporting.md](references/conflict-resolution-and-reporting.md) |
+| STEP-8 | 完了報告 | 全工程完了 or 停止 | L1 タイムスタンプ、4次元集約、OU処理ループ、結果状態の分離報告 | [references/conflict-resolution-and-reporting.md](references/conflict-resolution-and-reporting.md) |
 
 ### STEP 間の依存と分岐
 
-- **正常経路**: STEP-{N} → STEP-{N} → STEP-{N} → STEP-{N}（全工程完了時）
-- **停止経路**: STEP-{N} → STEP-{N}（停止条件検出時）→ STEP-{N}（停止報告）
-- **経路H**: STEP-{N} → STEP-{N}（user-decision-required 受領時）→ ユーザー判断待機 → resume point から再開
-- **bounded parent decision**: STEP-{N} → STEP-{N}（decision_context 受領時）→ 自律解決時は STEP-{N} へ戻る、上位合意矛盾/新規ユーザー判断時は STEP-{N} 停止経路へ
-- **コンフリクトエスカレーション**: STEP-{N}（case-close 委譲時）→ STEP-{N}（Level 1 失敗時）→ 解消時は STEP-{N} へ戻る、Level 3 失敗時は STEP-{N} 停止経路へ
+- **正常経路**: STEP-1 → STEP-2 → STEP-3 → STEP-8（全工程完了時）
+- **停止経路**: STEP-3 → STEP-4（停止条件検出時）→ STEP-8（停止報告）
+- **経路H**: STEP-3 → STEP-5（user-decision-required 受領時）→ ユーザー判断待機 → resume point から再開
+- **bounded parent decision**: STEP-3 → STEP-6（decision_context 受領時）→ 自律解決時は STEP-3 へ戻る、上位合意矛盾/新規ユーザー判断時は STEP-4 停止経路へ
+- **コンフリクトエスカレーション**: STEP-3（case-close 委譲時）→ STEP-7（Level 1 失敗時）→ 解消時は STEP-3 へ戻る、Level 3 失敗時は STEP-4 停止経路へ
 
 ### resume protocol
 
@@ -137,7 +137,7 @@ case-auto workflow は次の8 STEP で構成する。各 STEP は resume point �
 - **自走境界（G01-G06）**: repo にファイルとして残る変更のみ自走対象。DB migration 実行、deploy/apply、クラウドリソース操作、外部SaaS 設定変更、課金、権限、認証情報、repo外実データ操作、通知送信は対象外
 - **委譲・参照制約（G07-G09, G13-G21, G27-G32）**: 各工程は対応するコマンド定義を authoritative source として実行（case-auto 定義内再実装回避）。case-run はインライン実行（標準動作、AG-{NNN}）。Epic Issue 本文書き込みは case-close 単一書き手（case-auto は読取のみ、G16）。case-auto は Issue 階層決定ロジックを持たない（G13）、Epic Issue 化の判定に関与しない（G21）
 - **3つの「5件」文脈の区別**: (1) case-run Wave 内子 Issue 並列、(2) case-auto Phase 2 同時起動数、(3) execution_unit 全体並列（上限なし）。混同しない
-- **OU処理ループ**: Standard flow の case-close 完了後に未処理 OU が残存する場合は次 OU の処理を STEP-{N} から開始（全 OU 処理完了時のみ全体完了報告）
+- **OU処理ループ**: Standard flow の case-close 完了後に未処理 OU が残存する場合は次 OU の処理を STEP-3 から開始（全 OU 処理完了時のみ全体完了報告）
 - **親コンテキスト非累積（G28）**: 委譲工程の完了結果（Issue/PR番号、pass/warn/fail）のみを親コンテキストに保持し、委譲工程内部の調査過程、中間ログ、読解メモを親コンテキストに累積しない
 - **L1 タイムスタンプ**: 開始時刻（`case_auto_started_at`）、工程別タイムスタンプ（req-save+spec-save 統合委譲 / case-open / case-run / case-close）、終了時刻を記録。case-run の L2 内訳は case-run result から読み取って含める
 

--- a/src/opencode/skills/agentdev-workflow-case-auto/references/conflict-resolution-and-reporting.md
+++ b/src/opencode/skills/agentdev-workflow-case-auto/references/conflict-resolution-and-reporting.md
@@ -1,8 +1,8 @@
-# STEP-{N}/8: コンフリクト解消 Level 2/3・完了報告（conflict-resolution-and-reporting）
+# STEP-7/8: コンフリクト解消 Level 2/3・完了報告（conflict-resolution-and-reporting）
 
-> 本 reference は `agentdev-workflow-case-auto` SKILL.md の Control Plane STEP-{N}, STEP-{N} 詳細である。コンフリクト解消 Level 2/3（インライン case-run 再実行、オーケストレーション級判断）と完了報告（L1 タイムスタンプ、4次元集約、OU処理ループ）を提供する。
+> 本 reference は `agentdev-workflow-case-auto` SKILL.md の Control Plane STEP-7, STEP-8 詳細である。コンフリクト解消 Level 2/3（インライン case-run 再実行、オーケストレーション級判断）と完了報告（L1 タイムスタンプ、4次元集約、OU処理ループ）を提供する。
 
-## STEP-{N}: コンフリクト解消 Level 2/3
+## STEP-7: コンフリクト解消 Level 2/3
 
 ### Purpose
 
@@ -27,14 +27,14 @@ PR マージコンフリクト発生時は、以下3レベルのエスカレー�
 |---|---|---|---|
 | Level 1 | case-close | `git rebase` による機械的解消、自動解決時は再マージ | case-auto へエスカレーション |
 | Level 2 | case-auto | 両PR の diff を読み取りコンフリクト箇所を特定しコンフリクト文脈を付けてインライン case-run を再実行、最大2回（元の並列実行を含む計3回の case-run 実行 AG-{NNN}） | Level 3 へ |
-| Level 3 | case-auto | マージ順序変更、blocked 単位の隔離 | 停止（STEP-{N} 停止条件 (8)） |
+| Level 3 | case-auto | マージ順序変更、blocked 単位の隔離 | 停止（STEP-4 停止条件 (8)） |
 
 Level 2 コンフリクト文脈付きインライン case-run 再実行（AG-{NNN}）、Level 3 オーケストレーション級判断、発生元非依存、停止条件の段階化の詳細は `agentdev-workflow-orchestration` を参照。
 
 ### Result
 
-- コンフリクト解消（Level 2 or 3 で解消時）→ STEP-{N} へ戻り再マージ
-- 解消不能時（Level 3 失敗）→ STEP-{N} 停止経路（停止条件 (8)）
+- コンフリクト解消（Level 2 or 3 で解消時）→ STEP-3 へ戻り再マージ
+- 解消不能時（Level 3 失敗）→ STEP-4 停止経路（停止条件 (8)）
 
 ### Evidence
 
@@ -48,7 +48,7 @@ Level 2 コンフリクト文脈付きインライン case-run 再実行（AG-{N
 
 - Level 2 再実行は回数上限（最大2回）を durable に数え、上限到達時は Level 3 へ遷移する。解消済みコンフリクトの再処理は行わない
 
-## STEP-{N}: 完了報告
+## STEP-8: 完了報告
 
 ### Purpose
 
@@ -63,7 +63,7 @@ Level 2 コンフリクト文脈付きインライン case-run 再実行（AG-{N
 
 ### Preconditions
 
-- 全工程完了 または 停止判定（STEP-{N}/5/6/7 のいずれか）
+- 全工程完了 または 停止判定（STEP-4/5/6/7 のいずれか）
 
 ### Procedure
 
@@ -71,7 +71,7 @@ Level 2 コンフリクト文脈付きインライン case-run 再実行（AG-{N
 
 完了報告には以下を含める（停止時フォーマットを含む）。
 
-- **停止理由分類**: STEP-{N} 経由、または経路H の user-decision-required
+- **停止理由分類**: STEP-4 経由、または経路H の user-decision-required
 - **開始時刻・終了時刻・所要時間**: 人間が読みやすい形式
 - **工程別タイムスタンプ内訳（L1）**: req-save+spec-save 統合委譲 / case-open / case-run / case-close、スキップした工程は除外可、case-run の L2 内訳は case-run result から読み取って含める
 - **インライン実行の記録**: case-run をインライン実行した旨
@@ -89,7 +89,7 @@ Level 2 コンフリクト文脈付きインライン case-run 再実行（AG-{N
 
 #### OU処理ループ
 
-Standard flow の case-close 完了後に未処理 OU が残存する場合は次 OU の処理を STEP-{N} から開始（全 OU 処理完了時のみ全体完了報告）。
+Standard flow の case-close 完了後に未処理 OU が残存する場合は次 OU の処理を STEP-3 から開始（全 OU 処理完了時のみ全体完了報告）。
 
 ### Result
 
@@ -116,8 +116,8 @@ Standard flow の case-close 完了後に未処理 OU が残存する場合は�
 
 ## 関連 STEP
 
-- 前: STEP-{N}（input-resolution-and-orchestration）、STEP-{N}（stop-and-decision-resolution）、STEP-{N}（bounded parent decision resolution 上位合意矛盾/新規ユーザー判断時）
-- 次: なし（workflow 終了、または OU処理ループで STEP-{N} へ戻る）
+- 前: STEP-3（input-resolution-and-orchestration）、STEP-4（stop-and-decision-resolution）、STEP-6（bounded parent decision resolution 上位合意矛盾/新規ユーザー判断時）
+- 次: なし（workflow 終了、または OU処理ループで STEP-3 へ戻る）
 
 ## 関連 Capability Skill
 

--- a/src/opencode/skills/agentdev-workflow-case-auto/references/input-resolution-and-orchestration.md
+++ b/src/opencode/skills/agentdev-workflow-case-auto/references/input-resolution-and-orchestration.md
@@ -1,14 +1,14 @@
-# STEP-{N}/2/3: 入力解決・工程分岐・orchestration 実行（input-resolution-and-orchestration）
+# STEP-1/2/3: 入力解決・工程分岐・orchestration 実行（input-resolution-and-orchestration）
 
-> 本 reference は `agentdev-workflow-case-auto` SKILL.md の Control Plane STEP-{N}, STEP-{N}, STEP-{N} 詳細である。入力解決、work_type 読取・工程分岐、orchestration 実行（stage モデル、Wave 反復、bg task 管理）を提供する。
+> 本 reference は `agentdev-workflow-case-auto` SKILL.md の Control Plane STEP-1, STEP-2, STEP-3 詳細である。入力解決、work_type 読取・工程分岐、orchestration 実行（stage モデル、Wave 反復、bg task 管理）を提供する。
 
 ## 目次
 
-- STEP-{N}: 入力解決・開始時刻記録
-- STEP-{N}: work_type 読取・工程分岐
-- STEP-{N}: orchestration 実行
+- STEP-1: 入力解決・開始時刻記録
+- STEP-2: work_type 読取・工程分岐
+- STEP-3: orchestration 実行
 
-## STEP-{N}: 入力解決・開始時刻記録
+## STEP-1: 入力解決・開始時刻記録
 
 ### Purpose
 
@@ -27,9 +27,9 @@
 
 ### Procedure
 
-実行開始時刻を JST（Etc/GMT-{N}）で記録し `case_auto_started_at` に保持。STEP-{N}（停止時報告）・STEP-{N}（完了報告）での所要時間算出の基準として使用。
+実行開始時刻を JST（Etc/GMT-{N}）で記録し `case_auto_started_at` に保持。STEP-8（停止時報告）・STEP-8（完了報告）での所要時間算出の基準として使用。
 
-- **Issue番号/URL入力モード**: 引数が数値のみまたは GitHub Issue URL の場合、Issue番号として解決し case-run 移行モードへ分岐（STEP-{N} の Issue番号/URL入力分岐へ）。要件doc入力より優先。要件doc の入力解決・work_type 読取はスキップ
+- **Issue番号/URL入力モード**: 引数が数値のみまたは GitHub Issue URL の場合、Issue番号として解決し case-run 移行モードへ分岐（STEP-1 の Issue番号/URL入力分岐へ）。要件doc入力より優先。要件doc の入力解決・work_type 読取はスキップ
 - **要件doc入力モード**:
   - (1) 引数なし: `.agentdev/drafts/req-draft-*.md` 全件処理（デフォルト）。1件以上なら全件（1件含む）処理、0件なら停止し req-define 実行またはパス指定を求める。複数draftは無確認で全件処理
   - (2) 明示パス指定: 当該draftのみ。不在時は停止しエラー報告
@@ -54,7 +54,7 @@
 
 - 読取と記録のみで副作用を持たない。`case_auto_started_at` は durable state として停止時報告・完了報告で再利用する
 
-## STEP-{N}: work_type 読取・工程分岐
+## STEP-2: work_type 読取・工程分岐
 
 ### Purpose
 
@@ -69,7 +69,7 @@
 
 ### Preconditions
 
-- STEP-{N} で入力解決完了
+- STEP-1 で入力解決完了
 
 ### Procedure
 
@@ -77,7 +77,7 @@
 
 #### 工程分岐（`work_type` 固定分岐ではなく `artifact_actions` 存在による動的判定）
 
-- **Issue番号/URL入力**: case-run → case-close（req-save、spec-save、case-open、work_type読取をスキップ）。STEP-{N} で解決した Issue番号/URL を case-run にそのまま渡す。draft-data の読取は行わない
+- **Issue番号/URL入力**: case-run → case-close（req-save、spec-save、case-open、work_type読取をスキップ）。STEP-1 で解決した Issue番号/URL を case-run にそのまま渡す。draft-data の読取は行わない
 - **artifact_actions ベース分岐**:
   - `artifact: req` または `artifact: decision` entry → req-save を実行
   - `artifact: spec` entry → spec-save を実行（req-save の後、entry が空ならスキップ、`artifact_actions` フィールド不存在は後方互換で spec-save スキップ）
@@ -103,7 +103,7 @@
 
 - draft-data からの読取のみで副作用を持たない
 
-## STEP-{N}: orchestration 実行
+## STEP-3: orchestration 実行
 
 ### Purpose
 
@@ -118,13 +118,13 @@
 
 ### Preconditions
 
-- STEP-{N} で工程順序確定
+- STEP-2 で工程順序確定
 
 ### Procedure
 
 実行モデル原則、工程別契約（req-save+spec-save 統合委譲 AG-{NNN}、case-open、case-run インライン実行 AG-{NNN}/002、case-close）、QG-{N}〜QG-{N} の継承、タイムスタンプ計測（L1）、インライン実行時のコンテキスト管理、結果状態の4次元集約、case-open 完了後の分岐（Standard flow / Epic Issue flow、クリーンアップ検証ゲート）、Wave 反復制御、OU 処理順序、クリーンアップ検証ゲート、委譲起動判定（AG-{NNN}、delegation-unavailable 停止条件）、Subagent 委譲プロトコル（category 選定ガイドライン、MUST NOT DO 必須化）、orchestration stage モデル、子 task bg task 破棄検知時の回復（AG-{NNN}〜AG-{NNN}、3状態分類、ライフサイクル分離）の各詳細は `agentdev-workflow-orchestration`、`agentdev-case-run-execution-adapter`、`agentdev-git-worktree`、各対応 skill を参照。case-run インライン実行時も case-run.md を authoritative source として読み込む。
 
-case-auto は各工程の結果に基づいて次工程へ進むか停止条件（STEP-{N}）を判定する。req-save/case-open の委譲に draft path と OU ID のみを渡す（OU 本文の切り出しは行わない）。OU の統合・分割・REQ 操作分類・Issue 階層判定を再評価しない（各工程の判定結果に従う）。
+case-auto は各工程の結果に基づいて次工程へ進むか停止条件（STEP-4）を判定する。req-save/case-open の委譲に draft path と OU ID のみを渡す（OU 本文の切り出しは行わない）。OU の統合・分割・REQ 操作分類・Issue 階層判定を再評価しない（各工程の判定結果に従う）。
 
 #### orchestration stage モデル
 
@@ -174,7 +174,7 @@ req-save 委譲の出力から複数 REQ doc または scale:large を検出し�
 
 ### Completion Verification
 
-- 全工程の結果が4状態/結果状態4次元で受領済みであること。停止条件該当時は STEP-{N}（stop-and-decision-resolution）へ遷移していること
+- 全工程の結果が4状態/結果状態4次元で受領済みであること。停止条件該当時は STEP-4（stop-and-decision-resolution）へ遷移していること
 
 ### Resume-Idempotency
 
@@ -190,7 +190,7 @@ req-save 委譲の出力から複数 REQ doc または scale:large を検出し�
 ## 関連 STEP
 
 - 前: なし（workflow 開始）
-- 次: STEP-{N}（stop-and-decision-resolution、停止条件検出時）、STEP-{N}（conflict-resolution-and-reporting、完了時）
+- 次: STEP-4（stop-and-decision-resolution、停止条件検出時）、STEP-8（conflict-resolution-and-reporting、完了時）
 
 ## 関連 Capability Skill
 

--- a/src/opencode/skills/agentdev-workflow-case-auto/references/stop-and-decision-resolution.md
+++ b/src/opencode/skills/agentdev-workflow-case-auto/references/stop-and-decision-resolution.md
@@ -1,14 +1,14 @@
-# STEP-{N}/5/6: 停止条件検出・adversarial-review 経路H・bounded parent decision resolution（stop-and-decision-resolution）
+# STEP-4/5/6: 停止条件検出・adversarial-review 経路H・bounded parent decision resolution（stop-and-decision-resolution）
 
-> 本 reference は `agentdev-workflow-case-auto` SKILL.md の Control Plane STEP-{N}, STEP-{N}, STEP-{N} 詳細である。停止条件検出（11項目）・停止理由分類（7軸＋上位合意矛盾/新規ユーザー判断）、adversarial-review 経路H 停止伝播、bounded parent decision resolution（限定的親判断解決）を提供する。
+> 本 reference は `agentdev-workflow-case-auto` SKILL.md の Control Plane STEP-4, STEP-5, STEP-6 詳細である。停止条件検出（11項目）・停止理由分類（7軸＋上位合意矛盾/新規ユーザー判断）、adversarial-review 経路H 停止伝播、bounded parent decision resolution（限定的親判断解決）を提供する。
 
 ## 目次
 
-- STEP-{N}: 停止条件検出・停止理由分類
-- STEP-{N}: adversarial-review 経路H 停止伝播
-- STEP-{N}: bounded parent decision resolution
+- STEP-4: 停止条件検出・停止理由分類
+- STEP-5: adversarial-review 経路H 停止伝播
+- STEP-6: bounded parent decision resolution
 
-## STEP-{N}: 停止条件検出・停止理由分類
+## STEP-4: 停止条件検出・停止理由分類
 
 ### Purpose
 
@@ -23,7 +23,7 @@
 
 ### Preconditions
 
-- STEP-{N} で各工程の結果を受領
+- STEP-3 で各工程の結果を受領
 
 ### Procedure
 
@@ -45,7 +45,7 @@
 
 #### 停止時タイミング情報の追記
 
-停止報告に `case_auto_started_at`、停止時刻（JST、人間が読みやすい形式）、経過時間、STEP-{N} で記録した工程別タイムスタンプ内訳（停止時点までの工程分）を含める。
+停止報告に `case_auto_started_at`、停止時刻（JST、人間が読みやすい形式）、経過時間、STEP-3 で記録した工程別タイムスタンプ内訳（停止時点までの工程分）を含める。
 
 #### 停止理由分類（7軸＋上位合意矛盾/新規ユーザー判断）
 
@@ -83,7 +83,7 @@ execution_unit 分割可能性があるにも関わらず case-open が停止し
 
 - 停止判定は各工程の durable state からの評価であり副作用を持たない。再開時は停止報告の再開ポイントから再構成する
 
-## STEP-{N}: adversarial-review 経路H 停止伝播
+## STEP-5: adversarial-review 経路H 停止伝播
 
 ### Purpose
 
@@ -98,19 +98,19 @@ execution_unit 分割可能性があるにも関わらず case-open が停止し
 
 ### Preconditions
 
-- STEP-{N}（各工程の実行）で下位 command から adversarial-review 由来の user-decision-required + decision_context を受領
+- STEP-3（各工程の実行）で下位 command から adversarial-review 由来の user-decision-required + decision_context を受領
 
 ### Procedure
 
 case-auto は当該 execution_unit の自走を停止し、ユーザー判断を待機する。停止伝播契約の詳細は case-auto command SPEC（project extension 経由参照）「adversarial-review 由来の停止伝播（経路H）」節を正とする。
 
 - **受領**: case-run 起源は result `blocked` + user-decision-required 分類、工程委譲起源は既存 status + `parent_decision_required`（workflow-contracts SPEC「adversarial-review 由来の停止信号」節、delegation-contracts SPEC「review 経路での parent_decision_required / decision_context 適用」節）。user-decision-required は case-run result enum 第5状態ではなく停止理由分類である
-- **自走停止**: 当該 execution_unit のみ停止。他 ready 対象は継続（部分停止、STEP-{N} Wave 反復制御）
+- **自走停止**: 当該 execution_unit のみ停止。他 ready 対象は継続（部分停止、STEP-3 Wave 反復制御）
 - **ユーザー提示**: decision_context をユーザーへ提示し判断を待機
 - **resume point**: case-run 起源は当該 Issue の case-run 再開ポイント（準備フェーズ、実装フェーズ、提出フェーズのいずれか）、工程委譲起源は当該工程の委譲起点
 - **再開**: ユーザー判断解決後、resume point から再開。adversarial-review 再発動要否は adversarial-review SPEC「再 review 条件」「再 review 停止条件」に従い case-auto は独自判断しない
 
-case-auto は経路H において review 直接起動、finding 解釈、採否、再評価を行わない。これらは下位 command の責務であり、case-auto は伝播と再開のみを担う。user-decision-required は STEP-{N} の HITL 境界停止条件分類とは独立する停止理由分類である。停止報告（STEP-{N}）には user-decision-required を停止理由分類として含める。
+case-auto は経路H において review 直接起動、finding 解釈、採否、再評価を行わない。これらは下位 command の責務であり、case-auto は伝播と再開のみを担う。user-decision-required は STEP-4 の HITL 境界停止条件分類とは独立する停止理由分類である。停止報告（STEP-8）には user-decision-required を停止理由分類として含める。
 
 ### Result
 
@@ -130,7 +130,7 @@ case-auto は経路H において review 直接起動、finding 解釈、採否�
 
 - ユーザー判断解決後、resume point（durable state: Issue/PR 状態、委譲起点）から再開する。再 review 要否は case-auto が独自判断しない
 
-## STEP-{N}: bounded parent decision resolution
+## STEP-6: bounded parent decision resolution
 
 ### Purpose
 
@@ -155,8 +155,8 @@ case-auto は下位 command から受領した decision_context を限定的に�
 |---|---|---|
 | 自律解決 | decision_context が現行正規成果物（REQ、Decision、SPEC、Issue その他合意済み情報）から一意に回答可能 | ユーザー停止せず回答して下位 command を resume |
 | 作業仮定で継続 | 外部仕様・互換性・データ保持・セキュリティ・対象範囲・受け入れ条件を変更しない可逆的内部詳細 | 既存契約で許容された範囲に限り作業仮定と根拠を明示して自走継続 |
-| 上位合意矛盾 | decision_context が現行正規成果物間の矛盾に起因 | 当該矛盾そのものが finding の対象であり一方を勝手に採用せず停止（STEP-{N} 停止理由分類「上位合意矛盾」） |
-| 新規ユーザー判断事項 | 新しいユーザー価値判断、対象範囲変更、外部契約変更が必要 | 既存停止経路でユーザーへ返す（STEP-{N} 停止理由分類「新規ユーザー判断事項」） |
+| 上位合意矛盾 | decision_context が現行正規成果物間の矛盾に起因 | 当該矛盾そのものが finding の対象であり一方を勝手に採用せず停止（STEP-4 停止理由分類「上位合意矛盾」） |
+| 新規ユーザー判断事項 | 新しいユーザー価値判断、対象範囲変更、外部契約変更が必要 | 既存停止経路でユーザーへ返す（STEP-4 停止理由分類「新規ユーザー判断事項」） |
 
 - **resume**: 回答、根拠、作業仮定を下位 command へ返し、既存 resume point から処理を継続する。新規永続結果型は導入しない。adversarial-review 再実行要否は adversarial-review 側の再 review 契約に従い case-auto は独自判断しない
 - **中央集約 review engine とはならない**: case-auto は raw finding を解釈、採否、候補反映しない。下位 command が構造化した decision_context のみを解決対象とし、raw finding を case-auto へそのまま渡さない（AG-{NNN}）
@@ -164,7 +164,7 @@ case-auto は下位 command から受領した decision_context を限定的に�
 ### Result
 
 - 自律解決時: 回答・根拠・作業仮定を下位 command へ返し resume
-- 上位合意矛盾/新規ユーザー判断時: STEP-{N} 停止経路へ
+- 上位合意矛盾/新規ユーザー判断時: STEP-4 停止経路へ
 
 ### Evidence
 
@@ -187,8 +187,8 @@ case-auto は下位 command から受領した decision_context を限定的に�
 
 ## 関連 STEP
 
-- 前: STEP-{N}（input-resolution-and-orchestration）
-- 次: STEP-{N}（conflict-resolution-and-reporting、停止報告時）
+- 前: STEP-3（input-resolution-and-orchestration）
+- 次: STEP-8（conflict-resolution-and-reporting、停止報告時）
 
 ## 関連 Capability Skill
 

--- a/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
@@ -27,8 +27,8 @@ extension（`.agentdev/extensions/skills/agentdev-workflow-case-close.yaml`）�
 ## USE FOR
 
 - case-close command の実行時 workflow 制御（全 STEP）
-- 単一 Issue クローズフロー（Step 1-1, Step 2〜12）
-- Epic Wave クローズフロー（Step E1〜E6、子Issue 一括マージ・クローズ、Epic status table 更新）
+- 単一 Issue クローズフロー（STEP-1〜STEP-6、STEP-1-1 重複ファイルチェックを含む）
+- Epic Wave クローズフロー（STEP-E1〜E6、子Issue 一括マージ・クローズ、Epic status table 更新）
 - QG-4 最終完了判定ゲート（完了条件チェックボックス評価・更新、観点8 PR対象範囲 vs 全体）
 - docs 検証・SPEC 確定（targeted docs guard、IR-{NNN} check_extensions.ts、SPEC status 昇格）
 - PR マージ（squash merge、mergeable UNKNOWN ポーリング、先行 commit 検出、コンフリクト Level 1 rebase）
@@ -85,12 +85,12 @@ case-close workflow は次の STEP で構成する。Epic Wave クローズは S
 ### STEP 間の依存と分岐
 
 - **単一 Issue クローズ**: STEP-1（単一 ルート）→ STEP-2 → STEP-3（配布依存境界 最終 gate 含む）→ STEP-4 → STEP-5 → STEP-6
-- **Epic Wave クローズ**: STEP-1（Epic ルート、ステータス追跡テーブル存在時）→ STEP-E1〜E6（E4 内で配布依存境界 最終 gate を各子Issue に適用、single-Issue STEP-3 Step 3-1 と同一 detector）
+- **Epic Wave クローズ**: STEP-1（Epic ルート、ステータス追跡テーブル存在時）→ STEP-E1〜E6（E4 内で配布依存境界 最終 gate を各子Issue に適用、single-Issue STEP-3-1 と同一 detector）
 - **コンフリクトエスカレーション**: STEP-4 で Level 1 rebase 失敗時、case-auto Level 2/3 エスカレーションへ（本 workflow の対象外）
 
 ### 共通事前マージ gate（両ルート共通、DEC-{N}、配布依存境界 SPEC）
 
-配布依存境界の最終 gate は single-Issue ルート（STEP-3 Step 3-1）と Epic Wave ルート（STEP-E4-0）の両方で、PR マージ前に必ず経由する共用事前マージ seam である。両ルートとも同一 detector（`check_distribution_boundary.ts` 経由の `lib/distribution-boundary.ts`、IR-{NNN}）を呼び出し、どちらかのルートだけ gate を省略しない（DEC-{N}「事前書き込み gate と最終 gate の契約」、case-run Step 7-1 と case-close で同一 detector を再利用）。gate 違反時は両ルートとも PR マージを停止する。
+配布依存境界の最終 gate は single-Issue ルート（STEP-3-1）と Epic Wave ルート（STEP-E4-0）の両方で、PR マージ前に必ず経由する共用事前マージ seam である。両ルートとも同一 detector（`check_distribution_boundary.ts` 経由の `lib/distribution-boundary.ts`、IR-{NNN}）を呼び出し、どちらかのルートだけ gate を省略しない（DEC-{N}「事前書き込み gate と最終 gate の契約」、case-run command Step 7-1 と case-close で同一 detector を再利用）。gate 違反時は両ルートとも PR マージを停止する。
 
 ### resume protocol
 

--- a/src/opencode/skills/agentdev-workflow-case-close/references/cleanup-and-capture.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/cleanup-and-capture.md
@@ -27,11 +27,11 @@
 
 ### Procedure
 
-#### Step 5: Post-merge テスト戦略検証
+#### STEP-5-1: Post-merge テスト戦略検証
 
 マージ後のみ確認可能な項目（CI通過等）を反映。Issue 本文更新手続き（`agentdev-gh-cli`）で更新 → VERIFY。
 
-#### Step 6: Issue クローズ
+#### STEP-5-2: Issue クローズ
 
 Issue close 手続き（理由: completed、`agentdev-gh-cli`）。
 
@@ -72,7 +72,7 @@ worktree/branch 削除、親Epic 自動クローズ判定、実行前同期、Ca
 
 ### Procedure
 
-#### Step 7: ブランチ、worktree 削除
+#### STEP-6-1: ブランチ、worktree 削除
 
 `agentdev-git-worktree` の worktree 削除手順に従う。
 
@@ -86,7 +86,7 @@ worktree/branch 削除、親Epic 自動クローズ判定、実行前同期、Ca
 - リモートブランチ削除
 - 削除失敗時は警告表示して停止すること
 
-#### Step 8: 親Epic Issue 更新
+#### STEP-6-2: 親Epic Issue 更新
 
 `agentdev-epic-tracker` スキル参照。
 
@@ -96,17 +96,17 @@ worktree/branch 削除、親Epic 自動クローズ判定、実行前同期、Ca
 - **子Issue 状態事前取得**: Issue 補助データ読込手続き（`agentdev-gh-cli`）で全子Issue の OPEN/CLOSED 状態を一覧取得しログ出力
 - **Epic 自動クローズ判定**: 全子Issue CLOSED → 自動クローズ。1件以上 OPEN → スキップ
 
-#### Step 9: 実行前同期
+#### STEP-6-3: 実行前同期
 
-##### Step 9-1: 重複ファイルチェック再実行
+##### STEP-6-3-1: 重複ファイルチェック再実行
 
-`git pull --ff-only` 直前に、`agentdev-git-worktree` の「PR merge 前重複ファイルチェック」プロシージャを再実行する（L-013、PR #1128 由来、共有 main worktree で Step 1-1 実行時点から Step 9-1 実行までの間に並列セッションが加えた未コミット変更を検知するため）。重複ファイルを検出した場合、構造化エラーで停止しユーザーによる対応（stash/commit/checkout）を促すこと。
+`git pull --ff-only` 直前に、`agentdev-git-worktree` の「PR merge 前重複ファイルチェック」プロシージャを再実行する（L-013、PR #1128 由来、共有 main worktree で STEP-1-1 実行時点から STEP-6-3-1 実行までの間に並列セッションが加えた未コミット変更を検知するため）。重複ファイルを検出した場合、構造化エラーで停止しユーザーによる対応（stash/commit/checkout）を促すこと。
 
-##### Step 9-2: git main 同期リスク事前検出・代替同期手順選択（REQ）
+##### STEP-6-3-2: git main 同期リスク事前検出・代替同期手順選択（REQ）
 
 `agentdev-git-worktree` の「git main 同期リスク事前検出プロシージャ（REQ）」に従い、worktree 状態（dirty tree）・並列実行による ref lock 競合・非 main ブランチ占有の3リスク事前検出と代替同期手順選択を実行する。`agentdev-git-worktree` に従い `git pull --ff-only` を実行（ローカル変更事前チェック、hash 検証、不一致時は評価・承認のやり直し）。
 
-#### Step 10: 学びの検知・抽出・Capture 回収
+#### STEP-6-4: 学びの検知・抽出・Capture 回収
 
 ##### 学び検知
 
@@ -125,13 +125,13 @@ PR 本文の `## Findings / Capture候補` セクションから intake/ learnin
 - **Capture 境界**: intake/ learning 境界は `agentdev-workflow-orchestration`（capture-boundaries）を参照。intake と learning を別々の成果物として扱う
 - **一時会話コンテキスト不入力**: case-run の一時会話コンテキスト（ローカル変数、中間ファイル等）を capture の入力として使用しない。capture 情報の入力源は PR 本文のみ
 
-#### Step 11: ドメイン状態永続化
+#### STEP-6-5: ドメイン状態永続化
 
 `agentdev-git-worktree` に従い `.agentdev/` 配下を commit/push。learning と intake を同一 commit に含める。
 
 > **auto-close 回避の留意点**: 本コマンド名 `case-close` は "close" を含む複合語。コミットメッセージに `(case-close #N)` 等のコマンド名と Issue 番号の近接表記を用いると、GitHub が "close" を auto-close キーワードと誤認し Issue を意図せずクローズするリスクがある。コミットメッセージのフォーマットは `agentdev-conventional-commits` skill の「GitHub auto-close 回避ガイドライン」に従い、コマンド名と Issue 番号を分離し `#` 記号による近接参照を避けること（例: `case-close for Issue N`）
 
-#### Step 12: 完了報告
+#### STEP-6-6: 完了報告
 
 完了報告 template に従って出力。結果状態に応じた種別を選択。
 
@@ -200,7 +200,7 @@ GitHub 完了後に `.agentdev` push 失敗の場合は standard 種別を使用
 - G11（コメントテンプレートの【必須】セクション確認）
 - G13（学びの検知はエージェント自律、ユーザーに問わない）
 - G15/G16/G18（intake と learning を混合した単一成果物にしない、learning と intake を同一 commit に含める、今回の完了条件に含まれる未対応事項を intake に逃がして完了扱いにしない）
-- G17（Step 11 の commit は並列実行安全ステージングプロシージャに従い、明示パスでステージ、`git add` は `.agentdev/` 全体の一括スコープにしない）
-- G19（Step 12 は結果状態を分離して報告、`.agentdev` push 失敗時は完了扱いにしない）
+- G17（STEP-6-5 の commit は並列実行安全ステージングプロシージャに従い、明示パスでステージ、`git add` は `.agentdev/` 全体の一括スコープにしない）
+- G19（STEP-6-6 は結果状態を分離して報告、`.agentdev` push 失敗時は完了扱いにしない）
 - G21/G22/G23（case-close の capture 責務は「回収・保存」、SPEC status 昇格は case-close の責務、SPEC 確定候補の処理は `## SPEC確定候補` を入力とし `## Findings / Capture候補` とは区別）
 - G27/G28（`git pull --ff-only` 実行前に worktree 状態・ref lock 競合・非 main ブランチ占有の3リスクを事前検出し代替同期手順を選択）

--- a/src/opencode/skills/agentdev-workflow-case-close/references/docs-and-spec-promotion.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/docs-and-spec-promotion.md
@@ -27,11 +27,11 @@ PR マージ前の docs 検証、拡張検査、配布依存境界 最終 gate �
 
 ### docs/ 検証
 
-機能追加固有の検証（REQ作成、インデックス記載、spec更新、ADR作成）および全 work_type 共通の関連ドキュメント整合性確認、README 索引整合性確認。不足時は警告表示してユーザー判断を仰ぐ。PR 本文の `## SPEC確定候補` セクションから SPEC 確定フロー（Step 3-2）を実行する。
+機能追加固有の検証（REQ作成、インデックス記載、spec更新、ADR作成）および全 work_type 共通の関連ドキュメント整合性確認、README 索引整合性確認。不足時は警告表示してユーザー判断を仰ぐ。PR 本文の `## SPEC確定候補` セクションから SPEC 確定フロー（STEP-3-2）を実行する。
 
 **文書分類ポリシー適合確認**: document-model SPEC（extension 経由）の Document Classification Policy に基づき、最終ドキュメント状態が分類ポリシーに適合していることを確認する。
 
-### Step 3-1: close 時 SPEC/ commands/ skills 更新漏れの局所確認
+### STEP-3-1: close 時 SPEC/ commands/ skills 更新漏れの局所確認
 
 実装完了、PR マージ前に、SPEC 本文と実装の最終矛盾確認、command 定義の更新漏れ、skill 責務境界の変更漏れを確認。更新漏れ検出時は警告表示してユーザー判断。局所予防の範囲で `/agentdev/inspect-docs` の全体意味レビューの代替ではない。
 
@@ -56,20 +56,20 @@ PR マージ前の docs 検証、拡張検査、配布依存境界 最終 gate �
 - **モード使い分けの標準**: コミット前の worktree 上での検証は `--base-ref`、コミット後・PR 作成後の main 環境は `--files`（case-close はマージ後 main 環境で実行されるため `--files` を使用）
 - **JSON 出力の `failures`**: strict severity が含まれる場合はマージを停止し対象ファイルを修正して再実行
 - **`full_docs_check_recommended`**: true の場合は全体監査（self-hosting リポジトリ限定の自己監査コマンド）の実行をユーザーに提案
-- **draft → accepted 等の SPEC status 変更時**: `spec_readme_update_required` を Step 3-2 SPEC 確定フローに反映
+- **draft → accepted 等の SPEC status 変更時**: `spec_readme_update_required` を STEP-3-2 SPEC 確定フローに反映
 - **`files_checked` 空時の確認（REQ）**: targeted docs guard の JSON 出力で `files_checked` が空の場合、検査見逃しリスクとして扱い、`warnings` 配列の警告を確認、`--files` 指定の妥当性を確認、必要に応じて再実行または手動確認、空の理由が正当であることを確認してから続行する
 
 #### 配布依存境界の最終変更経路 gate（REQ-{NNNN}-{NNN} 再利用、REQ-{NNNN}-{NNN}、DEC-{N}）
 
-PR 変更ファイルが `--profile source` の配布 command/skill ソース面に含まれる場合、PR マージ前に配布依存境界の最終 gate を実行する。本 gate は共用 detector（`.opencode/skills/<integrity-detector-skill>/scripts/lib/distribution-boundary.ts`）を経由する adapter（`check_distribution_boundary.ts`）経路であり、REQ-{NNNN}-{NNN} の最終 gate 基底を再利用する（REQ-{NNNN}-{NNN}、DEC-{N} 決定4）。adapter が bypass されても最終 gate で停止する（DEC-{N} 決定3、4）。trigger 条件は detector の `--profile source` が分類する配布ソース面を基準とする（case-run Step 7-1 と同一。junction 領域は git 非追跡のため PR 差分に現れず、junction を trigger にすると gate が不発になる）
+PR 変更ファイルが `--profile source` の配布 command/skill ソース面に含まれる場合、PR マージ前に配布依存境界の最終 gate を実行する。本 gate は共用 detector（`.opencode/skills/<integrity-detector-skill>/scripts/lib/distribution-boundary.ts`）を経由する adapter（`check_distribution_boundary.ts`）経路であり、REQ-{NNNN}-{NNN} の最終 gate 基底を再利用する（REQ-{NNNN}-{NNN}、DEC-{N} 決定4）。adapter が bypass されても最終 gate で停止する（DEC-{N} 決定3、4）。trigger 条件は detector の `--profile source` が分類する配布ソース面を基準とする（case-run command Step 7-1 と同一。junction 領域は git 非追跡のため PR 差分に現れず、junction を trigger にすると gate が不発になる）
 
 - **実行コマンド**: `bun run .opencode/skills/<integrity-detector-skill>/scripts/check_distribution_boundary.ts --profile source --json`
 - **検査対象**: PR HEAD の worktree（マージ前の実際の PR ブランチ内容）を検査する。現在の main 状態ではなく、PR で提案されている実際の変更内容を検査対象とする（Oracle finding 5: inspect PR head before merge）
 - **`--profile source`**: case-close は PR マージ前に実行され、配布ソース面を検査するため `source` を使用する（junction は原本への鏡像）
 - **検査エラーの扱い**: 読込不能、未分類エントリ、adapter 起動失敗は全て gate-not-passed として扱う（DEC-{N} 決定5、TS-{NNN}）。clean として通過させない。違反時はマージを停止しユーザー判断を仰ぐ
-- **検出結果の記録**: 検出事項（failures）は PR 本文の `## Findings / Capture候補` セクションに `### distribution-boundary` 小見出しで記録する（既に case-run Step 7-1 で記録済みの場合は上書きせず、case-close で新たに検出された事項のみ追記）
+- **検出結果の記録**: 検出事項（failures）は PR 本文の `## Findings / Capture候補` セクションに `### distribution-boundary` 小見出しで記録する（既に case-run command Step 7-1 で記録済みの場合は上書きせず、case-close で新たに検出された事項のみ追記）
 
-### Step 3-2: SPEC 確定フロー
+### STEP-3-2: SPEC 確定フロー
 
 PR 本文の `## SPEC確定候補` セクション（case-run/ driver が記録）を読み取り、SPEC の確定、昇格を処理する。セクション不存在・空の場合はスキップ。
 

--- a/src/opencode/skills/agentdev-workflow-case-close/references/epic-wave-close.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/epic-wave-close.md
@@ -42,16 +42,16 @@ Epic Issue 本文を読み込み、ステータス追跡テーブル（`agentdev
 
 ### E4: 各子Issue の PR マージ・子Issue クローズ・完了条件チェックボックス評価・Capture 回収・コンフリクト解消の準並列化（REQ）
 
-各子Issue について次を**準並列**で実行する。ただし各子Issue の PR マージへ進む前に、当該子Issue の PR HEAD で配布依存境界の最終 gate（STEP-3 Step 3-1「配布依存境界の最終変更経路 gate」と同一手続き）を必ず実行する。single-Issue ルート（STEP-3）と Epic Wave ルート（本 STEP）で同一の最終 gate を経由し、どちらかのルートだけ gate を省略しない（DEC-{N}「事前書き込み gate と最終 gate の契約」、 配布依存境界 SPEC）。
+各子Issue について次を**準並列**で実行する。ただし各子Issue の PR マージへ進む前に、当該子Issue の PR HEAD で配布依存境界の最終 gate（STEP-3-1「配布依存境界の最終変更経路 gate」と同一手続き）を必ず実行する。single-Issue ルート（STEP-3）と Epic Wave ルート（本 STEP）で同一の最終 gate を経由し、どちらかのルートだけ gate を省略しない（DEC-{N}「事前書き込み gate と最終 gate の契約」、 配布依存境界 SPEC）。
 
-#### E4-0: 各子Issue の配布依存境界 最終 gate（マージ前、single-Issue STEP-3 Step 3-1 と同一手続き）
+#### E4-0: 各子Issue の配布依存境界 最終 gate（マージ前、single-Issue STEP-3-1 と同一手続き）
 
-各子Issue の PR マージへ進む前に、当該 PR の変更ファイルが `--profile source` の配布 command/skill ソース面に含まれる場合、配布依存境界の最終 gate を実行する。含まない PR（docs のみ等）ではスキップする。trigger 条件は detector の `--profile source` が分類する配布ソース面を基準とする（case-run Step 7-1 と同一）。手続きの正規所有者は STEP-3 Step 3-1（[docs-and-spec-promotion.md](docs-and-spec-promotion.md)）であり、本 STEP は同一手続きを Epic Wave の各子Issue に適用する。
+各子Issue の PR マージへ進む前に、当該 PR の変更ファイルが `--profile source` の配布 command/skill ソース面に含まれる場合、配布依存境界の最終 gate を実行する。含まない PR（docs のみ等）ではスキップする。trigger 条件は detector の `--profile source` が分類する配布ソース面を基準とする（case-run command Step 7-1 と同一）。手続きの正規所有者は STEP-3-1（[docs-and-spec-promotion.md](docs-and-spec-promotion.md)）であり、本 STEP は同一手続きを Epic Wave の各子Issue に適用する。
 
 - **実行コマンド**: `bun run .opencode/skills/<integrity-detector-skill>/scripts/check_distribution_boundary.ts --profile source --json`。検査対象は当該子Issue PR の HEAD（マージ前の実際の PR ブランチ内容）。現在の main 状態ではなく、PR で提案されている実際の変更内容を検査する
 - **`--profile source`**: case-close は PR マージ前に実行され、配布ソース面を検査するため `source` を使用する（junction は原本への鏡像）
 - **検査エラーの扱い**: 読込不能、未分類エントリ、adapter 起動失敗は全て gate-not-passed として扱う（DEC-{N} 決定5、TS-{NNN}）。clean として通過させない
-- **gate 違反時**: 当該子Issue の PR マージを中止し、PR 本文の `## Findings / Capture候補` セクションに `### distribution-boundary` 小見出しで記録する（既に case-run Step 7-1 で記録済みの場合は上書きせず、case-close で新たに検出された事項のみ追記）。当該子Issue は後続 E4-1 シーケンスへ進めず、E5 Epic status table で `blocked` 状態として記録する（`agentdev-epic-tracker` 準拠、`completed` へ上書きしない、べき等性）
+- **gate 違反時**: 当該子Issue の PR マージを中止し、PR 本文の `## Findings / Capture候補` セクションに `### distribution-boundary` 小見出しで記録する（既に case-run command Step 7-1 で記録済みの場合は上書きせず、case-close で新たに検出された事項のみ追記）。当該子Issue は後続 E4-1 シーケンスへ進めず、E5 Epic status table で `blocked` 状態として記録する（`agentdev-epic-tracker` 準拠、`completed` へ上書きしない、べき等性）
 
 #### E4-1: 各子Issue のマージ並列シーケンス（gate 合格子Issue のみ）
 
@@ -118,7 +118,7 @@ QG-4 観点8 に基づく評価スコープ切替（中間 Wave vs 最終 Wave�
 - `agentdev-quality-gates`: QG-4 完了条件チェックボックス評価・更新、観点8 評価スコープ切替
 - `agentdev-workflow-orchestration`: capture 境界（intake/learning 分離、Epic 横断回収）
 - `agentdev-learning-capture` / `agentdev-intake-pipeline`: Capture 回収
-- integrity checker skill（repo-local）: E4-0 配布依存境界 最終 gate（check_distribution_boundary.ts、single-Issue STEP-3 Step 3-1 と同一 detector、IR-{NNN}）
+- integrity checker skill（repo-local）: E4-0 配布依存境界 最終 gate（check_distribution_boundary.ts、single-Issue STEP-3-1 と同一 detector、IR-{NNN}）
 
 ## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
 

--- a/src/opencode/skills/agentdev-workflow-case-close/references/issue-resolution-and-qg4.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/issue-resolution-and-qg4.md
@@ -26,9 +26,9 @@ Issue 番号を解決し、単一 Issue クローズと Epic Wave クローズ�
 **Epic Issue 判定**: 解決した Issue 番号の本文を `agentdev-gh-cli` の安全な読み取り手順で取得し、ステータス追跡テーブル（`agentdev-epic-tracker` の新4列/旧4列形式）が存在するか確認。
 
 - **テーブル存在時**: **Epic Wave クローズ**（STEP-E1〜E6、[references/epic-wave-close.md](epic-wave-close.md)）へ分岐
-- **テーブル不存在時**: **単一 Issue クローズ**（Step 1-1〜）へ進む（後方互換）
+- **テーブル不存在時**: **単一 Issue クローズ**（STEP-1-1〜）へ進む（後方互換）
 
-### Step 1-1: 重複ファイルチェック（merge/pull 実行前、単一 Issue クローズ時）
+### STEP-1-1: 重複ファイルチェック（merge/pull 実行前、単一 Issue クローズ時）
 
 `agentdev-git-worktree` の「PR merge 前重複ファイルチェック」プロシージャに従い、ローカル未コミット変更ファイルと対象 PR 変更ファイルの重複を検出、停止条件の判定を行う。PR 補助データ読込手続き（`agentdev-gh-cli`）実行不可時は後方互換性として STEP-6（実行前同期）でフォールバック検出を維持する。
 

--- a/src/opencode/skills/agentdev-workflow-case-close/references/pr-merge-and-conflict.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/pr-merge-and-conflict.md
@@ -26,18 +26,18 @@ PR を squash マージし、mergeable UNKNOWN ポーリング、先行 commit �
 
 ## Procedure
 
-### Step 4-0: squash merge 前の mergeable UNKNOWN ポーリング
+### STEP-4-1: squash merge 前の mergeable UNKNOWN ポーリング
 
 `agentdev-gh-cli` の「squash merge 前の mergeable UNKNOWN ポーリング」手続きに従い、次を実行する。
 
 - 対象 PR の `mergeable` 状態事前確認
 - `UNKNOWN` ポーリング待機
 - 上限超過時の構造化エラー停止
-- 待機中の `CONFLICTING` 遷移検出を自動分岐させ、コンフリクト解消パス（Step 4-2）へ即時接続する
+- 待機中の `CONFLICTING` 遷移検出を自動分岐させ、コンフリクト解消パス（STEP-4-4）へ即時接続する
 
 ポーリング間隔・上限値は gh-cli 手続き側が所有する（AG-{NNN}）。
 
-### Step 4: PR merge 実行
+### STEP-4-2: PR merge 実行
 
 PR merge 手続き（squash 方式、`agentdev-gh-cli`）を実行 → HEAD commit hash 記録（`agentdev-git-worktree` skill に従い）。
 
@@ -47,18 +47,18 @@ PR merge 手続き（squash 方式、`agentdev-gh-cli`）を実行 → HEAD comm
 
 **`--delete-branch` 使用禁止（REQ）**: PR マージ時に `--delete-branch` オプションを使用しない（アクティブ worktree に checkout されたブランチで local 削除が失敗し remote 削除フェーズへ到達しないため）。ブランチ削除は STEP-6 で独立実施する。
 
-### Step 4-1: Squash merge 後のローカル先行 commit 検出・処理（REQ）
+### STEP-4-3: Squash merge 後のローカル先行 commit 検出・処理（REQ）
 
 squash merge 完了後、ローカルに remote 未 push の先行 commit が存在する場合、`agentdev-git-worktree` の「Squash merge 後分岐ハンドリング手続き（REQ）」に従い、ローカル先行 commit 検出、内容重複確認、reset を実行する。本処理により `git pull --ff-only` 失敗を予防する。
 
-### Step 4-2: コンフリクト解消 rebase パス（Level 1）
+### STEP-4-4: コンフリクト解消 rebase パス（Level 1）
 
-squash merge がコンフリクトで失敗した場合（Step 4 のリトライ全失敗後、エラー原因がコンフリクトの場合）に実行する機械的解消パス（コンフリクト解消モデル Level 1）。
+squash merge がコンフリクトで失敗した場合（STEP-4-2 のリトライ全失敗後、エラー原因がコンフリクトの場合）に実行する機械的解消パス（コンフリクト解消モデル Level 1）。
 
 `agentdev-git-worktree` の「コンフリクト解消 rebase パス（REQ）」に従い、rebase による機械的解消を試みる。
 
 - **実装変更は行わず** rebase のみ
-- **rebase 自動解決時**: squash merge（Step 4）へ戻り再マージ
+- **rebase 自動解決時**: squash merge（STEP-4-2）へ戻り再マージ
 - **rebase コンフリクト発生時**: case-auto へエスカレーションして停止する（コンフリクト解消モデル Level 2/3 は case-auto の責務）
 
 ## Evidence
@@ -77,7 +77,7 @@ squash merge がコンフリクトで失敗した場合（Step 4 のリトライ
 
 - mergeable 状態、ポーリング実行状態
 - PR merge 実行結果、HEAD commit hash
-- 先行 commit 検出・処理結果（Step 4-1）
+- 先行 commit 検出・処理結果（STEP-4-3）
 - コンフリクト発生時の Level 1 rebase 試行結果、Level 2/3 エスカレーション状態
 
 ## 関連 STEP

--- a/src/opencode/skills/agentdev-workflow-case-open/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/SKILL.md
@@ -31,7 +31,7 @@ extension（`.agentdev/extensions/skills/agentdev-workflow-case-open.yaml`）は
 - execution_unit 構成（連結成分アルゴリズム、3軸判断、Epic vs Standard ルーティング）
 - 構成生成事前検証（preflight 5項目）
 - adversarial-review 挿入境界（経路F）の発動条件判定と review 呼出
-- Epic flow（Step 5-9）と Standard flow（Step 10-12）の制御
+- Epic flow（STEP-5-1〜5-5）と Standard flow（STEP-5-6〜5-8）の制御
 - draft/RU 削除クリーンアップ（Form Zero、即時 commit/push、削除残存検証）
 - 子Issue 作成の並列化（最大5件、3つの「5件」文脈の (1) に該当）
 
@@ -72,17 +72,17 @@ case-open workflow は次の6 STEP で構成する。各 STEP は resume point �
 
 | STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
 |---|---|---|---|---|
-| STEP-{N} | 引き継ぎ・OU選択 | 要件doc 受領 | 処理対象確定（OU 単位） | [references/handoff-and-ou-gate.md](references/handoff-and-ou-gate.md) |
-| STEP-{N} | Issue本文生成・execution contract 確定 | 処理対象確定 | Issue 本文候補（EC-{N}〜EC-{N} 反映済み、QG-{N} 検証済み） | [references/issue-body-and-execution-contract.md](references/issue-body-and-execution-contract.md) |
-| STEP-{N} | 構成判定・preflight | Issue 本文候補確定 | execution structure（Epic vs Standard、Wave 構成、preflight合格） | [references/execution-unit-and-preflight.md](references/execution-unit-and-preflight.md) |
-| STEP-{N} | adversarial-review（経路F） | execution structure + Issue 本文 + 完了条件の3者確定 | review 結果反映（4パターン再実行ルール） | [references/adversarial-review-integration.md](references/adversarial-review-integration.md) |
-| STEP-{N} | Issue 作成（Epic flow / Standard flow） | adversarial-review skip または review 完了 | GitHub Issue 作成済み（親Epic + 子Issue群、または Standard Issue） | [references/issue-creation-flows.md](references/issue-creation-flows.md) |
-| STEP-{N} | 終了処理・クリーンアップ | Issue 作成完了 | コメント追加、draft/RU 削除（Form Zero）、完了報告 | [references/termination-and-cleanup.md](references/termination-and-cleanup.md) |
+| STEP-1 | 引き継ぎ・OU選択 | 要件doc 受領 | 処理対象確定（OU 単位） | [references/handoff-and-ou-gate.md](references/handoff-and-ou-gate.md) |
+| STEP-2 | Issue本文生成・execution contract 確定 | 処理対象確定 | Issue 本文候補（EC-{N}〜EC-{N} 反映済み、QG-{N} 検証済み） | [references/issue-body-and-execution-contract.md](references/issue-body-and-execution-contract.md) |
+| STEP-3 | 構成判定・preflight | Issue 本文候補確定 | execution structure（Epic vs Standard、Wave 構成、preflight合格） | [references/execution-unit-and-preflight.md](references/execution-unit-and-preflight.md) |
+| STEP-4 | adversarial-review（経路F） | execution structure + Issue 本文 + 完了条件の3者確定 | review 結果反映（4パターン再実行ルール） | [references/adversarial-review-integration.md](references/adversarial-review-integration.md) |
+| STEP-5 | Issue 作成（Epic flow / Standard flow） | adversarial-review skip または review 完了 | GitHub Issue 作成済み（親Epic + 子Issue群、または Standard Issue） | [references/issue-creation-flows.md](references/issue-creation-flows.md) |
+| STEP-6 | 終了処理・クリーンアップ | Issue 作成完了 | コメント追加、draft/RU 削除（Form Zero）、完了報告 | [references/termination-and-cleanup.md](references/termination-and-cleanup.md) |
 
 ### STEP 間の依存と分岐
 
-- **Standard flow**: STEP-{N} → STEP-{N} → STEP-{N}（Standard ルート）→ STEP-{N}（skip 条件該当時は省略）→ STEP-{N}（Standard flow）→ STEP-{N}
-- **Epic flow（単一REQ `scale: large`、マルチREQ、複数 OU）**: STEP-{N} → STEP-{N} → STEP-{N}（Epic ルート、execution_unit 構成）→ STEP-{N} → STEP-{N}（Epic flow、子Issue 並列作成）→ STEP-{N}
+- **Standard flow**: STEP-1 → STEP-2 → STEP-3（Standard ルート）→ STEP-4（skip 条件該当時は省略）→ STEP-5（Standard flow）→ STEP-6
+- **Epic flow（単一REQ `scale: large`、マルチREQ、複数 OU）**: STEP-1 → STEP-2 → STEP-3（Epic ルート、execution_unit 構成）→ STEP-4 → STEP-5（Epic flow、子Issue 並列作成）→ STEP-6
 - **adversarial-review skip 条件**: Standard flow で単一 OU の機械的確定、Wave 分割なし（REQ-{NNNN}-{NNN}）。ユーザー明示指定時は強制発動（REQ-{NNNN}-{NNN}）
 
 ### resume protocol
@@ -109,7 +109,7 @@ case-open workflow は次の6 STEP で構成する。各 STEP は resume point �
 - `agentdev-git-worktree`: 並列実行安全ステージングプロシージャ（draft/RU 削除、Form Zero）
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
 - `agentdev-adversarial-review`: 経路F review 呼出
-- `agentdev-learning-capture` / `agentdev-intake-pipeline`: deviation capture 委譲（STEP-{N}/5 で実観測時）
+- `agentdev-learning-capture` / `agentdev-intake-pipeline`: deviation capture 委譲（STEP-4/5 で実観測時）
 
 ## Workflow Extension 読込
 
@@ -119,7 +119,7 @@ case-open workflow は次の6 STEP で構成する。各 STEP は resume point �
 
 - **draft-data 入力**: 本スキルは構造化 `draft-data` を入力として読み取る。`auto_gate.auto_ready` が false、未解決質問、未解決衝突、repo 外操作、停止理由が残る場合は停止する。`conflict_resolutions` に記録済みの衝突は再確認しない
 - **OU 単位処理**: Issue 化単位は REQ doc 単位ではなく OU 単位（G19/G20/G21）。子Issue は OU 単位で作成し、Wave 単位のみの子Issue 構造は作成しない（G14）
-- **子Issue 上限**: Epic 1件あたり最大10件（G05）、case-open Step 8 子Issue 作成並列上限は5件（3つの「5件」文脈の (1) に該当）
+- **子Issue 上限**: Epic 1件あたり最大10件（G05）、case-open STEP-5-4 子Issue 作成並列上限は5件（3つの「5件」文脈の (1) に該当）
 - **Form Zero**: draft/RU 削除は `git rm <path>` で明示パスをステージし、同一ステップで `git commit -- <path>` により即時コミットし、未ステージ残存を許さない
 - **本文 verbatim・ファイル経由**: Issue 本文は `[System.IO.File]::WriteAllText`（UTF8Encoding($false)）による UTF‑8 BOM なし LF 一時ファイル経由で `gh --body-file` へ渡す（G25）
 

--- a/src/opencode/skills/agentdev-workflow-case-open/references/adversarial-review-integration.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/references/adversarial-review-integration.md
@@ -1,6 +1,6 @@
-# STEP-{N}: adversarial-review 統合（経路F、adversarial-review-integration）
+# STEP-4: adversarial-review 統合（経路F、adversarial-review-integration）
 
-> 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-{N} 詳細である。adversarial-review 挿入境界（経路F、REQ-{NNNN}-{NNN}）の発動条件判定と review 呼出、結果反映を提供する。
+> 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-4 詳細である。adversarial-review 挿入境界（経路F、REQ-{NNNN}-{NNN}）の発動条件判定と review 呼出、結果反映を提供する。
 
 ## Purpose
 
@@ -15,8 +15,8 @@
 
 ## Preconditions
 
-- STEP-{N} で execution structure が確定している
-- STEP-{N} で Issue 本文候補・完了条件（QG-{N} 検証済み）が生成されている
+- STEP-3 で execution structure が確定している
+- STEP-2 で Issue 本文候補・完了条件（QG-{N} 検証済み）が生成されている
 
 ## Procedure
 
@@ -24,8 +24,8 @@
 
 execution structure、Issue 本文候補、完了条件を構成した後、**最初の GitHub Issue 作成の前**に挿入する。
 
-- **Epic flow の場合**: STEP-{N}（テンプレート読込）、Epic Issue 本文生成完了後、Epic Issue 作成の前
-- **Standard flow の場合**: preflight（STEP-{N}）完了後、関連ADR特定の前
+- **Epic flow の場合**: STEP-5（テンプレート読込）、Epic Issue 本文生成完了後、Epic Issue 作成の前
+- **Standard flow の場合**: preflight（STEP-3）完了後、関連ADR特定の前
 
 ### 発動条件判定（REQ-{NNNN}-{NNN}、REQ-{NNNN}-{NNN}）
 
@@ -39,15 +39,15 @@ case-open は adversarial-review を**原則実行する**（default-on、REQ-{N
 
 発動条件判定で発動と判定された場合、次の3者を対象に adversarial-review を呼び出す。
 
-1. execution structure（STEP-{N} で確定）
+1. execution structure（STEP-3 で確定）
 2. Issue 本文候補（Epic flow は Epic Issue 本文、Standard flow は Issue 本文）
-3. 完了条件（STEP-{N} の QG-{N} で検証済み）
+3. 完了条件（STEP-2 の QG-{N} で検証済み）
 
 委譲契約は delegation-contracts SPEC（extension 経由）「adversarial-review との委譲契約接続」節に従う。
 
 ### 結果反映
 
-- execution structure に関わる finding は STEP-{N}（execution-unit-and-preflight）へ戻し再評価
+- execution structure に関わる finding は STEP-3（execution-unit-and-preflight）へ戻し再評価
 - Issue 本文、完了条件に関わる finding は該当 STEP へ戻す
 - accepted finding の反映は呼出元の責務（REQ-{NNNN}-{NNN}）
 
@@ -57,14 +57,14 @@ review の結果反映で review 対象の意味内容が変更された場合�
 
 | 変更影響 | 再実行パターン |
 |---|---|
-| 完了条件のみ変更 | QG-{N}（STEP-{N}）を再実行 |
-| execution structure のみ変更 | preflight（STEP-{N}）を再実行 |
+| 完了条件のみ変更 | QG-{N}（STEP-2）を再実行 |
+| execution structure のみ変更 | preflight（STEP-3）を再実行 |
 | 両方が変更 | QG-{N}、preflight 両方を再実行（順序は QG-{N} → preflight） |
-| 意味内容変更なし | 再実行不要、最初の GitHub Issue 作成 STEP（STEP-{N}）へ進む |
+| 意味内容変更なし | 再実行不要、最初の GitHub Issue 作成 STEP（STEP-5）へ進む |
 
 ### unresolved 判断事項
 
-未解決のユーザー判断事項が残る場合、最初の GitHub Issue 作成 STEP（STEP-{N}）へ進まない（REQ-{NNNN}-{NNN}）。工程委譲起源であるため既存 status に unresolved 判断事項を付加する（REQ-{NNNN}-{NNN}）。
+未解決のユーザー判断事項が残る場合、最初の GitHub Issue 作成 STEP（STEP-5）へ進まない（REQ-{NNNN}-{NNN}）。工程委譲起源であるため既存 status に unresolved 判断事項を付加する（REQ-{NNNN}-{NNN}）。
 
 ### 呼出失敗時の扱い
 
@@ -95,8 +95,8 @@ review の結果反映で review 対象の意味内容が変更された場合�
 
 ## 関連 STEP
 
-- 前: STEP-{N}（execution-unit-and-preflight）
-- 次: STEP-{N}（issue-creation-flows）
+- 前: STEP-3（execution-unit-and-preflight）
+- 次: STEP-5（issue-creation-flows）
 
 ## 関連 Capability Skill
 

--- a/src/opencode/skills/agentdev-workflow-case-open/references/execution-unit-and-preflight.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/references/execution-unit-and-preflight.md
@@ -1,6 +1,6 @@
-# STEP-{N}: 構成判定・preflight（execution-unit-and-preflight）
+# STEP-3: 構成判定・preflight（execution-unit-and-preflight）
 
-> 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-{N} 詳細である。execution_unit 構成（連結成分アルゴリズム、3軸判断）と規模判定、構成生成事前検証（preflight）を提供する。
+> 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-3 詳細である。execution_unit 構成（連結成分アルゴリズム、3軸判断）と規模判定、構成生成事前検証（preflight）を提供する。
 
 ## Purpose
 
@@ -15,7 +15,7 @@ execution_unit 構成（連結成分アルゴリズム、3軸判断）と規模�
 
 ## Preconditions
 
-- STEP-{N} で Issue 本文候補（execution contract 確定済み）が生成されている
+- STEP-2 で Issue 本文候補（execution contract 確定済み）が生成されている
 
 ## Procedure
 
@@ -23,9 +23,9 @@ execution_unit 構成（連結成分アルゴリズム、3軸判断）と規模�
 
 入力要件doc数を確認。
 
-- **単一REQ** → 規模判定（Step 4）へ
-- **複数REQ または draft-meta `scale: large`** → **マルチREQ Epic flow**（STEP-{N} issue-creation-flows の Epic flow へ）
-- **OU モード時**: STEP-{N} で選択した OU が複数または `scale: large` を含む場合 → Epic flow に分岐
+- **単一REQ** → 規模判定（後述）へ
+- **複数REQ または draft-meta `scale: large`** → **マルチREQ Epic flow**（STEP-5 issue-creation-flows の Epic flow へ）
+- **OU モード時**: STEP-1 で選択した OU が複数または `scale: large` を含む場合 → Epic flow に分岐
 
 ### 自律構成生成（OU モード、複数REQ時）
 
@@ -38,10 +38,10 @@ execution_unit 構成（連結成分アルゴリズム、3軸判断）と規模�
 
 ### 規模判定（単一REQの場合）
 
-- `scale: large` → **単一REQ Epic flow**（STEP-{N} Epic flow へ）
-- `scale: standard` / フィールドなし → **Standard flow**（STEP-{N} Standard flow へ）
+- `scale: large` → **単一REQ Epic flow**（STEP-5 Epic flow へ）
+- `scale: standard` / フィールドなし → **Standard flow**（STEP-5 Standard flow へ）
 
-### 構成生成事前検証（preflight、Step 4-1）
+### 構成生成事前検証（preflight）
 
 Standard/Epic/混在構成の全ルートで GitHub Issue 作成前に共通の事前検証を実施。
 
@@ -80,8 +80,8 @@ Standard/Epic/混在構成の全ルートで GitHub Issue 作成前に共通の�
 
 ## 関連 STEP
 
-- 前: STEP-{N}（issue-body-and-execution-contract）
-- 次: STEP-{N}（adversarial-review-integration）
+- 前: STEP-2（issue-body-and-execution-contract）
+- 次: STEP-4（adversarial-review-integration）
 
 ## 関連 Capability Skill
 

--- a/src/opencode/skills/agentdev-workflow-case-open/references/handoff-and-ou-gate.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/references/handoff-and-ou-gate.md
@@ -1,6 +1,6 @@
-# STEP-{N}: 引き継ぎ・OU 選択（handoff-and-ou-gate）
+# STEP-1: 引き継ぎ・OU 選択（handoff-and-ou-gate）
 
-> 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-{N} 詳細である。SKILL.md は control plane として STEP 遷移を管理し、本 reference は STEP-{N} の実行詳細を提供する。
+> 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-1 詳細である。SKILL.md は control plane として STEP 遷移を管理し、本 reference は STEP-1 の実行詳細を提供する。
 
 ## Purpose
 
@@ -31,7 +31,7 @@
 - **OU ID 指定あり**: 当該 OU のみを処理対象とする例外経路
 - **OU ID 指定なし**:
   - OU 1件なら自動選択
-  - 2件以上なら execution_unit 構成を生成し、STEP-{N}（execution-unit-and-preflight）へ分岐
+  - 2件以上なら execution_unit 構成を生成し、STEP-3（execution-unit-and-preflight）へ分岐
 - **`operation_units` セクションがない場合**: 従来どおり全要件docを処理（後方互換）
 
 ## Result
@@ -57,7 +57,7 @@
 
 ## 関連 STEP
 
-- 次: STEP-{N}（issue-body-and-execution-contract）
+- 次: STEP-2（issue-body-and-execution-contract）
 
 ## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
 

--- a/src/opencode/skills/agentdev-workflow-case-open/references/issue-body-and-execution-contract.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/references/issue-body-and-execution-contract.md
@@ -1,6 +1,6 @@
-# STEP-{N}: Issue 本文生成・execution contract 確定（issue-body-and-execution-contract）
+# STEP-2: Issue 本文生成・execution contract 確定（issue-body-and-execution-contract）
 
-> 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-{N} 詳細である。Issue 本文生成と execution contract（EC-{N}〜EC-{N}）確定の手順を提供する。
+> 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-2 詳細である。Issue 本文生成と execution contract（EC-{N}〜EC-{N}）確定の手順を提供する。
 
 ## Purpose
 
@@ -15,7 +15,7 @@ Issue 本文候補を生成し、execution contract（EC-{N}〜EC-{N}）を確�
 
 ## Preconditions
 
-- STEP-{N} で処理対象が確定している
+- STEP-1 で処理対象が確定している
 
 ## Procedure
 
@@ -108,8 +108,8 @@ Issue 作成前に変更影響候補を探索し、scope、完了条件、test s
 
 ## 関連 STEP
 
-- 前: STEP-{N}（handoff-and-ou-gate）
-- 次: STEP-{N}（execution-unit-and-preflight）
+- 前: STEP-1（handoff-and-ou-gate）
+- 次: STEP-3（execution-unit-and-preflight）
 
 ## 関連 Capability Skill
 

--- a/src/opencode/skills/agentdev-workflow-case-open/references/issue-creation-flows.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/references/issue-creation-flows.md
@@ -1,10 +1,10 @@
-# STEP-{N}: Issue 作成（Epic flow / Standard flow、issue-creation-flows）
+# STEP-5: Issue 作成（Epic flow / Standard flow、issue-creation-flows）
 
-> 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-{N} 詳細である。Epic flow（Step 5-9）と Standard flow（Step 10-12）の制御、GitHub Issue 作成手続きを提供する。
+> 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-5 詳細である。Epic flow（STEP-5-1〜5-5）と Standard flow（STEP-5-6〜5-8）の制御、GitHub Issue 作成手続きを提供する。
 
 ## Purpose
 
-Epic flow（Step 5-9）または Standard flow（Step 10-12）の制御に従い GitHub Issue を作成し、OU 結果を書き戻す。
+Epic flow（STEP-5-1〜5-5）または Standard flow（STEP-5-6〜5-8）の制御に従い GitHub Issue を作成し、OU 結果を書き戻す。
 
 ## Input Resolution
 
@@ -15,8 +15,8 @@ Epic flow（Step 5-9）または Standard flow（Step 10-12）の制御に従い
 
 ## Preconditions
 
-- STEP-{N} で execution structure が確定している
-- STEP-{N} で adversarial-review skip または review 完了（unresolved なし）
+- STEP-3 で execution structure が確定している
+- STEP-4 で adversarial-review skip または review 完了（unresolved なし）
 
 ## Result
 
@@ -25,23 +25,23 @@ Epic flow（Step 5-9）または Standard flow（Step 10-12）の制御に従い
 
 ## Procedure
 
-実行ルート（Epic flow / Standard flow）は STEP-{N} の execution structure による。各 flow の手順は以下のとおり。
+実行ルート（Epic flow / Standard flow）は STEP-3 の execution structure による。各 flow の手順は以下のとおり。
 
-## Epic flow（Step 5-9、`scale: large` またはマルチREQ または複数 OU）
+## Epic flow（STEP-5-1〜5-5、`scale: large` またはマルチREQ または複数 OU）
 
-### Step 5: テンプレート読込
+### STEP-5-1: テンプレート読込
 
-`agentdev-workflow-templates` の選定ルールに従いテンプレートを読み込む。詳細は `agentdev-issue-management` を参照。Epic flow は STEP-{N} のルーティングにより開始。マルチREQ/ 単一REQ の差分（分解ソース、Wave テーブル列、子Issue 数上限、子Issue 内容ソース、子Issue 追加要素）の詳細は `agentdev-epic-tracker` を参照。
+`agentdev-workflow-templates` の選定ルールに従いテンプレートを読み込む。詳細は `agentdev-issue-management` を参照。Epic flow は STEP-3 のルーティングにより開始。マルチREQ/ 単一REQ の差分（分解ソース、Wave テーブル列、子Issue 数上限、子Issue 内容ソース、子Issue 追加要素）の詳細は `agentdev-epic-tracker` を参照。
 
-### Step 6: Epic Issue 本文生成
+### STEP-5-2: Epic Issue 本文生成
 
-STEP-{N} の自律構成分析結果に基づき Epic 本文を構築。詳細、委譲接続点は `agentdev-issue-management` を参照。
+STEP-3 の自律構成分析結果に基づき Epic 本文を構築。詳細、委譲接続点は `agentdev-issue-management` を参照。
 
-### Step 7: Epic Issue 作成
+### STEP-5-3: Epic Issue 作成
 
 ラベル `enhancement`, `feature`, `epic`。Issue 作成手続き（`agentdev-gh-cli`）で本文を書き込み → VERIFY。Issue 番号を `{epic_number}` として記録。
 
-### Step 8: 子Issue 作成（並列化）
+### STEP-5-4: 子Issue 作成（並列化）
 
 - **Issue 化単位**: OU 単位（G14、G21）
 - **子Issue 本文**: `Parent: #{epic_number}`（G03）、対象 OU ID、紐づく REQ/Decision/SPEC 識別子を記載
@@ -51,31 +51,31 @@ STEP-{N} の自律構成分析結果に基づき Epic 本文を構築。詳細�
 
 詳細、委譲接続点は `agentdev-issue-management` を参照。
 
-### Step 9: Epic Issue 本文更新
+### STEP-5-5: Epic Issue 本文更新
 
 詳細、委譲接続点は `agentdev-issue-management` を参照。
 
-#### Step 9-1: OU 結果の書き戻し
+#### STEP-5-5-1: OU 結果の書き戻し
 
 `operation_units` セクションがある場合、作成した Issue/Epic 番号を当該 OU の `result` に書き戻す。
 
-**Epic flow 完了後、共通終了処理（STEP-{N} termination-and-cleanup）を必ず実行すること。**
+**Epic flow 完了後、共通終了処理（STEP-6 termination-and-cleanup）を必ず実行すること。**
 
-## Standard flow（Step 10-12、`scale: standard` またはフィールドなし、単一 OU）
+## Standard flow（STEP-5-6〜5-8、`scale: standard` またはフィールドなし、単一 OU）
 
-### Step 10: 関連Decision特定
+### STEP-5-6: 関連Decision特定
 
 `docs/decisions<README>.md` から、単一REQ Epic flow の内容反映にも活用。
 
-### Step 11: ラベル付与
+### STEP-5-7: ラベル付与
 
 `agentdev-workflow-lifecycle` に従う。
 
-### Step 12: GitHub Issue 作成
+### STEP-5-8: GitHub Issue 作成
 
 Issue 作成手続き（`agentdev-gh-cli`）→ VERIFY。
 
-#### Step 12-1: OU 結果の書き戻し
+#### STEP-5-8-1: OU 結果の書き戻し
 
 `operation_units` セクションがある場合、作成した Issue 番号を当該 OU の `result` に書き戻す。
 
@@ -89,7 +89,7 @@ case-open、case-auto、case-run で参照される「5件」上限は文脈ご�
 | (2) case-auto Phase 2 同時起動数 | 5件 | Phase 分離モデルにおける case-run bg task 同時起動数 |
 | (3) execution_unit 全体並列 | 上限なし | 必須依存がない execution_unit 群は全て並列実行可能 |
 
-case-open の Step 8「子 Issue 作成の並列化」は **(1) に該当**。3文脈は別なので混同しない。
+case-open の STEP-5-4「子 Issue 作成の並列化」は **(1) に該当**。3文脈は別なので混同しない。
 
 ## Evidence
 
@@ -112,8 +112,8 @@ case-open の Step 8「子 Issue 作成の並列化」は **(1) に該当**。3�
 
 ## 関連 STEP
 
-- 前: STEP-{N}（adversarial-review-integration）
-- 次: STEP-{N}（termination-and-cleanup）
+- 前: STEP-4（adversarial-review-integration）
+- 次: STEP-6（termination-and-cleanup）
 
 ## 関連 Capability Skill
 

--- a/src/opencode/skills/agentdev-workflow-case-open/references/termination-and-cleanup.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/references/termination-and-cleanup.md
@@ -1,6 +1,6 @@
-# STEP-{N}: 終了処理・クリーンアップ（termination-and-cleanup）
+# STEP-6: 終了処理・クリーンアップ（termination-and-cleanup）
 
-> 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-{N} 詳細である。コメント追加、draft/RU 削除（Form Zero）、完了報告を提供する。
+> 本 reference は `agentdev-workflow-case-open` SKILL.md の Control Plane STEP-6 詳細である。コメント追加、draft/RU 削除（Form Zero）、完了報告を提供する。
 
 ## Purpose
 
@@ -15,7 +15,7 @@ Issue 作成後の共通終了処理（コメント追加、draft/RU 削除、�
 
 ## Preconditions
 
-- STEP-{N} で GitHub Issue 作成が完了している
+- STEP-5 で GitHub Issue 作成が完了している
 
 ## Result
 
@@ -26,33 +26,33 @@ Issue 作成後の共通終了処理（コメント追加、draft/RU 削除、�
 
 ## Procedure
 
-### Step 13: コメント追加（共通終了処理）
+### STEP-6-1: コメント追加（共通終了処理）
 
 `agentdev-workflow-templates` の選定ルールに従いコメント用テンプレートを読み込む（Epic flow では Epic Issue にコメント追加）→ VERIFY。
 
-### Step 14: ドラフト削除（共通終了処理）
+### STEP-6-2: ドラフト削除（共通終了処理）
 
 ドラフトが存在する場合、`.agentdev/drafts/req-draft-{topic-slug}.md` を削除（Standard/Epic 全フロー共通）。
 
 **Form Zero**: 削除は並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、`git rm <draft-path>` で明示パスをステージし、同一ステップ内で `git commit -- <draft-path>` により即時コミットする。未ステージの削除を作業ツリーに残存させないこと。
 
-### Step 14-1: RU ファイル削除（共通終了処理）
+### STEP-6-2-1: RU ファイル削除（共通終了処理）
 
 詳細、委譲接続点は `agentdev-req-file-manager` を参照。削除は並列実行安全ステージングプロシージャに従い `git rm <RU-path>` で明示パスをステージし、同一ステップ内で `git commit -- <RU-path>` により即時コミットする（Form Zero）。
 
-### Step 14-2: draft/RU 削除残存検証（共通終了処理）
+### STEP-6-2-2: draft/RU 削除残存検証（共通終了処理）
 
-Step 14/14-1 の削除後、当該ファイルが作業ツリー、index に残存していないことを検証。
+STEP-6-2/6-2-1 の削除後、当該ファイルが作業ツリー、index に残存していないことを検証。
 
 - 検証コマンド: `git status --porcelain -- <draft-path> <RU-path>` が空、またはファイル非存在確認
 - 残存を検出した場合: 即座に停止し残存ファイル一覧を報告
 - Standard flow と Epic flow の双方で実施
 
-### Step 14-3: draft/RU 削除 commit 後の即時 push（REQ）
+### STEP-6-2-3: draft/RU 削除 commit 後の即時 push（REQ）
 
-Step 14/14-1 の削除コミット後に `git push` を即時実行（case-run 引き継ぎ時の `git pull --ff-only` 失敗を防止するため）。push 失敗時は構造化エラーメッセージを表示して停止する。
+STEP-6-2/6-2-1 の削除コミット後に `git push` を即時実行（case-run 引き継ぎ時の `git pull --ff-only` 失敗を防止するため）。push 失敗時は構造化エラーメッセージを表示して停止する。
 
-### Step 15: 完了報告（共通終了処理）
+### STEP-6-3: 完了報告（共通終了処理）
 
 テンプレート種別:
 
@@ -83,7 +83,7 @@ Step 14/14-1 の削除コミット後に `git push` を即時実行（case-run �
 
 ## 関連 STEP
 
-- 前: STEP-{N}（issue-creation-flows）
+- 前: STEP-5（issue-creation-flows）
 - 次: なし（workflow 終了）
 
 ## 関連 Capability Skill

--- a/src/opencode/skills/agentdev-workflow-case-run/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/SKILL.md
@@ -34,7 +34,7 @@ extension（`.agentdev/extensions/skills/agentdev-workflow-case-run.yaml`）は�
 - 再開フェーズ判定（Issue番号解決、実行モード分岐、べき等性チェック）
 - 実行担当サブエージェント委譲（adapter protocol、委譲 prompt、L2 タイムスタンプ計測、経路G）
 - result 4状態処理（completed-pr / blocked / failed / delegation-unavailable）
-- 前置 gate 群（worktree precondition gate、QG-{N} 前置 staleness check、targeted docs guard、配布依存境界 事前チェック）と配布依存境界 最終 gate（Step 7-1 相当）
+- 前置 gate 群（worktree precondition gate、QG-{N} 前置 staleness check、targeted docs guard、配布依存境界 事前チェック）と配布依存境界 最終 gate（STEP-S5 で実施）
 
 ## DO NOT USE FOR
 
@@ -99,7 +99,7 @@ workflow 選択は STEP-S1 の実行モード分岐で確定する（引数が E
 | STEP-S2 | Issue 抽出・確認・判定 | 実行モード確定（single） | 要件doc・受け入れ基準抽出、関連Decision 確認、work_type metadata 整合確認、execution contract 消費境界適用 | [references/single.md](references/single.md) |
 | STEP-S3 | Worktree 作成・ブランチ準備・前置 gate 群 | Issue 判定完了 | worktree+ブランチ作成（べき等）、前置 gate 群（precondition / staleness / targeted docs / 事前委譲チェック）合格、L2 計測 | [references/single.md](references/single.md) |
 | STEP-S4 | 実行担当サブエージェント委譲 | STEP-S3 合格（worktree 内検証済み） | 委譲起動、L2 計測、経路G（adapter 委譲内 adversarial-review） | [references/delegation-and-result.md](references/delegation-and-result.md) |
-| STEP-S5 | result 処理・配布依存境界 最終 gate | 委譲 result 受領 | result 4状態処理、Step 7-1 相当の最終 gate 判定、L2 受け渡し | [references/delegation-and-result.md](references/delegation-and-result.md) |
+| STEP-S5 | result 処理・配布依存境界 最終 gate | 委譲 result 受領 | result 4状態処理、配布依存境界 最終 gate 判定、L2 受け渡し | [references/delegation-and-result.md](references/delegation-and-result.md) |
 | STEP-S6 | worktree クリーンアップ確認・完了報告 | result 処理完了（completed-pr 時は最終 gate 合格後） | 未コミット変更確認、完了報告（L2 内訳含む） | [references/single.md](references/single.md) |
 
 ### epic-wave workflow（`case-run #epic` 受領時）

--- a/src/opencode/skills/agentdev-workflow-case-run/references/delegation-and-result.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/references/delegation-and-result.md
@@ -75,7 +75,7 @@
   - **failed**: repository context で回答不能な blocker。詳細本文は Issue コメントに構造化して記録済み。エラー処理に従い停止、ユーザー報告
   - **delegation-unavailable**: 実行インフラが委譲を起動できなかった状態。実行未試行のため `pending` に戻す
 - **L2 タイムスタンプ受け渡し**: result 状態（completed-pr/blocked/failed）にかかわらず、STEP-S3（worktree 設定）、STEP-S4（実行担当サブエージェント実行）で計測した L2 タイムスタンプを result に含める。case-auto は本 L2 内訳を case-run 委譲の L1 壁時計時間の内訳として読み取る
-- **Step 7-1 相当: 配布依存境界の最終変更経路 gate（実装後、REQ-{NNNN}-{NNN} 再利用、DEC-{N}）**: result が `completed-pr` の場合、STEP-S6 に進む前に、実装後の実際の worktree HEAD に対して最終 gate を行う（実装担当サブエージェントが追加した変更も含めて検査する）
+- **STEP-S5-1: 配布依存境界の最終変更経路 gate（実装後、command 公開順序の Step 7-1 に対応、REQ-{NNNN}-{NNN} 再利用、DEC-{N}）**: result が `completed-pr` の場合、STEP-S6 に進む前に、実装後の実際の worktree HEAD に対して最終 gate を行う（実装担当サブエージェントが追加した変更も含めて検査する）
   - 実行条件: result が `completed-pr` であり、PR 対象ファイルに `src/opencode/{commands,skills}/**` 変更を含む場合。当該変更を含まない PR（docs のみ等）ではスキップする
   - 実行コマンド: `bun run .opencode/skills/<integrity-detector-skill>/scripts/check_distribution_boundary.ts --profile source --json`。現在の worktree（実装後 HEAD）の配布物ソースツリーを検査する
   - 検出結果の分類: 検査エラー（読込不能、未分類エントリ、adapter 起動失敗）は全て gate-not-passed として扱う（DEC-{N} 決定5、TS-{NNN}）。clean として通過させない

--- a/src/opencode/skills/agentdev-workflow-case-run/references/single.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/references/single.md
@@ -193,7 +193,7 @@
 ## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
 
 - G04（全ファイル操作は worktree 内で実行）
-- G30/G31（Step 5-2 precondition gate、worktree root 相対パス引き渡し）
+- G30/G31（STEP-S3 precondition gate、worktree root 相対パス引き渡し）
 - G33/G34/G35（QG-{N} 前置 staleness check、差異検出時の引き渡しと case-update 連携）
 
 ## 関連ガイドライン

--- a/src/opencode/skills/agentdev-workflow-inspect-docs/references/distribution-check-and-output.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-docs/references/distribution-check-and-output.md
@@ -15,7 +15,7 @@
 
 ## 手順
 
-### Step 11: 配布物整合性検査
+### STEP-3-1: 配布物整合性検査
 
 配布物（`.opencode/commands/agentdev/`、`.opencode/skills/agentdev-*/`）について、docs-spec-rebuild-integrity SPEC（extension 経由）が定義する検査パターンに従い、構文健全性（frontmatter 重複、見出し重複、Markdown 構文破損、存在しない command 参照、エンコーディング不整合）、文意保持（壊れた括弧、壊れた参照表現、主語/目的語欠落文）、責務整合（command 本体と SPEC 間の責務説明照合、case-open/run/close/auto の責務境界一致）を診断する。`agentdev-req-structure-diagnostics` 参照。
 
@@ -23,30 +23,30 @@
 
 エンコーディング不整合の検出は、配布物 Markdown の UTF-8 BOM 付きファイルと単一ファイル内の CRLF/LF 混在を検出事項とし、BOM なし UTF-8 かつ単一改行コードで構成されたファイルは検出対象外とする（同上）。
 
-### Step 12: docs-check route 判定
+### STEP-3-2: docs-check route 判定
 
 意味的疑いのうち機械的検査に落とせるものを docs-check ルール／検査データ候補として提示する。
 
-### Step 13: 未処理 artifact 確認
+### STEP-3-3: 未処理 artifact 確認
 
 `agentdev-req-structure-diagnostics` 参照。
 
-### Step 14: 検出事項出力
+### STEP-4-1: 検出事項出力
 
 検出事項を `.agentdev/inspect/inbox/inspect-docs-finding-{timestamp}.md` へ出力する。
 source-of-truth priority: 現行 REQ > 承認済み ADR > SPEC > guides。
 NG 分類（false positive/ pre-existing/ 今回修正対象）は docs-spec-rebuild-integrity SPEC（extension 経由）の NG 分類表に従い、各検出事項に分類、理由、後続対象を付ける。
 
-### Step 15: 実行前同期（git pull --ff-only）
+### STEP-4-2: 実行前同期（git pull --ff-only）
 
 - `git pull --ff-only` を実行する
 - **失敗時**: 共通 template（`.opencode/commands/agentdev/templates/common/git-error-messages.md`）の該当形式で表示して停止する（自動解消しない）
 
-### Step 16: .agentdev/inspect/ 変更の commit と push
+### STEP-4-3: .agentdev/inspect/ 変更の commit と push
 
 `agentdev-git-worktree` の「ドメイン状態永続化プロシージャ」（並列実行安全ステージングプロシージャ含む）に従い、`.agentdev/inspect/` 配下の変更を commit/ push する。commit message は `chore(agentdev): capture inspect-docs finding`（Conventional Commits 形式）。変更なし時は commit/push せず完了報告で「変更なし」と報告する。push 失敗時は同プロシージャの構造化エラー形式で停止する（完了扱いにしない）。
 
-### Step 17: 完了報告
+### STEP-4-4: 完了報告
 
 完了報告 template（`.opencode/commands/agentdev/templates/inspect-docs/standard.md`）に従って出力する。
 

--- a/src/opencode/skills/agentdev-workflow-inspect-docs/references/scan-and-doc-diagnostics.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-docs/references/scan-and-doc-diagnostics.md
@@ -13,43 +13,43 @@
 
 ## 手順
 
-### Step 1: スキャン対象の収集
+### STEP-1-1: スキャン対象の収集
 
 `docs/requirements/`、`docs/decisions/`、`docs/specs/`、`docs/guides/`、`README.md`、`.opencode/` を収集する。
 
-### Step 2: REQ 参照ID整合性確認
+### STEP-2-1: REQ 参照ID整合性確認
 
 `agentdev-req-structure-diagnostics` 参照。
 
-### Step 3: 第一参照導線確認
+### STEP-2-2: 第一参照導線確認
 
 `agentdev-req-structure-diagnostics` 参照。
 
-### Step 4: 現行/廃止/世代境界確認
+### STEP-2-3: 現行/廃止/世代境界確認
 
 `agentdev-req-structure-diagnostics` 参照。
 
-### Step 5: SPEC 意味診断
+### STEP-2-4: SPEC 意味診断
 
 SPEC が REQ/Decision/guides の代替、将来計画の混入、実行時依存先としての不適切扱いを確認する。
 
-### Step 6: Decision 意味診断
+### STEP-2-5: Decision 意味診断
 
 承認済み ADR のみを現行判断の根拠として扱っているか確認する。
 
-### Step 7: guides 意味診断
+### STEP-2-6: guides 意味診断
 
 guides が navigation layer の範囲を超えていないか確認する。履歴混入を検出した場合 route を追加する。
 
-### Step 8: README 索引診断
+### STEP-2-7: README 索引診断
 
 README 索引が導線の範囲を超えていないか確認する。内容過多を検出した場合分割を誘導する。
 
-### Step 9: REQ structure review（6観点）
+### STEP-2-8: REQ structure review（6観点）
 
 SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT。`agentdev-req-structure-diagnostics` 参照。
 
-### Step 10: 文書分類一貫性検査
+### STEP-2-9: 文書分類一貫性検査
 
 document-model SPEC（extension 経由）の classification policy への適合確認。REQ 要件行に schema field、enum 値一覧、route/category/status 判定表、file pattern、テンプレート種別、report format、内部アルゴリズム、作業履歴、実装パラメータ等の SPEC分離基準違反が残留していないかを `agentdev-req-structure-diagnostics` に従って自動検出する。
 
@@ -67,7 +67,7 @@ document-model SPEC（extension 経由）の classification policy への適合�
 
 ## 関連 Capability Skill
 
-- `agentdev-req-structure-diagnostics`: Step 2〜4、9、10 の判定ロジック
+- `agentdev-req-structure-diagnostics`: STEP-2-1〜2-3、2-8、2-9 の判定ロジック
 - `agentdev-doc-diagnostics`: 診断カテゴリ、証拠構造、文書種別別ルーティング
 - `agentdev-project-extensions`: document-model SPEC の extension 経由解決
 

--- a/src/opencode/skills/agentdev-workflow-inspect-skills/references/finding-output-and-persist.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-skills/references/finding-output-and-persist.md
@@ -13,20 +13,20 @@
 
 ## 手順
 
-### Step 6: 検出事項出力
+### STEP-3-1: 検出事項出力
 
 検出事項を `.agentdev/inspect/inbox/inspect-skills-finding-{topic}.md` へ出力する。
 
-### Step 7: 実行前同期（git pull --ff-only）
+### STEP-3-2: 実行前同期（git pull --ff-only）
 
 - `git pull --ff-only` を実行する
 - **失敗時**: 共通 template（`.opencode/commands/agentdev/templates/common/git-error-messages.md`）の該当形式で表示して停止する（自動解消しない）
 
-### Step 8: .agentdev/inspect/ 変更の commit と push
+### STEP-3-3: .agentdev/inspect/ 変更の commit と push
 
 `agentdev-git-worktree` の「ドメイン状態永続化プロシージャ」（並列実行安全ステージングプロシージャ含む）に従い、`.agentdev/inspect/` 配下の変更を commit/ push する。commit message は `chore(agentdev): capture inspect-skills finding`（Conventional Commits 形式）。変更なし時は commit/push せず完了報告で「変更なし」と報告する。push 失敗時は同プロシージャの構造化エラー形式で停止する（完了扱いにしない）。
 
-### Step 9: 完了報告
+### STEP-3-4: 完了報告
 
 完了報告 template（`.opencode/commands/agentdev/templates/inspect-skills/standard.md`）に従って出力する。
 

--- a/src/opencode/skills/agentdev-workflow-inspect-skills/references/skill-structure-diagnostics.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-skills/references/skill-structure-diagnostics.md
@@ -13,15 +13,15 @@
 
 ## 手順
 
-### Step 1: 診断対象の読込
+### STEP-1-1: 診断対象の読込
 
 Command/ Skill 定義を読み込み、Command→Skill 参照、Skill frontmatter、本文構造、references 利用、template/ script 参照を把握する。
 
-### Step 2: 各診断観点の評価
+### STEP-2-1: 各診断観点の評価
 
 `agentdev-inspect-skills` に従い、参照妥当性、粒度、段階的開示、責務境界、canonical name、内部構造依存を評価する。
 
-### Step 3: 配布物構文健全性、責務整合診断
+### STEP-2-2: 配布物構文健全性、責務整合診断
 
 配布物（`.opencode/commands/agentdev/`、`.opencode/skills/agentdev-*/`）について、docs-spec-rebuild-integrity SPEC（extension 経由）が定義する検査パターンのうち Command/Skill 構造に関わる観点（frontmatter 重複、見出し重複、Markdown 構文破損、存在しない command 参照、エンコーディング不整合、壊れた括弧、command と関連 skill 間の責務説明矛盾）を `agentdev-inspect-skills` に従って診断する。
 
@@ -29,11 +29,11 @@ Command/ Skill 定義を読み込み、Command→Skill 参照、Skill frontmatte
 
 エンコーディング不整合の検出は、配布物 Markdown の UTF-8 BOM 付きファイルと単一ファイル内の CRLF/LF 混在を検出事項とし、BOM なし UTF-8 かつ単一改行コードで構成されたファイルは検出対象外とする（同上）。
 
-### Step 4: 分類
+### STEP-2-3: 分類
 
 検出事項ごとに診断分類ラベルを付与する。NG 分類（false positive/ pre-existing/ 今回修正対象）は docs-spec-rebuild-integrity SPEC（extension 経由）の NG 分類表に従い、各検出事項に分類、理由、後続対象を付ける。
 
-### Step 5: route 提示
+### STEP-2-4: route 提示
 
 修正は実行せず、推奨 route を提示する。
 
@@ -52,7 +52,7 @@ Command/ Skill 定義を読み込み、Command→Skill 参照、Skill frontmatte
 
 ## 関連 Capability Skill
 
-- `agentdev-inspect-skills`: 診断観点と判定基準（Step 2、3）
+- `agentdev-inspect-skills`: 診断観点と判定基準（STEP-2-1、2-2）
 - `agentdev-project-extensions`: docs-spec-rebuild-integrity SPEC の extension 経由解決
 
 ## 関連ガードレール（command 側で宣言、本 reference は詳細実装）

--- a/src/opencode/skills/agentdev-workflow-intake-capture/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-intake-capture/SKILL.md
@@ -58,13 +58,13 @@ extension（`.agentdev/extensions/skills/agentdev-workflow-intake-capture.yaml`�
 
 本スキルは capture-only型の workflow であり、STEP model の対象外である（REQ-{NNNN}-{NNN}）。resume point / export / import を持たない。工程は逐次実行し、中断時は workflow を最初から再実行する。保存済みファイルとの重複はファイル名への連番付与で吸収するため、再実行は安全である。
 
-| 工程 | 名称 | 内容 |
+| STEP | 名称 | 内容 |
 |---|---|---|
-| 工程-1 | 入力の受領 | ユーザーから変更候補の内容を受領する。自然言語で記述された内容をそのまま取り扱う |
-| 工程-2 | intake item の生成 | 入力を推奨標準形に整理する。ユーザーが明示的に指定していないセクションは推測・補完せず省略する |
-| 工程-3 | ファイル名の生成・実行前同期 | `YYYY-MM-DD-{topic-slug}.md` 形式でファイル名を生成する。`git pull --ff-only` を実行する |
-| 工程-4 | 保存・永続化 | `.agentdev/intake/inbox/` へ保存し、`.agentdev/intake/` 配下の変更を commit / push する |
-| 工程-5 | 完了報告 | 完了報告 template に従って出力する。git 永続化結果を含める |
+| STEP-1 | 入力の受領 | ユーザーから変更候補の内容を受領する。自然言語で記述された内容をそのまま取り扱う |
+| STEP-2 | intake item の生成 | 入力を推奨標準形に整理する。ユーザーが明示的に指定していないセクションは推測・補完せず省略する |
+| STEP-3 | ファイル名の生成・実行前同期 | `YYYY-MM-DD-{topic-slug}.md` 形式でファイル名を生成する。`git pull --ff-only` を実行する |
+| STEP-4 | 保存・永続化 | `.agentdev/intake/inbox/` へ保存し、`.agentdev/intake/` 配下の変更を commit / push する |
+| STEP-5 | 完了報告 | 完了報告 template に従って出力する。git 永続化結果を含める |
 
 ## Intake Item 形式
 

--- a/src/opencode/skills/agentdev-workflow-intake-from-github/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-intake-from-github/SKILL.md
@@ -62,16 +62,16 @@ extension（`.agentdev/extensions/skills/agentdev-workflow-intake-from-github.ya
 
 本スキルは capture-only型の workflow であり、STEP model の対象外である（REQ-{NNNN}-{NNN}）。resume point / export / import を持たない。工程は逐次実行し、中断時は workflow を最初から再実行する。抽出の再実行は読み取りのみのため安全であり、保存済みファイルとの重複はファイル名への連番付与で吸収する。
 
-| 工程 | 名称 | 内容 |
+| STEP | 名称 | 内容 |
 |---|---|---|
-| 工程-1 | 期間解釈 | 期間指定または Issue/PR 番号指定を解釈する（抽出アルゴリズムは `agentdev-intake-pipeline`） |
-| 工程-2 | データ取得 | クローズ済み Issue/PR のデータを取得する（gh CLI、`agentdev-gh-cli` の読み取り手続き） |
-| 工程-3 | 構造的検出 | 抽出ルールに基づき構造的に残課題候補を検出する（`agentdev-intake-pipeline`） |
-| 工程-4 | LLM 全文解析 | キーワードリスト、コンテキスト付与ルールに基づき全文解析する（`agentdev-intake-pipeline`） |
-| 工程-5 | intake item 生成・実行前同期 | item 生成ルール、ファイル名規則に従い item を生成する（`agentdev-intake-pipeline`）。`git pull --ff-only` を実行する |
-| 工程-6 | 保存・永続化 | `.agentdev/intake/inbox/` へ保存し、`.agentdev/intake/` 配下の変更を commit / push する |
-| 工程-7 | サマリーレポート提示 | 抽出結果をサマリーとしてユーザーに提示する（対象期間、対象数、抽出候補数、保存先、一覧表） |
-| 工程-8 | 完了報告 | 完了報告 template に従って出力する。git 永続化結果を含める |
+| STEP-1 | 期間解釈 | 期間指定または Issue/PR 番号指定を解釈する（抽出アルゴリズムは `agentdev-intake-pipeline`） |
+| STEP-2 | データ取得 | クローズ済み Issue/PR のデータを取得する（gh CLI、`agentdev-gh-cli` の読み取り手続き） |
+| STEP-3 | 構造的検出 | 抽出ルールに基づき構造的に残課題候補を検出する（`agentdev-intake-pipeline`） |
+| STEP-4 | LLM 全文解析 | キーワードリスト、コンテキスト付与ルールに基づき全文解析する（`agentdev-intake-pipeline`） |
+| STEP-5 | intake item 生成・実行前同期 | item 生成ルール、ファイル名規則に従い item を生成する（`agentdev-intake-pipeline`）。`git pull --ff-only` を実行する |
+| STEP-6 | 保存・永続化 | `.agentdev/intake/inbox/` へ保存し、`.agentdev/intake/` 配下の変更を commit / push する |
+| STEP-7 | サマリーレポート提示 | 抽出結果をサマリーとしてユーザーに提示する（対象期間、対象数、抽出候補数、保存先、一覧表） |
+| STEP-8 | 完了報告 | 完了報告 template に従って出力する。git 永続化結果を含める |
 
 ## Intake Item 形式
 


### PR DESCRIPTION
## 概要

Issue #2144（OU-010、Wave 2）。配布物の書式統一（RU-0014、RU-0015 の実装側）。
(1) check/install スクリプトの案内文言・既定 URL 定数の共有化、(2) case-open/case-auto の STEP 識別子マスク形式（STEP-{N}）の実番号化、(3) 既存16 Workflow Skill の順序ラベル3変種（### Step N / STEP-{N} / 工程-N）の統一基準適用。

前回 driver が途中で中断した未コミット実装を引き継ぎ、検証・補完して完了させた PR である。

## 実装内容

### 引き継ぎ分（前回 driver 実装、本 PR で検証により採用）

- `scripts/consumer-opencode-common.ps1`（新規）: URL・ブランチ定数（`$ConsumerRepoUrl` / `$ConsumerDefaultBranch`）、`Assert-ValidConsumerCwd`（cwd 安全化）、`Show-ConsumerCheckoutGuidance`（チェックアウト未検出時の案内）を単一定義として所有
- `scripts/check-consumer-opencode.ps1` / `scripts/install-consumer-opencode.ps1`: 上記モジュールを dot-source し、重複定義（計 2 関数・3 定数）を削除。案内文言は呼出元固有行（clone コマンド形式、ZIP 配置補足）をパラメータで注入し元出力を維持
- case-open / case-auto の SKILL.md・references/ のマスク形式（STEP-{N}）→ 実番号変換の大半（旧 command 番号の `### Step N` サブ見出しは `STEP-5-N` 等の階層付き実番号へ再解釈）

### 本 PR で新規に完了した分

- **case-auto の残件変換**: `references/conflict-resolution-and-reporting.md` にマスク形式 15 件が残存していた（引き継ぎ時の grep で検出）ため、SKILL.md の 8 STEP 表と突き合わせて STEP-7/8 系の実番号へ変換（停止経路=STEP-4、orchestration 戻り=STEP-3、OUループ=STEP-3 を整合確認）
- **完了条件3（他の Workflow Skill の3変種統一）**:
  - `agentdev-workflow-case-close`: 旧 command 番号サブ見出し（`#### Step 5`〜`Step 12`、`Step 1-1`、`Step 3-1/3-2`、`Step 4-0/4/4-1/4-2`、`Step 9-1/9-2`）を親 STEP 傘下の実番号（`STEP-5-1`〜`STEP-6-6`、`STEP-4-1`〜`STEP-4-4` 等）へ変換。本文中参照（G17/G19、重複チェック再実行の説明等）も同時に更新
  - `agentdev-workflow-case-run`: SKILL.md USE FOR・STEP-S5 行、`delegation-and-result.md` の「Step 7-1 相当」ラベル（→ `STEP-S5-1`、command 公開順序 Step 7-1 との対応を明記）、`single.md` の G30/G31（`Step 5-2` → `STEP-S3`）
  - `agentdev-workflow-inspect-docs`: 2 reference 計 17 個の `### Step N` を SKILL.md 工程表（STEP-1〜4）に整合する `STEP-N-M` 形式へ変換（`Step 1`→`STEP-1-1`、`Step 2〜10`→`STEP-2-1〜2-9`、`Step 11〜13`→`STEP-3-1〜3-3`、`Step 14〜17`→`STEP-4-1〜4-4`）
  - `agentdev-workflow-inspect-skills`: 同様に 9 個を `STEP-1-1`、`STEP-2-1〜2-4`、`STEP-3-1〜3-4` へ変換
  - `agentdev-workflow-intake-capture` / `agentdev-workflow-intake-from-github`: SKILL.md 工程一覧表の `工程-1〜5` / `工程-1〜8` を `STEP-1〜5` / `STEP-1〜8`（列名も `STEP`）へ変換
  - case-close/case-run からの「case-run Step 7-1」参照は、現行 case-run command の公開順序ラベル（`### Step 7-1` が現存）への正当参照のため「case-run command Step 7-1」と修飾して保持
- **完了条件4（workflow-skill-model SPEC 旧記述除去）**: 定義側保存（commit 151f559e）で Command 責務節は統一基準の記述に置換済みであり、3様式共存の旧記述は存在しないことを確認（grep `3様式` = 0 件、現行節は `### Step N` / 実番号形式の使い分けを規定）。本 PR は docs/ を変更しない

## 完了条件

- [ ] check/install スクリプトの案内文言・既定 URL 定数が共有化されていること（利用者可視挙動の変更なし）
- [ ] case-open / case-auto の SKILL.md・references/ からマスク形式（STEP-{N}）記述が 0 件となること
- [ ] 既存16 Workflow Skill の順序ラベル3変種が統一基準へ更新されていること
- [ ] workflow-skill-model SPEC の Command 責務節から3様式存在の旧記述が除去されていること
- [ ] 契約テスト期待値の更新と固定トークン確認: 実施済み確認（期待値更新対象: なし。command 定義は本 PR で変更しておらず、commands_e2e.test.ts 等の構造期待値は無修正で合格。skill 構造契約テスト skills_structure / lint_skills も無修正で合格）

## テスト結果

TS-012（test-fix ループ、全項目合格。不合格項目なしのため record-in-findings なし）:

1. **SPEC↔checker 突合（機械分類表 vs check_extensions.ts）**: `deriveSkillClassification` の規則（Workflow Skill = command が存在する `agentdev-workflow-{X}`、Capability = その他の `agentdev-*`、workflow-* プレフィックス例外を含む）が workflow-skill-model SPEC 機械分類表と一致。実行検証: `bun check_extensions.ts . --json` → ok=true、workflow_skills=16 = public_commands=16（SPEC 型分類の16 Workflow Skill と一致）、failures=0。`--scenario` 9/9 PASS、check_extensions.test.ts 10/10 PASS
2. **project-extensions SPEC 共有実装節 vs 実装構成**: 状態機械（不在/破損/旧kind/未知kind/有効の5状態、malformed 判定が kind 判定に先行、公式3値 enum、fail-open は malformed のみ）が runtime resolver（agentdev-project-extensions SKILL.md）と checker（`resolveExtensionState`）で同一であることを文書・実装突合で確認。シナリオ S1〜S9 全 PASS
3. **マスク形式 grep**: case-open/case-auto の SKILL.md・references/ で `STEP-{N}` = 0 件。ついでに src/opencode 全体でも 0 件
4. **workflow-skill-model SPEC 旧記述**: 上記のとおり不存在を確認（完了条件4は検証により充足）
5. **スクリプト定数共有化の単一定義参照**: scripts/*.ps1 中の `https://github.com/yogata/agent-dev-flow.git` は consumer-opencode-common.ps1 の1定義のみ。PowerShell Parser 構文検査 3 ファイル OK
6. **DEC-016 挙動同一性（新旧出力比較）**: HEAD 版と本 PR 版をサンドボックス消費リポジトリで実行し、7 シナリオ（check/install×check/dry-run の案内パス3、フルチェックパス3、cwd ガード1）すべてで stdout 完全一致・終了コード一致を確認

テスト実行（本 PR の全編集後）: check_extensions 10 pass / skills_structure + lint_skills 469 pass / check_workflow_preventive + check_command_format + commands_structure + commands_e2e + check_reference_paths + check_skill_rename_symmetry 223 pass / check_integrity + check_distribution_boundary + check_changed_docs + check_test_impact + check_autogen_freshness + current_refs + templates_structure + check_templates 249 pass / distribution-boundary-guard 105 pass。合計 1,156 pass / 0 fail

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| case-open/case-auto のマスク形式（STEP-{N}）件数 | 0 件 | 0 件 | ✅ |
| 16 Workflow Skill 内の3変種残存（自前の工程識別子としての ### Step N / STEP-{N} / 工程-N） | 0 件（残存 `Step 7-1` は現行 command 公開ラベルへの修飾付き参照のみ6件） | 0 件 | ✅ |
| scripts の URL 定義箇所数 | 1（共通モジュールのみ） | 1 | ✅ |
| 新旧スクリプト出力一致シナリオ | 7/7（stdout + 終了コード完全一致） | 全シナリオ一致 | ✅ |
| 関連テスト | 1,156 pass / 0 fail | 0 fail | ✅ |

## Findings / Capture候補

### intake

1. **Capability Skill・SPEC に残る旧 command 番号への参照（本 PR の実番号化で解決先が消失するものを含む）**: `agentdev-git-worktree/references/git-common-procedures.md`（`case-close Step 9/9-1/9-2/4-1/4-2`）、`agentdev-gh-cli/references/standard-procedures.md`（`case-close Step 4-0/4-2`）、`agentdev-quality-gates/references/*`（`case-run Step 5-3/6/7/11-1`）、`agentdev-workflow-orchestration`（`case-run Step 6` — 既に現行のどこにも存在しない stale 参照）、`agentdev-doc-diagnostics/references/diagnostic-routing.md`（inspect-docs 旧 `Step 2〜13` 表）、`docs/specs/foundations/system.md`（各 command の旧 Step 番号記述）。本 Issue の対象範囲（16 Workflow Skill と scripts）外のため未対応。command 再構成（OU-003 系）との整合を見ながら参照先更新の個別 Issue 化を推奨
2. **command の workflow 節の残る非標準ラベル**: `src/opencode/commands/agentdev/intake-capture.md`（`工程-1〜5`）と `intake-from-github.md`（`工程-1〜8`）の公開順序要約が `### Step N` 形式でない（Command 標準違反）。command 定義と commands_e2e.test.ts 期待値は OU-003 側の管理対象のため本 PR では未対応
3. **case-run command の孤立 `### Step 7-1` 見出し**: `src/opencode/commands/agentdev/case-run.md` の workflow 節に親 Step 7 を持たない `### Step 7-1` が単独で存在（command-file-format の連番規則と不整合）。command 側の修正対象として記録
4. **`epic-wave-close.md` のゼロ起点 E ラベル（`E4-0`）**: 3変種の対象外のため本 PR では未変換。E 系ラベルの副番号開始値の規約が未整備

### learning

1. **網羅 grep でのパス glob の落とし穴**: `Select-String -Path '<dir>/**/*'` 形式はスキル直下の SKILL.md（サブディレクトリ外のファイル）を取りこぼす場合がある（本 Issue では intake 系 SKILL.md の `工程-N` が一時見落とし）。ラベル網羅検査では `Get-ChildItem -Recurse -File` でファイル列挙してから `Select-String -LiteralPath` に渡す方式が安定する。件数整合の二重確認（列挙ベース集計と再 grep の一致）で検出した

## SPEC確定候補

1. **Workflow Skill 本文のサブステップ識別子様式の明文化**: 本 PR は case-open の先行変換例に倣い、reference 内の旧 `### Step N` サブ見出しを親 STEP 傘下の階層付き実番号（`STEP-5-4`、`STEP-6-3-2` 等）へ、capture-only 型 SKILL.md 工程一覧は `| STEP |` 列の `STEP-N` 値（順序ラベル）へ整理した。command-file-format.md の順序ラベル様式節は「実番号形式（STEP-1 等）」までしか規定しておらず、(a) サブステップの階層形式（`STEP-N-M`、ゼロ起点禁止）、(b) STEP model 対象外型（capture-only / read-only-diagnostic）の工程一覧表ラベル契約、を SPEC に確定する候補
2. **他成果物の工程ラベル参照の形式規約**: Workflow Skill 本文から当該 command の公開順序ラベルを参照する際の修飾形式（本 PR は「case-run command Step 7-1」の形式を採用）と、Capability Skill・SPEC から Workflow Skill の工程を参照する際の形式（`STEP-S5` 等の実番号）の使い分け規約

## 決定事項

- 旧 command 番号サブ見出しの変換先として、case-open 引き継ぎ分と同一の「親 STEP 傘下の階層付き実番号（STEP-N-M）」方式を採用（16 Skill 横断で様式を統一）
- 現行 command の公開ラベル（case-run `### Step 7-1`、case-close `### Step 1〜6`）への参照は Command 標準の正当な使い分けと判断し、`command` 修飾を付して保持

Refs: #2144