### PR TITLE
chore(integrity): AG-005 規則群の検査カテゴリ登録と導線整備（Refs: #2207）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/SKILL.md
+++ b/.opencode/skills/repo-agentdev-integrity/SKILL.md
@@ -66,6 +66,7 @@ agent-dev-flow リポジトリ（self-hosting repo）の artifact 整合性検�
 | Accepted ADR 引用 | `check_integrity.ts` | accepted 以外の ADR 引用検出（current baseline + retired 区別、推奨, REQ-0108-125, REQ-0112-050） |
 | Workflow template 構造 | `check_templates.ts` | frontmatter、必須セクション、placeholder、命名規則 |
 | Skill 構造 | `lint_skills.ts` | frontmatter name ↔ dir、USE FOR / DO NOT USE FOR、See Also |
+| AG-005 規則群 | `lint_skills.ts` | skill 記述基準（層1〜2）機械検査。hard 6規則（description 1024/600 文字上限、マーカー語・内部 ID 混入、USE FOR 二重保持、後続トリガー語（AG-004、command-bound のみ厳密検査）、300 行超 references の目次欠落）+ warn 1規則（description 集約予算 350×N）。検出規則の登録は integrity-rule-catalog「AG-005 規則群」節（REQ-0145-005 判定記録を含む）、既知違反は `baselines/lint-skills-baseline.json` で管理（delta-aware、baseline-known は info 降格） |
 | Junction 整合性 | `check_integrity.ts` | broken junction / symlink 検出（Windows junction / Unix symlink のリンク先不存在） |
 | Capture boundary | `check_integrity.ts` | capture-boundaries.md 存在確認、PR template セクション名検証、command capture 責務記述確認（REQ-0105） |
 | REQ verification basis | `check_integrity.ts` | REQ 要件行の検証基準が 規範語ではなく必達要件判定であること（REQ-0115-044） |

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -4892,6 +4892,7 @@ function checkSkillCategoryGap(
     ["Accepted ADR 引用", ["AcceptedAdrOnlyCitation"]],
     ["Workflow template 構造", ["checkNaming", "checkFrontmatter", "checkSectionMarkers"]],
     ["Skill 構造", ["lintSkill"]],
+    ["AG-005 規則群", ["Ag005"]],
     ["Junction 整合性", ["BrokenJunctions"]],
     ["Capture boundary", ["CaptureBoundaryReference", "PrTemplateCaptureSection", "CommandCaptureDuties"]],
     ["REQ verification basis", ["ReqVerificationBasis"]],


### PR DESCRIPTION
Refs: #2207

## 概要

OU-0011（Epic #2205 EU-B Wave 1）: AG-005 規則群（lint_skills.ts、層1〜2記述基準機械検査、hard 6規則 + warn 1規則、PR #2184 で main 入り済み）の正典登録確認と導線整備。

## 実装内容（変更概要）

- **repo-agentdev-integrity SKILL.md**: 「検査カテゴリ」表へ「AG-005 規則群」行（lint_skills.ts、層1〜2記述基準検査）を追加。検出規則の登録導線（integrity-rule-catalog「AG-005 規則群」節、baselines/lint-skills-baseline.json による delta-aware 管理）を併記
- **check_integrity.ts**: categoryToCheckPattern map へ AG-005 規則群 entry（パターン Ag005 → lintDescriptionAg005 / lintReferencesTocAg005 / aggregateBudgetResultAg005 に合致）を追加。REQ-0145-005 新規カテゴリ追加判定フロー項番6（skill-category-gap 解消）に従う。SKILL.md 表に行を追加しただけでは gap detector が NG（導線未整備）となるため必須の補完
- **確認のみ（変更なし）**: integrity-rule-catalog.md「AG-005 規則群」節（7規則表 + 正規所有者 + REQ-0145-005 登録判断の記録）と rule-ownership.md 行38 は ACT-SPEC-007/008（commit 3b8a42ff、main 反映済み）で適用済みであることを実体確認

## 完了条件（Issue #2207 の判定根拠）

完了条件チェックボックスの最終判定は case-close 責務のため、本 PR 本文では判定根拠のみ提示する。

- [x] integrity-rule-catalog.md と rule-ownership.md に lint_skills AG-005 規則群が登録されていること（main 適用済み分の実体確認）
- [x] REQ-0145-005 の新規カテゴリ追加判定の結果が記録されていること（catalog「登録判断」段落）
- [x] repo-agentdev-integrity SKILL.md 検査カテゴリ表に AG-005 行が追加されていること（本 PR）
- [x] TS-011 の pass_criteria を満たしていること（下記検証証拠）

## 検証証拠

| 項目 | 結果 | 判定 |
|---|---|---|
| TS-011: catalog・ownership 登録 + REQ-0145-005 判定記録の実体確認 | catalog「AG-005 規則群」節（7規則表、正規所有者、登録判断）・rule-ownership.md 行38 の存在を確認 | 合格 |
| TS-011: SKILL.md 検査カテゴリ表 AG-005 行 | line 69 に行追加。UTF-8 BOM なし、表構造 well-formed（3列） | 合格 |
| TS-011: docs-check 該当検査 | lint_skills.ts --profile source EXIT=0（AG-005 カテゴリ 224 OK / NG 0 / Warning 0。info 1件は既知の japanese-tech-writing prefix 観察） | 合格 |
| 導線: skill-category-gap | check_integrity.ts --profile source の AG-005 起因 NG を解消（追加前 1 NG → 0。delta は base 同等の pre-existing 30 warnings のみ） | 合格 |
| TS-QC-001: 文書品質査読 | 表行は catalog・ownership・lint_skills.ts 実装と内容一致、用語・backticks は既存行と整合、repo-local skill のため配布物 ID 汚染対象外 | 合格 |
| bun test lint_skills.test.ts | 26 pass / 0 fail | 合格 |
| bun test scripts 全体（83 files / 2028 tests） | 2026 pass / 2 fail（2 fail は base origin/main 5d89b9df で stash 検証により同一再現を確認した pre-existing。Findings 参照） | 新規失敗なし |
| bun run typecheck（scripts） | EXIT=0 | 合格 |
| check_changed_docs.ts --workflow case-run --base-ref origin/main | EXIT=0、failures なし（変更ファイルは .opencode/skills/repo-* 配下で docs/** 対象外） | 合格 |

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 変更ファイル数 | 2（SKILL.md +1 行、check_integrity.ts +1 行） | 最小 diff | pass |
| 新規テスト失敗 | 0 | 0 | pass |
| check_integrity 新規 NG delta（AG-005 起因） | 0 | 0 | pass |

## Findings / Capture候補

### intake

- pre-existing テスト失敗 2件（base で再現確認）: origin/main 5d89b9df（本 PR 適用前の stash 状態）で bun test 実行時点で失敗する（本 PR との因果なし）:
  - IR-055 runtime-unresolved-reference 実修復回帰 (Issue #1782) > 配布物に新規 delta from baseline なし
  - checkWorkflowPreventive (integration against real repo) > all 7 preventive items pass (ok=true)
- check_integrity.ts --profile source の baseline 未整備 delta 30 件（warnings）: LinkIntegrity 3 / LifecycleBoundary 19 / Decision 2 / SKILL 4 / RuntimeReference 2。すべて intake route の既知 delta（base と同数）

### learning

該当なし

## SPEC確定候補

該当なし（categoryToCheckPattern map 更新は REQ-0145-005 判定フロー項番6 の既定手順であり、新規の schema・enum・判定表の発見なし）

## 関連Issue

Refs: #2207
