### PR TITLE
feat(agentdev): backlog 一括整理コマンド backlog-auto を追加（Issue #2200）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts
@@ -273,8 +273,9 @@ const commands = getCommandFiles();
 const skillDirs = getSkillDirs();
 const templateFiles = getTemplateFiles();
 
-// Current 16 public agentdev commands (aligns with commands/agentdev/README.md listing)
+// Current 17 public agentdev commands (aligns with commands/agentdev/README.md listing)
 const EXPECTED_COMMANDS = [
+  "backlog-auto",
   "backlog-review",
   "case-auto",
   "case-close",

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ AgentDevFlow プラグインの設定を管理するリポジトリ。AI エー�
 | 検出事項を分類したい | `/agentdev/inspect-promote` | 採用済み成果物 |
 | ドキュメント整合性を検証したい | `/repo/docs-check` | 検証レポート（自己ホストリポジトリ専用） |
 | 要件docがあり、req-saveからcase-closeまで自走させたい | `/agentdev/case-auto` | マージ済み + クローズ済み |
+| backlog整理サイクル（検出→昇格→統合）を1回で実行したい | `/agentdev/backlog-auto` | 検出事項、採用済み成果物、`RU-*.md` |
 
 ## 参照先
 

--- a/docs/guides/command-selection.md
+++ b/docs/guides/command-selection.md
@@ -22,6 +22,7 @@
 | RU がある | `/agentdev/req-define` | 要件doc（draft） |
 | REQ 体系の健全性を検出したい | `/agentdev/inspect-docs` | 検出レポート |
 | 要件docがあり req-saveからcase-closeまで自走させたい / Issue番号、URL があり case-run〜case-close を自走させたい | `/agentdev/case-auto` | マージ済み + クローズ済み |
+| backlog整理サイクル（検出→昇格→統合）を1回で実行したい | `/agentdev/backlog-auto` | 検出事項、採用済み成果物、`RU-*.md` |
 
 ## リポジトリメンテナンス（AgentDevFlow 本体リポジトリのみ）
 
@@ -43,3 +44,4 @@
 - Intake / Learning パイプラインの詳細は [Intake / Learning / Backlog フロー](intake-learning-backlog-flow.md) を参照
 - 各コマンドの入出力の詳細は [要件定義 → Case実行フロー](req-case-flow.md) を参照
 - `/agentdev/case-auto` は明示指定時のみ使用する追加入口。標準ワークフローを置き換えない
+- `/agentdev/backlog-auto` は backlog 整理サイクル（検出→昇格→統合）を1回で実行する追加入口。標準の backlog 整理フローを置き換えず、既存5コマンド（inspect-docs、learning-promote、intake-promote、inspect-promote、backlog-review）は従来どおり単独実行できる

--- a/docs/specs/foundations/system.md
+++ b/docs/specs/foundations/system.md
@@ -1,5 +1,5 @@
 ---
-updated: 2026-08-14
+updated: 2026-08-17
 status: accepted
 ---
 
@@ -90,7 +90,7 @@ case-run が QG-1〜QG-3（ローカル検証、CI 検証、乖離検出）、ca
 
 ## Workflow Architecture Inventory
 
-全公開Command（16件）の Workflow Architecture Inventory を恒久カタログとして統合する。
+全公開Command（17件）の Workflow Architecture Inventory を恒久カタログとして統合する。
 各Command の11分析軸（公開契約・主要処理段階・分岐・副作用・HITL・並列性・resume・durable state・Harness依存・Capability依存・内部workflow候補）を記載する。
 個別Workflow Skill 移行（Wave 2）および Capability Skill 抽出の参照証拠とする。
 
@@ -122,6 +122,7 @@ Command 定義を権威情報源とする旧表現は、workflow 実装の権威
 | `/agentdev/intake-promote` | inbox item | `promoted/` 成果物 | intake |
 | `/agentdev/learning-promote` | `inbox.md` + `deferred.md` | `promoted/` 成果物 | learning |
 | `/agentdev/backlog-review` | `promoted/` 成果物 | `RU-*.md` | backlog |
+| `/agentdev/backlog-auto` | なし（durable state から解決） | 検出事項、採用済み成果物、`RU-*.md` | backlog |
 | `/agentdev/inspect-docs` | docs 全体スキャン | 検出事項 | inspect |
 | `/agentdev/inspect-skills` | Command/Skill 定義 | 検出事項 | inspect |
 | `/agentdev/inspect-promote` | 検出事項 | 採用済み成果物 | inspect |
@@ -307,6 +308,20 @@ Command 定義を権威情報源とする旧表現は、workflow 実装の権威
 - **Harness依存**: LLM 推論（統合/分割/矛盾検出）、subagent 起動（`agentdev-adversarial-review` 経路E）、git（pull/commit/push、並列実行安全ステージング）、拡張読込。
 - **Capability依存**: `agentdev-backlog-integration`、`agentdev-git-worktree`、`agentdev-adversarial-review`（経路E）、`agentdev-project-extensions`。
 - **内部workflow候補**: 統合/分割判定workflow（Step 4 前半）、矛盾検出workflow（Step 5）、RU生成+削除+永続化workflow（Step 6-8）。統合/分割判定基準と depends_on 依存解決ルールは Capability Skill 候補（`agentdev-backlog-integration` が所有）。
+
+### `/agentdev/backlog-auto`
+
+- **公開契約**: 引数なし → backlog 整理サイクル（inspect-docs → 昇格3系統 → backlog-review）を1回起動で実行し RU 生成まで一巡。追加入口（標準の backlog 整理フローを置換しない）。子ワークフロー内部の分類、評価、昇格、RU 生成ロジックは再実装しない。
+- **主要処理段階**: Step 1 開始時刻記録・進行状態初期化（durable state 再構成）→ Step 2 stage 1 inspect-docs 単独直列 → Step 3 stage 2 昇格3系統（learning-promote / intake-promote / inspect-promote、競合処理の直列化）→ Step 4 fan-in 判定 → Step 5 stage 3 backlog-review → Step 6 完了報告（工程別結果、停止理由、再開コマンド提示）。
+- **分岐**: stage 1 停止経路（inspect-docs blocked/failed で下流非開始）、fan-in 判定（全系統正常完了 or 対象なし終了で開始可、1系統でも blocked・failed・未完了で開始不可）、系統別結果状態の読み替え（対象なし終了を正常扱い、learning-promote の inbox.md 不在を対象なし扱い）、部分停止時の独立系統継続、新規 promoted 0件でも backlog-review 実行、inspect-promote --auto 非有効化。
+- **副作用**: 各子コマンドの既存副作用のみ（`.agentdev/` 配下の成果物作成・削除、git commit/push、ユーザー対話）。backlog-auto 自身は新規副作用を追加しない。capture 系コマンド、inspect-skills、req-define、req-save、Issue/PR 作成の自動起動はしない（G03）。
+- **HITL**: 各子ワークフローの既存 HITL 境界を維持（新規判断境界を追加しない）。複数系統が判断待ちの場合はユーザー対話を直列化し系統識別付きで表示。
+- **並列性**: orchestration stage 構成（stage 1 単独直列 / stage 2 昇格3系統は系統相互の先行依存なし、競合 Git 操作・共有成果物書き込み・ユーザー対話のみ直列化 / stage 3 単独）。並行実行を利用できない場合は順次インターリーブ。部分停止時も独立系統は連鎖停止しない。
+- **resume**: `backlog_auto_started_at`、stage 別完了状態、stage 2 系統別結果状態、直列化キュー実行記録。各系統内の再開は子ワークフローの既存 STEP model 再開契約に委譲。inspect-docs は中断時先頭再実行。
+- **durable state**: 各子コマンドの durable state（learning は inbox.md/deferred.md/evaluation-report.md/promoted/、intake は inbox//promoted/、inspect は inbox//promoted//auto-promote-log、backlog-review は promoted/ 残存と `RU-*.md` 実ファイル）から工程進行を再構成。
+- **Harness依存**: stage 2 の系統並行実行機構（利用できない場合は順次インターリーブ）、ユーザー対話の直列化表示、タイムスタンプ計測、拡張読込。
+- **Capability依存**: `agentdev-project-extensions`。子ワークフロー依存の Capability Skill（`agentdev-learning-pipeline`、`agentdev-intake-pipeline`、`agentdev-backlog-integration` 等）は各子 Workflow Skill 経由で継承。
+- **内部workflow候補**: orchestration workflow（stage 実行 + 直列化キュー + fan-in 判定 + 停止伝播）。Workflow Skill（`agentdev-workflow-backlog-auto`）として実装済み。
 
 ### `/agentdev/inspect-docs`
 

--- a/docs/specs/quality/req-health-metrics.md
+++ b/docs/specs/quality/req-health-metrics.md
@@ -104,6 +104,7 @@ SPLIT シグナルは `agentdev-req-structure-diagnostics` スキルの推奨ア
 | REQ-011 | 19 | +0 |  |
 | REQ-017 | 16 | +0 |  |
 | REQ-028 | 16 | +0 |  |
+| REQ-041 | 16 | +0 |  |
 | REQ-010 | 15 | +0 |  |
 | REQ-014 | 15 | +0 |  |
 | REQ-015 | 12 | +0 |  |

--- a/docs/specs/quality/spec-health-metrics.md
+++ b/docs/specs/quality/spec-health-metrics.md
@@ -86,8 +86,8 @@ AUTOGENブロックは `AUTOGEN:BEGIN` マーカーから対応する `AUTOGEN:E
 | commands/case-auto.md | 474 | accepted | commands |
 | commands/case-open.md | 438 | accepted | commands |
 | integrity/audits/classification-20260811.md | 422 | draft | integrity |
+| foundations/system.md | 421 | accepted | foundations |
 | integrity/baselines/pre-audit-baseline-20260811.md | 416 | accepted | integrity |
-| foundations/system.md | 406 | accepted | foundations |
 | skills/agentdev-artifact-graph.md | 399 | draft | skills |
 | responsibilities/document-type-responsibilities.md | 372 | accepted | responsibilities |
 | local/runtime-package-boundary.md | 359 | accepted | local |
@@ -98,10 +98,10 @@ AUTOGENブロックは `AUTOGEN:BEGIN` マーカーから対応する `AUTOGEN:E
 | commands/case-close.md | 302 | accepted | commands |
 | foundations/traceability-model.md | 293 | draft | foundations |
 | integrity/integrity-rule-catalog.md | 290 | accepted | integrity |
+| workflows/workflow-contracts.md | 284 | accepted | workflows |
 | workflows/backlog-artifact-lifecycle.md | 283 | accepted | workflows |
-| workflows/workflow-contracts.md | 283 | accepted | workflows |
 | workflows/delegation-contracts.md | 269 | accepted | workflows |
-| README.md | 264 | - | uncategorized |
+| README.md | 266 | - | uncategorized |
 | workflows/workflow-skill-model.md | 248 | draft | workflows |
 | skills/agentdev-gh-cli.md | 245 | accepted | skills |
 | local/local-case-file.md | 240 | accepted | local |
@@ -169,6 +169,7 @@ AUTOGENブロックは `AUTOGEN:BEGIN` マーカーから対応する `AUTOGEN:E
 | integrity/rules/IR-058-distribution-untracked-skill-reference.md | 70 | accepted | integrity |
 | integrity/rules/IR-056-project-extensions-integrity.md | 67 | accepted | integrity |
 | skills/agentdev-doc-writing.md | 67 | accepted | skills |
+| skills/agentdev-workflow-backlog-auto.md | 66 | draft | skills |
 | skills/agentdev-issue-management.md | 65 | accepted | skills |
 | integrity/rules/IR-060-forbidden-japanese-word-detection.md | 64 | accepted | integrity |
 | foundations/references/concrete-abstraction.md | 61 | accepted | foundations |
@@ -178,6 +179,7 @@ AUTOGENブロックは `AUTOGEN:BEGIN` マーカーから対応する `AUTOGEN:E
 | skills/agentdev-workflow-lifecycle.md | 59 | accepted | skills |
 | skills/agentdev-workflow-orchestration.md | 57 | accepted | skills |
 | integrity/backticks-identifier-threshold.md | 56 | accepted | integrity |
+| commands/backlog-auto.md | 55 | draft | commands |
 | integrity/checker-execution-contracts.md | 55 | draft | integrity |
 | skills/agentdev-epic-tracker.md | 55 | accepted | skills |
 | skills/agentdev-inspect-skills.md | 54 | accepted | skills |

--- a/src/opencode/commands/agentdev/README.md
+++ b/src/opencode/commands/agentdev/README.md
@@ -18,6 +18,7 @@ AgentDevFlow の各コマンドの入力、出力、次アクションを一覧�
 | `/agentdev/case-update` | Issue | 更新済み Issue | 継続または `/agentdev/case-close` |
 | `/agentdev/case-close` | PR + Issue | マージ済み + クローズ済み | 完了 |
 | `/agentdev/case-auto` | 要件doc/ Issue番号、URL | マージ済み + クローズ済み（req-save〜spec-save〜case-close自走） | 完了 |
+| `/agentdev/backlog-auto` | なし（durable state から解決） | 検出事項、採用済み成果物、`RU-*.md`（backlog整理サイクル一巡） | RU がある場合: `/agentdev/req-define` |
 | `/agentdev/intake-capture` | ユーザー手動入力 | `inbox/` item | `/agentdev/intake-promote` |
 | `/agentdev/intake-from-github` | クローズ済み Issue/PR | `inbox/` item | `/agentdev/intake-promote` |
 | `/agentdev/intake-promote` | `inbox/` item | `promoted/` 成果物 | `/agentdev/backlog-review` |
@@ -37,6 +38,7 @@ AgentDevFlow の各コマンドの入力、出力、次アクションを一覧�
 - [case-update.md](./case-update.md)
 - [case-close.md](./case-close.md)
 - [case-auto.md](./case-auto.md)
+- [backlog-auto.md](./backlog-auto.md)
 - [backlog-review.md](./backlog-review.md)
 - [intake-capture.md](./intake-capture.md)
 - [intake-from-github.md](./intake-from-github.md)

--- a/src/opencode/commands/agentdev/backlog-auto.md
+++ b/src/opencode/commands/agentdev/backlog-auto.md
@@ -1,0 +1,72 @@
+---
+description: backlog整理サイクル（inspect-docs→昇格3系統→backlog-review）を1回の起動で実行する（追加入口）
+---
+
+# backlog 一括整理
+
+backlog 整理サイクル（inspect-docs による文書診断、learning、intake、inspect の3昇格系統、backlog-review による統合と RU 生成）を1回の起動で一巡させる。
+既存5コマンド（inspect-docs、learning-promote、intake-promote、inspect-promote、backlog-review）を置換せず、標準の backlog 整理フロー（個別コマンドの逐次実行）を置き換えない追加入口である。
+
+## workflow 実装の権威情報源
+
+本コマンドの workflow 実装本体（orchestration stage 構成、昇格3系統の並行実行と競合処理の直列化契約、fan-in 判定、停止伝播、resume 契約）は `agentdev-workflow-backlog-auto` Workflow Skill を権威情報源とする（責務3層分化、workflow-skill-model SPEC 準拠）。
+本コマンド定義は公開 interface / dispatch のみを所有し、workflow 実装本体を複製しない。
+
+**子ワークフローの権威情報源**: 各工程は対応する Workflow Skill（`agentdev-workflow-inspect-docs`、`agentdev-workflow-learning-promote`、`agentdev-workflow-intake-promote`、`agentdev-workflow-inspect-promote`、`agentdev-workflow-backlog-review`）を権威情報源として実行する。
+backlog-auto は子ワークフロー内部の分類、評価、昇格、RU 生成ロジックを再実装しない。
+
+## project extensions
+
+本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-backlog-auto`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-backlog-auto.yaml`、kind: workflow-extension）を読み込む（ADR）。
+
+- extension は `context` / `rules` / `checks` / `acceptance_gates` / `must_not` の5セクションを持ち、本コマンドの標準動作に追加・拡張される（上書きではない）
+- extension が存在しない場合は標準動作で続行する
+- extension が破損している場合はエラーを表示して当該 extension を無視し、標準動作で続行する
+- 詳細な読み込み契約は `agentdev-project-extensions` skill 参照
+
+## 入力
+
+- なし（対象状態は各子コマンドの durable state から解決する）
+
+## 出力
+
+- 各子コマンドの既存出力（`.agentdev/inspect/inbox/` の検出事項、各 promoted/、`.agentdev/backlog/req-units/RU-*.md` 等、子コマンド公開契約どおり）
+- backlog-auto 全体の実行結果報告（工程別結果、停止理由、再開コマンド提示を含む共通実行契約形式）
+
+## workflow
+
+本コマンドは workflow 実装本体を `agentdev-workflow-backlog-auto` スキルへ委譲する（DEC-{N}、REQ-{NNNN}-{NNN}）。
+同スキルが6 STEP の control plane として制御構造を所有する。各工程を前出出力検証表で示す（工程ラベルが推奨順）。
+
+| 工程 | 前提条件 | 出力契約 | 検証基準 |
+|---|---|---|---|
+| STEP-1 開始時刻記録・進行状態初期化 | コマンド起動 | 開始時刻記録、durable state からの進行状態再構成 | 対象状態が各子コマンドの durable state から解決されていること |
+| STEP-2 stage 1: inspect-docs 実行 | 開始時刻記録済み | 検出事項（`.agentdev/inspect/inbox/`）または検出事項なし完了 | inspect-docs の公開契約どおりに実行されていること |
+| STEP-3 stage 2: 昇格3系統実行 | inspect-docs 正常終了 | 系統別実行結果（正常完了、対象なし終了、blocked、failed の別） | 系統相互の先行依存がなく、競合する Git 操作、共有成果物書き込み、ユーザー対話が直列化されていること |
+| STEP-4 fan-in 判定 | 3系統の結果受領 | backlog-review 開始可否の判定 | 全系統が正常完了または対象なし終了の時のみ開始可と判定していること |
+| STEP-5 stage 3: backlog-review 実行 | fan-in 判定が開始可 | `RU-*.md` 生成、成功成果物削除（backlog-review 公開契約どおり） | backlog-review の公開契約どおりに実行されていること |
+| STEP-6 完了報告 | 全工程完了または停止 | 工程別結果、停止理由、再開コマンド提示を含む実行結果報告 | 停止時に再開点と再開可能な次コマンドが明示され、全体完了が報告されていないこと |
+
+同スキルは本コマンドの工程経由でのみ利用し、単独の skill 起動は soft guard（REQ-{NNNN}-{NNN}）で抑制する。
+
+## 不変条件
+
+工程上の選好を肯定形の不変条件として示す:
+
+- 実行順序は inspect-docs、昇格3系統（learning-promote、intake-promote、inspect-promote）、backlog-review の順とし、工程間の開始条件ゲートを制御する。inspect-docs が正常終了する前に昇格3系統を開始せず、昇格3系統すべてが正常完了または対象なしで終了する前に backlog-review を開始しない
+- 昇格3系統相互に先行依存を設けない。1系統の blocked、failed で独立して進行可能な他系統を停止しない
+- 同一作業ツリーに対する競合する Git 操作、共有成果物への競合書き込み、ユーザー対話を直列化する。ユーザー対話は対象子ワークフローを識別可能に表示する
+- 各子ワークフローの既存 HITL 境界、安全境界、停止条件、自動昇格 opt-in を維持する。通常の backlog-auto 実行で inspect-promote の `--auto` を暗黙的に有効化しない
+- 対象なし終了を正常終了として扱う。昇格3系統で新規 promoted が0件でも全系統正常終了後に backlog-review を実行し、実行前から存在する promoted を処理対象にできる
+- 中断、再実行時は子ワークフローの既存再開契約を利用する。inspect-docs は中断時に先頭から再実行する
+- backlog-auto 自身は新規の副作用を追加しない。各子コマンドの既存副作用のみを発生させる
+- 既存5コマンドの定義と公開契約を変更しない。各コマンドは従来どおり単独実行できる
+
+## ガードレール
+
+硬い境界（破壊的操作、state 破壊等の否定規則）に限定する:
+
+- G01: 子ワークフロー内部の分類、評価、昇格、RU 生成を代行しない（各子 Workflow Skill の責務）
+- G02: inspect-promote の `--auto` を明示 opt-in なしに有効化しない
+- G03: capture 系コマンド（learning-capture、intake-capture、intake-from-github）、inspect-skills、req-define、req-save、GitHub Issue / PR 作成を自動起動しない
+- G04: 既存5コマンドの定義ファイルと公開契約を変更しない

--- a/src/opencode/skills/agentdev-workflow-backlog-auto/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-backlog-auto/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: agentdev-workflow-backlog-auto
+description: "backlog-auto command の workflow 実装本体。orchestration stage 構成（stage 1: inspect-docs 単独直列、stage 2: 昇格3系統の並行実行と競合直列化、stage 3: backlog-review）、fan-in 判定、停止伝播、resume 契約を所有する。USE FOR: backlog-auto 実行時の workflow 制御（工程間順序制御、昇格3系統の並行実行と競合処理の直列化、fan-in 判定、停止伝播、再開）。DO NOT USE FOR: 単独起動（対応する /agentdev/* コマンド経由で利用すること）、子ワークフロー内部の分類、評価、昇格、RU 生成ロジックの所有（各子 Workflow Skill が正規の処理主体）。"
+---
+
+# backlog-auto workflow スキル
+
+backlog-auto command の workflow 実装本体。
+backlog 整理サイクル（inspect-docs → 昇格3系統 → backlog-review）の工程間制御（順序、並列と直列化、fan-in、停止伝播、再開）を所有する。
+子ワークフロー内部の分類、評価、昇格、RU 生成ロジックは各子 Workflow Skill が正規の処理主体として所有し、本スキルはこれらを複製しない。
+
+backlog-auto command は公開 interface（入出力契約、ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}、REQ-{NNNN}-{NNN}）。
+
+## 原本（SSoT）
+
+本スキルの原本仕様は SKILL.md（control plane）と `references/` 配下（各 STEP 詳細）が担う。
+Workflow Skill 固有契約（Command / Workflow Skill / Capability Skill 責務、1:N 分割基準、依存方向、配置契約）は `<workflows/workflow-skill-model>` SPEC が正規所有する。
+extension（`.agentdev/extensions/skills/agentdev-workflow-backlog-auto.yaml`）は標準 SKILL.md を前提とし、SKILL.md と重複しない補完情報のみを提供する。
+
+## skill extension 参照方針
+
+本スキルは以下の方針に従う（ADR、`agentdev-skill-authoring` 準拠）。
+
+1. **前提とする固定知識の範囲**: docs/ ディレクトリ構成（requirements/decisions/specs）と backlog-auto command の公開契約のみを前提とする。SPEC ディレクトリの内部構成は仮定しない
+2. **extension の読込契約**: 呼び出し元 command から渡された解決済み文脈を優先し、不足分のみ skill extension を読む。reference ごとの extension は作らない
+3. **SPEC 内部パスの固定知識化の禁止**: extension に列挙されていない SPEC 内部パスを固定知識として参照しない
+4. **extension 未配置時の挙動**: skill extension が存在しない場合は標準動作で続行し、推測で docs を読みに行かない
+
+## 入力
+
+- backlog-auto command から渡される入力（引数なし。対象状態は各子コマンドの durable state から解決する）
+
+## 出力
+
+- 各子コマンドの既存出力（子コマンド公開契約どおり）
+- backlog-auto 全体の実行結果報告（工程別結果、停止理由、再開コマンド提示を含む共通実行契約形式）
+
+## 副作用
+
+- 各子ワークフローの既存副作用（`.agentdev/` 配下の成果物作成、削除、git commit / push、ユーザー対話）を子コマンド公開契約どおりに発生させる。本スキルは新規の副作用を追加しない
+- 当該 Workflow Skill は worktree root 配下以外を編集しない
+
+## Control Plane（STEP 一覧）
+
+backlog-auto workflow は次の6 STEP で構成する。
+各 STEP は resume point を持ち（DEC-{N}、`<workflows/step-reference-contract>` SPEC）、会話コンテキストに依存せず、durable state（`backlog_auto_started_at`、各子コマンドの durable state）から再開点を再構成する。
+
+| STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
+|---|---|---|---|---|
+| STEP-1 | 開始時刻記録・進行状態初期化 | backlog-auto 起動 | 開始時刻記録、durable state からの進行状態再構成 | [references/stage-execution.md](references/stage-execution.md) |
+| STEP-2 | stage 1: inspect-docs 実行 | 開始時刻記録済み | 検出事項生成または検出事項なし完了 | [references/stage-execution.md](references/stage-execution.md) |
+| STEP-3 | stage 2: 昇格3系統実行 | stage 1 正常終了 | 系統別実行結果（正常完了 / 対象なし終了 / blocked / failed / 未完了） | [references/stage-execution.md](references/stage-execution.md) |
+| STEP-4 | fan-in 判定 | 3系統の結果受領 | backlog-review 開始可否の判定 | [references/fan-in-and-reporting.md](references/fan-in-and-reporting.md) |
+| STEP-5 | stage 3: backlog-review 実行 | fan-in 判定が開始可 | RU 生成、成功成果物削除（backlog-review 公開契約どおり） | [references/fan-in-and-reporting.md](references/fan-in-and-reporting.md) |
+| STEP-6 | 完了報告 | 全工程完了 or 停止 | 工程別結果、停止理由、再開コマンド提示を含む実行結果報告 | [references/fan-in-and-reporting.md](references/fan-in-and-reporting.md) |
+
+### STEP 間の依存と分岐
+
+- **正常経路**: STEP-1 → STEP-2 → STEP-3 → STEP-4 → STEP-5 → STEP-6
+- **stage 1 停止経路**: STEP-2 で inspect-docs が blocked / failed → 下流工程（stage 2、stage 3）を開始せず STEP-6（停止報告）
+- **fan-in 不合格経路**: STEP-4 で1系統でも blocked、failed、未完了 → backlog-review を開始せず STEP-6（停止報告、全体完了報告の抑制）
+- **系統内再開**: STEP-3 の各系統は子ワークフローの既存再開契約（STEP model、durable state）で系統内の再開点から再開する
+
+### resume protocol
+
+- 再開点は durable state から再構成する: `backlog_auto_started_at`、stage 1 の完了証跡（直近 inspect-docs 実行の検出事項ファイル群または検出事項なし完了）、stage 2 系統別の durable state（learning は `inbox.md` / `deferred.md` / `evaluation-report.md` / `promoted/`、intake は `inbox/` と `promoted/` の実ファイル状態、inspect は `inbox/` と `promoted/` と auto-promote-log）、stage 3 の durable state（各 `promoted/` 残存成果物、`.agentdev/backlog/req-units/` の `RU-*.md` 実ファイル）
+- 完了済み工程を重複実行せず、未完了工程を完了済みと誤認しない。確定不能な工程は未完了として扱う
+- inspect-docs は STEP model 対象外であり、実行途中の中断時は先頭から再実行する
+- 停止時報告に再開点と再開可能な次コマンド（`/agentdev/backlog-auto` 再実行または対象子コマンドの単独実行）を明示し、会話コンテキストの記憶に依存しない
+
+### termination
+
+- 正常終了: stage 3（backlog-review）完了時の完了報告まで（全系統対象なし終了であっても backlog-review 実行後の完了報告を含む）
+- 停止終了: inspect-docs の blocked / failed（下流非開始）、fan-in 判定不合格（blocked / failed / 未完了残存時の backlog-review 非開始）のいずれかの検出時（停止理由分類済み報告）
+
+## 下位 Workflow Skill 連携（上位 orchestrator）
+
+本スキルは上位 orchestrator として次の下位 Workflow Skill を名レベルで参照する。
+下位 workflow の契約詳細を複製しない。
+
+- `agentdev-workflow-inspect-docs`: stage 1 工程（診断専用、STEP model 対象外、中断時は先頭再実行）
+- `agentdev-workflow-learning-promote`: stage 2 learning 系統
+- `agentdev-workflow-intake-promote`: stage 2 intake 系統
+- `agentdev-workflow-inspect-promote`: stage 2 inspect 系統（`--auto` は子コマンドの明示 opt-in のみで有効化され、本 workflow の通常実行では渡さない）
+- `agentdev-workflow-backlog-review`: stage 3 工程
+
+## 主要 Capability Skill 連携
+
+本スキルは次の Capability Skill を名レベルで参照する。
+
+- `agentdev-project-extensions`: project extension 読込
+- 各子ワークフローが依存する Capability Skill（`agentdev-learning-pipeline`、`agentdev-intake-pipeline`、`agentdev-backlog-integration` 等）は各子 Workflow Skill 経由で継承され、本スキルから直接参照しない
+
+## Workflow Extension 読込
+
+本スキルは workflow extension（`.agentdev/extensions/skills/agentdev-workflow-backlog-auto.yaml`、`kind: workflow-extension`）を読み込む場合がある。
+標準動作に追加・拡張される（上書きではない）。
+存在しない場合は標準動作で続行する。
+Workflow Skill のみが読み、backlog-auto command は直接読まない。
+
+## 共通制約
+
+- **soft guard**: 本スキルは `/agentdev/backlog-auto` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わない
+- **順序ゲート**: inspect-docs が正常終了する前に昇格3系統を開始しない。昇格3系統すべてが正常完了または対象なしで終了する前に backlog-review を開始しない
+- **直列化契約**: 競合する Git 操作（同期、commit、push）、共有成果物への競合書き込み、ユーザー対話は直列化する。ユーザー対話は系統識別付きで表示する
+- **HITL 境界の維持**: 各子ワークフローの既存 HITL 境界、安全境界、停止条件、自動昇格 opt-in を維持し、本スキルは新規の判断境界を追加しない
+- **部分停止の非連鎖**: 1系統の blocked、failed で独立して進行可能な他系統を停止しない。blocked、failed、未完了残存時は backlog-review を開始せず、全体完了を報告しない
+- **対象なしの正常扱い**: 昇格3系統の対象なし終了は正常終了として扱う。新規 promoted 0件でも backlog-review を実行する（実行前から存在する promoted を処理対象にできる）
+- **親コンテキスト非累積**: 系統別の完了結果（結果状態、出力パス、次アクション）のみを親コンテキストに保持し、系統内部の調査過程、中間ログ、読解メモを親コンテキストに累積しない
+- **実装分類**: manager-orchestrator（既存の実装分類を利用）。子ワークフロー内部の分類、評価、昇格、RU 生成ロジックは子 Workflow Skill の責務であり、本スキルは工程間の順序制御のみを所有する
+
+## See Also
+
+- **`<workflows/workflow-skill-model>` SPEC**: Workflow Skill 固有契約の正規所有者
+- **`<workflows/step-reference-contract>` SPEC**: STEP reference 構造、resume point
+- **`docs/decisions/DEC-{N}.md`**: Command / Workflow Skill / Capability Skill 責務3層分化と1:N分割原則
+- **`docs/decisions/DEC-{N}.md`**: STEP resume point と会話記憶非依存
+- **backlog-auto command**: 本スキルの呼出元（公開 interface、ガードレール、dispatch を所有）

