### PR TITLE
docs(agentdev): REQ-024 RETIRE 由来参照の履歴文脈注記化 (#2166)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ AgentDevFlow の基本原則と管理方式は [DEC-001](decisions/DEC-001.md) �
 
 現行要件は35件である（REQ-013 は後継 REQ-012 への移行として、REQ-022〜REQ-024 は達成済みとして retired/ へ移行済み、REQ-036〜REQ-039 を追加。番号には欠番が存在する）。
 REQ-022 の規範内容は、後継の [agentdev-artifact-graph SPEC](specs/skills/agentdev-artifact-graph.md)「augmentation 配置先」節が正規所有する。
+REQ-024 の抽出規則と warning 分類は、後継の [agentdev-artifact-graph SPEC](specs/skills/agentdev-artifact-graph.md)「check_graph.ts 抽出規則と warning 分類」節と `scripts/lib/checker.ts` が正規所有する。
 各 REQ の詳細は各 REQ ファイル本文を参照。
 
 | REQ | タイトル |


### PR DESCRIPTION
## 概要

REQ-024（Artifact Graph 未解決参照 warning の分類と抽出規則改善）RETIRE 由来の参照整理（AG-007 規則7 の REQ-024 担当分）。
docs/** 現行ファイル中の REQ-024 形式参照を、後継（docs/specs/skills/agentdev-artifact-graph.md「check_graph.ts 抽出規則と warning 分類」節、scripts/lib/checker.ts）を明示する履歴文脈注記へ置換した。

Refs: #2166

## 変更内容

- docs/README.md: 現行要件数の補足文（REQ-013、REQ-022〜REQ-024 の retired 移行説明）へ REQ-024 の後継明示（agentdev-artifact-graph SPEC「check_graph.ts 抽出規則と warning 分類」節、`scripts/lib/checker.ts`）を追記
- 編集対象外の確認: docs/specs/integrity/audits/、baselines/ に REQ-024 参照なし（規則5 の最小置換も不要）。REQ-010-024 等（REQ-010 行ID）への干渉なし。AUTOGEN ブロックは #2167 が再生成

## 検証結果（テスト戦略）

### TS-006-OU009（RETIRE 整合）: PASS

- docs/requirements/retired/REQ-024.md が存在、frontmatter status は migrated、work_type 残存なし
- 本文冒頭に後継と達成根拠の履歴注記あり（req-save 8eacc06b 適用分、本 Issue では検証のみ）
- 旧パス docs/requirements/REQ-024.md は存在しない
- docs/requirements/README.md の AUTOGEN req-retired 表に REQ-024 行が登録済み
- check_integrity retired 系 check: REQ-024 起因 ng 0件

### TS-007-OU009（RETIRE 由来の参照整理）: PASS（1件 record-in-findings）

- grep による docs/** 全域検出: carve-out（retired/REQ-024.md、audits/、baselines/、AUTOGEN）を除く現行ファイル中の REQ-024 形式参照は docs/README.md の履歴文脈注記化済み1件のみ
- 残存参照の内訳: AUTOGEN ブロック 2件（docs/requirements/README.md req-retired 表、docs/specs/quality/req-health-metrics.md req-metrics-measurement-example）は #2167 再生成対象、retired/REQ-024.md 自身は履歴保持
- REQ-010-024 等の REQ-010 行ID との一致なし（PATTERN TRAP 確認済み）
- check_integrity: REQ-024 起因 ng 0件。warning 1件（retired-req-primary-ref、req-health-metrics.md:119 の AUTOGEN ブロック内参照）は #2167 の再生成対象のため record-in-findings（後述 docs-integrity）。origin/main 最新版（16803417）でも同状態を確認

### TS-QC-OU009（文書品質）: PASS

- agentdev-doc-writing の観点で変更差分（docs/README.md 1文）を査読
- 文書種別責務、文意品質、機械判定（中黒、em-dash、一文一行、LLM 表現）、リンク実在（specs/skills/agentdev-artifact-graph.md）、実行主体分類のいずれも違反なし

## 品質ゲート

- check_changed_docs.ts --workflow case-run --base-ref origin/main --json: PASS（files_checked: docs/README.md、failures 0、warnings 0）
- check_integrity.ts --json: baseline 比較。REQ-024 起因 ng 0件。新規 ng 3件はすべて既知（REQ-013 起因 broken-file-link 2件は兄弟Issue 対応、req-health-metrics AUTOGEN 不整合は #2167 対応）

## Findings / Capture候補

### intake

該当なし

### learning

- retired REQ の参照整理では、対象 REQ の ID（REQ-024）が他 REQ の行ID 接頭辞（REQ-010-024 等）と部分一致する。grep 検出時は REQ-024 単独と REQ-024-NNN 行ID を検索語とし、REQ-010- 等の前置に一致するものを除外する検索設計が必要（本 Issue では PATTERN TRAP として事前指定あり、誤検出0件で完了）

### docs-integrity

- check_integrity warning 1件: retired-req-primary-ref（REQ-024 is retired but referenced in docs/specs/quality/req-health-metrics.md、AUTOGEN req-metrics-measurement-example ブロック内 119行目）。AUTOGEN 再生成は #2167 の担当のため本 PR では対処しない（既知の req-health-metrics AUTOGEN staleness の一症状）
- check_integrity 新規 ng: broken-file-link 2件（docs/specs/integrity/references/docmap-reference-audit.md、docs/specs/skills/agentdev-artifact-graph.md の REQ-013 起因リンク）— 兄弟Issue（REQ-013 担当）territory、本 PR の対象外
- check_changed_docs: strict-severity failures なし

- Level 2 コンフリクト解消（case-auto 再委譲、2026-08-16）: squash-merge コンフリクトを rebase により解消した。コンフリクトファイルは docs/README.md のみ（12行目の同行衝突）。rebase 範囲: 7e7db5df → bc93ff20（base を旧 main から origin/main 1751d01e へ移動）
- 解消原則（semantic union）: main 側（1751d01e、#2172/#2173/#2176 適用後）を正とした。main の12行目（REQ-013 後継 REQ-012 移行の文言）と13行目（REQ-022 後継注記）を保持し、ブランチの REQ-024 後継注記を REQ-022 注記と同一形式の独立行として14行目に追加した。#2176 の範囲書き換えと AUTOGEN 再生成内容は main 側を採用し、再導入していない
- 再検証（rebase 後 TS-007-OU009 相当）: docs/** の REQ-024 参照掃引は履歴文脈注記化済みのみ（REQ-010-024 等の行ID との混同なし）。check_changed_docs.ts --workflow case-run --base-ref origin/main: failures 0 / warnings 0。check_integrity.ts: REQ-024 起因 ng 0件、AUTOGEN staleness / index-generation-consistency の再発なし。残 warning 5件の内訳は junction 由来 See Also 4件（worktree 環境起因）と REQ-013 起因 retired-req-primary-ref 1件（docmap-reference-audit.md、本 PR 差分外の既存状態）
- PR 状態: OPEN / MERGEABLE（mergeStateStatus CLEAN）。feature/issue-2166 を force-with-lease で push 済み（マージは case-close 担当、本 PR では未実施）

## SPEC確定候補

該当なし
