### PR TITLE
docs(specs): TIM 語彙カタログ・AG SPEC の実測突合確定（OU-0001、Issue #2203）

### DIFF
--- a/docs/specs/foundations/traceability-model.md
+++ b/docs/specs/foundations/traceability-model.md
@@ -192,6 +192,7 @@ Trace Query 層は、独立した関係モデルを持たず本定義に従う�
 - implementation: 実現、実装、充足の系列を構成する関係型（`realizes`、`satisfies`、`implements`、探索方向は逆向き）が参加する。`specifies`、`verifies`、`validates` は参加しない。検証と妥当性確認の系列は将来の coverage 問い合わせへの統合対象とする（REQ-040-005）
 
 related は、明示的なトレースと一般参照のすべてを返すため、参加区分表から除外する（REQ-040-002）。
+探索経路からの索引・集約成果物ノードの除外は「索引・集約成果物の役割識別」節の確定値に従う。
 
 ## 関係制約
 
@@ -229,13 +230,19 @@ related は、明示的なトレースと一般参照のすべてを返すため
 **拡張関係型**とは、プロジェクト拡張によって追加されるトレースリンク型を指す。
 拡張関係型を高位問い合わせへ参加させる場合は、次の意味情報を augmentation 内に明示する（REQ-012-023）。
 
-| 必須項目 | 内容 |
-|---|---|
-| 関係型名 | 英字 snake_case。標準コア語彙と重複しないこと |
-| 関係の意味 | リンク元とリンク先の役割を含む自然言語の定義 |
-| 変更影響方向 | `forward`、`backward`、`bidirectional`、`none` のいずれか |
-| 高位問い合わせ参加区分 | related、impact、dependency、implementation への参加可否 |
-| 関係制約 | リンク元とリンク先の成果物型の組合せ。制約しない場合は「なし」と明記 |
+| 明示項目 | 必須性 | 内容 |
+|---|---|---|
+| 関係型名 | 必須 | 英字 snake_case。標準コア語彙と重複しないこと |
+| 関係の意味 | 必須 | リンク元とリンク先の役割を含む自然言語の定義 |
+| 変更影響方向 | 必須 | `forward`、`backward`、`bidirectional`、`none` のいずれか |
+| 意味スロット | 任意 | 標準コアの意味スロット ID（`general_reference`、`supersede`、`decompose`、`refine`、`specify`、`constrain`、`depend`、`realize`、`satisfy`、`implement`、`verify`、`validate`）のいずれか。依存・実現系列の走行方向の導出に使用する |
+| 標準語彙対応 | 任意 | 出典となる標準語彙。対応がない場合は空として宣言する |
+| 関係制約 | 任意 | リンク元とリンク先の成果物型の組合せ（`source_types`、`target_types`）。制約しない場合は省略する |
+
+高位問い合わせへの参加区分は宣言項目とせず、意味スロットと変更影響方向から導出する（REQ-012-022）。
+導出規則は「高位問い合わせへの参加区分」節の判断基準と同一である。
+impact は変更影響方向が `none` 以外か否かから、dependency と implementation は意味スロットの走行方向から導かれる。
+意味スロットを持たない拡張関係型は、変更影響方向が `none` 以外であれば impact にのみ参加する。
 
 ### 意味の自動推定の禁止
 
@@ -245,11 +252,14 @@ related は、明示的なトレースと一般参照のすべてを返すため
 
 ### 意味定義の例（self-hosting augmentation）
 
+参加区分の欄は宣言値ではなく、意味スロットと変更影響方向からの導出結果である。
+
 | 項目 | `delegates_to` | `governs` |
 |---|---|---|
 | 関係の意味 | リンク元が処理の一部をリンク先へ委譲する | リンク元がリンク先の内容または品質を統治する |
+| 意味スロット | `depend`（依存） | なし（ADF 固有の意味） |
 | 変更影響方向 | `backward` | `forward` |
-| 高位問い合わせ参加区分 | dependency のみ | impact のみ |
+| 導出される参加区分 | impact、dependency | impact |
 | 関係制約 | なし | なし |
 
 ## 索引・集約成果物の役割識別
@@ -271,12 +281,15 @@ README、INDEX、CATALOG 等の名称そのものではなく、この役割に�
 
 索引・集約成果物であることだけを理由として、成果物またはその関係をグラフから削除しない（REQ-012-024）。
 