--- a/src/opencode/skills/agentdev-workflow-backlog-auto/references/fan-in-and-reporting.md
+++ b/src/opencode/skills/agentdev-workflow-backlog-auto/references/fan-in-and-reporting.md
@@ -1,0 +1,155 @@
+# STEP-4/5/6: fan-in 判定、stage 3 実行、完了報告（fan-in-and-reporting）
+
+> 本 reference は `agentdev-workflow-backlog-auto` SKILL.md の Control Plane STEP-4, STEP-5, STEP-6 詳細である。
+> fan-in 判定（backlog-review 開始条件）、stage 3（backlog-review 実行）、完了報告（工程別結果、停止理由、再開コマンド提示）を提供する。
+
+## 目次
+
+- STEP-4: fan-in 判定
+- STEP-5: stage 3: backlog-review 実行
+- STEP-6: 完了報告
+
+## STEP-4: fan-in 判定
+
+### Purpose
+
+stage 2 の系統別結果状態から backlog-review の開始可否を判定する。
+
+### Input Resolution
+
+1. SSoT 再構成: 系統別結果状態（STEP-3 の結果）、各 `promoted/` の実ファイル状態
+2. identifier 保持: 系統識別子（learning-promote / intake-promote / inspect-promote）
+3. 最小 scalar: なし
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-3 で全系統が終了している、または再構成時に未完了系統が残っている
+
+### Procedure
+
+判定表に従って backlog-review の開始可否を判定する。
+
+| 条件 | 判定 | 次遷移 |
+|---|---|---|
+| 3系統すべてが正常完了または対象なし終了 | 開始可 | STEP-5 |
+| 1系統でも blocked、failed、未完了 | 開始不可 | STEP-6（停止報告） |
+
+新規 promoted が0件かどうかは判定に影響しない。
+全系統が正常終了していれば、`promoted/` が空の場合でも backlog-review を開始する（実行前から存在する promoted の処理と、対象0件時の扱いは backlog-review の公開契約どおり）。
+
+未完了（中断残り）の系統は開始不可の条件に含める。
+再構成の結果、全系統が正常完了または対象なし終了と確定できた場合は開始可とする。
+
+### Result
+
+- backlog-review 開始可否と判定根拠（系統別結果状態の一覧）
+
+### Evidence
+
+- 系統別結果状態、各 `promoted/` の観測結果
+
+### Completion Verification
+
+- 3系統すべてが正常完了または対象なし終了の場合のみ開始可と判定されていること
+
+### Resume-Idempotency
+
+- 判定は durable state（系統別 durable state と結果報告）から再実行可能であり、副作用を持たない
+
+## STEP-5: stage 3: backlog-review 実行
+
+### Purpose
+
+backlog-review を実行し、採用済み成果物の分析、統合、ユーザー承認を経た RU 生成を行う。
+工程内部の手続きは `agentdev-workflow-backlog-review` が正規の処理主体である。
+
+### Input Resolution
+
+1. SSoT 再構成: `.agentdev/intake/promoted/*.md`、`.agentdev/learning/promoted/*.md`、`.agentdev/inspect/promoted/*.md`、`.agentdev/backlog/req-units/` の `RU-*.md`
+2. identifier 保持: なし
+3. 最小 scalar: stage 3 の開始時刻、終了時刻
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-4 で backlog-review 開始可と判定されている
+
+### Procedure
+
+`agentdev-workflow-backlog-review` を権威情報源として backlog-review を実行する（引数なし、全ディレクトリの採用済み成果物が対象。実行前から存在する promoted を含む）。
+
+backlog-review の既存 HITL（RU 作成承認）、矛盾検出時のユーザー指示待機、破壊的変更の明示承認を維持する。
+stage 3 は単独実行であるため直列化キューは使用しない。
+
+結果の分類:
+
+- 正常完了（RU 生成と完了報告の受領）→ STEP-6 へ（全体完了報告）
+- blocked / failed → STEP-6 へ（停止報告）
+
+### Result
+
+- stage 3 実行結果（正常完了 / blocked / failed）
+
+### Evidence
+
+- 生成された `RU-*.md` のパス一覧、成功成果物削除結果、blocked / failed 時はその理由
+
+### Completion Verification
+
+- backlog-review が公開契約どおりに完了していること（完了報告の受領）
+
+### Resume-Idempotency
+
+- 再開点の再構成は `agentdev-workflow-backlog-review` の既存 STEP model 再開契約（promoted/ 残存成果物、RU 実ファイルと frontmatter）に委譲する
+
+## STEP-6: 完了報告
+
+### Purpose
+
+工程別結果、停止理由、再開コマンド提示を含む backlog-auto 全体の実行結果報告を出力する。
+共通実行契約形式に従う。
+
+### Input Resolution
+
+1. SSoT 再構成: 各 stage の結果状態、`backlog_auto_started_at`、直列化キューの実行記録
+2. identifier 保持: 系統識別子
+3. 最小 scalar: 終了時刻（`backlog_auto_started_at` からの所要時間）
+4. runtime artifact: なし
+
+### Preconditions
+
+- 全工程完了または停止条件の検出
+
+### Procedure
+
+全体完了時（stage 3 正常完了後）は次を報告する:
+
+- 工程別結果（stage 1、stage 2 系統別、stage 3）
+- 生成成果物サマリ（検出事項、採用済み成果物、RU）
+- 所要時間（`backlog_auto_started_at` からの差分）
+- 次アクション（RU がある場合は `/agentdev/req-define`）
+
+停止時は次を報告し、全体完了扱いにしない:
+
+- 停止理由（どの工程、系統が blocked、failed、未完了か、その理由）
+- 再開点（完了済み工程と再開対象）
+- 再開可能な次コマンド（`/agentdev/backlog-auto` 再実行、または対象子コマンドの単独実行）
+
+報告には工程別結果の内訳を含め、系統別の詳細は子ワークフロー自身の完了報告と durable state を参照させる。
+
+### Result
+
+- backlog-auto 全体の実行結果報告（共通実行契約形式）
+
+### Evidence
+
+- 報告本文（工程別結果、停止理由、再開コマンド）
+
+### Completion Verification
+
+- 停止時に全体完了が報告されておらず、再開点と再開可能な次コマンドが明示されていること
+
+### Resume-Idempotency
+
+- 報告は durable state から再構成した工程進行に基づいて出力する。報告自体は副作用を持たない

