### PR TITLE
feat(integrity): Decision 索引 AUTOGEN 検査契約の checker 追従（OU-0012、Issue #2208）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -32,30 +32,27 @@ import {
   CATALOG_PRE_BLOCK_ID,
   CATALOG_POST_BLOCK_ID,
   RULE_OWNERSHIP_BLOCK_ID,
-  collectAdrFiles,
-  collectRetiredAdrFiles,
+  collectDecisionFiles,
+  collectRetiredDecisionFiles,
   collectReqFiles,
   collectRetiredReqFiles,
-  countSpecFiles,
-  generateAdrBaselineCaption,
-  generateAdrBaselineTable,
-  generateAdrStatusList,
-  generateAdrRetiredTable,
+  generateDecisionBaselineCaption,
+  generateDecisionBaselineTable,
+  generateDecisionStatusList,
+  generateDecisionRetiredTable,
   generateReqActiveCaption,
   generateReqActiveTable,
   generateReqRetiredTable,
-  generateDocMapInventory,
-  ADR_BASELINE_COUNT_BLOCK_ID,
-  ADR_BASELINE_TABLE_BLOCK_ID,
-  ADR_STATUS_ACCEPTED_BLOCK_ID,
-  ADR_STATUS_PROPOSED_BLOCK_ID,
-  ADR_STATUS_SUPERSEDED_BLOCK_ID,
-  ADR_STATUS_DEPRECATED_BLOCK_ID,
-  ADR_RETIRED_TABLE_BLOCK_ID,
+  DECISION_BASELINE_COUNT_BLOCK_ID,
+  DECISION_BASELINE_TABLE_BLOCK_ID,
+  DECISION_STATUS_ACCEPTED_BLOCK_ID,
+  DECISION_STATUS_PROPOSED_BLOCK_ID,
+  DECISION_STATUS_SUPERSEDED_BLOCK_ID,
+  DECISION_STATUS_DEPRECATED_BLOCK_ID,
+  DECISION_RETIRED_TABLE_BLOCK_ID,
   REQ_ACTIVE_COUNT_BLOCK_ID,
   REQ_ACTIVE_TABLE_BLOCK_ID,
   REQ_RETIRED_TABLE_BLOCK_ID,
-  DOCMAP_INVENTORY_BLOCK_ID,
   REQ_METRICS_BLOCK_ID,
   SPEC_METRICS_BLOCK_ID,
   collectReqMetrics,
@@ -8310,33 +8307,32 @@ function checkIndexGenerationConsistency(root: string): CheckResult[] {
     }
   }
 
