### PR TITLE
docs(agentdev): REQ-012 クリーンアップ検証と EU-2 RETIRE 統合検証 (#2167)

### DIFF
--- a/docs/specs/integrity/references/docmap-reference-audit.md
+++ b/docs/specs/integrity/references/docmap-reference-audit.md
@@ -5,15 +5,15 @@
 
 ## 目的
 
-`docs/DOC-MAP.md` は REQ-013-001（PR #1953/#1958）で除去済みである。
-本監査は integrity スクリプト群に残存する DOC-MAP 参照全件について、一律の dead code 断定を禁じ（REQ-013-020）、参照ごとに「生きている（必要）」「死んでいる（除去可能）」を個別に判定し、判定結果の記録様式と除去優先度を整備する。
+`docs/DOC-MAP.md` は旧REQ-013-001（PR #1953/#1958）で除去済みである。
+本監査は integrity スクリプト群に残存する DOC-MAP 参照全件について、一律の dead code 断定を禁じ（旧REQ-013-020）、参照ごとに「生きている（必要）」「死んでいる（除去可能）」を個別に判定し、判定結果の記録様式と除去優先度を整備する。
 
 前提事実を以下に示す。
 
-- `docs/DOC-MAP.md` は存在しない（REQ-013-001 達成済み）。
-- DOC-MAP が担っていた導線は `docs/specs/README.md`、`docs/README.md`、各 README へ統合済み（REQ-013-018/019）。
-- `agentdev-doc-map` 配布スキル、`docs/specs/skills/agentdev-doc-map.md` SPEC は REQ-013-002/003 で除去済み。
-- IR-017（DOC-MAP ↔ 実体整合性）は REQ-013-006 で抹消済み。
+- `docs/DOC-MAP.md` は存在しない（旧REQ-013-001 達成済み）。
+- DOC-MAP が担っていた導線は `docs/specs/README.md`、`docs/README.md`、各 README へ統合済み（旧REQ-013-018/019）。
+- `agentdev-doc-map` 配布スキル、`docs/specs/skills/agentdev-doc-map.md` SPEC は旧REQ-013-002/003 で除去済み。
+- IR-017（DOC-MAP ↔ 実体整合性）は旧REQ-013-006 で抹消済み。
 
 ## 監査範囲
 
@@ -37,9 +37,9 @@ Issue #1996 が挙げる「45件」は主スクリプト群（テスト除く）
 
 対象外。
 
-- `src/opencode/skills/agentdev-*/`（配布スキル）。REQ-013-013/014/015 で個別に扱う。
-- `docs/` 配下の SPEC、ガイド、README。REQ-013-010/016/017/018/019 で個別に扱う。
-- 過去版 tag `v2.11.0` の歴史記録（REQ-013 適用範囲外）。
+- `src/opencode/skills/agentdev-*/`（配布スキル）。旧REQ-013-013/014/015 で個別に扱う。
+- `docs/` 配下の SPEC、ガイド、README。旧REQ-013-010/016/017/018/019 で個別に扱う。
+- 過去版 tag `v2.11.0` の歴史記録（旧REQ-013 適用範囲外）。
 
 ## 監査手法
 
@@ -87,7 +87,7 @@ Phase 別集計（除去 Roadmap対応）。
 | `regression_*.test.ts`（3 ファイル） | 3 | `DEAD-FN`（フィクスチャ、assertion） |
 
 生存 1 件は後段「参照 31」で詳述する。
-生存が 1 件のみにとどまる理由は、DOC-MAP が完全除去（REQ-013-001）された結果、DOC-MAP を読む全コードが到達不能になったためである。
+生存が 1 件のみにとどまる理由は、DOC-MAP が完全除去（旧REQ-013-001）された結果、DOC-MAP を読む全コードが到達不能になったためである。
 生存 1 件も「参照しないと inventory 出力形式が変わり下遊互換性が壊れる」だけであり、本質的には DOC-MAP を必要としていない。
 
 ## 個別判定
@@ -534,7 +534,7 @@ const docMapUpdateRequired = profile.rules.includes("docmap-update-required")
 
 ## 除去優先度
 
-除去は本監査の対象外（REQ-013-020 は「判定と記録様式と優先度の整備」を要求）。
+除去は本監査の対象外（旧REQ-013-020 は「判定と記録様式と優先度の整備」を要求）。
 後続 Issue が Phase 順に実施する。
 各 Phase は独立して実施可能だが、Phase 1 内のエントリは相互に依存するため一括実施を推奨する。
 


### PR DESCRIPTION
## 概要

Issue #2167（Epic #2162 Wave 2、EU-2 最終、OU-010）の実施。REQ-012 クリーンアップ適用結果の検証（TS-006-OU010）と EU-2（RETIRE 系）統合検証（TS-007-OU010）を行い、検出された残存リーク 1 件を修正した。

Refs: #2167

## 変更内容

- `docs/specs/integrity/references/docmap-reference-audit.md`（11 行）: REQ-013 由来の行 ID 参照（`REQ-013-NNN`）へ「旧」プリフィクスを付与し `旧REQ-013-NNN` 形式へ揃えた。check_integrity `retired-req-primary-ref` warning 1 件を解消する。行 ID の文字列は部分文字列として保持するため監査根拠の特定可能性は変わらず、監査記録の本文構造・文意に変更はない。

## 検証結果（テスト戦略）

### TS-006-OU010（REQ-012 クリーンアップ整合）: 合格

- `docs/requirements/REQ-012.md` 関連 REQ 列（42 行）は「REQ-013（旧: DOC-MAP 依存除去、docs/requirements/retired/ へ移行、後継は本 REQ）」であり、要求された履歴注記形式と完全一致する。REQ-012.md は本 Issue で無変更。
- `git diff 8eacc06b -- docs/requirements/REQ-012.md` は空ではない。差分は 287effea（PR #2172、Issue #2163、Wave 1「REQ-013 RETIRE 由来参照の履歴文脈注記化」）による 2 ハンク（目的 10 行・対象外 38 行）のみで、いずれも REQ-013 参照箇所への履歴文脈注記である。req-save 適用ハンク（関連 REQ 列）は後続コミットで変更されておらず、8eacc06b..HEAD の間に REQ-012.md を変更したコミットは 287effea のみ。要件行の差分は存在せず、完了条件 2（当該箇所以外の本文に diff がないこと）は「REQ-013 参照箇所以外の差分ゼロ」として満たす。

### TS-007-OU010（EU-2 RETIRE 統合検証）: 合格

- 修正前 `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts --json`: `retired-req-primary-ref` warning 1 件（docmap-reference-audit.md、evidence: REQ-013）、ng 0 件。
- docs/** 全域 grep（`docs/**/*.md` 225 ファイル、retired/・audits/・baselines/ 除外）: REQ-013/REQ-022/REQ-023/REQ-024 形式参照 63 件 / 18 ファイル。req-health-metrics.md は 0 件。docmap-reference-audit.md 以外の 17 ファイルは Wave 1 で履歴文脈注記済み（check_integrity が当該ファイル群を検出しないことで裏付け）。
- 修正後 check_integrity --json: `retired-req-primary-ref` **0 件**、ng 0 件、warning 計 4 件（後述 docs-integrity の worktree 環境 artifact）。
- docs-check Step 1 スクリプト群（bun run）: check_command_format / check_extensions / check_distribution_boundary / check_autogen_freshness / lint_skills / check_templates すべて終了コード 0。
- check_changed_docs.ts（`--workflow docs-check --base-ref origin/main`、コミット後）: 対象 1 ファイル（docmap-reference-audit.md）、連想対象 2 ファイル（docs/README.md、docs/specs/README.md）、failures 0、warnings 0、各種 update_required すべて false。
- docs-check コマンドの Step 2〜5（`.agentdev/integrity/reports/`・`.agentdev/intake/inbox/` への書き込み）は case-run 実行担当の capture 境界（`.agentdev/**` 非操作）に反するため実施せず、Step 1 スクリプト層の検証で代替した。

### TS-QC-OU010（文書品質査読）: 合格

- agentdev-doc-writing の観点で本 PR 差分 11 行を査読した。「旧REQ」は check_integrity の RETIREMENT_CONTEXT_RE が履歴文脈語として定義する表現（`旧REQ`/`旧ADR` トークン）であり、文意変更を伴わない。前提事実リスト内の表記一貫性のため L14（旧REQ-013-018/019）も同一形式に揃えた。一文一行・用語政策・LLM 表現規範への未解決違反なし。

## Findings / Capture候補

### intake

- 該当なし

### learning

- 該当なし

### docs-integrity

- worktree 環境で check_integrity を実行すると `ir035-skill-see-also-reference` warning が 4 件発生する（agentdev-req-file-manager、agentdev-decision-file-manager、agentdev-gh-cli、agentdev-workflow-templates の See Also スキルディレクトリ未検出）。junction が worktree へ反映されない環境由来であり main では発生しない。既知の環境差異として記録する（修正不要）。
- `check_changed_docs.ts --base-ref` はコミット前の作業ツリー変更を対象に検出しない（files checked: 0、コミット後は files checked: 1）。仕様通りだが、case-run の事前検証タイミングでは機能しないことの観察記録。

## SPEC確定候補

該当なし