--- a/src/opencode/skills/agentdev-workflow-backlog-auto/references/stage-execution.md
+++ b/src/opencode/skills/agentdev-workflow-backlog-auto/references/stage-execution.md
@@ -1,0 +1,195 @@
+# STEP-1/2/3: 開始時刻記録、stage 1、stage 2 実行（stage-execution）
+
+> 本 reference は `agentdev-workflow-backlog-auto` SKILL.md の Control Plane STEP-1, STEP-2, STEP-3 詳細である。
+> 開始時刻記録と進行状態初期化、stage 1（inspect-docs 単独直列実行）、stage 2（昇格3系統の並行実行と直列化契約）を提供する。
+
+## 目次
+
+- STEP-1: 開始時刻記録・進行状態初期化
+- STEP-2: stage 1: inspect-docs 実行
+- STEP-3: stage 2: 昇格3系統実行
+- 直列化キュー
+- 系統別結果状態の読み替え
+
+## STEP-1: 開始時刻記録・進行状態初期化
+
+### Purpose
+
+実行開始時刻を記録し、durable state から工程進行を再構成する。
+
+### Input Resolution
+
+1. SSoT 再構成: 各子コマンドの durable state（learning は `.agentdev/learning/` 配下の `inbox.md` / `deferred.md` / `evaluation-report.md` / `promoted/`、intake は `.agentdev/intake/inbox/` と `.agentdev/intake/promoted/`、inspect は `.agentdev/inspect/inbox/` と `.agentdev/inspect/promoted/`、backlog-review は各 `promoted/` と `.agentdev/backlog/req-units/`）
+2. identifier 保持: なし
+3. 最小 scalar: `backlog_auto_started_at`（JST）
+4. runtime artifact: なし
+
+### Preconditions
+
+- backlog-auto command から起動されている（引数なし）
+
+### Procedure
+
+実行開始時刻を JST で記録し `backlog_auto_started_at` に保持する。
+STEP-6（完了報告）での所要時間算出の基準として使用する。
+
+再実行時（進行状態の再構成が必要な場合）は次の表で工程進行を再構成する。
+
+| 工程 | 再構成に使う durable state | 判定 |
+|---|---|---|
+| stage 1（inspect-docs） | 下流工程の進行痕跡、直近実行の完了証跡（`.agentdev/inspect/inbox/` の検出事項ファイル群または検出事項なし完了） | 下流工程に進行痕跡がある、または完了証跡が確定できる場合は完了。確定できない場合は未完了扱いで先頭から再実行 |
+| stage 2 learning 系統 | `inbox.md`（ヘッダーのみへのクリア）、`evaluation-report.md`、`promoted/`、`deferred.md` | 系統内の再開点の再構成は `agentdev-workflow-learning-promote` の既存 STEP model 再開契約に委譲 |
+| stage 2 intake 系統 | `.agentdev/intake/inbox/` と `.agentdev/intake/promoted/` の実ファイル状態、分類確定状態 | `agentdev-workflow-intake-promote` の既存再開契約に委譲 |
+| stage 2 inspect 系統 | `.agentdev/inspect/inbox/`、`.agentdev/inspect/promoted/`、auto-promote-log | `agentdev-workflow-inspect-promote` の既存再開契約に委譲 |
+| stage 3（backlog-review） | 各 `promoted/` 残存成果物、`.agentdev/backlog/req-units/` の `RU-*.md` 実ファイルと frontmatter | `agentdev-workflow-backlog-review` の既存再開契約に委譲 |
+
+初回起動（未実行）と判定した場合は stage 1 から開始する。
+
+### Result
+
+- `backlog_auto_started_at` 記録
+- 工程進行の再構成結果（各 stage の完了 / 未完了、stage 2 の系統別状態）
+
+### Evidence
+
+- `backlog_auto_started_at` の値、工程進行の再構成根拠（durable state の観測内容）
+
+### Completion Verification
+
+- 工程進行が一意に再構成されていること（確定不能な工程は未完了扱いであること）
+
+### Resume-Idempotency
+
+- 読取と記録のみで副作用を持たない。進行状態は各 STEP の実行で durable state に反映される子コマンド成果物から常に再構成できる
+
+## STEP-2: stage 1: inspect-docs 実行
+
+### Purpose
+
+inspect-docs を単独直列実行し、docs 全体の意味整合診断の検出事項を `.agentdev/inspect/inbox/` へ出力する。
+工程内部の手続きは `agentdev-workflow-inspect-docs` が正規の処理主体である。
+
+### Input Resolution
+
+1. SSoT 再構成: なし（inspect-docs はコマンド実行時に全対象成果物を自動スキャンする）
+2. identifier 保持: なし
+3. 最小 scalar: stage 1 の開始時刻、終了時刻
+4. runtime artifact: なし
+
+### Preconditions
+
+- STEP-1 で開始時刻記録と進行状態再構成が完了している
+- stage 1 が未完了と判定されている（完了済みの場合は STEP-3 へ進む）
+
+### Procedure
+
+`agentdev-workflow-inspect-docs` を権威情報源として inspect-docs を実行する（引数なし、単独直列）。
+
+結果の分類:
+
+- 正常終了（検出事項ファイル群の生成、または検出事項0件の完了）→ stage 2 開始条件成立、STEP-3 へ
+- blocked / failed → 下流工程（stage 2、stage 3）を開始せず STEP-6 へ（停止報告）
+
+inspect-docs の既存ガードレール（診断専用、検出事項ファイル生成以外の副作用禁止）を変更しない。
+
+### Result
+
+- stage 1 実行結果（正常終了 / blocked / failed）
+
+### Evidence
+
+- 検出事項ファイル群のパス一覧または検出事項0件の完了報告、blocked / failed 時はその理由
+
+### Completion Verification
+
+- inspect-docs が公開契約どおりに完了していること（完了報告の受領）
+- blocked / failed 時に下流工程が開始されていないこと
+
+### Resume-Idempotency
+
+- inspect-docs は STEP model 対象外である。実行途中の中断時は先頭から再実行する（診断専用であるため再実行の副作用は検出事項ファイルの再生成に限定される）
+
+## STEP-3: stage 2: 昇格3系統実行
+
+### Purpose
+
+learning-promote、intake-promote、inspect-promote の3系統を、系統相互の先行依存なしに実行する。
+競合する処理のみ直列化キューで排他する。
+各系統内部の手続きは各子 Workflow Skill が正規の処理主体である。
+
+### Input Resolution
+
+1. SSoT 再構成: 各系統の durable state（STEP-1 と同じ）
+2. identifier 保持: 系統識別子（learning-promote / intake-promote / inspect-promote）
+3. 最小 scalar: 系統別の開始時刻、終了時刻、結果状態
+4. runtime artifact: なし（系統内部の過程は親コンテキストに累積しない）
+
+### Preconditions
+
+- stage 1 が正常終了している（検出事項0件の完了を含む）
+
+### Procedure
+
+3系統を起動する。
+系統相互に先行依存を設けない。
+並行実行を利用できる場合は並行し、利用できない場合は順次インターリーブ実行とする（いずれの場合も系統間の待ち合わせとブロッキングを行わない）。
+
+各系統は対応する Workflow Skill を権威情報源として実行する:
+
+- learning 系統: `agentdev-workflow-learning-promote`
+- intake 系統: `agentdev-workflow-intake-promote`
+- inspect 系統: `agentdev-workflow-inspect-promote`（通常実行で起動し `--auto` は渡さない。`--auto` は利用者が inspect-promote を単独実行して明示的に opt-in した場合のみ有効化される）
+
+競合する処理は「直列化キュー」の規則に従って排他する。
+ユーザー対話（HITL、確認、承認）は直列化し、対話の冒頭で対象系統を識別表示する（例: `[learning-promote]`）。
+
+1系統の blocked、failed を検出しても他系統を連鎖停止しない。
+全系統が終了（正常完了、対象なし終了、blocked、failed のいずれか）を待って STEP-4 へ進む。
+親コンテキストには系統別の結果状態と次アクションのみ保持する。
+
+系統の結果状態の読み替えは「系統別結果状態の読み替え」の表に従う。
+
+### Result
+
+- 系統別結果状態（正常完了 / 対象なし終了 / blocked / failed）と系統別成果物サマリ
+
+### Evidence
+
+- 系統別の完了報告（結果状態、出力パス、次アクション）、blocked / failed 時はその理由、直列化キューの実行記録（操作種別、対象系統、順序）
+
+### Completion Verification
+
+- 全系統がいずれかの結果状態で終了していること
+- 競合する Git 操作、共有成果物書き込み、ユーザー対話が同時実行されていないこと
+- ユーザー対話に系統識別が付されていること
+
+### Resume-Idempotency
+
+- 各系統の再開点は子 Workflow Skill の既存 STEP model 再開契約（durable state から再構成）に従う。本 STEP は系統別の起動と結果受領のみを管理する
+
+## 直列化キュー
+
+直列化の対象と規則を示す。
+
+| 直列化対象 | 規則 |
+|---|---|
+| Git 同期、commit、push | 系統が Git 操作を開始する時点でキューへ投入し、先着順に排他実行する。実行単位は子ワークフローが定義する永続化ポイント（commit 単位）とする |
+| 共有成果物への競合書き込み | 同一パスへの同時書き込みが競合しうる場合（git インデックス、`.agentdev/` 配下の同一ファイル）に排他する |
+| ユーザー対話（HITL、確認、承認） | 複数系統が判断待ちとなった場合に直列化し、対話の冒頭で対象系統を識別表示する |
+
+直列化対象以外の処理（読取、分析、整形、報告書作成）は待機しない。
+キューは実行中の系統処理を中断しない（投入済みの非競合処理は継続する）。
+
+## 系統別結果状態の読み替え
+
+子コマンドの終了報告を本 workflow の系統別結果状態へ読み替える。
+子コマンドの動作と公開契約は変更しない（オーケストレーション側の結果分類である）。
+
+| 系統 | 正常完了 | 対象なし終了 | blocked / failed |
+|---|---|---|---|
+| learning-promote | HITL 承認を経た永続化と完了報告の受領 | `inbox.md` に未処理エントリなし。`inbox.md` 不在時の子コマンドのエラー報告（`agentdev-learning-capture` 案内）も、処理対象が存在しないことを意味するため対象なし終了として扱い、案内内容は完了報告に付記する | 子コマンドの blocked / failed 報告 |
+| intake-promote | 分類確定と永続化の完了報告の受領 | `.agentdev/intake/inbox/` に item なし | 同上 |
+| inspect-promote | 分類確定と処理実行の完了報告の受領 | `.agentdev/inspect/inbox/` に検出事項なし（子ワークフロー STEP-1 の「対象なし」終了と同一判定） | 同上 |
+
+対象なし終了は正常終了として扱い、一括処理の失敗としない。
+新規 promoted が0件かどうかは fan-in 判定（STEP-4）に影響しない。