-  // AG-008: ADR README (docs/adr/README.md) — 7 AUTOGEN blocks
-  const adrDir = path.join(root, "docs", "adr");
-  const adrRetiredDir = path.join(adrDir, "retired");
-  const adrReadmePath = path.join(adrDir, "README.md");
-  const adrReadmeContent = readText(adrReadmePath);
-  if (adrReadmeContent !== null && fs.existsSync(adrDir)) {
-    const adrInfos = collectAdrFiles(adrDir);
-    const adrRetiredInfos = collectRetiredAdrFiles(adrRetiredDir);
-    const acceptedAdrs = adrInfos.filter((a) => a.status === "accepted");
-    const adrSpecs: AutogenBlockSpec[] = [
-      { blockId: ADR_BASELINE_COUNT_BLOCK_ID, expected: generateAdrBaselineCaption(acceptedAdrs), label: "adr-baseline-count" },
-      { blockId: ADR_BASELINE_TABLE_BLOCK_ID, expected: generateAdrBaselineTable(acceptedAdrs), label: "adr-baseline-table" },
-      { blockId: ADR_STATUS_ACCEPTED_BLOCK_ID, expected: generateAdrStatusList(adrInfos, "accepted"), label: "adr-status-accepted" },
-      { blockId: ADR_STATUS_PROPOSED_BLOCK_ID, expected: generateAdrStatusList(adrInfos, "proposed"), label: "adr-status-proposed" },
-      { blockId: ADR_STATUS_SUPERSEDED_BLOCK_ID, expected: generateAdrStatusList(adrInfos, "superseded"), label: "adr-status-superseded" },
-      { blockId: ADR_STATUS_DEPRECATED_BLOCK_ID, expected: generateAdrStatusList(adrInfos, "deprecated"), label: "adr-status-deprecated" },
-      { blockId: ADR_RETIRED_TABLE_BLOCK_ID, expected: generateAdrRetiredTable(adrRetiredInfos), label: "adr-retired-table" },
+  // AG-008 (DEC-009): Decision README (docs/decisions/README.md) — 7 AUTOGEN blocks
+  const decisionsDir = path.join(root, "docs", "decisions");
+  const decisionRetiredDir = path.join(decisionsDir, "retired");
+  const decisionReadmePath = path.join(decisionsDir, "README.md");
+  const decisionReadmeContent = readText(decisionReadmePath);
+  if (decisionReadmeContent !== null && fs.existsSync(decisionsDir)) {
+    const decisionInfos = collectDecisionFiles(decisionsDir);
+    const decisionRetiredInfos = collectRetiredDecisionFiles(decisionRetiredDir);
+    const decisionSpecs: AutogenBlockSpec[] = [
+      { blockId: DECISION_BASELINE_COUNT_BLOCK_ID, expected: generateDecisionBaselineCaption(decisionInfos), label: "decision-baseline-count" },
+      { blockId: DECISION_BASELINE_TABLE_BLOCK_ID, expected: generateDecisionBaselineTable(decisionInfos), label: "decision-baseline-table" },
+      { blockId: DECISION_STATUS_ACCEPTED_BLOCK_ID, expected: generateDecisionStatusList(decisionInfos, "accepted"), label: "decision-status-accepted" },
+      { blockId: DECISION_STATUS_PROPOSED_BLOCK_ID, expected: generateDecisionStatusList(decisionInfos, "proposed"), label: "decision-status-proposed" },
+      { blockId: DECISION_STATUS_SUPERSEDED_BLOCK_ID, expected: generateDecisionStatusList(decisionInfos, "superseded"), label: "decision-status-superseded" },
+      { blockId: DECISION_STATUS_DEPRECATED_BLOCK_ID, expected: generateDecisionStatusList(decisionInfos, "deprecated"), label: "decision-status-deprecated" },
+      { blockId: DECISION_RETIRED_TABLE_BLOCK_ID, expected: generateDecisionRetiredTable(decisionRetiredInfos), label: "decision-retired-table" },
     ];
-    const adrOutcome = verifyAutogenBlocksInFile(
-      adrReadmeContent,
-      adrReadmePath,
+    const decisionOutcome = verifyAutogenBlocksInFile(
+      decisionReadmeContent,
+      decisionReadmePath,
       root,
-      adrSpecs,
+      decisionSpecs,
       foundViolation,
     );
-    results.push(...adrOutcome.results);
-    foundViolation = adrOutcome.foundViolation;
+    results.push(...decisionOutcome.results);
+    foundViolation = decisionOutcome.foundViolation;
   }
 
   // AG-009: REQ README (docs/requirements/README.md) — 3 AUTOGEN blocks
@@ -8363,34 +8359,8 @@ function checkIndexGenerationConsistency(root: string): CheckResult[] {
     foundViolation = reqOutcome.foundViolation;
   }
 
-  // AG-013: DOC-MAP (docs/DOC-MAP.md) — 1 AUTOGEN block
+  // 旧 AG-013 docmap-inventory 検査は docs/DOC-MAP.md 削除（REQ-013 段階4a）に伴い除去。
   const specsDir = path.join(root, "docs", "specs");
-  const docMapPath = path.join(root, "docs", "DOC-MAP.md");
-  const docMapContent = readText(docMapPath);
-  if (docMapContent !== null) {
-    const docMapSpecs: AutogenBlockSpec[] = [
-      {
-        blockId: DOCMAP_INVENTORY_BLOCK_ID,
-        expected: generateDocMapInventory({
-          activeReqCount: fs.existsSync(reqDir) ? collectReqFiles(reqDir).length : 0,
-          retiredReqCount: fs.existsSync(reqRetiredDir) ? collectRetiredReqFiles(reqRetiredDir).length : 0,
-          activeAdrCount: fs.existsSync(adrDir) ? collectAdrFiles(adrDir).length : 0,
-          retiredAdrCount: fs.existsSync(adrRetiredDir) ? collectRetiredAdrFiles(adrRetiredDir).length : 0,
-          specCount: countSpecFiles(specsDir),
-        }),
-        label: "docmap-inventory",
-      },
-    ];
-    const docMapOutcome = verifyAutogenBlocksInFile(
-      docMapContent,
-      docMapPath,
-      root,
-      docMapSpecs,
-      foundViolation,
-    );
-    results.push(...docMapOutcome.results);
-    foundViolation = docMapOutcome.foundViolation;
-  }
 
   // AG-006 候補5 (Wave 3): req-health-metrics.md — 1 AUTOGEN block
   const qualityDir = path.join(specsDir, "quality");
@@ -8471,7 +8441,7 @@ function checkIndexGenerationConsistency(root: string): CheckResult[] {
       ok(
         "IndexGenerationConsistency",
         "index-generation-consistency",
-        `索引類自動生成整合性: All AUTOGEN blocks consistent (catalog pre=${expectedPre.length}, post=${expectedPost.length}; rule-ownership=${expectedRuleOwnership.length}; ADR README + REQ README + DOC-MAP + req-health-metrics + spec-health-metrics + docs/README.md) (IR-061, SC-002 Phase C/E)`,
+        `索引類自動生成整合性: All AUTOGEN blocks consistent (catalog pre=${expectedPre.length}, post=${expectedPost.length}; rule-ownership=${expectedRuleOwnership.length}; Decision README + REQ README + req-health-metrics + spec-health-metrics + docs/README.md) (IR-061, SC-002 Phase C/E)`,
       ),
     );
   }


### PR DESCRIPTION
## 変更概要

OU-0012（Epic #2205 EU-B Wave 1）として、Decision 索引 AUTOGEN 生成・検査契約を checker 側へ追従させた。

- check_integrity.ts checkIndexGenerationConsistency（IR-061）の検査対象を旧 adr-* block 7種（docs/adr/README.md、DEC-009 で廃止済み）から decision-* block 7種（docs/decisions/README.md）へ移行した。期待値は generate_indexes.ts の Decision 生成関数（generateDecision*、DECISION_*_BLOCK_ID）と共通ロジックを使用する（検査と生成の論理的同一性、AG-002 G01 分離原則維持）
- 旧 docmap-inventory 検査（docs/DOC-MAP.md、REQ-013 段階4a で本体削除済み）を除去し、ADR_*_BLOCK_ID / generateAdr* / collectAdrFiles / countSpecFiles / generateDocMapInventory 等の残余 import を整理した
- IR-061 ok 集約メッセージを現行検査対象構成（Decision README + REQ README + req-health-metrics + spec-health-metrics + docs/README.md）へ更新した

SPEC（docs/specs/integrity/index-auto-generation.md）は ACT-SPEC-009（commit 3b8a42ff）で適用済み分の確認のみ実施し、本 PR では無編集である（前工程完了度「補完あり」→ 補完不要と判定）。

## 完了条件

- [x] SPEC 例示と実装キャプションの不一致が解消し、全件出力規則が SPEC に明文化されていること（ACT-SPEC-009 適用済みを確認。検証証拠 TS-012 参照）
- [x] check_integrity.ts の decision-* block が IR-061 検査対象となっていること（checker 実行 + 変異テストで確認）
- [x] adr/docmap 残余参照が整理されていること（IR-061 関数内の adr-* block 検査・docmap-inventory 検査・関連 import を除去）
- [x] TS-012 の pass_criteria を満たしていること（不合格項目なし）
- [x] 契約テスト期待値の更新と固定トークン確認: 該当なし（command、skill、template の構造変更なし。checker 実装のみの変更）

## 検証証拠

### TS-012（SPEC 例示整合・全件出力規則・checker 移行）: 合格

- SPEC「decision-baseline 索引生成（count キャプション・table 全件出力）」節の例示「現行の承認済み Decision はN件、提案中の Decision はM件」が、実装 generateDecisionBaselineCaption の出力形式（accepted + proposed の2値、superseded をキャプションへ含めない）と一致することを確認した
- decision-baseline-table の全件出力規則（現行 Decision 全件をステータス列付きで出力、件数絞り込み・行の省略を行わない）が SPEC に明文化されていることを確認した
- checker 実行（bun run check_integrity.ts --json）: IR-061 = ok、集約メッセージ「Decision README + REQ README + req-health-metrics + spec-health-metrics + docs/README.md」に Decision README が含まれることを確認した
- 変異テスト: docs/decisions/README.md の decision-baseline-count ブロック本文を破壊したところ、IR-061 が ng を検出した（file=docs/decisions/README.md, line=11, expected=「現行の承認済み Decision は14件、提案中の Decision は2件である。」）。検出確認後、README は git checkout で復元し、作業差分は check_integrity.ts のみであることを git diff --stat で確認した

### TS-QC-001（index-auto-generation.md 文書品質査読）: 合格

- 本 PR で docs/** は無変更。対象基準（SPEC 例示と実装の整合、全件出力規則の明文化、AUTOGEN block ID 命名パターン {target}-{section}-{subsection} と checker 実装の整合、旧 adr-* 不採用の明記）に未解決違反がないことを確認した

### TS-QC-002（full integrity suite）: 合格

- bun test（.opencode/skills/repo-agentdev-integrity/scripts/）: 2025 pass / 3 fail
- 3 fail はいずれも real repo projection（.opencode/skills/agentdev-*）走査系テストで、worktree のジャンクション未伝播（projection ディレクトリが空）に起因する。自変更を stash した baseline でも同一テストの fail と exit 1 を再現し、本 PR 起因ではないことを確認した
  - checkWorkflowPreventive「all 7 preventive items pass (ok=true)」
  - checkExtensions「classifies the real skill tree deterministically」（workflowSkills.has("agentdev-workflow-case-run") が false — projection 不在のため）
  - check_integrity.test.ts IR-055 回帰「構成後（新規delta from baseline）runtime-unresolved-reference 違反がない」

### check_integrity 実行（delta 比較）

- 自変更あり/なしの結果差分は IR-061 ok メッセージの文言（ADR README + ... + DOC-MAP → Decision README + ...）のみ。summary は同一（ok 240 / ng 0 / warning 30 / info 128）
- exit 1 は worktree 環境起因の既存 delta（30 new unmanaged NG。RuntimeReference 系 = junction 未伝播による projection 参照解決不能）で、baseline でも同一 exit code・同一 summary を確認した

### docs-integrity / distribution-boundary

- check_changed_docs.ts --workflow case-run --base-ref origin/main --json: exit 0、files_checked: []（docs/** 無変更。strict failure なしのため docs-integrity 記載対象なし）
- check_distribution_boundary.ts --profile source --json: baseline と同一結果（zero scan targets found for projection 'source' — worktree junction 未伝播起因、自変更無関係）

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| bun test（integrity suite） | 2025 pass / 3 fail（3 fail は baseline 同一の環境起因） | 自変更起因の fail 0 | ✅ |
| check_integrity NG 増分 | 0（baseline と同一 summary） | NG 増分 0 | ✅ |
| 変異テスト（decision-baseline-count 破壊） | IR-061 ng 検出（line 11） | 検出すること | ✅ |
| 変更ファイル | 1 ファイル（+37 / −67） | Issue 対象範囲内 | ✅ |

## Findings / Capture候補

### intake

- docs/specs/integrity/index-auto-generation.md「関連情報」節の検査契約列挙に「IR-038（ADR index consistency）」とあるが、IR-038 rule は既に title「Decision-index-consistency」へ改題済み（検査対象も docs/decisions/README.md）。ラベルのみ旧称が残存する微小な事実ズレ。本 Issue の完了条件外のため本 PR では未修正（rule ファイル名 IR-038-adr-index-consistency.md の旧称残存も同様）

### learning

該当なし

## SPEC確定候補

- なし。decision-baseline-count キャプション形式（accepted + proposed の2値）と decision-baseline-table 全件出力規則は index-auto-generation SPEC「decision-baseline 索引生成」節に既に明文化済みであり、checker 側の追従のみで契約は完結した。checker の missing-marker 時挙動は REQ README 系と同一の info-skip 規約に従う（verifyAutogenBlocksInFile 共通ヘルパー）

## 決定事項

- 旧 adr-* block 検査・docmap-inventory 検査は、検査対象ファイルが存在しない場合の skip パスとして残すのではなく除去する判断とした（generate_indexes.ts 側の DOC-MAP 更新レガシーパスは本 Issue 対象外のため現状維持）

Refs: #2208