### PR TITLE
feat(agentdev): ADF ワークフロー定義へトレーサビリティ高位問い合わせ利用を統合（OU-0003、Refs: #2192）

### DIFF
--- a/src/opencode/skills/agentdev-adversarial-review/SKILL.md
+++ b/src/opencode/skills/agentdev-adversarial-review/SKILL.md
@@ -44,6 +44,14 @@ Reviewer と Reviewee の双方が自身の以前の主張を撤回、限定、�
 
 OpenAI/Codex adversarial-review 等の外部知見を観点、問い、failure mode、検証方法を構成する知識源として活用する。実行時の外部サービス・外部リポジトリへの必須依存にせず、必要な知見を ADF 側の配布可能なレビュー知識として保持する。
 
+## Artifact Graph 利用
+
+本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（diagnostics、および論点に応じた他の問い合わせ）を、レビュー対象候補と evidence の探索に利用できる。論点候補には複数の規範的成果物から到達する対象、複数経路、cycle、relation 集中ノード、isolated node、複数 owner または governing relation を持つ候補を含む。問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` SPEC（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
+
+- Graph から得た情報は未検証 evidence として扱い、Reviewer または Reviewee の対論、正規成果物確認を経ずに finding を確定しない
+- 問い合わせ結果は候補提供であり、レビュー結論の確定根拠としない
+- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、正規成果物の直接読取、`rg`、ファイル探索などの従来の探索手段で審議を継続する（fail-open）。派生索引側の障害だけを理由に審議を停止しない
+
 ## 振る舞いプロトコルと合意候補再検証
 
 審議は strategy → challenge → counter-challenge → convergence → convergence audit の状態遷移で進行する。合意候補を形成しただけでは完了とせず、Reviewer と Reviewee が合意候補とその成立根拠を再度対論的に検証する（convergence audit）。再検証で新しい本質的争点が見つかった場合、当該争点について対論を再開する。
@@ -98,5 +106,6 @@ user-decision-required の位置づけ（case-run result enum の第5状態で�
 - **agentdev-quality-gates**: QG-{N}〜QG-{N} 品質ゲート基準
 - **agentdev-doc-diagnostics**: 証拠付き finding の診断
 - **agentdev-skill-authoring**: スキル設計とレビュー規約
+- **`agentdev-artifact-graph`**: トレーサビリティ派生索引への高位問い合わせ（ワークフロー利用の割り当ては同 SPEC が正規所有）
 - **SPEC `docs/specs/<skills/agentdev-adversarial-review>.md`**: 振る舞い契約の正典
 - **references/adversarial-review-protocol.md**: 審議プロトコルの詳細手続き

--- a/src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md
+++ b/src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md
@@ -66,7 +66,7 @@ harness execution mechanism は本 SKILL の規範対象外とし、`references/
 実行担当サブエージェントは以下を順に実行する:
 
 1. **Issue 読込**: 対象 Issue 本文、受け入れ基準を読み込む。実行 command が Issue を success criteria に分解する
-2. **context 再確認**: ADR/ REQ/ SPEC/ docs/ repository context を再確認し、実装が既存の決定事項に矛盾しないことを担保する
+2. **context 再確認**: ADR/ REQ/ SPEC/ docs/ repository context を再確認し、実装が既存の決定事項に矛盾しないことを担保する。トレーサビリティ派生索引への高位問い合わせ（implementation）を実行対象と正規成果物の実現関係確認の候補探索に利用できる（`agentdev-artifact-graph` 経由）。問い合わせ結果は候補提供であり最終判断としない、新規の依存関係、実行構成、Wave 構成、実行順序の設計には使用しない、派生索引の不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は代替探索で継続する（fail-open）
 3. **実装、検証、PR 作成**: 実行 command に従い evidence-backed に実装を実行し、品質ゲートを通して PR 作成手続き（`agentdev-gh-cli`）で PR を作成する。ハーネスの plan artifact 等の中間成果物は解釈せず、PR URL で最終結果を受領する。実装完了後、test strategy 項目の test-fix ループ（後述）を実行する
 4. **blocker 処理**: 回答可能な blocker（ADR/REQ/SPEC/docs/Issue本文で回答できるもの）は自律的に実行 command 内で再評価できる
 5. **result 返却**: 後述の result 契約に従い case-run へ返却する