### PR DESCRIPTION
Refs: #2200

## 概要

Issue #2200（OU-001: REQ-041 create、backlog 一括整理コマンド backlog-auto）の配布物実装である。backlog 整理サイクル（inspect-docs → 昇格3系統 → backlog-review）を1回の公開コマンド起動で一巡させるオーケストレータ /agentdev/backlog-auto と、専用の Workflow Skill agentdev-workflow-backlog-auto を追加した。
REQ-041、command/skill SPEC、workflow-contracts コマンド分類表は Phase 0（commit e864af5e、7ad962cf）で適用済みであり、本 PR の主作業は配布物実装（コマンド定義、Workflow Skill、README 系追記）と検査期待値更新である。

## 実装内容

- src/opencode/commands/agentdev/backlog-auto.md（新規、73行）: 公開 interface のみを所有。frontmatter は description 単一、6 STEP の workflow dispatch 表、workflow 実装の権威情報源宣言、project extensions、入出力、不変条件（順序ゲート、並行と直列化、HITL 境界維持、対象なし正常扱い、既存5コマンド不改変等）、ガードレール G01〜G04、soft guard 宣言

- src/opencode/skills/agentdev-workflow-backlog-auto/SKILL.md（新規、119行）: workflow 実装本体の control plane。6 STEP 一覧、STEP 間依存と分岐、resume protocol（durable state 再構成）、termination、下位 Workflow Skill 連携（5子スキルの名レベル参照）、共通制約、soft guard 宣言

