### PR TITLE
docs(agentdev): REQ-037 参照再配線（旧 REQ-010-034〜040, 050〜052）(#2158)

### DIFF
--- a/docs/specs/commands/intake-capture.md
+++ b/docs/specs/commands/intake-capture.md
@@ -88,5 +88,5 @@ updated: 2026-08-15
 - [intake-from-github.md](intake-from-github.md)（GitHub からの自動抽出）
 - `agentdev-workflow-intake-capture` skill（workflow 実装本体）
 - `agentdev-intake-pipeline` skill（共通手順）
-- REQ-010（Intake command群）
+- REQ-037（Intake command群）
 

--- a/docs/specs/commands/intake-from-github.md
+++ b/docs/specs/commands/intake-from-github.md
@@ -91,5 +91,5 @@ updated: 2026-08-15
 - [intake-promote.md](intake-promote.md)（後続コマンド（採用判断））
 - `agentdev-workflow-intake-from-github` skill（workflow 実装本体）
 - `agentdev-intake-pipeline` skill（抽出アルゴリズム）
-- REQ-010（Intake command群）
+- REQ-037（Intake command群）
 

--- a/docs/specs/commands/intake-promote.md
+++ b/docs/specs/commands/intake-promote.md
@@ -129,7 +129,7 @@ intake-promote は change_nature と併せて、observed_evidence（根拠とな
 - [backlog-review.md](backlog-review.md)（後続コマンド（RU 生成））
 - `agentdev-workflow-intake-promote` skill（workflow 実装本体）
 - `agentdev-intake-pipeline` skill（inbox スキャン、レビュー評価、分類提示、整形保存）
-- REQ-010（Intake command群）
+- REQ-037（Intake command群）
 
 ## adversarial-review 挿入境界（経路C）
 

--- a/docs/specs/foundations/document-model.md
+++ b/docs/specs/foundations/document-model.md
@@ -148,7 +148,7 @@ REQ 要件行の粒度を判定するテスト:
 
 ### REQ 品質維持基準
 
-SPLIT / MERGE / MOVE / DUPLICATE / RETIRE / DRIFT は、inspect-docs の診断観点に加え、REQ 運用品質維持の恒常的基準として参照する（REQ-010-039）。
+SPLIT / MERGE / MOVE / DUPLICATE / RETIRE / DRIFT は、inspect-docs の診断観点に加え、REQ 運用品質維持の恒常的基準として参照する（REQ-037-006）。
 REQ 体系の健全性を維持するため、これらの観点で定期的に REQ 体系を評価する。
 
 ### 恒久契約適格性と既存成果物処置分類 <!-- v2:REQ-0155-005, REQ-010-047, v2:REQ-0140-021 -->

--- a/docs/specs/skills/agentdev-intake-pipeline.md
+++ b/docs/specs/skills/agentdev-intake-pipeline.md
@@ -56,7 +56,7 @@ Command→Skill 依存方向（[artifact-contracts.md](../responsibilities/artif
 #### 本操作の責務（呼出元に対する提供）
 
 - 実観測ベースで intake 該当分を判定する（[capture-boundaries.md](../workflows/capture-boundaries.md) Split Rule 準拠）
-- `.agentdev/intake/inbox/*.md` へ item を生成、保存する。REQ 再構成 intake は `.agentdev/intake/inbox/req-restructure/` 配下へ配置する（REQ-010）
+- `.agentdev/intake/inbox/*.md` へ item を生成、保存する。REQ 再構成 intake は `.agentdev/intake/inbox/req-restructure/` 配下へ配置する（REQ-037）
 - Split Rule に基づき learning 該当分を `agentdev-learning-capture` skill へ分割指示する（混在させない）
 
 #### 呼出元 command の責務（本操作が委譲しないもの）
@@ -85,7 +85,7 @@ Command→Skill 依存方向（[artifact-contracts.md](../responsibilities/artif
 
 - 抽出と promote の双方のロジックを提供
 - RU 生成は backlog-review に委譲
-- intake 系コマンドは `.agentdev/intake/` 更新前後に git 永続化を実行（REQ-010）
+- intake 系コマンドは `.agentdev/intake/` 更新前後に git 永続化を実行（REQ-037）
 
 ## 対象外
 
@@ -106,7 +106,7 @@ Command→Skill 依存方向（[artifact-contracts.md](../responsibilities/artif
 - [commands/intake-from-github.md](../commands/intake-from-github.md)
 - [commands/intake-promote.md](../commands/intake-promote.md)
 - [../workflows/capture-boundaries.md](../workflows/capture-boundaries.md)
-- REQ-010（Intake command群）
+- REQ-037（Intake command群）
 
 ## adversarial-review 候補判断と内部挿入
 


### PR DESCRIPTION
## 概要

Issue #2158（OU-002）として、旧 REQ-010 の取り込みパイプライン（intake）移動行（REQ-010-034〜040、050〜052）への docs 全域参照を REQ-037 へ再配線した。

Refs: #2158

## 変更内容

AG-007 マッピング表のうち intake 分を適用した。
置換は「参照する全行が REQ-037 へ映射する場合のみ書き換える」の決定論に従う。

- `docs/specs/foundations/document-model.md`: `REQ-010-039` → `REQ-037-006`（単一行参照）
- `docs/specs/commands/intake-capture.md`、`docs/specs/commands/intake-from-github.md`、`docs/specs/commands/intake-promote.md`: See Also の `REQ-010（Intake command群）` → `REQ-037（Intake command群）`（intake 責務文脈のタイトル注記参照）
- `docs/specs/skills/agentdev-intake-pipeline.md`: 本文2箇所のファイルレベル参照 `（REQ-010）` → `（REQ-037）`、See Also 1箇所の `REQ-010（Intake command群）` → `REQ-037（Intake command群）`

対象外は規則に従う。
`src/**`、`docs/specs/integrity/audits/`、`baselines/`（規則5）、`docs/requirements/REQ-037.md` 本体、README 群の AUTOGEN ブロック（OU-005/#2161 の再生成対象）は変更していない。

## 検証結果（テスト戦略）

- TS-003（AG-003 移動行整合）: 合格。
  REQ-037 要件表10行の本文が git 履歴（`8eacc06b~1`）の旧 REQ-010-034〜040、050〜052 各行本文と一致した（ID は新採番、行順は 034〜040→001〜007、050〜052→008〜010）。
  関連情報の capture-boundaries SPEC 導線を確認した。
- TS-007-OU002（参照残存）: 合格。
  docs/** 全域（audits/、baselines/ 除く）の grep で担当レンジ（旧 034〜040、050〜052）への参照残存は、後述の cross-family carve-out 対象を除き 0 件である。
- TS-008-OU002（第一参照導線）: 合格。
  REQ-037 の関連情報セクションに REQ-008 参照と capture-boundaries SPEC 参照が存在する。
- TS-QC-OU002（文書品質）: 合格。
  変更差分7行（5ファイル）を agentdev-doc-writing の査読観点で査読し、未解決の違反はない。

## 品質ゲート

- `check_changed_docs.ts --workflow case-run --base-ref origin/main --json`: failures 0、warnings 0（対象5ファイル、耦合ファイル2件）。
- `check_integrity.ts --json`: NG 3件、いずれも本変更対象外の既知事項（詳細は Findings の docs-integrity）。

## Findings / Capture候補

### intake

該当なし。

### learning

該当なし。

### docs-integrity

cross-family range left for #2161 integration（参照する全行が REQ-037 へ映射しないため、本 Issue では未変更）:

- `docs/specs/integrity/rule-ownership.md:89` — `REQ-002-013, 039, REQ-010-039, 040, 094`（039/040 は intake 分だが、094 が未映射の混在リスト）
- `docs/specs/integrity/rule-ownership.md:144` — `REQ-010-039/040/094`（同上の混在リスト）
- `docs/specs/integrity/rules/IR-014-singular-reference-dir-residual.md:15` — `[REQ-002-013, 039, REQ-010-039, 040, 094]`（同上の混在リスト）
- `docs/specs/integrity/integrity-contracts.md:65` — `REQ-010-026〜038`（026〜033 が intake 範囲外を含む範囲表記。履歴文脈注記付き）
- `docs/requirements/REQ-008.md:99` — `取り込み、学習、検出の各 command 群の実行手順と分類判定（REQ-010）`（intake/learning/検出の3系が混在するファイルレベル参照。REQ-037/REQ-038/REQ-036 への調整更新が必要）

観察（本変更に起因しない既存事象）:

- `docs/specs/foundations/document-model.md:151` の引用文脈は SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT の REQ 運用観点を主題とし、移動先行 `REQ-037-006`（intake と learning の分離）とは文脈が一致しない。
  行再採番前の旧引用の疑いがあり、#2161 統合時に inspect-docs での確認を推奨する。
- `check_integrity.ts` の既知 NG 3件（本 PR 起因なし）:
  `docs/specs/integrity/references/docmap-reference-audit.md` と `docs/specs/skills/agentdev-artifact-graph.md` の REQ-013 retired パス broken-link 2件、`docs/specs/quality/req-health-metrics.md` の AUTOGEN block 不整合 1件（SC-002、#2161 の再生成対象）。
- 既存の重複表記 `REQ-010, REQ-010`（`docs/specs/foundations/document-model.md:69`、`docs/specs/integrity/integrity-rule-catalog.md:178`）は検証系の文脈であり本 Issue 対象外。#2161 での確認候補。

## SPEC確定候補

該当なし。