--- a/src/opencode/skills/agentdev-workflow-backlog-review/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-backlog-review/SKILL.md
@@ -93,6 +93,15 @@ HITL（STEP-5）の承認状態は単独では durable state に記録されな�
 - `agentdev-adversarial-review`: 経路E の review 呼出（共通契約の正規所有者は adversarial-review SPEC、REQ-{NNNN}）
 - `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング、構造化エラー形式）
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open。document-model SPEC の文書7分類モデルは extension 経由で参照）
+- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（統合、分割、depends_on の補助 evidence 探索。fail-open）
+
+## Artifact Graph 利用
+
+本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（related、impact、必要に応じて dependency）を利用できる。採用済み成果物に含まれる REQ、Decision、SPEC、canonical owner 等の明示情報を起点に、統合、分割、depends_on 依存解決（STEP-3）の補助 evidence 探索を行う。問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` SPEC（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。問い合わせ目的を指定し、返された候補を用いて判断する。
+
+- 問い合わせ結果は候補提供であり、統合、分割、depends_on、意味的重複の判断は正規成果物本文と `rg` 等の独立探索での確認後に下す
+- 派生索引の不在、生成失敗、空結果、候補過多だけを理由として「関係なし」「影響なし」と判断しない
+- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、README 索引、正規成果物の直接読取、`rg`、ファイル探索などの代替探索で workflow を継続する（fail-open）。正規成果物そのものの異常と派生索引側の異常を区別する
 
 ## Workflow Extension 読込
 

--- a/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
@@ -92,7 +92,16 @@ case-close workflow は次の STEP で構成する。Epic Wave クローズは S
 - `agentdev-workflow-orchestration`: capture 境界（intake/learning 分離）
 - `agentdev-conventional-commits`: GitHub auto-close 回避ガイドライン
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+- `agentdev-artifact-graph`: トレーサビリティ派生索引（変更後の整合性確認、verification feedback。fail-open）
 - integrity checker skill（repo-local）: check_changed_docs.ts（targeted docs guard）、check_extensions.ts（IR-{NNN}）
+
+## Artifact Graph 利用
+
+本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引を、変更後の整合性確認（必要に応じて）に利用できる。確認対象は変更後の派生索引の生成と鮮度、整合性、unresolved relation、dangling relation、provenance defect、独立確認結果との差異である（STEP-3 docs 検証）。問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` SPEC（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
+
+- Graph defect（派生索引側の抽出問題）と canonical defect（正規成果物側の実不整合）を区別する
+- 派生索引の不在、破損、生成失敗、問い合わせ失敗、候補過多のみを理由に本 workflow を失敗させない（fail-open）。代替検証経路（既存の品質ゲート、targeted docs guard、`rg` 等の独立探索）で継続する
+- 正規成果物側の実不整合が確認された場合は、既存の品質ゲート、受け入れ条件に従って fail とする
 
 ## Workflow Extension 読込
 

--- a/src/opencode/skills/agentdev-workflow-case-open/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/SKILL.md
@@ -85,6 +85,16 @@ case-open workflow は次の6 STEP で構成する。各 STEP は resume point �
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
 - `agentdev-adversarial-review`: 経路F review 呼出
 - `agentdev-learning-capture` / `agentdev-intake-pipeline`: deviation capture 委譲（STEP-4/5 で実観測時）
+- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（変更影響候補の評価。fail-open）
+
+## Artifact Graph 利用
+
+本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（impact、dependency）を利用できる。Issue の対象範囲、完了条件、test strategy の確定前に変更影響候補を評価し、候補を in scope、verification only、out of scope に分類する（STEP-2、STEP-3）。問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` SPEC（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。問い合わせ目的を指定し、返された候補を用いて判断する。
+
+- 問い合わせ結果は候補提供であり、対象範囲の分類判断は正規成果物本文と `rg` 等の独立探索での確認後に下す
+- 必須品質統制の導出は artifact type から品質能力キーへの変換（品質統制 routing SPEC が定める）に従い、問い合わせで得た関係から必須 skill を直接決定しない
+- 派生索引の不在、生成失敗、空結果、候補過多だけを理由として「関係なし」「影響なし」と判断しない
+- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、README 索引、正規成果物の直接読取、`rg`、ファイル探索などの代替探索で workflow を継続する（fail-open）。正規成果物そのものの異常と派生索引側の異常を区別する
 
 ## Workflow Extension 読込
 