- src/opencode/skills/agentdev-workflow-backlog-auto/references/stage-execution.md（新規、196行）: STEP-1〜3 の詳細（Purpose / Input Resolution / Preconditions / Procedure / Result / Evidence / Completion Verification / Resume-Idempotency の8要素構造）。開始時刻記録と durable state による進行状態再構成テーブル、stage 1 inspect-docs 単独直列実行と下流非開始ゲート、stage 2 昇格3系統の並行実行、直列化キュー（Git 同期・commit・push、共有成果物への競合書き込み、ユーザー対話の排他規則）、系統別結果状態の読み替え表（対象なし終了の正常扱いを含む）

- src/opencode/skills/agentdev-workflow-backlog-auto/references/fan-in-and-reporting.md（新規、155行）: STEP-4〜6 の詳細。fan-in 判定表（全系統正常完了 or 対象なし終了時のみ開始可、新規 promoted 0件は判定に影響しない）、stage 3 backlog-review 実行（引数なし全ディレクトリ対象、既存 promoted を含む）、完了報告（工程別結果、停止理由、再開コマンド提示、停止時の全体完了報告抑制）

- README 系追記: src/opencode/commands/agentdev/README.md（コマンド一覧行、定義ファイルリンク）、README.md 入口表（backlog整理サイクル行）、docs/guides/command-selection.md（入口表行、補足に追加入口の注記）