-### 変更影響除外の判断基準
+### 変更影響除外と探索経路からの除外
 
 索引・集約成果物をリンク元とする包含や参照のリンクは、索引構造の記述であって当該成果物の内容の分解を意味しない。
 このようなリンクは関係意味を持たないため、impact、dependency、implementation の探索経路へ参加しない。
 変更影響等から除外する主たる判断は、成果物名ではなくトレースリンクの意味に基づく（REQ-012-024）。
-一般参照探索と明示的な索引構造問い合わせでは、引き続き利用できる。
+
+実装は、索引・集約成果物を経由する候補増幅を抑制するため、role が `index` または `aggregation` の成果物ノードを高位問い合わせ（related、impact、dependency、implementation）の探索経路から除外する（REQ-040-008）。
+除外は中間経路と到達点の両方へ適用し、グラフからの削除は行わない。
+索引・集約成果物を起点とする問い合わせ、低位問い合わせ（neighbors、path、provenance）、明示的な索引構造問い合わせ（index）では、索引・集約成果物とそこからの関係を引き続き利用できる（REQ-012-024）。
 
 ## 語彙カタログの確定（実測基準）
 
@@ -287,6 +300,14 @@ README、INDEX、CATALOG 等の名称そのものではなく、この役割に�
 - `defined_in` の `depends_on`（依存）への集約は実装側に移行残差として残る。集約完了まで `defined_in` は仕様化スロット・変更影響方向 `backward` の関係型として実装が保持し、カタログは集約完了後に当該移行行を完結する
 - 標準コア語彙は実現系列関係型（`realizes`、`satisfies`、`implements`）を含む。implementation プロファイルの参加範囲は「高位問い合わせへの参加区分」節の確定値に従う。implementation プロファイルが常に空結果となる欠陥は実装側是正として扱い、カタログ側の参加範囲変更の根拠にしない
 - 索引・集約成果物の役割識別は node_type の role 属性（`index`、`aggregation`）で表現し、専用 node_type は追加しない
+
+Issue #2203（OU-0001）の突合で確認した差分と確定記録は次のとおりである。
+影響方向の値名、標準5関係型への割当て、参加導出（`deriveProfileParticipation`）、集約規則を実装と突合した結果、参加区分は本カタログの表と一致し、解消すべき乖離は残っていない。
+
+- `extends` の依存方向の導出は、実装が具体化スロット（`refine`）の走行方向を共有して行う。導出結果（impact 参加、dependency 参加、implementation 不参加）は本カタログの参加区分表と一致しており、`extends` の意味定義（追加定義で適用範囲を広げる）を `refines` と共有するものではない
+- 実装は語彙出典の記録として、`supersedes` に Dublin Core（dct:replaces）、`extends` に UML（«extend»）を追加する。本カタログの3標準調査枠（SysML、OSLC、OpenFastTrace）を補完する出典記録であり、`supersedes` を ADF 既存語彙、`extends` を ADF 固有関係型とする本カタログの分類を変更しない
+- 標準コアの既定抽出関係型は5型（`references`、`supersedes`、`defined_in`、`contains`、`extends`）であり、カタログの採用語彙13型の残り（`refines`、`specifies`、`constrains`、`depends_on`、`realizes`、`satisfies`、`implements`、`verifies`、`validates`）は既定抽出対象に含まれない。これらの語彙でリンクを張る場合は、augmentation の relation_types 宣言（semantics による意味定義）を通じてグラフへ参加する。実現系列関係型が存在しないグラフで implementation プロファイルが空結果となる場合は正常な空結果であり、実装側欠陥ではない
+- 索引・集約成果物のデフォルトコアでの扱いは、ノード化対象に含めないと確定する。デフォルトコアの標準3成果物型は README 等の索引・集約成果物をノード化しないため、索引構造の検査、所在確認、明示的な索引構造問い合わせに索引・集約成果物を利用する場合は、augmentation が role 付きの node_type を追加して宣言する。専用 node_type は追加しない（role 属性方式を維持する）
 
 ## 語彙採用基準
 

--- a/docs/specs/skills/agentdev-artifact-graph.md
+++ b/docs/specs/skills/agentdev-artifact-graph.md
@@ -289,9 +289,14 @@ project-owned source（`src/tests/scripts/config` 等）は `indexed_paths` へ�
 augmentation ファイル（`.agentdev/artifact-graph.yaml`）のスキーマ拡張点を次の4系統として確定する。各拡張点は宣言的に記述し、手続き的ロジックを含めない。
 
 1. `node_types` 定義: `name`、`path_pattern`、`id_template`、`label_source`、`extraction_rule`、`role`（`index` / `aggregation`）