--- a/src/opencode/skills/agentdev-workflow-case-run/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/SKILL.md
@@ -120,7 +120,17 @@ workflow 選択は STEP-S1 の実行モード分岐で確定する（引数が E
 - `agentdev-quality-gates`: QG-{N} 前置 staleness check
 - `agentdev-gh-cli`: Issue 本文読取等の I/O 手続き
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（実行対象と正規成果物の実現関係確認のみ。fail-open）
 - integrity checker skill（repo-local）: check_changed_docs.ts（targeted docs guard）、check_extensions.ts（IR-{NNN}）、check_distribution_boundary.ts（配布依存境界）
+
+## Artifact Graph 利用
+
+本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせのうち implementation を、既に決定された実装対象（Issue 本文）と正規成果物の実現関係確認（STEP-S2 の関連Decision確認、委譲内 context 再確認）に利用できる。問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` SPEC（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。問い合わせ目的を指定し、返された候補を用いて判断する。
+
+- トレーサビリティ問い合わせを利用して新規の依存関係、実行構成、Wave 構成、実行順序を設計しない。依存関係と実行構成の決定責務は上流工程（case-open の execution_unit 構成、Epic Wave モデル）が所有する
+- 問い合わせ結果は候補提供であり、実現関係の確認は正規成果物本文と `rg` 等の独立探索で行う。Issue scope、完了条件、REQ、Decision、SPEC、必須品質統制の変更が必要な候補は blocked として case-update 連携とし、scope の自律拡大は行わない
+- 派生索引の不在、生成失敗、空結果、候補過多だけを理由として「関係なし」「影響なし」と判断しない
+- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、README 索引、正規成果物の直接読取、`rg`、ファイル探索などの代替探索で workflow を継続する（fail-open）。正規成果物そのものの異常と派生索引側の異常を区別する
 
 ## Workflow Extension 読込
 

--- a/src/opencode/skills/agentdev-workflow-inspect-docs/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-docs/SKILL.md
@@ -79,6 +79,15 @@ extension（`.agentdev/extensions/skills/agentdev-workflow-inspect-docs.yaml`）
 - `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング含む）
 - `agentdev-conventional-commits`: commit message 規約
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（diagnostics、構造診断候補の探索。fail-open）
+
+## Artifact Graph 利用
+
+本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（diagnostics）を構造診断候補の探索に利用できる。候補には unresolved reference、superseded artifact への現行参照、dangling relation、provenance 欠落、orphan candidate、不自然な relation path、structural duplicate candidate を含む（STEP-2 意味診断の入力）。問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` SPEC（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
+
+- Graph は候補提供者であり、決定的検査（参照実在、委譲先 skill 実在、YAML 構文、必須 field）は docs-check、整合性ルール群が所有する。本スキルは Graph 構造候補を未検証 evidence として意味診断の入力に利用し、構造診断と意味診断を区別する
+- SPLIT、MERGE、MOVE、DUPLICATE、RETIRE、DRIFT 等の意味判断を問い合わせ結果の構造情報だけから確定しない
+- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、正規成果物の直接読取、`rg`、ファイル探索などの従来の診断経路で workflow を継続する（fail-open）。派生索引側の障害だけを理由に本 workflow を停止しない
 
 ## Workflow Extension 読込契約
 

--- a/src/opencode/skills/agentdev-workflow-inspect-skills/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-skills/SKILL.md
@@ -80,6 +80,15 @@ extension（`.agentdev/extensions/skills/agentdev-workflow-inspect-skills.yaml`�
 - `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング含む）
 - `agentdev-conventional-commits`: commit message 規約
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（diagnostics、構造診断候補の探索。fail-open）
+
+## Artifact Graph 利用
+
+本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（diagnostics）を構造診断候補の探索に利用できる。self-hosting augmentation が利用可能な場合、command と skill 関係、command と extension と skill 関係、予期しない delegation、orphan skill candidate の候補を探索できる（STEP-2 の入力）。問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` SPEC（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
+
+- Graph は候補提供者であり、委譲先 skill 実在などの決定的検査は docs-check、整合性ルール群が所有する。本スキルは Graph 構造候補を未検証 evidence として意味診断の入力に利用し、構造診断と意味診断を区別する
+- consumer 環境で対応 node type、relation type が存在しない場合は異常とせず、配布物定義の直接読取、`rg` などの従来の診断経路で継続する
+- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合も従来の診断経路で workflow を継続する（fail-open）。派生索引側の障害だけを理由に本 workflow を停止しない
 
 ## Workflow Extension 読込契約
 

--- a/src/opencode/skills/agentdev-workflow-req-define/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-req-define/SKILL.md
@@ -88,6 +88,15 @@ req-define workflow は次の11 STEP で構成する。各 STEP は resume point
 - `agentdev-workflow-lifecycle`: work_type・Scale 判定、前工程引き継ぎ判定
 - `agentdev-adversarial-review`: 経路A review 呼出
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（既存 REQ、関連 Decision、関連 SPEC、影響候補の探索。fail-open）
+
+## Artifact Graph 利用
+
+本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（related、impact、必要に応じて dependency）を利用できる。既存 REQ、関連 Decision、関連 SPEC、canonical owner、変更影響候補の探索（STEP-3 既存REQ照合、STEP-4 要件展開）を補助する。問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` SPEC（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。問い合わせ目的を指定し、返された候補を用いて判断する。
+
+- 問い合わせ結果は候補提供であり、CREATE、APPEND、UPDATE、SPLIT、MERGE、意味的重複、canonical owner の判断は正規成果物本文と `rg` 等の独立探索での確認後に下す
+- 派生索引の不在、生成失敗、空結果、候補過多だけを理由として「関係なし」「影響なし」と判断しない
+- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、README 索引、正規成果物の直接読取、`rg`、ファイル探索などの代替探索で workflow を継続する（fail-open）。正規成果物そのものの異常と派生索引側の異常を区別する
 
 ## Workflow Extension 読込
 