- docs/specs/foundations/system.md: 新コマンド登録に伴う整合性検査期待値の更新（check_integrity expanded-readme-sync 対応。コマンド数表記 16→17、Workflow Architecture Inventory 一覧表へ行追加、11分析軸セクション追加、updated 日付）

- .opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts: 契約テスト EXPECTED_COMMANDS へ backlog-auto を追記（公開コマンド数期待値 16→17）

子ワークフロー内部のロジック（分類基準、評価軸、昇格基準、RU 生成）は再定義していない（委譲参照のみ、TS-001c 検査 pass）。既存5コマンドの定義ファイルに差分なし（git diff --name-only origin/main で確認）。

## 完了条件

- [x] backlog-auto.md が公開コマンド定義として追加（REQ-041-001）
- [x] agentdev-workflow-backlog-auto/（SKILL.md + references）が workflow 実装本体として追加（REQ-041-002）
- [x] オーケストレータが工程間の順序制御のみを所有し、子ワークフローロジックを重複定義しない（REQ-041-003）
- [x] 実行順序ゲート（inspect-docs 正常終了前の昇格3系統非開始、全系統正常完了 or 対象なし終了後のみ backlog-review 開始）の実装（REQ-041-004、010）
- [x] 並行実行と直列化（系統相互の先行依存なし、競合 Git 操作・共有成果物書き込み・ユーザー対話の直列化、系統識別付き対話表示）の実装（REQ-041-005〜007）
- [x] 各子ワークフローの既存 HITL 境界、安全境界、停止条件、自動昇格 opt-in の維持（REQ-041-008）
- [x] 停止伝播と fan-in 判定（独立系統継続、blocked/failed/未完了時の backlog-review 非開始と全体完了報告抑制、inspect-docs 失敗時の下流非開始、対象なし正常扱い、新規 promoted 0件でも backlog-review 実行）の実装（REQ-041-009〜014）
- [x] 中断・再実行時の子ワークフロー既存再開契約の利用と inspect-docs 中断時の先頭再実行（REQ-041-015）
- [x] 既存5コマンドの定義ファイルに差分なし、従来どおり単独実行可、通常実行での inspect-promote --auto 暗黙有効化なし（REQ-041-016）
- [x] TS-001〜TS-009、TS-QC-001〜TS-QC-002 の検証実施（下記テスト結果）
- [x] repo-agentdev-integrity 全体実行と docs-check 相当検査の実施（本 PR 起因の新規 NG なし。origin/main 既存の NG 2件は Findings docs-integrity に記録）
- [x] 契約テスト期待値の更新と固定トークン確認: 実施済み（期待値更新対象: commands_e2e.test.ts の EXPECTED_COMMANDS、docs/specs/foundations/system.md のコマンド登録。固定トークン grep: 新規配布物を参照する *.test.ts 固定トークンなしを確認）

