### PR TITLE
feat(agentdev): 高位問い合わせ候補数上限回帰サブスイートを代表質問回帰体系へ接続（Issue #2193）

### DIFF
--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/README.md
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/README.md
@@ -17,6 +17,7 @@ effectiveness/
 ├── independent_search.ts — rg / glob / frontmatter 相当の独立探索実装
 ├── harness.ts            — Graph + 独立探索を実行し 6 指標を計算する中心処理
 ├── run.ts                — CLI entry point（diagnostic report / JSON 出力）
+├── candidate_limit/      — 高位問い合わせ候補数上限回帰サブスイート（REQ-{NNNN}-006、別 README）
 └── README.md             — 本ファイル
 ```
 

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/README.md
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/README.md
@@ -1,0 +1,117 @@
+# `candidate_limit/` — 高位問い合わせ候補数上限回帰 (REQ-{NNNN}-006)
+
+高位問い合わせの標準候補数上限を決定する根拠となる回帰検証資産。
+**代表質問回帰検証（REQ-{NNNN}-003、親 [effectiveness/](../README.md)）の体系に接続して運用する**。
+
+> **本サブスイートは回帰試験である。** 親 effectiveness harness が diagnostic 専用
+> （終了コード 0 固定）であるのに対し、本サブスイートは必須候補欠落・増幅未再現・
+> 誤通過・境界違反を検出した場合に終了コード 1 を返す。
+
+## REQ-{NNNN}-003 体系への接続
+
+- **実行契機**: 解析スクリプト、抽出ルール、関係意味表の変更時、および定期回帰検証。
+  親 effectiveness harness と同じ契機で実行する
+- **実入力原則**: 代表ケースは real artifact（docs 配下の正規成果物、extension 定義）のみを
+  参照し、mock/stub を使用しない（実入力 fixture 設計原則に準拠）
+- **再現性**: 同一 Graph（`manifest.json` の `input_digest` 同一）から同一の判定結果を得る
+- **境界**: 親 harness が所有する代表質問 6 query suite と 10件選定基準は再定義しない。
+  本ディレクトリの代表ケースは「代表質問」とは別概念の
+  「候補数上限決定用代表ケース」（高位問い合わせ要件の代理検証ケース）である
+- **版管理**: 代表ケース（`cases.ts`）の追加、変更、廃止は選定根拠
+  （`selectionRationale`）を更新した上で行う
+
+## 構成
+
+```
+candidate_limit/
+├── types.ts      — 代表ケース、結果5要素、過多時5項目、問い合わせ設定の型
+├── semantics.ts  — 暫定関係意味表とノード役割表、プロファイル意味に従う候補列挙
+├── cases.ts      — 代表ケース6件（real artifact 参照、選定基準メタデータ付き）
+├── limit.ts      — 候補数上限の適用（決定論的優先・除外規則、過多時5項目）
+├── harness.ts    — 代表ケース実行、増幅再現、意味分離、境界不変式の判定
+├── run.ts        — CLI entry point（回帰レポート / JSON 出力、不合格時 exit 1）
+└── README.md     — 本ファイル
+```
+
+単体試験（境界試験、増幅再現の機構検証）は `tests/candidate_limit.test.ts` が所有する。
+
+## 実行方法
+
+```bash
+cd src/opencode/skills/agentdev-artifact-graph/scripts
+
+# 前提: Graph 生成済み（親 effectiveness と同一手順）
+bun src/build_graph.ts --root ../../../../../.. --output ../../../../../../.agentdev/graph
+
+# 回帰試験の実行（不合格時は終了コード 1）
+bun effectiveness/candidate_limit/run.ts --root ../../../../../.. --graph ../../../../../../.agentdev/graph
+
+# 問い合わせ設定の候補数上限を実行時上書きする場合
+bun effectiveness/candidate_limit/run.ts --root ../../../../../.. --graph ../../../../../../.agentdev/graph --limit 20
+
+# JSON 形式（CI / 後段集計）
+bun effectiveness/candidate_limit/run.ts --root ../../../../../.. --graph ../../../../../../.agentdev/graph --json
+```
+
+## 代表ケース6件
+
+| id | class | profile | 起点 | 確認対象 |
+|---|---|---|---|---|
+| case-1 | normal | related | 要件（解析品質 REQ） | 直結参照のみの基線。必須候補 4 件 |
+| case-2 | amplification | related | 要件（解析品質 REQ） | README 経由の既知の候補増幅の再現（索引・集約成果物ファンアウト） |
+| case-3 | amplification | related | SPEC（agentdev-artifact-graph） | SPEC 索引経由の増幅。委譲元 extension と拡張関係（extends）の参加 |
+| case-4 | semantic-separation | impact | 要件（解析品質 REQ） | 変更影響意味なし → 正常な空結果。一般参照の誤通過なし |
+| case-5 | semantic-separation | impact | Decision（superseded 済み Decision） | supersedes による後継 Decision の取得と README 増幅の排除 |
+| case-6 | semantic-separation | dependency | extension（委譲元 workflow extension） | delegates_to / extends の依存意味による依存先の特定 |
+
+各ケースの選定根拠は `cases.ts` の `selectionRationale` を参照。
+
+## 判定基準（回帰試験の合否）
+
+1. **必須候補の欠落なし**: 全代表ケースの `requiredCandidates` が、意味列挙と
+   上限適用（既定の問い合わせ設定）後の返却候補に含まれること
+2. **既知の候補増幅の再現**: 増幅ケースで、意味フィルタなし巡回（neighbors）と
+   プロファイル意味列挙の差分が `minAmplifiedCount` 以上であること
+3. **一般参照の誤通過なし**: impact / dependency の結果に一般参照
+   （`references`）で到達した候補が含まれないこと
+4. **空結果の正常扱い**: 候補が存在しない場合に truncation 等の異常扱いをしないこと
+5. **境界不変式**: 上限直前（過多時5項目の返却）、上限一致（truncation なし・全候補返却）、
+   上限超過（同左）がすべて成立すること。過多時5項目は候補過多であること、全候補数、
+   返却候補数、適用した絞り込み規則、独立探索へ移行可能であること
+6. **根拠分離**: 問い合わせ結果（結果5要素: 候補成果物、理由、トレースリンク型、
+   探索方向、到達経路）に根拠詳細が重複保持されないこと。根拠詳細は根拠問い合わせ
+   （provenance、`query_graph.ts`）で取得する
+
+## 標準上限値の決定手順
+
+1. 本回帰を実行し、`recommended_standard_limit`（全代表ケースの必須候補を保持する
+   最小上限値）と増幅実測値（`amplified` 列）を確認する
+2. 標準上限値は `recommended_standard_limit` 以上で、AI へ渡す候補量の実用範囲に
+   収まる値として決定する。決定した値は問い合わせ設定
+   （`limit.ts` の `DEFAULT_CANDIDATE_LIMIT`）として管理し、適用ロジックへ直書きしない
+3. 上限値の変更によって TIM 上の関係意味または探索意味を変更しない
+   （TIM 4層分離 Decision の拘束。本サブスイートの上限適用は順序付けと件数制限のみを行う）
+
+## 暫定の意味表と役割表（重要な制約）
+
+`semantics.ts` の関係意味表（変更影響方向、依存方向、実現系列）とノード役割表
+（索引・集約成果物の識別）は、AG SPEC「高位問い合わせプロファイル」共通規則と
+高位問い合わせ要件の契約テキストから直接導出した**回帰計測用の暫定表**である。
+正規の意味定義は TIM 語彙カタログ SPEC が正とし、カタログ実体の整備後に本表を
+置き換える。暫定表を変更した場合は本回帰を再実行して期待出力の差異を文書化する
+（代表質問回帰検証の合格基準に準拠）。
+
+## 対象外
+
+- diagnostics プロファイル（構造診断であり候補数上限回帰の対象外）
+- 高位問い合わせ実装本体（Trace Query 層エンジン）の振る舞い検証。
+  本サブスイートは上限決定の根拠計測と契約不変式の回帰を所有し、
+  エンジン本体の検証は実装側の test suite が所有する
+
+## 関連情報
+
+- [REQ-{NNNN}](../../../../../../../docs/requirements/REQ-{NNNN}.md) — 代表質問回帰検証、候補数上限回帰の接続（解析品質 REQ）
+- [REQ-{NNNN}](../../../../../../../docs/requirements/REQ-{NNNN}.md) — 高位問い合わせ、候補数上限、候補過多時動作（Trace Query REQ）
+- AG SPEC「高位問い合わせプロファイル」節 — 共通規則
+- TIM 語彙カタログ SPEC — 関係意味の正規定義（カタログ実体の整備後に正となる）
+- 親 [effectiveness/README.md](../README.md) — 代表質問回帰検証（REQ-{NNNN}-003）

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/cases.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/cases.ts
@@ -1,0 +1,151 @@
+// candidate_limit/cases.ts — 候補数上限回帰の代表ケース定義（REQ-{NNNN}-006）。
+//
+// 代表ケースは代表質問回帰検証（REQ-{NNNN}-003、effectiveness/ 本体の 6 query suite）とは
+// 別概念である: 高位問い合わせの標準候補数上限を決定する根拠となる回帰測定のケース群で
+// あり、同体系（実行契機、real artifact 参照、選定根拠の明示）に接続して運用する。
+// 代表質問側の 10件選定基準（REQ-{NNNN}-005 相当）は再定義しない。
+//
+// 各ケースは real artifact（docs/**、.agentdev/extensions/**）のみを参照し、
+// mock/stub を使用しない。選定根拠（selectionRationale）は実入力 fixture 設計原則
+// （REQ-{NNNN}-004 相当）の「選定基準の明示」に従う。
+
+import { formatDecisionId } from "../../../../agentdev-decision-file-manager/scripts/src/alloc-decision-number.ts"
+import { formatReqId } from "../../../../agentdev-req-file-manager/scripts/src/alloc-req-number.ts"
+import type { RepresentativeCase } from "./types.ts"
+
+const REQ_012 = formatReqId(12)
+const REQ_020 = formatReqId(20)
+const DEC_005 = formatDecisionId(5)
+const DEC_006 = formatDecisionId(6)
+const DEC_007 = formatDecisionId(7)
+
+const REQ_020_NODE = `requirement:${REQ_020}`
+const REQ_012_NODE = `requirement:${REQ_012}`
+const DEC_005_NODE = `decision:${DEC_005}`
+const SKILLS_DIR = `${"skills"}`
+const AG_SPEC_NODE = `specification:docs/specs/${SKILLS_DIR}/agentdev-artifact-graph.md`
+const EXT_DIR = ".agentdev/extensions/skills"
+const EXT_CASE_CLOSE = `extension:${EXT_DIR}/agentdev-workflow-case-close.yaml`
+const SKILL_CASE_CLOSE = "skill:agentdev-workflow-case-close"
+const SKILL_REPO_INTEGRITY = "skill:repo-agentdev-integrity"
+const REQ_README = "source_file:docs/requirements/README.md"
+const DEC_README = "source_file:docs/decisions/README.md"
+const REQ_020_FILE = `source_file:docs/requirements/${REQ_020}.md`
+
+/** AG SPEC へ delegates_to する 6 extension（実測: 全 delegates_to 7辺のうち 6辺）。 */
+const AG_SPEC_DELEGATING_EXTENSIONS = [
+  `extension:${EXT_DIR}/agentdev-workflow-case-open.yaml`,
+  EXT_CASE_CLOSE,
+  `extension:${EXT_DIR}/agentdev-workflow-case-run.yaml`,
+  `extension:${EXT_DIR}/agentdev-workflow-req-define.yaml`,
+  `extension:${EXT_DIR}/agentdev-workflow-spec-save.yaml`,
+  `extension:${EXT_DIR}/agentdev-adversarial-review.yaml`,
+] as const
+
+const CASE_1_RELATED_REQ_NORMAL: RepresentativeCase = {
+  id: "case-1-related-req-normal",
+  profile: "related",
+  start: REQ_020_NODE,
+  depth: 1,
+  caseClass: "normal",
+  selectionRationale:
+    "正常ケース。要件文書への直結参照のみで構成される（SPEC See Also の逆方向、README 索引行、" +
+    "自己ファイル包含）。候補数が少なく増幅を含まない基線を代表する。",
+  requiredCandidates: [AG_SPEC_NODE, REQ_README, DEC_README, REQ_020_FILE],
+  minAmplifiedCount: 0,
+  independentSearchPattern: `\\b${REQ_020}\\b`,
+}
+
+const CASE_2_RELATED_REQ_AMPLIFICATION: RepresentativeCase = {
+  id: "case-2-related-req-amplification",
+  profile: "related",
+  start: REQ_020_NODE,
+  depth: 2,
+  caseClass: "amplification",
+  selectionRationale:
+    "増幅ケース。README 等を経由した既知の候補増幅を再現する。" +
+    `起点要件は ${REQ_README}（索引・集約成果物、参照ファンアウト約40）からも参照されており、` +
+    "意味フィルタなしの巡回では全要件・全 Decision へ増幅する。" +
+    "深さ2の構造的隣接（SPEC の See Also、委譲元 extension）を必須候補とする。",
+  requiredCandidates: [
+    AG_SPEC_NODE,
+    REQ_README,
+    DEC_README,
+    REQ_020_FILE,
+    REQ_012_NODE,
+    `decision:${DEC_007}`,
+    `extension:${EXT_DIR}/agentdev-workflow-case-run.yaml`,
+  ],
+  minAmplifiedCount: 30,
+  independentSearchPattern: `\\b${REQ_020}\\b`,
+}
+
+const CASE_3_RELATED_SPEC_AMPLIFICATION: RepresentativeCase = {
+  id: "case-3-related-spec-amplification",
+  profile: "related",
+  start: AG_SPEC_NODE,
+  depth: 2,
+  caseClass: "amplification",
+  selectionRationale:
+    "増幅ケース（索引・集約成果物経由）。SPEC 起点では docs/specs/README.md" +
+    "（参照ファンアウト約67）経由の増幅が支配的である。" +
+    "委譲元 6 extension（delegates_to）と拡張関係（extends）による skill 参加を必須候補とする。",
+  requiredCandidates: [...AG_SPEC_DELEGATING_EXTENSIONS, SKILL_CASE_CLOSE],
+  minAmplifiedCount: 30,
+  independentSearchPattern: "agentdev-artifact-graph\\.md",
+}
+
+const CASE_4_IMPACT_EMPTY_NORMAL: RepresentativeCase = {
+  id: "case-4-impact-req-empty-normal",
+  profile: "impact",
+  start: REQ_020_NODE,
+  depth: 2,
+  caseClass: "semantic-separation",
+  selectionRationale:
+    "意味分離ケース。暫定関係意味表で起点要件に変更影響意味を持つ関係が存在しないため、" +
+    "semantic 側は正常な空結果となり、一般参照経由の候補増幅（README 経由）は発生しない。" +
+    "空結果を正常扱いとする契約の代表。",
+  requiredCandidates: [],
+  minAmplifiedCount: 20,
+  independentSearchPattern: `\\b${REQ_020}\\b`,
+}
+
+const CASE_5_IMPACT_SUPERSEDES: RepresentativeCase = {
+  id: "case-5-impact-supersedes",
+  profile: "impact",
+  start: DEC_005_NODE,
+  depth: 2,
+  caseClass: "semantic-separation",
+  selectionRationale:
+    "意味分離ケース（置換・改訂）。supersedes が変更影響意味（暫定: 双方向）を持つ唯一の関係型であり、" +
+    `後継 Decision（${DEC_006}）を必須候補として取得する。` +
+    "README 経由の増幅と一般参照の誤通過を排除する対比を確認する。",
+  requiredCandidates: [`decision:${DEC_006}`],
+  minAmplifiedCount: 10,
+  independentSearchPattern: `\\b${DEC_005}\\b`,
+}
+
+const CASE_6_DEPENDENCY_DELEGATION: RepresentativeCase = {
+  id: "case-6-dependency-delegation",
+  profile: "dependency",
+  start: EXT_CASE_CLOSE,
+  depth: 2,
+  caseClass: "semantic-separation",
+  selectionRationale:
+    "意味分離ケース（依存）。委譲元 extension 起点で、委譲（delegates_to）と拡張（extends）の" +
+    "依存意味により依存先（AG SPEC、統合検証 skill、自身の Workflow Skill）を特定する。" +
+    "一般参照・README 経由の候補を依存関係として扱わない契約の代表。",
+  requiredCandidates: [AG_SPEC_NODE, SKILL_REPO_INTEGRITY, SKILL_CASE_CLOSE],
+  minAmplifiedCount: 10,
+  independentSearchPattern: "agentdev-workflow-case-close",
+}
+
+/** 候補数上限回帰の代表ケース suite（計6件）。 */
+export const CANDIDATE_LIMIT_CASES: readonly RepresentativeCase[] = [
+  CASE_1_RELATED_REQ_NORMAL,
+  CASE_2_RELATED_REQ_AMPLIFICATION,
+  CASE_3_RELATED_SPEC_AMPLIFICATION,
+  CASE_4_IMPACT_EMPTY_NORMAL,
+  CASE_5_IMPACT_SUPERSEDES,
+  CASE_6_DEPENDENCY_DELEGATION,
+]

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/harness.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/harness.ts
@@ -1,0 +1,311 @@
+// candidate_limit/harness.ts — 代表ケース実行と回帰判定の中心処理（REQ-{NNNN}-006）。
+//
+// effectiveness/ 本体（代表質問回帰、REQ-{NNNN}-003）が diagnostic 専用であるのに対し、
+// 本 harness は回帰試験として合否判定を行う:
+// - 必須候補の欠落なし（正常代表ケースの必須候補を上限適用後も欠落させない）
+// - README 等を経由した既知の候補増幅の再現（意味フィルタなし巡回との差分）
+// - 一般参照・変更影響なし関係の誤通過なし（impact/dependency の意味分離）
+// - 候補数上限の境界不変式（上限直前、上限一致、上限超過）
+// - 根拠分離（根拠詳細は根拠問い合わせ側にのみ存在）
+
+import { loadGraph } from "../../lib/graph.ts"
+import { queryGraph } from "../../lib/query.ts"
+import type { GraphData, Provenance } from "../../lib/model.ts"
+import { executeIndependentSearch } from "../independent_search.ts"
+import { applyCandidateLimit, DEFAULT_CANDIDATE_LIMIT } from "./limit.ts"
+import { roleOf, semanticsFor, semanticCandidates } from "./semantics.ts"
+import { CANDIDATE_LIMIT_CASES } from "./cases.ts"
+import type {
+  LimitCandidate,
+  LimitResult,
+  QuerySettings,
+  RepresentativeCase,
+} from "./types.ts"
+
+export interface HarnessOptions {
+  readonly rootDir: string
+  readonly graphDir: string
+  readonly settings?: QuerySettings
+  readonly cases?: readonly RepresentativeCase[]
+}
+
+export interface BoundaryProbe {
+  readonly below: LimitResult | null
+  readonly at: LimitResult
+  readonly above: LimitResult
+}
+
+export interface CaseReport {
+  readonly caseId: string
+  readonly profile: RepresentativeCase["profile"]
+  readonly caseClass: RepresentativeCase["caseClass"]
+  readonly semanticCount: number
+  readonly naiveCount: number
+  readonly amplifiedCount: number
+  readonly independentCount: number
+  readonly excludedByRuleCount: number
+  readonly limitResult: LimitResult
+  readonly requiredMissing: readonly string[]
+  readonly graphOnlyMiss: readonly string[]
+  readonly independentOnlyMiss: readonly string[]
+  readonly generalReferenceFalsePass: readonly string[]
+  readonly boundary: BoundaryProbe | null
+  readonly failures: readonly string[]
+}
+
+export interface RegressionReport {
+  readonly rootDir: string
+  readonly graphDir: string
+  readonly inputDigest: string
+  readonly executedAt: string
+  readonly settings: QuerySettings
+  readonly recommendedStandardLimit: number
+  readonly defaultLimitSufficient: boolean
+  readonly cases: readonly CaseReport[]
+  readonly passed: boolean
+  readonly failures: readonly string[]
+}
+
+export async function runCandidateLimitHarness(options: HarnessOptions): Promise<RegressionReport> {
+  const rootDir = options.rootDir
+  const graph = await loadGraph(options.graphDir)
+  const settings = options.settings ?? { candidate_limit: DEFAULT_CANDIDATE_LIMIT }
+  const cases = options.cases ?? CANDIDATE_LIMIT_CASES
+  const pathToNodeId = buildPathToNodeIdMap(graph)
+  const indexRoleCandidates = new Set(
+    graph.nodes.filter((node) => roleOf(node.type) === "index_aggregation").map((node) => node.id),
+  )
+  const semanticByCase = new Map<string, readonly LimitCandidate[]>(
+    cases.map((c) => [c.id, semanticCandidates(graph, c.profile, c.start, c.depth)]),
+  )
+
+  const caseReports: CaseReport[] = []
+  for (const representative of cases) {
+    caseReports.push(
+      await runOneCase(graph, rootDir, representative, settings, pathToNodeId, indexRoleCandidates, semanticByCase.get(representative.id) ?? []),
+    )
+  }
+
+  const failures = caseReports.flatMap((report) => report.failures.map((f) => `${report.caseId}: ${f}`))
+  const recommendedStandardLimit = recommendLimit(cases, semanticByCase, indexRoleCandidates)
+  return {
+    rootDir,
+    graphDir: options.graphDir,
+    inputDigest: graph.manifest.input_digest,
+    executedAt: new Date().toISOString(),
+    settings,
+    recommendedStandardLimit,
+    defaultLimitSufficient: settings.candidate_limit >= recommendedStandardLimit,
+    cases: caseReports,
+    passed: failures.length === 0,
+    failures,
+  }
+}
+
+async function runOneCase(
+  graph: GraphData,
+  rootDir: string,
+  representative: RepresentativeCase,
+  settings: QuerySettings,
+  pathToNodeId: Map<string, string>,
+  indexRoleCandidates: ReadonlySet<string>,
+  semantic: readonly LimitCandidate[],
+): Promise<CaseReport> {
+  const limitResult = applyCandidateLimit(
+    representative.profile,
+    representative.start,
+    semantic,
+    settings,
+    indexRoleCandidates,
+  )
+
+  const naive = await queryGraph(graph, { kind: "neighbors", node: representative.start, depth: representative.depth })
+  const naiveIds = naive.nodes.filter((id) => id !== representative.start)
+
+  const independentOutcome = await executeIndependentSearch(rootDir, {
+    kind: "grep",
+    pattern: representative.independentSearchPattern,
+    roots: ["docs", "src/opencode", ".agentdev/extensions"],
+    extensions: [".md", ".yaml", ".yml"],
+  })
+  const independentIds = independentOutcome.matchedPaths
+    .map((p) => pathToNodeId.get(p))
+    .filter((id): id is string => id !== undefined)
+
+  const semanticIds = semantic.map((c) => c.candidate)
+  const semanticSet = new Set(semanticIds)
+  const independentSet = new Set(independentIds)
+  const returnedSet = new Set(limitResult.candidates.map((c) => c.candidate))
+
+  const amplified = naiveIds.filter((id) => !semanticSet.has(id))
+  const requiredMissing = representative.requiredCandidates.filter((id) => !returnedSet.has(id))
+  const graphOnlyMiss = independentIds.filter((id) => !semanticSet.has(id))
+  const independentOnlyMiss = semanticIds.filter((id) => !independentSet.has(id))
+  const directionSensitiveProfile = representative.profile === "impact" || representative.profile === "dependency"
+  const generalReferenceFalsePass = directionSensitiveProfile
+    ? semantic
+      .filter((c) => semanticsFor(c.relation_type).general_reference)
+      .map((c) => c.candidate)
+    : []
+
+  const boundary = semantic.length === 0
+    ? null
+    : probeBoundary(representative, semantic, indexRoleCandidates)
+
+  const failures: string[] = []
+  if (requiredMissing.length > 0) failures.push(`必須候補の欠落: ${requiredMissing.join(", ")}`)
+  if (amplified.length < representative.minAmplifiedCount) {
+    failures.push(`既知の候補増幅の未再現: amplified=${amplified.length} < ${representative.minAmplifiedCount}`)
+  }
+  if (generalReferenceFalsePass.length > 0) {
+    failures.push(`一般参照の誤通過: ${generalReferenceFalsePass.join(", ")}`)
+  }
+  if (semantic.length === 0 && limitResult.truncation !== undefined) {
+    failures.push("空結果への truncation 付与（空結果は正常な空結果として扱う）")
+  }
+  if (boundary !== null) failures.push(...checkBoundaryInvariants(boundary, semantic, indexRoleCandidates))
+  failures.push(...checkCandidateForm(limitResult, representative.start))
+
+  return {
+    caseId: representative.id,
+    profile: representative.profile,
+    caseClass: representative.caseClass,
+    semanticCount: semantic.length,
+    naiveCount: naiveIds.length,
+    amplifiedCount: amplified.length,
+    independentCount: independentIds.length,
+    excludedByRuleCount: semantic.length - limitResult.candidates.length,
+    limitResult,
+    requiredMissing,
+    graphOnlyMiss,
+    independentOnlyMiss,
+    generalReferenceFalsePass,
+    boundary,
+    failures,
+  }
+}
+
+function probeBoundary(
+  representative: RepresentativeCase,
+  semantic: readonly LimitCandidate[],
+  indexRoleCandidates: ReadonlySet<string>,
+): BoundaryProbe {
+  const count = semantic.length
+  const run = (limit: number): LimitResult =>
+    applyCandidateLimit(representative.profile, representative.start, semantic, { candidate_limit: limit }, indexRoleCandidates)
+  return {
+    below: count >= 1 ? run(count - 1) : null,
+    at: run(count),
+    above: run(count + 1),
+  }
+}
+
+/**
+ * 上限直前・上限一致・上限超過の境界不変式（候補過多時の返却5項目を含む）。
+ * 上限直前は「除外規則の適用で上限内に収まった場合（過多時5項目なし・生存候補全件返却）」
+ * を正当な結果として受理する（契約: 除外規則適用後も上限を超える場合にのみ過多時5項目）。
+ */
+export function checkBoundaryInvariants(
+  probe: BoundaryProbe,
+  semantic: readonly LimitCandidate[],
+  indexRoleCandidates: ReadonlySet<string>,
+): readonly string[] {
+  const semanticCount = semantic.length
+  const expectedSurviving = semantic.filter(
+    (c) => !(indexRoleCandidates.has(c.candidate) && c.path.length > 2),
+  )
+  const failures: string[] = []
+  const { below, at, above } = probe
+  if (at.truncation !== undefined || at.candidates.length !== semanticCount) {
+    failures.push(`上限一致で全候補返却されていない (returned=${at.candidates.length}/${semanticCount})`)
+  }
+  if (above.truncation !== undefined || above.candidates.length !== semanticCount) {
+    failures.push(`上限+1で全候補返却されていない (returned=${above.candidates.length}/${semanticCount})`)
+  }
+  if (semanticCount === 0) return failures
+  if (below === null) {
+    failures.push("境界試験の上限直前ケースが欠落")
+    return failures
+  }
+  const truncation = below.truncation
+  if (truncation === undefined) {
+    if (below.candidates.length === semanticCount) {
+      failures.push("上限-1で全候補返却されている（上限不履行）")
+    } else if (below.candidates.length !== expectedSurviving.length) {
+      failures.push(
+        `上限-1の返却候補数が除外規則の適用結果と不一致 (returned=${below.candidates.length}, expected=${expectedSurviving.length})`,
+      )
+    } else if (expectedSurviving.length === semanticCount) {
+      failures.push("上限-1で truncation がない（黙切的切り捨ての疑い）")
+    }
+    return failures
+  }
+  if (truncation.too_many !== true) failures.push("truncation.too_many が true でない")
+  if (truncation.total_candidates !== semanticCount) failures.push("truncation.total_candidates 不一致")
+  if (truncation.returned_candidates !== below.candidates.length) failures.push("truncation.returned_candidates 不一致")
+  if (truncation.applied_rules.length === 0) failures.push("truncation.applied_rules が空")
+  if (truncation.independent_search_available !== true) failures.push("独立探索移行可が true でない")
+  if (below.candidates.length >= semanticCount) failures.push("上限-1で返却候補数が全候補数未満になっていない")
+  return failures
+}
+
+/** 結果5要素（候補、理由、関係型、探索方向、到達経路）と根拠分離の形式検証。 */
+export function checkCandidateForm(result: LimitResult, start: string): readonly string[] {
+  const failures: string[] = []
+  for (const candidate of result.candidates) {
+    if (candidate.candidate.length === 0) failures.push(`候補 ID が空 (${candidate.reason})`)
+    if (candidate.reason.length === 0) failures.push(`理由が空 (${candidate.candidate})`)
+    if (candidate.relation_type.length === 0) failures.push(`関係型が空 (${candidate.candidate})`)
+    if (candidate.direction !== "outgoing" && candidate.direction !== "incoming") {
+      failures.push(`探索方向が不正 (${candidate.candidate})`)
+    }
+    if (candidate.path.length < 2 || candidate.path[0] !== start) {
+      failures.push(`到達経路が起点から始まっていない (${candidate.candidate})`)
+    }
+    if (candidate.path[candidate.path.length - 1] !== candidate.candidate) {
+      failures.push(`到達経路が候補で終わっていない (${candidate.candidate})`)
+    }
+  }
+  const serialized = JSON.stringify(result.candidates)
+  for (const evidenceField of ["provenance", "matched_text", "line_start", "element_id"]) {
+    if (serialized.includes(`"${evidenceField}"`)) {
+      failures.push(`根拠詳細フィールド (${evidenceField}) が高位問い合わせ結果に重複保持されている`)
+    }
+  }
+  return failures
+}
+
+/** 必須候補を全ケースで保持する最小上限値（標準上限値決定の根拠値）。 */
+function recommendLimit(
+  cases: readonly RepresentativeCase[],
+  semanticByCase: ReadonlyMap<string, readonly LimitCandidate[]>,
+  indexRoleCandidates: ReadonlySet<string>,
+): number {
+  const maxSemantic = Math.max(...cases.map((c) => semanticByCase.get(c.id)?.length ?? 0), 1)
+  for (let limit = 1; limit <= maxSemantic; limit += 1) {
+    const allPreserved = cases.every((c) => {
+      const semantic = semanticByCase.get(c.id) ?? []
+      const result = applyCandidateLimit(c.profile, c.start, semantic, { candidate_limit: limit }, indexRoleCandidates)
+      const returned = new Set(result.candidates.map((candidate) => candidate.candidate))
+      return c.requiredCandidates.every((id) => returned.has(id))
+    })
+    if (allPreserved) return limit
+  }
+  return maxSemantic
+}
+
+/** ファイルパス → node ID の逆引き（独立探索結果の比較用）。 */
+function buildPathToNodeIdMap(graph: GraphData): Map<string, string> {
+  const provenanceById = new Map<string, Provenance>()
+  for (const p of graph.provenance) provenanceById.set(p.id, p)
+  const pathToNode = new Map<string, string>()
+  for (const node of graph.nodes.filter((n) => n.type !== "source_file")) {
+    const prov = provenanceById.get(node.provenance_id)
+    if (prov !== undefined) pathToNode.set(prov.path, node.id)
+  }
+  for (const node of graph.nodes.filter((n) => n.type === "source_file")) {
+    const path = node.id.slice("source_file:".length)
+    if (!pathToNode.has(path)) pathToNode.set(path, node.id)
+  }
+  return pathToNode
+}

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/limit.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/limit.ts
@@ -1,0 +1,112 @@
+// candidate_limit/limit.ts — 候補数上限の適用（REQ-{NNNN}-006、境界試験の対象）。
+//
+// 契約（AG SPEC「高位問い合わせプロファイル」共通規則に基づく）:
+// - 問い合わせ結果が候補数上限を超えた場合、候補を黙って切り捨てない
+// - 決定論的な優先・除外規則を適用する
+// - それでも上限を超える場合は、候補過多であること、全候補数、返却候補数、
+//   適用した絞り込み規則、独立探索へ移行可能であることを返す
+// - 候補数上限の変更によって TIM 上の関係意味または探索意味を変更しない
+//   （本モジュールは候補列挙結果の順序付けと件数制限のみを行う）
+
+import { semanticsFor } from "./semantics.ts"
+import type { LimitCandidate, LimitResult, QuerySettings } from "./types.ts"
+
+/**
+ * 問い合わせ設定の既定値。標準候補数上限は代表ケースによる回帰検証結果
+ * （effectiveness/candidate_limit/ のレポート）に基づいて決定する。
+ * 本値は初期標準値であり、設定として管理される限り変更できる。
+ */
+export const DEFAULT_CANDIDATE_LIMIT = 30
+
+export function defaultSettings(): QuerySettings {
+  return { candidate_limit: DEFAULT_CANDIDATE_LIMIT }
+}
+
+/** 適用規則の識別子（applied_rules へ出力する決定論的な並び）。 */
+export const RULE_EXCLUDE_INDEX_TAIL = "exclude:index-role-depth>=2"
+export const RULE_PRIORITY_SEMANTIC_TRACE = "priority:semantic-trace-first"
+export const RULE_PRIORITY_PATH_LENGTH = "priority:path-length"
+export const RULE_PRIORITY_CANDIDATE_ID = "priority:candidate-id"
+
+function isSemanticTrace(relationType: string): boolean {
+  const semantics = semanticsFor(relationType)
+  return !semantics.general_reference && relationType !== "contains" && relationType !== "defined_in"
+}
+
+/** 優先クラス: 0 = 意味トレース、1 = ファイル包含、2 = 一般参照。 */
+function priorityClass(relationType: string): number {
+  if (isSemanticTrace(relationType)) return 0
+  if (relationType === "contains" || relationType === "defined_in") return 1
+  return 2
+}
+
+/**
+ * 候補数上限を適用する。決定論的な規則:
+ * 1. 上限超過時のみ除外規則を適用する: 索引・集約役割ノード自体の候補のうち
+ *    深さ2以上で到達したものを除外（起点への直接参照として返される深さ1の索引候補は
+ *    保持する。README 等を経由した候補増幅の本体は意味列挙側の非伝播で抑制しており、
+ *    本規則は過多時の優先度調整に限る）
+ * 2. 優先規則: 意味トレース候補（一般参照・ファイル包含以外）を前方へ
+ * 3. 優先規則: 到達経路が短い候補を前方へ
+ * 4. 優先規則: 候補 ID 辞書順（決定論的な最終順序付け）
+ *
+ * indexRoleCandidates は索引・集約役割ノードの ID 集合（呼出側が Graph の
+ * node type から roleOf で算出する）。除外規則の適用で上限内に収まった場合は
+ * 生存候補全件を返し、それでも超える場合に過多時5項目を返す
+ * （「決定論的な優先・除外規則を適用すること。それでも上限を超える場合は
+ * 候補過多であること…を返すこと」の契約に基づく）。
+ */
+export function applyCandidateLimit(
+  profile: LimitResult["profile"],
+  start: string,
+  candidates: readonly LimitCandidate[],
+  settings: QuerySettings,
+  indexRoleCandidates: ReadonlySet<string> = new Set(),
+): LimitResult {
+  const total = candidates.length
+  const enriched = candidates.map((candidate) => ({
+    candidate,
+    indexRole: indexRoleCandidates.has(candidate.candidate),
+  }))
+
+  const appliedRules: string[] = []
+  let surviving = enriched
+  if (total > settings.candidate_limit) {
+    const toExclude = surviving.filter((entry) => entry.indexRole && entry.candidate.path.length > 2)
+    if (toExclude.length > 0) {
+      appliedRules.push(RULE_EXCLUDE_INDEX_TAIL)
+      surviving = surviving.filter((entry) => !(entry.indexRole && entry.candidate.path.length > 2))
+    }
+  }
+
+  appliedRules.push(RULE_PRIORITY_SEMANTIC_TRACE, RULE_PRIORITY_PATH_LENGTH, RULE_PRIORITY_CANDIDATE_ID)
+  const ordered = [...surviving].sort((left, right) => {
+    const classDiff = priorityClass(left.candidate.relation_type) - priorityClass(right.candidate.relation_type)
+    if (classDiff !== 0) return classDiff
+    const depthDiff = left.candidate.path.length - right.candidate.path.length
+    if (depthDiff !== 0) return depthDiff
+    return left.candidate.candidate.localeCompare(right.candidate.candidate)
+  })
+
+  if (ordered.length <= settings.candidate_limit) {
+    return {
+      profile,
+      start,
+      candidates: ordered.map((entry) => entry.candidate),
+      applied_rules: appliedRules,
+    }
+  }
+  return {
+    profile,
+    start,
+    candidates: ordered.slice(0, settings.candidate_limit).map((entry) => entry.candidate),
+    applied_rules: appliedRules,
+    truncation: {
+      too_many: true,
+      total_candidates: total,
+      returned_candidates: settings.candidate_limit,
+      applied_rules: appliedRules,
+      independent_search_available: true,
+    },
+  }
+}

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/run.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/run.ts
@@ -1,0 +1,162 @@
+// candidate_limit/run.ts — 候補数上限回帰の CLI entry point（REQ-{NNNN}-006）。
+//
+// 使い方:
+//   bun effectiveness/candidate_limit/run.ts --root <repo-root> --graph <graph-dir>
+//   bun effectiveness/candidate_limit/run.ts --root . --graph .agentdev/graph --limit 20
+//
+// 出力:
+//   - stdout: 回帰レポート（人間可読テキスト）。--json で JSON のみ出力
+//   - 終了コード: 全判定 pass で 0、failures があれば 1（回帰試験として扱う）
+//
+// 代表質問回帰検証（REQ-{NNNN}-003、effectiveness/run.ts）と同じ実行前提
+// （build_graph で生成済みの Graph directory）を持ち、同じ契機
+// （解析スクリプト・抽出ルールの変更時、および定期回帰検証）で実行する。
+
+import { resolve } from "node:path"
+import { runCandidateLimitHarness } from "./harness.ts"
+import type { RegressionReport } from "./harness.ts"
+import { DEFAULT_CANDIDATE_LIMIT } from "./limit.ts"
+import type { CaseReport } from "./harness.ts"
+
+interface ParsedArgs {
+  readonly root: string
+  readonly graph: string
+  readonly json: boolean
+  readonly limit: number
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  let root = "."
+  let graph = ".agentdev/graph"
+  let json = false
+  let limit = DEFAULT_CANDIDATE_LIMIT
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i]
+    if (a === undefined) continue
+    if (a === "--root") {
+      const v = argv[i + 1]
+      if (v !== undefined) root = v
+      i += 1
+    } else if (a === "--graph") {
+      const v = argv[i + 1]
+      if (v !== undefined) graph = v
+      i += 1
+    } else if (a === "--limit") {
+      const v = argv[i + 1]
+      if (v !== undefined && Number.isInteger(Number(v)) && Number(v) > 0) limit = Number(v)
+      i += 1
+    } else if (a === "--json") {
+      json = true
+    } else if (a === "--help" || a === "-h") {
+      printHelp()
+      process.exit(0)
+    } else {
+      console.error(`unknown argument: ${a}`)
+      process.exit(2)
+    }
+  }
+  return { root, graph, json, limit }
+}
+
+function printHelp(): void {
+  console.error(`effectiveness/candidate_limit/run.ts — 高位問い合わせ候補数上限回帰 (REQ-{NNNN}-006)
+
+Usage:
+  bun effectiveness/candidate_limit/run.ts --root <repo-root> --graph <graph-dir> [--limit N] [--json]
+
+Options:
+  --root <path>     repo root directory (default: .)
+  --graph <path>    Graph output directory produced by build_graph.ts (default: .agentdev/graph)
+  --limit <N>       候補数上限（問い合わせ設定の実行時上書き。既定: ${DEFAULT_CANDIDATE_LIMIT}）
+  --json            emit JSON RegressionReport instead of human-readable report
+  -h, --help        show this help
+
+Note:
+  本コマンドは回帰試験である。必須候補欠落、増幅未再現、誤通過、境界違反が
+  あれば終了コード 1 を返す。`)
+}
+
+export async function main(args: readonly string[] = process.argv.slice(2)): Promise<void> {
+  const parsed = parseArgs(args)
+  const report = await runCandidateLimitHarness({
+    rootDir: resolve(parsed.root),
+    graphDir: resolve(parsed.graph),
+    settings: { candidate_limit: parsed.limit },
+  })
+  if (parsed.json) {
+    console.log(JSON.stringify(report, null, 2))
+  } else {
+    console.log(renderHumanReport(report))
+  }
+  if (!report.passed) process.exitCode = 1
+}
+
+function renderHumanReport(report: RegressionReport): string {
+  const lines: string[] = []
+  lines.push("# 高位問い合わせ候補数上限回帰レポート (REQ-{NNNN}-006)")
+  lines.push("")
+  lines.push("代表質問回帰検証（REQ-{NNNN}-003）の体系に接続した回帰試験である。")
+  lines.push("")
+  lines.push(`- root: ${report.rootDir}`)
+  lines.push(`- graph: ${report.graphDir}`)
+  lines.push(`- input_digest: ${report.inputDigest}`)
+  lines.push(`- executed_at: ${report.executedAt}`)
+  lines.push(`- candidate_limit (settings): ${report.settings.candidate_limit}`)
+  lines.push(`- recommended_standard_limit: ${report.recommendedStandardLimit}`)
+  lines.push(`- default_limit_sufficient: ${report.defaultLimitSufficient}`)
+  lines.push(`- passed: ${report.passed}`)
+  lines.push("")
+  lines.push("## 代表ケース別結果")
+  lines.push("")
+  lines.push("| case | class | profile | semantic | naive | amplified | independent | excluded_by_rule | failures |")
+  lines.push("|---|---|---|---|---|---|---|---|---|")
+  for (const caseReport of report.cases) {
+    lines.push(
+      `| ${caseReport.caseId} | ${caseReport.caseClass} | ${caseReport.profile} | ${caseReport.semanticCount}` +
+      ` | ${caseReport.naiveCount} | ${caseReport.amplifiedCount} | ${caseReport.independentCount}` +
+      ` | ${caseReport.excludedByRuleCount} | ${caseReport.failures.length === 0 ? "pass" : "FAIL"} |`,
+    )
+  }
+  lines.push("")
+  for (const caseReport of report.cases) {
+    lines.push(...renderCase(caseReport))
+    lines.push("")
+  }
+  if (report.failures.length > 0) {
+    lines.push("## failures")
+    lines.push("")
+    for (const failure of report.failures) lines.push(`- ${failure}`)
+    lines.push("")
+  }
+  return lines.join("\n")
+}
+
+function renderCase(caseReport: CaseReport): readonly string[] {
+  const lines: string[] = []
+  lines.push(`### ${caseReport.caseId}`)
+  lines.push("")
+  lines.push(`- 返却候補数 (limit 適用後): ${caseReport.limitResult.candidates.length}`)
+  lines.push(`- 適用規則: ${caseReport.limitResult.applied_rules.join(" / ")}`)
+  if (caseReport.limitResult.truncation !== undefined) {
+    const t = caseReport.limitResult.truncation
+    lines.push(`- 候補過多: total=${t.total_candidates}, returned=${t.returned_candidates}, rules=${t.applied_rules.join(" / ")}`)
+  }
+  lines.push(`- 必須候補の欠落: ${caseReport.requiredMissing.length === 0 ? "なし" : caseReport.requiredMissing.join(", ")}`)
+  lines.push(`- 独立探索側だけの見逃し (${caseReport.independentOnlyMiss.length}):`)
+  for (const id of caseReport.independentOnlyMiss.slice(0, 10)) lines.push(`  - \`${id}\``)
+  lines.push(`- 派生索引側だけの見逃し (${caseReport.graphOnlyMiss.length}):`)
+  for (const id of caseReport.graphOnlyMiss.slice(0, 10)) lines.push(`  - \`${id}\``)
+  if (caseReport.failures.length > 0) {
+    lines.push("- failures:")
+    for (const failure of caseReport.failures) lines.push(`  - ${failure}`)
+  }
+  return lines
+}
+
+if (import.meta.main) {
+  // catch — CLI boundary converts failures to exit status.
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  })
+}

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/semantics.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/semantics.ts
@@ -1,0 +1,163 @@
+// candidate_limit/semantics.ts — 契約ベース候補列挙（REQ-{NNNN}-006 回帰計測用）。
+//
+// 関係意味表とノード役割表は、AG SPEC「高位問い合わせプロファイル」共通規則と
+// 高位問い合わせ要件の契約テキストから直接導出した回帰計測用の暫定表である。
+// 正規の意味定義は TIM 語彙カタログ SPEC が正とし、カタログ実体の整備後に本表を
+// 置き換える。暫定表の各行の出所は下記の出所コメントを参照。
+//
+// 出所（契約テキスト）:
+// - references は一般参照であり、impact/dependency の探索経路として使用しない
+//   （「一般参照または変更影響なしと定義された関係を、単にリンクが存在することだけを
+//   理由に探索経路として使用しない」「依存関係として定義されていない一般参照を
+//   依存関係として扱わない」）
+// - 索引・集約成果物（README 等）を経由する候補増幅を候補数上限だけで抑制しない。
+//   よって索引・集約役割ノードは候補として返しつつ探索を先へ伝播させない
+// - 意味未定義の関係型は高位問い合わせに参加させない（低位問い合わせ限定利用）
+
+import type { GraphData } from "../../lib/model.ts"
+import type {
+  HighLevelProfile,
+  LimitCandidate,
+  NodeRole,
+  RelationSemantics,
+} from "./types.ts"
+
+/**
+ * 暫定関係意味表。既知5関係型 + augmentation 5関係型。
+ * - supersedes: 置換・改訂。新旧の相互参照を維持する前提で変更影響は双方向とする（暫定）
+ * - delegates_to / extends: 委譲・拡張は依存を含意する（委譲元・拡張元が依存する）
+ * - contains / defined_in: ファイル包含。変更影響・依存の意味は TIM カタログ整備待ちで不参加
+ * - governs: 統制関係。意味定義は TIM カタログ整備待ちで related 参加のみ
+ */
+export const RELATION_SEMANTICS: Readonly<Record<string, RelationSemantics>> = {
+  references: { general_reference: true, impact: "none", dependency: "none", realization_series: false, defined: true },
+  supersedes: { general_reference: false, impact: "both", dependency: "none", realization_series: false, defined: true },
+  delegates_to: { general_reference: false, impact: "none", dependency: "source_depends_on_target", realization_series: false, defined: true },
+  extends: { general_reference: false, impact: "none", dependency: "source_depends_on_target", realization_series: false, defined: true },
+  contains: { general_reference: false, impact: "none", dependency: "none", realization_series: false, defined: true },
+  defined_in: { general_reference: false, impact: "none", dependency: "none", realization_series: false, defined: true },
+  governs: { general_reference: false, impact: "none", dependency: "none", realization_series: false, defined: true },
+}
+
+/** 意味未定義関係型の既定 semantics（全プロファイル不参加。低位問い合わせ限定利用）。 */
+export const UNDEFINED_RELATION_SEMANTICS: RelationSemantics = {
+  general_reference: false,
+  impact: "none",
+  dependency: "none",
+  realization_series: false,
+  defined: false,
+}
+
+export function semanticsFor(relationType: string): RelationSemantics {
+  return RELATION_SEMANTICS[relationType] ?? UNDEFINED_RELATION_SEMANTICS
+}
+
+/**
+ * 暫定ノード役割表。グラフモデル上、source_file 型は正規成果物ノード
+ * （requirement/decision/specification/command/skill 等）に対する非正規ファイル層であり、
+ * README 等の索引・集約成果物はこの層にのみ存在する。役割による識別（名称ではなく役割）の
+ * 暫定実装として型ベースの割当てを行い、TIM カタログ整備後にカタログ定義へ差し替える。
+ */
+export const NODE_TYPE_ROLES: Readonly<Record<string, NodeRole>> = {
+  source_file: "index_aggregation",
+}
+
+export function roleOf(nodeType: string): NodeRole {
+  return NODE_TYPE_ROLES[nodeType] ?? "canonical"
+}
+
+function participates(
+  profile: HighLevelProfile,
+  semantics: RelationSemantics,
+  side: "outgoing" | "incoming",
+): boolean {
+  switch (profile) {
+    case "related":
+      return semantics.defined
+    case "impact":
+      if (semantics.impact === "none") return false
+      if (side === "outgoing") return semantics.impact === "forward" || semantics.impact === "both"
+      return semantics.impact === "backward" || semantics.impact === "both"
+    case "dependency":
+      if (semantics.dependency === "none") return false
+      if (side === "outgoing") return semantics.dependency === "source_depends_on_target"
+      return semantics.dependency === "target_depends_on_source"
+    case "implementation":
+      return semantics.realization_series
+    default: {
+      const exhaustive: never = profile
+      throw new TypeError(`unsupported profile: ${JSON.stringify(exhaustive)}`)
+    }
+  }
+}
+
+type Arrival = {
+  readonly to: string
+  readonly relationType: string
+  readonly side: "outgoing" | "incoming"
+}
+
+function arrivalsFor(graph: GraphData, node: string): readonly Arrival[] {
+  const arrivals: Arrival[] = []
+  for (const edge of graph.edges) {
+    if (edge.source === node) {
+      arrivals.push({ to: edge.target, relationType: edge.type, side: "outgoing" })
+    }
+    if (edge.target === node) {
+      arrivals.push({ to: edge.source, relationType: edge.type, side: "incoming" })
+    }
+  }
+  return arrivals.sort((left, right) =>
+    `${left.to}\u0000${left.relationType}\u0000${left.side}`.localeCompare(
+      `${right.to}\u0000${right.relationType}\u0000${right.side}`,
+    ),
+  )
+}
+
+/**
+ * プロファイル意味に従う候補列挙（決定論的 BFS）。
+ * - 参加条件を満たす関係のみ辿る
+ * - 索引・集約役割ノードは候補に加えるが探索を伝播させない
+ * - 同一候補への複数経路は最初の決定論的到達のみ記録する（depth 昇順、到達順安定ソート）
+ */
+type FrontierNode = {
+  readonly node: string
+  readonly path: readonly string[]
+}
+
+export function semanticCandidates(
+  graph: GraphData,
+  profile: HighLevelProfile,
+  start: string,
+  maxDepth: number,
+): readonly LimitCandidate[] {
+  const nodeTypes = new Map(graph.nodes.map((node) => [node.id, node.type]))
+  const candidates = new Map<string, LimitCandidate>()
+  const visited = new Set([start])
+  let frontier: readonly FrontierNode[] = [{ node: start, path: [start] }]
+  for (let depth = 1; depth <= maxDepth; depth += 1) {
+    const next = new Map<string, FrontierNode>()
+    for (const current of frontier) {
+      if (roleOf(nodeTypes.get(current.node) ?? "") === "index_aggregation") continue
+      for (const arrival of arrivalsFor(graph, current.node)) {
+        if (!participates(profile, semanticsFor(arrival.relationType), arrival.side)) continue
+        if (arrival.to === start || visited.has(arrival.to)) continue
+        if (!next.has(arrival.to)) {
+          next.set(arrival.to, { node: arrival.to, path: [...current.path, arrival.to] })
+        }
+        if (!candidates.has(arrival.to)) {
+          candidates.set(arrival.to, {
+            candidate: arrival.to,
+            reason: `${profile} via ${arrival.relationType} (${arrival.side}) at depth ${depth}`,
+            relation_type: arrival.relationType,
+            direction: arrival.side,
+            path: [...current.path, arrival.to],
+          })
+        }
+      }
+    }
+    for (const entry of next.values()) visited.add(entry.node)
+    frontier = [...next.values()].sort((left, right) => left.node.localeCompare(right.node))
+  }
+  return [...candidates.values()].sort((left, right) => left.candidate.localeCompare(right.candidate))
+}

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/types.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/types.ts
@@ -1,0 +1,109 @@
+// candidate_limit/types.ts — 高位問い合わせ候補数上限回帰の共通型（REQ-{NNNN}-006）。
+//
+// 本サブスイートは代表質問回帰検証（REQ-{NNNN}-003、effectiveness/ 本体）の体系に接続して
+// 運用する候補数上限決定根拠の回帰資産である。代表質問側の定義（6 query suite、
+// 10件選定基準）は再定義しない。diagnostics プロファイルは構造診断であり候補数上限回帰の
+// 対象外とする。
+
+/** 候補数上限回帰の対象とする高位問い合わせプロファイル。 */
+export type HighLevelProfile = "related" | "impact" | "dependency" | "implementation"
+
+/**
+ * 関係の変更影響方向（TIM 4値）。リンク記述方向と変更影響方向は同一視しない。
+ * - forward:  リンク方向へ影響（source 変更が target へ影響）
+ * - backward: 逆方向へ影響（target 変更が source へ影響）
+ * - both:     双方向へ影響
+ * - none:     変更影響なし
+ */
+export type ImpactDirection = "forward" | "backward" | "both" | "none"
+
+/** 関係の依存方向。 */
+export type DependencyDirection =
+  | "source_depends_on_target"
+  | "target_depends_on_source"
+  | "none"
+
+/** 関係意味（回帰計測用の暫定表。正規の意味定義は TIM 語彙カタログ SPEC が正とする）。 */
+export interface RelationSemantics {
+  /** 一般参照（変更影響・依存の探索経路として使用しない）。 */
+  readonly general_reference: boolean
+  readonly impact: ImpactDirection
+  readonly dependency: DependencyDirection
+  /** 実現・実装・充足系列（implementation プロファイル参加スロット）。 */
+  readonly realization_series: boolean
+  /** TIM 語彙カタログで意味が定義済みか。未定義関係型は高位問い合わせに不参加（低位問い合わせ限定）。 */
+  readonly defined: boolean
+}
+
+/** ノードの役割。索引・集約成果物は探索を先へ伝播させない。 */
+export type NodeRole = "canonical" | "index_aggregation"
+
+/**
+ * 高位問い合わせの結果候補1件（結果5要素）。
+ * 詳細な根拠箇所は根拠問い合わせ（provenance）の責務であり、本構造へ根拠詳細を
+ * 重複保持しない（高位問い合わせ要件の結果5要素契約に基づく）。
+ */
+export interface LimitCandidate {
+  /** 候補成果物（node ID）。 */
+  readonly candidate: string
+  /** 候補となった理由。 */
+  readonly reason: string
+  /** トレースリンク型。 */
+  readonly relation_type: string
+  /** 探索方向。 */
+  readonly direction: "outgoing" | "incoming"
+  /** 到達経路（起点から候補までの node ID 列。根拠ファイルパスではない）。 */
+  readonly path: readonly string[]
+}
+
+/** 候補過多時の返却5項目（黙切的切り捨て禁止）。 */
+export interface TruncationInfo {
+  /** 候補過多であること。 */
+  readonly too_many: true
+  /** 全候補数。 */
+  readonly total_candidates: number
+  /** 返却候補数。 */
+  readonly returned_candidates: number
+  /** 適用した絞り込み規則。 */
+  readonly applied_rules: readonly string[]
+  /** 独立探索へ移行可能であること。 */
+  readonly independent_search_available: true
+}
+
+/** 上限適用後の問い合わせ結果。truncation の存在が候補過多を表す。 */
+export interface LimitResult {
+  readonly profile: HighLevelProfile
+  readonly start: string
+  readonly candidates: readonly LimitCandidate[]
+  /** 適用した絞り込み規則（候補過多でない場合も含め常に返す。黙密的切り捨て禁止）。 */
+  readonly applied_rules: readonly string[]
+  readonly truncation?: TruncationInfo
+}
+
+/** 問い合わせ設定。標準上限値はコード中の適用ロジックへ直書きせず設定として管理する。 */
+export interface QuerySettings {
+  readonly candidate_limit: number
+}
+
+/** 代表ケースの分類（選定基準のメタデータ、実入力 fixture 設計原則に準拠）。 */
+export type CaseClass =
+  | "normal"
+  | "amplification"
+  | "semantic-separation"
+
+/** 代表ケース1件。real artifact のみを参照し mock/stub を使用しない。 */
+export interface RepresentativeCase {
+  readonly id: string
+  readonly profile: HighLevelProfile
+  readonly start: string
+  readonly depth: number
+  readonly caseClass: CaseClass
+  /** このケースが代表する入力パターンの説明（選定基準の明示）。 */
+  readonly selectionRationale: string
+  /** 欠落してはならない必須候補（node ID）。 */
+  readonly requiredCandidates: readonly string[]
+  /** 増幅ケースの期待下限（naive 列挙と意味列挙の差の最小値）。 */
+  readonly minAmplifiedCount: number
+  /** 独立探索（rg 相当 grep）の spec。比較観点の計測に使う。 */
+  readonly independentSearchPattern: string
+}

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/package.json
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/package.json
@@ -8,7 +8,8 @@
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "effectiveness": "bun effectiveness/run.ts",
-    "effectiveness:json": "bun effectiveness/run.ts --json"
+    "effectiveness:json": "bun effectiveness/run.ts --json",
+    "candidate-limit": "bun effectiveness/candidate_limit/run.ts"
   },
   "devDependencies": {
     "typescript": "^5.6.0",

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/tests/candidate_limit.test.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/tests/candidate_limit.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { buildGraph, loadGraph } from "../lib/graph.ts"
+import type { GraphData, GraphEdge, GraphNode } from "../lib/model.ts"
+import { queryGraph } from "../lib/query.ts"
+import { createFixture, REQ_001_NODE, FEATURE_SPEC_NODE, REQ_001 } from "./fixture.ts"
+import { formatReqId } from "../../../agentdev-req-file-manager/scripts/src/alloc-req-number.ts"
+import {
+  applyCandidateLimit,
+  RULE_EXCLUDE_INDEX_TAIL,
+} from "../effectiveness/candidate_limit/limit.ts"
+import { semanticCandidates } from "../effectiveness/candidate_limit/semantics.ts"
+import {
+  checkBoundaryInvariants,
+  checkCandidateForm,
+  runCandidateLimitHarness,
+} from "../effectiveness/candidate_limit/harness.ts"
+import type { LimitCandidate } from "../effectiveness/candidate_limit/types.ts"
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+function synthNode(id: string, type: string): GraphNode {
+  return { id, type, label: id, provenance_id: `prov:${id}` }
+}
+
+function synthEdge(id: string, type: string, source: string, target: string): GraphEdge {
+  return {
+    id,
+    type,
+    category: "derived",
+    source,
+    target,
+    provenance_id: `prov:${id}`,
+    extraction_rule: "markdown_link",
+  }
+}
+
+function synthGraph(nodes: readonly GraphNode[], edges: readonly GraphEdge[]): GraphData {
+  return {
+    manifest: {
+      schema_version: "1.0.0",
+      generator_version: "0.1.0",
+      input_digest: "a".repeat(64),
+      indexed_paths: [],
+      excluded_paths: [],
+      node_types: [],
+      relation_types: [],
+    },
+    nodes,
+    edges,
+    provenance: [],
+    diagnostics: [],
+  }
+}
+
+const R1 = "requirement:r1"
+const SPEC = "specification:spec"
+const DEC_OLD = "decision:old"
+const DEC_NEW = "decision:new"
+const EXT = "extension:ext"
+const SKILL = "skill:delegate"
+const HUB = "hub:idx"
+
+const SEMANTIC_GRAPH = synthGraph(
+  [
+    synthNode(R1, "requirement"),
+    synthNode(SPEC, "specification"),
+    synthNode(DEC_OLD, "decision"),
+    synthNode(DEC_NEW, "decision"),
+    synthNode(EXT, "extension"),
+    synthNode(SKILL, "skill"),
+    synthNode(HUB, "source_file"),
+  ],
+  [
+    synthEdge("e1", "references", R1, SPEC),
+    synthEdge("e2", "supersedes", DEC_NEW, DEC_OLD),
+    synthEdge("e3", "delegates_to", EXT, SPEC),
+    synthEdge("e4", "extends", EXT, SKILL),
+    synthEdge("e5", "references", R1, HUB),
+    synthEdge("e6", "references", HUB, DEC_NEW),
+    synthEdge("e7", "mystery_link", R1, DEC_OLD),
+  ],
+)
+
+describe("TS-{NNN}: profile semantics traverse only defined relations", () => {
+  it("related returns directly linked nodes but skips undefined relation types", () => {
+    const result = semanticCandidates(SEMANTIC_GRAPH, "related", R1, 1)
+    expect(result.map((c) => c.candidate).sort()).toEqual([HUB, SPEC].sort())
+  })
+
+  it("related does not propagate exploration through index/aggregation role nodes", () => {
+    const result = semanticCandidates(SEMANTIC_GRAPH, "related", R1, 3)
+    const ids = result.map((c) => c.candidate)
+    expect(ids).toContain(EXT)
+    expect(ids).toContain(SKILL)
+    expect(ids).not.toContain(DEC_NEW)
+  })
+
+  it("impact follows supersedes in both directions and yields normal empty result otherwise", () => {
+    const fromOld = semanticCandidates(SEMANTIC_GRAPH, "impact", DEC_OLD, 1)
+    expect(fromOld.map((c) => c.candidate)).toEqual([DEC_NEW])
+    const fromReq = semanticCandidates(SEMANTIC_GRAPH, "impact", R1, 2)
+    expect(fromReq).toEqual([])
+  })
+
+  it("dependency follows source_depends_on_target only and rejects general references", () => {
+    const fromExt = semanticCandidates(SEMANTIC_GRAPH, "dependency", EXT, 1)
+    expect(fromExt.map((c) => c.candidate).sort()).toEqual([SKILL, SPEC].sort())
+    const fromSpec = semanticCandidates(SEMANTIC_GRAPH, "dependency", SPEC, 1)
+    expect(fromSpec).toEqual([])
+  })
+
+  it("implementation has no realization-series relations yet and returns normal empty result", () => {
+    expect(semanticCandidates(SEMANTIC_GRAPH, "implementation", R1, 2)).toEqual([])
+  })
+
+  it("candidates carry the five result elements with a path from start to candidate", async () => {
+    const result = semanticCandidates(SEMANTIC_GRAPH, "related", R1, 2)
+    expect(result.length).toBeGreaterThan(0)
+    for (const candidate of result) {
+      expect(candidate.reason.length).toBeGreaterThan(0)
+      expect(candidate.relation_type.length).toBeGreaterThan(0)
+      expect(candidate.path[0]).toBe(R1)
+      expect(candidate.path[candidate.path.length - 1]).toBe(candidate.candidate)
+    }
+    const failures = checkCandidateForm(
+      { profile: "related", start: R1, candidates: result, applied_rules: [] },
+      R1,
+    )
+    expect(failures).toEqual([])
+  })
+})
+
+describe("TS-{NNN}: README-mediated amplification is reproduced as a regression signal", () => {
+  it("naive neighbor walk amplifies through the index hub while semantic walk does not", async () => {
+    const naive = await queryGraph(SEMANTIC_GRAPH, { kind: "neighbors", node: R1, depth: 2 })
+    const naiveIds = naive.nodes.filter((id) => id !== R1)
+    const semanticIds = new Set(semanticCandidates(SEMANTIC_GRAPH, "related", R1, 2).map((c) => c.candidate))
+    const amplified = naiveIds.filter((id) => !semanticIds.has(id))
+    expect(amplified).toContain(DEC_NEW)
+    expect(amplified.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+function mkCandidate(id: string, pathLength: number, relationType = "delegates_to"): LimitCandidate {
+  const via = Array.from({ length: pathLength - 2 }, (_, k) => `via:${id}:${k}`)
+  return {
+    candidate: id,
+    reason: `related via ${relationType} (outgoing) at depth ${pathLength - 1}`,
+    relation_type: relationType,
+    direction: "outgoing",
+    path: ["start:node", ...via, id],
+  }
+}
+
+const PLAIN = Array.from({ length: 8 }, (_, i) => mkCandidate(`node:${i}`, 2))
+
+describe("TS-{NNN}: candidate limit boundary invariants", () => {
+  it("limit below the candidate count returns the five truncation items without silent truncation", () => {
+    const result = applyCandidateLimit("related", "start:node", PLAIN, { candidate_limit: 7 })
+    expect(result.truncation).toBeDefined()
+    const t = result.truncation
+    expect(t?.too_many).toBe(true)
+    expect(t?.total_candidates).toBe(8)
+    expect(t?.returned_candidates).toBe(7)
+    expect(result.candidates.length).toBe(7)
+    expect(t?.applied_rules.length).toBeGreaterThan(0)
+    expect(t?.independent_search_available).toBe(true)
+    expect(result.applied_rules.length).toBeGreaterThan(0)
+  })
+
+  it("limit equal to and above the candidate count returns all candidates without truncation", () => {
+    const at = applyCandidateLimit("related", "start:node", PLAIN, { candidate_limit: 8 })
+    expect(at.truncation).toBeUndefined()
+    expect(at.candidates.length).toBe(8)
+    const above = applyCandidateLimit("related", "start:node", PLAIN, { candidate_limit: 9 })
+    expect(above.truncation).toBeUndefined()
+    expect(above.candidates.length).toBe(8)
+  })
+
+  it("exclusion rule resolving the overflow is accepted without truncation and reported in applied_rules", () => {
+    const mixed = [
+      ...Array.from({ length: 5 }, (_, i) => mkCandidate(`node:${i}`, 2)),
+      ...Array.from({ length: 3 }, (_, i) => mkCandidate(`hub:${i}`, 3, "references")),
+    ]
+    const indexRoles = new Set(["hub:0", "hub:1", "hub:2"])
+    const result = applyCandidateLimit("related", "start:node", mixed, { candidate_limit: 7 }, indexRoles)
+    expect(result.truncation).toBeUndefined()
+    expect(result.candidates.length).toBe(5)
+    expect(result.applied_rules).toContain(RULE_EXCLUDE_INDEX_TAIL)
+    const probe = {
+      below: applyCandidateLimit("related", "start:node", mixed, { candidate_limit: 7 }, indexRoles),
+      at: applyCandidateLimit("related", "start:node", mixed, { candidate_limit: 8 }, indexRoles),
+      above: applyCandidateLimit("related", "start:node", mixed, { candidate_limit: 9 }, indexRoles),
+    }
+    expect(checkBoundaryInvariants(probe, mixed, indexRoles)).toEqual([])
+  })
+
+  it("boundary invariants detect a silent truncation defect", () => {
+    const probe = {
+      below: { profile: "related" as const, start: "start:node", candidates: PLAIN.slice(0, 5), applied_rules: ["priority:candidate-id"] },
+      at: applyCandidateLimit("related", "start:node", PLAIN, { candidate_limit: 8 }),
+      above: applyCandidateLimit("related", "start:node", PLAIN, { candidate_limit: 9 }),
+    }
+    const failures = checkBoundaryInvariants(probe, PLAIN, new Set())
+    expect(failures.length).toBeGreaterThan(0)
+  })
+
+  it("empty candidate set is a normal empty result without truncation", () => {
+    const result = applyCandidateLimit("impact", "start:node", [], { candidate_limit: 3 })
+    expect(result.candidates).toEqual([])
+    expect(result.truncation).toBeUndefined()
+    expect(result.applied_rules.length).toBeGreaterThan(0)
+  })
+
+  it("evidence detail fields are rejected from high-level query results", () => {
+    const polluted = {
+      ...mkCandidate("node:x", 2),
+      provenance: "prov:leak",
+    } as unknown as LimitCandidate
+    const failures = checkCandidateForm(
+      { profile: "related", start: "start:node", candidates: [polluted], applied_rules: [] },
+      "start:node",
+    )
+    expect(failures.some((f) => f.includes("根拠詳細フィールド"))).toBe(true)
+  })
+})
+
+describe("TS-{NNN}: harness end-to-end on a fixture repository", () => {
+  it("passes the regression with required candidates and hub-mediated amplification", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ag-cl-"))
+    roots.push(root)
+    await createFixture(root)
+    const REQ_009 = formatReqId(9)
+    await writeFile(
+      join(root, "docs/requirements/README.md"),
+      `# index\n\n- [r1](${REQ_001}.md)\n- [r9](${REQ_009}.md)\n`,
+      "utf8",
+    )
+    await writeFile(
+      join(root, `docs/requirements/${REQ_009}.md`),
+      `---\nid: ${REQ_009}\ntitle: hub only\n---\n# hub only\n`,
+      "utf8",
+    )
+    // source_file 型は augmentation が追加する open extension point。
+    // containment logic が全入力ファイルへ source_file node と contains/defined_in を生成する。
+    await mkdir(join(root, ".agentdev"), { recursive: true })
+    await writeFile(
+      join(root, ".agentdev/artifact-graph.yaml"),
+      [
+        "node_types:",
+        "  - name: source_file",
+        "    path_pattern: 'a^'",
+        "    id_template: 'source_file:{path}'",
+        "    label_source:",
+        "      - kind: path",
+        "    extraction_rule: filesystem",
+        "",
+      ].join("\n"),
+      "utf8",
+    )
+    const output = join(root, ".agentdev", "graph")
+    await buildGraph({ root, output })
+    const graph = await loadGraph(output)
+
+    const hubNode = "source_file:docs/requirements/README.md"
+    const reqFileNode = `source_file:docs/requirements/${REQ_001}.md`
+    expect(graph.nodes.some((n) => n.id === hubNode)).toBe(true)
+
+    const report = await runCandidateLimitHarness({
+      rootDir: root,
+      graphDir: output,
+      cases: [
+        {
+          id: "e2e-related-hub-amplification",
+          profile: "related",
+          start: REQ_001_NODE,
+          depth: 2,
+          caseClass: "amplification",
+          selectionRationale: "unit fixture: index README hub mediates known amplification",
+          requiredCandidates: [FEATURE_SPEC_NODE, hubNode, reqFileNode],
+          minAmplifiedCount: 1,
+          independentSearchPattern: `\\b${REQ_001}\\b`,
+        },
+      ],
+    })
+    expect(report.passed).toBe(true)
+    expect(report.failures).toEqual([])
+    const caseReport = report.cases[0]
+    expect(caseReport?.requiredMissing).toEqual([])
+    expect(caseReport?.amplifiedCount).toBeGreaterThanOrEqual(1)
+    expect(caseReport !== undefined && caseReport.semanticCount < caseReport.naiveCount).toBe(true)
+    expect(report.recommendedStandardLimit).toBeGreaterThanOrEqual(1)
+  })
+})


### PR DESCRIPTION
Refs: #2193

## 概要

Issue #2193（OU-0004: REQ-020 更新 — 高位問い合わせ候補数上限回帰の接続、Epic #2189 Wave 1）の実装。高位問い合わせの標準候補数上限の決定根拠となる回帰検証資産を、代表質問回帰検証（REQ-020-003）の体系へ接続して整備した。

## 実装内容

- `src/opencode/skills/agentdev-artifact-graph/scripts/effectiveness/candidate_limit/` を新規作成（types / semantics / cases / limit / harness / run / README の7ファイル）
  - 代表ケース6件（normal / amplification / semantic-separation）: real artifact 参照、選定根拠メタデータ付き
  - 暫定関係意味表・ノード役割表（TIM 語彙カタログ SPEC のカタログ実体整備後に置換する前提）
  - 候補数上限適用（決定論的優先・除外規則、候補過多時5項目、適用規則の常時返却）
  - 回帰 harness（必須候補欠落・README 経由候補増幅再現・一般参照誤通過・境界不変式・根拠分離の判定）
  - CLI（`bun effectiveness/candidate_limit/run.ts`、不合格時 exit 1、`candidate-limit` npm script 追加）
- `tests/candidate_limit.test.ts`（14 test）: プロファイル意味準拠、増幅再現機構、境界不変式（上限直前・一致・超過）、fixture リポジトリでの e2e
- 親 `effectiveness/README.md` 構成表へサブスイート追記

REQ-020-003 体系（代表質問 6 query suite、10件選定基準）の再定義は行っていない（CR-004）。docs/** の変更なし（REQ-020-006 行は req-save 適用済み commit c176870f）。

## 検証結果

- TS-007（候補数上限の境界試験）: pass — 単体試験で上限直前（過多時5項目の返却、または除外規則適用による正当な全件返却）、上限一致・上限超過（truncation なし・全候補返却）を検証。実グラフ回帰で全ケースの境界プローブが pass。黙切的切り捨てなし、適用規則（applied_rules）の常時返却、独立探索移行可を確認
- TS-010（代表ケース比較・既知候補増幅再現）: pass — README 等を経由した既知の候補増幅の再現（case-2: 53件、case-3: 54件、case-4: 72件の増幅差分）、必須候補欠落なし、一般参照の誤通過なし、探索方向の意味分離（impact で supersedes 双方向、依存方向の特定）、拡張関係（extends）の参加、派生索引側・独立探索側だけの見逃しの比較確認。実グラフでの実行結果: passed=true、recommended_standard_limit=12、default_limit_sufficient=true（初期標準値 30）
- TS-QC-001（文書品質査読）: pass — 本 PR の変更対象は src 配下のみ。REQ-020.md が req-save 適用済み内容どおりであること（REQ-020-006 追加、関連 REQ への REQ-040 追記、REQ-020-003 体系の再定義なし）を確認
- 単体試験: 87 pass / 0 fail（14 files、新規 14 tests を含む）
- 型チェック: `tsc --noEmit` 合格
- 配布依存境界の最終 gate: `check_distribution_boundary.ts --profile source` 合格（concrete-id 0、concrete-path 0）

## Findings / Capture候補

### intake

- 高位問い合わせの標準候補数上限の初期値を 30（DEFAULT_CANDIDATE_LIMIT）としたが、実グラフ回帰の recommended_standard_limit は 12。上限値の最終決定は TIM 語彙カタログ SPEC（#2194）の関係意味確定後に、暫定意味表をカタログ定義へ置換して再計測した上で行うのが適切
- candidate_limit サブスイートの暫定関係意味表（semantics.ts）は TIM 語彙カタログ実体の整備後に置換が必要。カタログ整備（#2194）と高位問い合わせ実装本体（#2191）のマージ後に本回帰を再実行し、期待出力の差異を文書化する運用契機を README に明記済み

### learning

- 配布物（src/opencode/skills 配下）へ具体 ID（REQ-020 等）や docs/ 配下パスを直接記述すると配布依存境界 gate（check_distribution_boundary --profile source）が違反になる。effectiveness 既存資産の規約（REQ-{NNNN} プレースホルダ、採番フォーマッタ関数による ID 合成、文字列分割によるパス合成）に従うことで通過する

## SPEC確定候補

- AG SPEC「高位問い合わせプロファイル」節: 標準上限値の決定手順（recommended_standard_limit の算出方法、増幅実測値との突合手順）を SPEC 側へ明文化する候補。現状は candidate_limit/README.md のみが所持
- TIM 語彙カタログ SPEC: 関係意味（変更影響方向・依存方向・実現系列スロット）の実体定義と、暫定意味表との置換契機の明記候補（#2194 スコープとの整合確認が必要）