### PR TITLE
docs(agentdev): REQ-022 RETIRE 由来参照の履歴文脈注記化 (#2164)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ AgentDevFlow の基本原則と管理方式は [DEC-001](decisions/DEC-001.md) �
 <!-- AUTOGEN:END -->
 
 現行要件は35件である（REQ-013 は後継 REQ-012 への移行として、REQ-022〜REQ-024 は達成済みとして retired/ へ移行済み、REQ-036〜REQ-039 を追加。番号には欠番が存在する）。
+REQ-022 の規範内容は、後継の [agentdev-artifact-graph SPEC](specs/skills/agentdev-artifact-graph.md)「augmentation 配置先」節が正規所有する。
 各 REQ の詳細は各 REQ ファイル本文を参照。
 
 | REQ | タイトル |


### PR DESCRIPTION
Refs: #2164

## 概要

REQ-022（augmentation 配置先正規化）RETIRE 由来の参照整理（AG-007 規則7 の REQ-022 担当分）。
docs/** 現行ファイル中の REQ-022 形式参照を、後継（docs/specs/skills/agentdev-artifact-graph.md「augmentation 配置先」節）を明示する履歴文脈注記へ整理した。

## 変更内容

- docs/README.md: REQ-022 の規範内容の後継（agentdev-artifact-graph SPEC「augmentation 配置先」節）を明示する履歴文脈注記を1行追加。既存の retired 移行済み列挙文（REQ-013、REQ-022〜REQ-024 は達成済みとして retired/ へ移行済み）は列挙の意図を保持して維持

## 検証結果（テスト戦略）

| TS | 結果 | 概要 |
|---|---|---|
| TS-006-OU007 | 合格 | docs/requirements/retired/REQ-022.md の存在、frontmatter status: migrated、本文冒頭の履歴注記（後継: agentdev-artifact-graph SPEC「augmentation 配置先」節、達成根拠 REQ-022-001/002 の SPEC 正規所有）を確認。旧パス docs/requirements/REQ-022.md の不存在を確認。docs/requirements/README.md の AUTOGEN retired 表に REQ-022 行の登録を確認（表の再生成自体は #2167 担当、本 PR では検証のみ）。check_integrity retired 系 check に REQ-022 起因の ng は 0 件 |
| TS-007-OU007 | 合格（Findings 記録あり） | grep により docs/** 全域（retired/REQ-022.md、audits/、baselines/ を除く）の REQ-022 形式参照を検出。現行ファイルの non-AUTOGEN 参照は docs/README.md の履歴文脈注記化済み箇所のみ。残りは AUTOGEN ブロック2件（docs/requirements/README.md retired 表、docs/specs/quality/req-health-metrics.md 計測例テーブル。いずれも #2167 の再生成対象、Findings 参照）。audits/、baselines/ には該当なし（規則5 無操作）。REQ-010-022 等（REQ-010 行 ID）は不該当を確認。check_integrity の REQ-022 起因 ng 0 件、warning 1 件は既知 AUTOGEN staleness 由来（#2167 で解消予定） |
| TS-QC-OU007 | 合格 | 文書品質査読（agentdev-doc-writing）により本 PR 差分（docs/README.md +1 行）を査読。文書種別責務（README ナビゲーション層への適切な配置）、一文一行、repo 標準語彙（SPEC/retired/正規所有）、相対リンク形式、LLM っぽい表現なし、実行主体誤認なし。違反 0 件 |

## 品質ゲート

- `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref origin/main --json`: files_checked=[docs/README.md]、failures 0、warnings 0
- `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts --json`: REQ-022 起因の ng 0 件（既知 pre-existing 項は Findings docs-integrity に記録）

## Findings / Capture候補

### intake

- docs/specs/quality/req-health-metrics.md の AUTOGEN 計測例テーブル（req-metrics-measurement-example）に REQ-022 行が残存（REQ-013/023/024 行も同様に残存）。check_integrity の retired-req-primary-ref warning 4件および IR-061 index-generation-consistency ng の原因。generate_indexes.ts による再生成は #2167 担定。本 PR の変更は同テーブルの入力（REQ ファイル群）に影響しないため、委譲条件上の自己再生成要件（入力への直接影響 + check_integrity 検出）を満たさず見送った
- docs/README.md、docs/requirements/README.md の AUTOGEN ブロック（件数カウント、retired 表）の再生成は #2167 担定。本 PR では README retired 表の REQ-022 行の存在検証のみ実施した（行は登録済み）

### learning

該当なし

### docs-integrity

- REQ-022 起因の check_integrity 検出は retired-req-primary-ref warning 1 件のみ（docs/specs/quality/req-health-metrics.md AUTOGEN 内の bare トークン。intake 記載の通り #2167 の再生成で解消予定）。REQ-022 起因の ng は 0 件
- 並列 sibling 由来の既知 pre-existing（本 PR スコープ外、記録のみ）: REQ-013 broken file-link ng 2件（docs/specs/integrity/references/docmap-reference-audit.md、docs/specs/skills/agentdev-artifact-graph.md）、req-health-metrics AUTOGEN 同期 ng（first mismatch は REQ-010/REQ-003 の行順序で REQ-022 起因ではない）
- 本 PR の変更ファイル（docs/README.md）に対する check_integrity / check_changed_docs の検出は 0 件
- Level 2 コンフリクト解消（case-auto 再委譲、Level 1 機械的 rebase で解消不能の adjacent-line コンフリクト）: PR #2172（#2163）が docs/README.md 12行目を REQ-013 新語彙（「REQ-013 は後継 REQ-012 への移行として…」）へ書き換えた一方、本ブランチは旧12行目を前提に REQ-022 履歴注記行（13行目）を追加していたため、git auto-merge で両立できなかった。feature/issue-2164 を origin/main（6263dfd8）へ rebase し、両者の和集合（main 側の新12行目 + 本ブランチの REQ-022 注記行）として解決。rebase 後の本 PR 差分は docs/README.md +1 行のみ。再検証: TS-007-OU007 residual grep 合格（履歴注記化済み・AUTOGEN 由来以外の standalone 参照 0 件）、check_integrity ng 1 件は既知 pre-existing（req-health-metrics AUTOGEN staleness、#2167 担当）で新規 ng なし。`git push --force-with-lease` により c78c0505 → ab36f23b へ更新（Level 2 回復として本ブランチのみ承認済み）

## SPEC確定候補

該当なし