## テスト結果

実行時振る舞い系（TS-002〜008）は LLM ワークフローのコマンド実行が機械的実行不可能なため、workflow 定義本文（SKILL.md + references）の制御構造検証（19項目の構造マーカー検査）を observable evidence とした。この検証方法の限界: 実行時の実際の挙動（対話の実際の直列化、Git 排他の実際の機能等）は検証対象外であり、定義された制御構造の存在と整合のみを検証する。

| TS | 検証方法 | 結果 |
|---|---|---|
| TS-001 | ファイル存在確認、git diff --name-only origin/main で既存5コマンド定義の非変更を確認、子ワークフローロジック重複キーワード（8軸評価、分類値、採用・保留・却下、promote/defer/reject、tentative_classification、depends_on、RU フォーマット等）の grep 検査 | pass（重複定義なし） |
| TS-002 | 順序宣言、stage 2 開始条件、fan-in 経由の backlog-review 開始条件の構造検証 | pass |
| TS-003 | 対象なし終了の正常扱い宣言、全系統対象なし時の backlog-review 実行と完了報告の構造検証 | pass |
| TS-004 | inspect-docs blocked/failed 時の下流非開始（STEP-2 手順 + stage 1 停止経路宣言）の構造検証 | pass |
| TS-005 | 連鎖停止しない宣言、fan-in 開始不可判定、停止時の全体完了報告抑制の構造検証 | pass |
| TS-006 | 直列化キュー表（Git 操作、共有成果物、ユーザー対話）と系統識別表示の構造検証 | pass |
| TS-007 | 新規 promoted 0件が fan-in 判定に影響しない宣言、引数なし全ディレクトリ対象の backlog-review 起動の構造検証 | pass |
| TS-008 | durable state 再構成テーブル、確定不能時の未完了扱い、inspect-docs 先頭再実行、重複実行排除の構造検証 | pass |
| TS-009 | 既存5コマンド定義の diff なし、--auto が禁止・非渡し宣言のみで起動指示を含まないことの grep 検査（該当4行すべて禁止宣言） | pass |
| TS-QC-001 | agentdev-command-authoring 査読: frontmatter description 単一、73行（150行以内）、STEP 6工程（5〜12範囲）、詳細判定表の reference 移譲、実行時パス参照、check_command_format.ts OK | pass（未解決違反なし） |
| TS-QC-002 | agentdev-skill-authoring 査読: frontmatter name スカラー値・name/description のみ、USE FOR/DO NOT USE FOR 付き3人称 description、参照深度1階層、100行超 references に目次、フォワードスラッシュ、lint_skills.ts NG 0、check_skill_rename_symmetry 新規 NG 0 | pass（未解決違反なし） |

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| check_command_format.ts | OK | OK | ✅ |
| lint_skills.ts | OK 673 / NG 0 / Warning 0 | NG 0 | ✅ |
| check_integrity.ts（source profile） | OK 246 / NG 2 / Warning 8。NG 2件・Warning 8件は origin/main 時点と同一（Phase 0 起因の AUTOGEN 鮮度、既知 IR-055/ir035。本 PR 起因の新規 NG 0） | 本 PR 起因の新規 NG 0 | ✅ |
| check_extensions.ts | failures 0 | 0 | ✅ |
| check_distribution_boundary.ts | failures 0 | 0 | ✅ |
| check_workflow_preventive.ts | 本 PR 起因の追加 failure 0（check #3 の16件は main 既存。新規 backlog-auto を含む全7項目で追加指摘なし） | 追加 0 | ✅ |
| check_skill_rename_symmetry.ts | backlog-auto 起因 NG 0（Phase 0 で作成済み SPEC と新規 skill dir の対称性成立、SPEC 不足 NG を1件解消） | 新規 0 | ✅ |
| check_changed_docs.ts --workflow case-run --base-ref origin/main | failures 0 / warnings 0 | 0 | ✅ |
| integrity test suite（bun test 83ファイル） | 2025 pass / 3 fail。3 fail（IR-055 実修復回帰、checkWorkflowPreventive integration、checkExtensions deterministic）は detached worktree の origin/main で同一失敗を確認済みの既存 | 本 PR 起因の新規失敗 0 | ✅ |