-2. `relation_types` 定義: `name`、`fields`、`reverse_direction`、`semantics`（意味スロット・変更影響方向・標準語彙対応）
+2. `relation_types` 定義: `name`、`fields`、`reverse_direction`、`semantics`（関係の意味、意味スロット、変更影響方向、標準語彙対応、関係制約（`source_types` / `target_types`））
 3. `indexed_paths` と `discovery_roots`（対象と探索起点の宣言）
 4. `query_settings` と `relation_constraints`（問い合わせ上限・深さの上書きと関係制約）
+
+標準コアの成果物型・関係型の意味は TIM 語彙カタログ（[../foundations/traceability-model.md](../foundations/traceability-model.md)）が正規所有する。
+augmentation は標準コアの node_type への `role` 宣言、relation_type への `semantics` 宣言を拒否する。
+抽出規則（`path_pattern`、`fields` 等）の上書きはこの限りでない。
+拡張関係型の高位問い合わせ参加区分は宣言せず、`semantics` の意味スロットと変更影響方向から導出する。
 
 ### self-hosting augmentation
 
@@ -421,6 +426,18 @@ Artifact Graph 自身の接続確認のみを workflow effectiveness の成立�
 - **未対応構造の診断**: 解析スクリプトが未対応 YAML 構造を検出し、構造種別と出現位置を診断情報として出力すること（REQ-020-002）
 - **代表質問回帰検証**: 実入力 fixture（10件）を解析スクリプトへの入力として組み込み、過去期待出力との一致を検証すること（REQ-020-003、REQ-020-005）
 - **fixture 設計原則の遵守**: 実入力 fixture が選定基準明示、配置先、再現性、機密情報除去、版管理の各原則を満たすこと（REQ-020-004）
+
+## SPEC 反映提案群の採否確定
+
+Epic #2189 の実行時に各 PR の SPEC確定候補として提起され、case-close で確定できなかった反映提案群4項目について、Issue #2203（OU-0001）の AG SPEC 確定時に採否を確定する。
+4項目とも本 SPEC の該当節へ反映済みであり、実装（`scripts/lib/`、`scripts/src/`）との突合で乖離を確認しなかったため、すべて採用とする。
+
+| 提案 | 反映先 | 採否 | 確定根拠 |
+|---|---|---|---|
+| manifest スキーマ 2.0.0 の確定 | 「決定論性と鮮度」節 | 採用 | `model.ts` の `SCHEMA_VERSION`（`2.0.0`）、manifest 必須項目、`generated_at` 非保持、同一入力からのバイト同一生成（`determinism.test.ts`）と整合する |
+| query_graph サブコマンド構成の確定 | 「問い合わせ結果の出力形式」節 | 採用 | `query_graph.ts` の構造問い合わせ5種（neighbors、path、provenance、discover、index）、プロファイル直指定、JSON 出力のみの構成と整合する |
+| augmentation スキーマ4拡張点の確定 | 「augmentation モデル」節 | 採用 | `augmentation.ts` のスキーマ（node_types、relation_types、indexed_paths と discovery_roots、query_settings と relation_constraints）と整合する |
+| 「ワークフロー利用」割当表への backlog-review 行追加 | 「ワークフロー利用」節 | 採用 | backlog-review 行（related、impact、統合・分割判定と depends_on 依存解決の補助 evidence）を割当表へ明記済みである |
 
 ## See Also
 


### PR DESCRIPTION
Refs: #2203

## 変更概要

OU-0001（source: RU-0046、Epic #2202 Wave 1）。TIM 語彙カタログ SPEC（draft）と agentdev-artifact-graph SPEC（draft）を実測基準で確定する（CR-001: 実測に基づきカタログを修正して確定）。