--- a/src/opencode/skills/agentdev-workflow-spec-save/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-spec-save/SKILL.md
@@ -85,7 +85,16 @@ spec-save workflow は次の11 STEP で構成する。各 STEP は resume point 
 - `agentdev-conventional-commits`: commit message 生成
 - `agentdev-git-worktree`: 並列実行安全ステージングプロシージャ（明示パスステージ、`git commit -- <paths>`）
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
+- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（対応 REQ、同一 canonical owner の SPEC、関連 command、skill、integrity rule の探索。fail-open）
 - integrity checker skill（AG-{NNN} detector、repo 固有）: check_changed_docs.ts（--workflow spec-save）
+
+## Artifact Graph 利用
+
+本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（related）を利用できる。対応 REQ、同一 canonical owner の SPEC、関連 command、skill、integrity rule の探索（STEP-3 配置先解決、STEP-4 SPEC 分離基準の最終確認）を補助する。問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` SPEC（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。問い合わせ目的を指定し、返された候補を用いて判断する。
+
+- 問い合わせ結果は候補提供であり、SPEC 正規配置先、target_area、canonical owner、SPEC 操作分類の判断は正規成果物本文と `rg` 等の独立探索での確認後に下す
+- 派生索引の不在、生成失敗、空結果、候補過多だけを理由として「関係なし」「影響なし」と判断しない
+- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、README 索引、正規成果物の直接読取、`rg`、ファイル探索などの代替探索で workflow を継続する（fail-open）。正規成果物そのものの異常と派生索引側の異常を区別する
 
 ## Workflow Extension 読込
 


### PR DESCRIPTION
Refs: #2192
Parent: #2189

## 概要

OU-0003（REQ-021 更新、ADF Integration 層）の実装。REQ-021 の適用範囲9ワークフロー定義（src/opencode 側）へ、`agentdev-artifact-graph` SPEC「ワークフロー利用」割当表に整合するトレーサビリティ高位問い合わせ利用を統合した。

REQ-021.md（req-save 適用済み: c176870f）と AG SPEC ワークフロー利用セクション（spec-save 適用済み: e73ba8e5）は編集しておらず、本 PR はワークフロー定義（利用側）の統合のみを含む。

## 実装内容

各 Workflow Skill の SKILL.md へ「Artifact Graph 利用」セクションを追加し、Capability Skill 連携へ `agentdev-artifact-graph` を登録した。

| ワークフロー | 問い合わせ目的 | 主な用途 |
|---|---|---|
| req-define | related、impact、必要に応じて dependency | 既存 REQ、関連 Decision、関連 SPEC、canonical owner、変更影響候補の探索 |
| spec-save | related | 対応 REQ、同一 canonical owner の SPEC、関連 command、skill、integrity rule の探索 |
| backlog-review | related、impact、必要に応じて dependency | 統合、分割、depends_on の補助 evidence 探索 |
| case-open | impact、dependency | 対象範囲、完了条件、test strategy 確定前の変更影響候補評価と in scope / verification only / out of scope 分類 |
| case-run | implementation（のみ） | 既に決定された実装対象（Issue 本文）と正規成果物の実現関係確認 |
| case-close | 必要に応じて整合性確認 | 変更後の生成、鮮度、整合性、unresolved relation、dangling relation、provenance defect、独立確認結果との差異の検証 |
| inspect-docs | diagnostics | 構造診断候補の探索（未検証 evidence として意味診断へ入力） |
| inspect-skills | diagnostics | command と skill 関係、予期しない delegation、orphan skill candidate の探索 |
| adversarial-review | diagnostics、論点に応じた他 | レビュー対象候補と evidence の探索 |

全ワークフローで守る共通原則:

- 問い合わせ結果は候補提供であり、最終判断としない（正規成果物本文、`rg` 等の独立確認を併用）
- 派生索引の不在、生成失敗、空結果、候補過多だけを理由として「関係なし」「影響なし」と判断しない
- TIM、派生索引、問い合わせ内部規則を独自に再定義しない（問い合わせ目的を指定し、返された候補で判断）
- 不在、破損、生成失敗、問い合わせ失敗、候補過多の5状況で代替探索により継続する（fail-open）

case-run（`agentdev-workflow-case-run/SKILL.md`、`agentdev-case-run-execution-adapter/SKILL.md`）は implementation に限定し、新規の依存関係、実行構成、Wave 構成、実行順序の設計への利用を明示的に禁止した。

## 実装方針（経路G）

- 発動条件判定: ユーザー明示指定なしのため adversarial-review 呼出なし（従来フローで実装）
- command .md は公開 interface のみを所有する（DEC-010）ため変更せず、Workflow Skill と Capability Skill へ統合
- 配布物 ID 規約に従い、具体 REQ/DEC/SPEC 番号は不使用（プレースホルダ、スキル名称参照）

## 検証結果（test strategy）

### TS-008: PASS

- ADF 側独自定義 0 件: 変更後のワークフロー定義10ファイルで「探索方向」「関係の意味」「node_types」「relation_types」の定義記述 0 件（rg 検証）。TIM への言及はすべて「独自に再定義しない」禁止文言のみ
- case-run の責務が実現関係確認に限定: `agentdev-workflow-case-run/SKILL.md` と `agentdev-case-run-execution-adapter/SKILL.md` の両方に「新規の依存関係、実行構成、Wave 構成、実行順序を設計しない」と上流工程（case-open の execution_unit 構成、Epic Wave モデル）への責務留保を明記

### TS-009: PASS

- 5障害状況（不在、破損、生成失敗、問い合わせ失敗、候補過多）すべてで代替探索（README 索引、正規成果物の直接読取、`rg`、ファイル探索、従来の診断経路）への移行を10ファイルすべてへ明記
- 既存低位問い合わせの公開動作維持: `src/opencode/skills/agentdev-artifact-graph/` 配下の差分 0 件（git diff 検証）。query_graph.ts の公開サブコマンド（neighbors、path、provenance、discover）無変更。`bun test` 73 pass / 0 fail（query.test.ts 8 pass を含む）

### TS-QC-001: PASS（Findings 1件）

- 対象2文書（docs/requirements/REQ-021.md、docs/specs/skills/agentdev-artifact-graph.md）を agentdev-doc-writing の査読観点で査読
- 本 PR 差分（src/opencode 10ファイル）: concrete ID 汚染 0 件、中黒と em-dash 違反 0 件、実行主体分類の誤認なし
- 対象2文書の機械判定で中黒の流動的並列候補を検出。docs は本 Issue の編集禁止パスのため Findings へ記録した（本 PR 差分由来ではない）

### 完了条件・品質 gate

- REQ-021.md が ACT-REQ-003 の内容どおり適用済みであることを確認（目的、REQ-021-001〜005、REQ-021-007〜010、関連情報の REQ-040 と DEC-017 追記）: 前工程 c176870f
- AG SPEC「ワークフロー利用」割当表と REQ-021 要件表の整合確認: 矛盾なし（backlog-review 行の欠落は SPEC確定候補へ記録）
- 配布依存境界 最終 gate（check_distribution_boundary.ts --profile source、worktree 内 src 側パス）: ok=true、failures 0、concrete_id_hits 0（306ファイル走査）
- targeted docs guard（--workflow case-run）: docs/** 変更なしのため対象外

## Findings / Capture候補

### intake

1. docs/specs/commands/req-define.md、spec-save.md、case-open.md、case-close.md、backlog-review.md と docs/specs/skills/agentdev-adversarial-review.md の計6ファイルが AG SPEC の旧見出し「利用上の防護」を参照している。現行見出しは「ワークフロー利用」（e73ba8e5 で更新済み）。参照切れの修正候補（本 Issue スコープ外のため記録のみ）
2. 文書品質査読（TS-QC-001）で検出した中黒の流動的並列候補: REQ-021.md の REQ-021-005「生成・鮮度」、AG SPEC の「提供する判断・操作」（L36）、「実現・実装」（L102-103）、「統合・上位化」（L103）、「優先・除外規則」（L111）、「識別子・説明語」（L221）、「補完・反証」（L223）、「競合・混同」（L289）。読点または箇条書きへの置換候補（docs 編集禁止のため本 PR では未対処）

### learning

1. ジャンクション未伝播の git worktree では `.opencode/skills/agentdev-*` が空のため `.opencode` 前提の検査（check_extensions.ts 等）が実行不能。src 側の `check_distribution_boundary.ts --profile source` と artifact-graph scripts の `bun test` で代替検証できる。また新規 worktree では scripts/node_modules が未伝播のため、テスト実行前に `bun install --cwd src/opencode/skills/agentdev-artifact-graph/scripts` が必要

## SPEC確定候補

1. docs/specs/skills/agentdev-artifact-graph.md「ワークフロー利用」割当表への backlog-review 行追加提案: `| backlog-review | related、impact、必要に応じて dependency |`。REQ-021-001 は req-define、spec-save、backlog-review の3ワークフローに同プロファイル群の利用を要件化しており、割当表（正規所有者）に backlog-review 行がない状態は未網羅である（矛盾ではない）。本 PR では backlog-review のワークフロー定義を REQ-021-001 に基づき更新した
2. 同割当表の spec-save 行は「related」のみであり、REQ-021-001 第1文（3ワークフロー共通で related、impact、必要に応じて dependency の利用を認める記述）との語彙対応に解釈余地が残る。表の「主な問い合わせ」表記であるため矛盾ではないが、REQ との対応明確化の検討余地がある
3. コマンド SPEC 6ファイルの旧見出し参照更新（「利用上の防護」から「ワークフロー利用」へ）。ワークフロー定義側（本 PR）と docs 側 SPEC の整合を保つための追従更新