## Findings / Capture候補

### intake

該当なし

### learning

- worktree 環境で git stash を使用しない運用知見。git stash の stash list は worktree 間で共有されるため、worktree 内で変更がない状態で git stash を実行すると stash が作成されず、続けて git stash pop すると他 worktree 由来の無関係な既存 stash を pop して conflict 状態になる（本 Issue の検証作業中に発生、git reset --hard HEAD で復旧し stash エントリは保持）。worktree では stash の代わりに detached worktree による baseline 比較を使う

### docs-integrity

- check_integrity と check_autogen_freshness の NG 2件（docs/specs/quality/req-health-metrics.md の req-metrics-measurement-example、docs/specs/quality/spec-health-metrics.md の spec-metrics-measurement-example の AUTOGEN ブロック陳腐化）は、Phase 0 の req-save / spec-save コミット（e864af5e、7ad962cf）が REQ-041 と backlog-auto 両 SPEC を追加した際に計測例ブロックを再生成しなかったことが起因で、origin/main 時点から存在する。修復には bun run .opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts による再生成が必要だが、本 Issue では docs/specs/** の変更が制約されるため実施していない。従来履歴では case-close 検出分として別途コミットされている（061c255a）。本 PR の system.md 編集（410→428行）に伴い spec-metrics ブロック内の system.md 行数行にも不一致が加わったが、同一ブロックの再生成で同時に解消される

## SPEC確定候補

- agentdev-workflow-backlog-auto SPEC「fan-in 判定」節への系統別結果状態読み替え表の明記候補。現行 SPEC は「対象なし終了」の正常扱いのみを定義し、learning-promote の inbox.md 不在時の子コマンドエラー報告を対象なし終了へ読み替える mapping は references/stage-execution.md の実装詳細として定義した。SPEC 側へ昇格するかは case-close の SPEC 確定チェックで判断する
- 直列化キューの実行単位（子ワークフローが定義する永続化ポイント = commit 単位）の SPEC 明記候補。現行 SPEC の直列化契約は対象種別のみを列挙し、実行単位は reference 側の詳細としている