- docs/specs/foundations/traceability-model.md
  - 「語彙カタログの確定（実測基準）」節へ Issue #2203 突合結果を追記: `extends` の依存方向導出における具体化スロット（`refine`）走行方向の共有、語彙出典の補完（Dublin Core dct:replaces、UML «extend»）、既定抽出関係型5型と採用語彙13型の対応、索引・集約成果物のデフォルトコアでの扱い（ノード化対象外、role 属性方式維持、専用 node_type 追加せず）
  - 「拡張関係型の意味定義様式」を実装（semantics スキーマと参加導出）へ一致させて更新: 高位問い合わせ参加区分を宣言項目から導出結果へ変更（REQ-012-022、REQ-012-023）、意味定義の例を導出整合値へ更新
  - 「索引・集約成果物の役割識別」の除外基準を実測へ一致させて更新: role 付きノードの高位問い合わせ（related 含む）探索経路からの除外（REQ-040-008 の候補増幅抑制）、低位問い合わせ・明示的な索引構造問い合わせでの利用維持（REQ-012-024）
- docs/specs/skills/agentdev-artifact-graph.md
  - 「SPEC 反映提案群の採否確定」節を新設: Epic #2189 由来の反映提案群4項目（manifest スキーマ 2.0.0、query_graph サブコマンド構成、augmentation スキーマ4拡張点、ワークフロー利用割当表への backlog-review 行）をすべて採用と確定し、実装との整合根拠を記録
  - 「augmentation モデル」節へ標準コア再定義の拒否境界（`role` / `semantics` 宣言）と参加区分導出の規則を追記
- scripts/lib/tim.ts（実装側）: 突合の結果、実装側欠陥なし（変更なし）。影響方向4値、標準5関係型への割当て、参加導出（`deriveProfileParticipation`）、集約規則はカタログと一致。implementation プロファイルは実現系列スロット（realize / satisfy / implement）の逆向き探索として機能し（`trace_query.test.ts`）、常に空結果となる欠陥は存在しない

## 検証証拠

- TS-001（語彙突合）: 合格
  - 影響方向の値名（forward / backward / bidirectional / none）: 差分なし
  - 標準5関係型への割当て（references=none、supersedes=none、defined_in=backward・仕様化スロット、contains=bidirectional、extends=bidirectional）: 差分なし
  - 参加区分（impact / dependency / implementation）: `deriveProfileParticipation` の導出結果がカタログ参加区分表と全関係型で一致
  - 集約規則: defined_in→depends_on 集約の実装側移行残差はカタログ確定節に意図明記済み
  - AG SPEC 反映提案群4項目の反映状況: 4項目とも反映済み・採用として確定記録を追加
  - 索引・集約成果物の扱いの記載: 判断記録を追加
- TS-QC-001（文書品質査読）: 合格（一文一行、backticks 識別子、REQ 引用の正確性、旧節名「変更影響除外の判断基準」への参照なしを確認）
- `bun test`（src/opencode/skills/agentdev-artifact-graph/scripts）: 157 pass / 0 fail（19 files。tim.test.ts、trace_query.test.ts、determinism.test.ts、augmentation.test.ts を含む）
- `bun run tsc --noEmit`（同 scripts）: exit 0
- `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref origin/main --json`: failures 0 / warnings 0（files_checked 2件、spec_readme_update_required false）

## 完了条件

- [x] カタログと実装の語彙乖離が解消済みであること（差分なし、または差分の意図が明記済み）
- [x] SPEC 反映提案群4項目の採否がすべて確定していること
- [x] 実現系列関係型と implementation プロファイル参加範囲がカタログに定義されていること
- [x] 索引・集約成果物のデフォルトコアでの扱い（専用 node_type 追加の要否含む）が判断記録されていること
- [x] TS-001 の pass_criteria を満たしていること
- 契約テスト期待値の更新と固定トークン確認: 該当なし（構造変更なし。docs-only 変更）

## Findings / Capture候補

### intake

- self-hosting augmentation（.agentdev/artifact-graph.yaml）の delegates_to / governs は semantics 宣言を持たず、高位問い合わせへ不参加のまま（低位問い合わせのみ利用可能）。本 PR で参加区分の導出規則が確定したため、semantics 宣言の追加（delegates_to: 意味スロット depend、governs: スロットなし・impact 参加など）を検討できる。本 Issue のスコープ外（.agentdev/ は case-run 編集対象外）のため候補として記録する

### learning

該当なし

## SPEC確定候補

該当なし（本 PR の SPEC 変更が確定内容そのものであり、追加の確定候補は検出していない）

## 決定事項

- CR-001（語彙移行は実測基準でカタログを修正して確定）に従い、extends のスロット共有・出典補完・索引除外の実装実態をカタログ側へ反映して確定した
