### PR TITLE
fix(integrity): NG baseline パス bucket key 正規化と運用契約明文化の確認（OU-0008）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.test.ts
@@ -16,6 +16,7 @@ import {
   resolveExtensionState,
   runExtensionScenarios,
   deriveSkillClassification,
+  extBaselineKey,
 } from "./check_extensions.ts";
 import * as path from "path";
 import * as fs from "fs";
@@ -103,5 +104,35 @@ describe("runExtensionScenarios (TS-006 extension scenarios)", () => {
     } finally {
       fs.rmSync(baseDir, { recursive: true, force: true });
     }
+  });
+});
+
+// Issue #2206 (OU-0008): パス bucket key の環境依存対策。`.opencode/...`（main
+// junction 環境）と `src/opencode/...`（worktree fallback 環境）の表記差異が
+// baseline bucket key 比較で解消されることを固定する。
+describe("extBaselineKey path normalization (Issue #2206, OU-0008)", () => {
+  test("unifies .opencode/ and src/opencode/ notations into one bucket key", () => {
+    const projection = extBaselineKey(
+      3,
+      "id-target-consistency",
+      ".opencode/commands/agentdev/case-close.md",
+      "same message",
+    );
+    const source = extBaselineKey(
+      3,
+      "id-target-consistency",
+      "src/opencode/commands/agentdev/case-close.md",
+      "same message",
+    );
+    expect(projection).toBe(source);
+  });
+
+  test("normalizes backslash separators; null file stays empty", () => {
+    expect(
+      extBaselineKey(1, "check", ".opencode\\skills\\agentdev-x\\SKILL.md", null),
+    ).toBe(
+      extBaselineKey(1, "check", "src/opencode/skills/agentdev-x/SKILL.md", null),
+    );
+    expect(extBaselineKey(1, "check", null, "m")).toBe("1\tcheck\t\tm");
   });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
@@ -155,13 +155,24 @@ interface ExtensionsNgBaseline {
   entries: ExtensionsNgBaselineEntry[];
 }
 
-function extBaselineKey(
+// OU-0008 (Issue #2206): パス bucket key の環境依存対策（SPEC integrity-contracts
+// 「baseline entry 運用契約」第2点）。check_integrity.ts と同じ正規化で
+// `.opencode/...` 表記と `src/opencode/...` 表記を相対パス基準へ統一する。
+function normalizeExtBaselineFilePath(file: string | null): string {
+  if (!file) return "";
+  const unified = file.replace(/\\/g, "/").replace(/^\.\//, "");
+  return unified.startsWith(".opencode/")
+    ? unified.replace(/^\.opencode\//, "src/opencode/")
+    : unified;
+}
+
+export function extBaselineKey(
   check: number,
   checkName: string,
   file: string | null,
   message: string | null,
 ): string {
-  return `${check}\t${checkName}\t${file ?? ""}\t${message ?? ""}`;
+  return `${check}\t${checkName}\t${normalizeExtBaselineFilePath(file)}\t${message ?? ""}`;
 }
 
 function loadExtensionsNgBaseline(

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -2682,6 +2682,109 @@ describe("NG baseline aggregation / provenance / classification (Issue #1780, RE
   });
 });
 
+// ─── NG baseline パス bucket key 正規化（Issue #2206, OU-0008） ─────────────
+// SPEC integrity-contracts「baseline entry 運用契約」第2点: worktree（src fallback）
+// と main（junction projection）で `.opencode/...` ↔ `src/opencode/...` 表記が
+// 変化しても同一 bucket として baseline-known 降格することを検証する。
+
+const NGBASELINE_PATHNORM_ROOT_MAIN = join(TEMP_ROOT, "ngbaseline2206-main");
+const NGBASELINE_PATHNORM_ROOT_WORKTREE = join(TEMP_ROOT, "ngbaseline2206-worktree");
+
+function buildPathNormFixture(
+  root: string,
+  commandDirKind: "projection" | "source",
+): void {
+  buildNgBaselineFixture(root);
+  copyScriptsComplete(root);
+  const cmdDir =
+    commandDirKind === "projection"
+      ? join(root, ".opencode", "commands", "agentdev")
+      : join(root, "src", "opencode", "commands", "agentdev");
+  mkdirp(cmdDir);
+  // broken.md has no frontmatter → command-inventory NG whose bucket key `file`
+  // is the command file path in the environment's own notation.
+  writeFileSync(join(cmdDir, "broken.md"), "# broken\n\nNo frontmatter.\n", "utf-8");
+}
+
+describe("NG baseline path bucket key normalization (Issue #2206, OU-0008)", () => {
+  afterAll(() => {
+    rmSync(NGBASELINE_PATHNORM_ROOT_MAIN, { recursive: true, force: true });
+    rmSync(NGBASELINE_PATHNORM_ROOT_WORKTREE, { recursive: true, force: true });
+  });
+
+  it("main 環境表記 (.opencode/...) の NG が src/opencode 表記の baseline entry で降格する", () => {
+    const root = NGBASELINE_PATHNORM_ROOT_MAIN;
+    rmSync(root, { recursive: true, force: true });
+    buildPathNormFixture(root, "projection");
+    writeNgBaselineFile(root, [
+      {
+        category: "Command",
+        check: "command-inventory",
+        file: "src/opencode/commands/agentdev/broken.md",
+        evidence: null,
+        count: 1,
+        provenance: "legacy",
+        reason: "path-notation fixture (Issue #2206)",
+      },
+    ]);
+
+    const r = runScript(root, ["--json"]);
+    const parsed = JSON.parse(r.stdout) as {
+      results: Array<{
+        check: string;
+        level: string;
+        file?: string;
+        message?: string;
+      }>;
+    };
+    const inv = parsed.results.filter(
+      (res) =>
+        res.check === "command-inventory" &&
+        (res.file ?? "").endsWith("broken.md"),
+    );
+    expect(inv.length).toBeGreaterThanOrEqual(1);
+    expect(inv[0].file).toBe(".opencode/commands/agentdev/broken.md");
+    expect(inv[0].level).toBe("info");
+    expect(inv[0].message).toContain("[baseline-known]");
+  });
+
+  it("worktree 環境表記 (src/opencode/...) の NG が .opencode 表記の baseline entry で降格する", () => {
+    const root = NGBASELINE_PATHNORM_ROOT_WORKTREE;
+    rmSync(root, { recursive: true, force: true });
+    buildPathNormFixture(root, "source");
+    writeNgBaselineFile(root, [
+      {
+        category: "Command",
+        check: "command-inventory",
+        file: ".opencode/commands/agentdev/broken.md",
+        evidence: null,
+        count: 1,
+        provenance: "legacy",
+        reason: "path-notation fixture (Issue #2206)",
+      },
+    ]);
+
+    const r = runScript(root, ["--json"]);
+    const parsed = JSON.parse(r.stdout) as {
+      results: Array<{
+        check: string;
+        level: string;
+        file?: string;
+        message?: string;
+      }>;
+    };
+    const inv = parsed.results.filter(
+      (res) =>
+        res.check === "command-inventory" &&
+        (res.file ?? "").endsWith("broken.md"),
+    );
+    expect(inv.length).toBeGreaterThanOrEqual(1);
+    expect(inv[0].file).toBe("src/opencode/commands/agentdev/broken.md");
+    expect(inv[0].level).toBe("info");
+    expect(inv[0].message).toContain("[baseline-known]");
+  });
+});
+
 // ─── IR-055 実修復回帰テスト（Issue #1782, OU-005, RU-0012） ──────────────
 // 配布物（src/opencode/commands/agentdev/**/*.md,
 // src/opencode/skills/agentdev-*/**/*.md）の runtime-unresolved-reference

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -7408,13 +7408,27 @@ interface NgBaselineReport {
   newNg: number;
 }
 
+// OU-0008 (Issue #2206): パス bucket key の環境依存対策（SPEC integrity-contracts
+// 「baseline entry 運用契約」第2点）。main 環境（junction projection 実在）は
+// `.opencode/...` 表記、worktree 環境（junction 未伝播、§7.3 fallback）は
+// `src/opencode/...` 表記で同一ファイルを報告するため、bucket key 比較時のみ
+// 表記を正規化して相対パス基準へ統一する。bucket key 仕様自体
+// （category/check/file/evidence の4組）は維持する。
+function normalizeNgBaselineFilePath(file: string | null): string {
+  if (!file) return "";
+  const unified = file.replace(/\\/g, "/").replace(/^\.\//, "");
+  return unified.startsWith(".opencode/")
+    ? unified.replace(/^\.opencode\//, "src/opencode/")
+    : unified;
+}
+
 function ngBaselineKey(
   category: string,
   check: string,
   file: string | null,
   evidence: string | null,
 ): string {
-  return `${category}\t${check}\t${file ?? ""}\t${evidence ?? ""}`;
+  return `${category}\t${check}\t${normalizeNgBaselineFilePath(file)}\t${evidence ?? ""}`;
 }
 
 // Normalize a parsed entry to fill provenance/reason for backward compat with
@@ -7565,7 +7579,13 @@ function applyNgBaseline(
   const baselineIndex = new Map<string, { count: number; provenance: string }>();
   for (const entry of baseline.entries) {
     const key = ngBaselineKey(entry.category, entry.check, entry.file, entry.evidence);
-    baselineIndex.set(key, { count: entry.count, provenance: entry.provenance });
+    // OU-0008 (Issue #2206): 正規化により `.opencode/` 表記 entry と
+    // `src/opencode/` 表記 entry が同一 bucket へ衝突する場合、両者は同一論理 NG の
+    // 環境別観測であるため count の大きい方（通常は同数）を採用する。
+    const prev = baselineIndex.get(key);
+    if (!prev || entry.count > prev.count) {
+      baselineIndex.set(key, { count: entry.count, provenance: entry.provenance });
+    }
   }
 
   const currentSummary = summarizeNgResults(results);
@@ -7627,10 +7647,13 @@ function updateNgBaseline(
 
   const index = new Map<string, NgBaselineEntry>();
   for (const entry of baseline.entries) {
-    index.set(
-      ngBaselineKey(entry.category, entry.check, entry.file, entry.evidence),
-      entry,
-    );
+    const key = ngBaselineKey(entry.category, entry.check, entry.file, entry.evidence);
+    // OU-0008 (Issue #2206): 正規化で同一 bucket へ衝突する環境別表記 entry は
+    // 同一論理 NG として count の大きい方を採用する。
+    const prev = index.get(key);
+    if (!prev || entry.count > prev.count) {
+      index.set(key, entry);
+    }
   }
 
   // Current NG counts per bucket — used to cap the merged baseline count so a

--- a/docs/specs/integrity/integrity-contracts.md
+++ b/docs/specs/integrity/integrity-contracts.md
@@ -378,7 +378,7 @@ NG baseline は v2:REQ-0161-005（旧 `docs/requirements/v2:REQ-0161.md`、現 `
 NG baseline entry の運用は次の契約に従う。
 
 1. entry 追加は機械生成を必須とし、手書きによる追加を行わない。`--update-ng-baseline --ng-baseline-additions` が manifest 入力から provenance・reason を付与して生成する。手書き追加は NG 隠蔽（禁止）と同様に扱う
-2. パス bucket key は環境依差を含む。worktree と main でパス表記が変化する場合、正規化（相対パス基準への統一）または unmatched additions / unmanaged delta 対警告により検知可能にする。bucket key 仕様自体（category/check/file/evidence の4組）は維持する
+2. パス bucket key は環境依存差を含む。worktree と main でパス表記が変化する場合、正規化（相対パス基準への統一）または unmatched additions / unmanaged delta 対警告により検知可能にする。bucket key 仕様自体（category/check/file/evidence の4組）は維持する
 3. baseline の生成環境を前提として明示する。worktree 環境で生成した baseline は main 環境（junction 実在環境）で新規未管理 NG が 0 件であることを確認してから確定する
 4. 由来ラベル（legacy、superseded、AUTOGEN、実欠陥等）と報告分類（baseline-known 降格、approved additions、新規未管理）の対応を明確に保つ。承認済み entry の解消（実装修復完了）後は当該 entry を除去する（ratchet の純減）
 


### PR DESCRIPTION
## 変更概要

OU-0008（Issue #2206、Epic #2205 EU-B Wave 1、source: RU-0053）。integrity-contracts SPEC「NG baseline 運用手順」節の運用契約4点（機械生成必須・手書き禁止、パス bucket key 環境依存対策、baseline 生成環境前提、由来ラベルと報告分類対応）の明文化確認と、checker 実装修正（パス bucket key 正規化）。

- **SPEC 明文化（ACT-SPEC-006 適用済みの確認）**: docs/specs/integrity/integrity-contracts.md L376-383「baseline entry 運用契約（機械生成・パス bucket key・生成環境・報告分類）」に4点全ての記載を確認。REQ-028-015/016 移管受入れ節（L385-390）も確認。TS-QC-001 査読で検出したタイポ「環境依差」→「環境依存差」を修正（意味変更なし）
- **checker 実装修正（本 Issue スコープ、SPEC 明文化と分離した段階対応）**: check_integrity.ts の ngBaselineKey が file 成分を正規化（バックスラッシュ→スラッシュ、先頭 ./ 除去、.opencode/ → src/opencode/ 換算）。main 環境（junction projection 実在）と worktree 環境（junction 未伝播、§7.3 src fallback）で同一ファイルの表記が変わっても同一 bucket として baseline-known 降格する。applyNgBaseline / updateNgBaseline では正規化により同一 bucket へ衝突する環境別表記 entry（例: case-close.md の src / .opencode 双 entry、Issue #2179 の暫定措置分）を同一論理 NG として扱う（count の大きい方を採用）
- check_extensions.ts の extBaselineKey にも同一正規化を適用（テスト用に export）
- bucket key 仕様自体（category/check/file/evidence の4組）は維持（ACT-SPEC-006 拘束、対象外: baseline 分類体系の変更）

## 検証証拠

### TS-008（運用契約4点の明文化確認）

- integrity-contracts.md L380: (1) 機械生成必須・手書き禁止 ✓
- L381: (2) パス bucket key の環境依存差と正規化/対警告の選択肢 ✓（本 PR で正規化を実装）
- L382: (3) baseline 生成環境の前提（worktree 生成 → main で新規未管理 NG 0 件確認）✓
- L383: (4) 由来ラベル（legacy 等）と報告分類の対応 ✓
- checker 実装修正が段階対応である構成: Issue 完了条件が SPEC 明文化と checker 修正を分離しており、SPEC テキストは正規化・対警告を代替手段として列挙 → 合格

### SC3（worktree / main 環境でパス表記差異が解消）

- 回帰テスト2件を追加（check_integrity.test.ts「NG baseline path bucket key normalization (Issue #2206, OU-0008)」）: (a) .opencode/commands/agentdev/broken.md 検出（main junction 環境の再現）が src/opencode/... 表記 baseline entry で info 降格、(b) src/opencode/... 検出（worktree fallback 環境の再現）が .opencode/... 表記 baseline entry で info 降格 — 両方向で合格
- 実 worktree ラン（bun run check_integrity.ts --json）で修正前後の報告が完全一致: 2 baseline-known / 5 approved additions / 30 new unmanaged NG（stash による before/after 比較）— 既存挙動の退行なし
- check_extensions.test.ts に extBaselineKey 正規化の単体テスト2件を追加 — 合格

### TS-QC-001（文書品質査読）

- 対象節の査読で「環境依差」タイポを検出し fix-and-reverify で修正。他に未解決違反なし — 合格

### TS-QC-002（full integrity suite）

- bun test ./.opencode/skills/repo-agentdev-integrity/scripts/: 2030 pass / 2 fail / 4491 expect() calls（83 files）
- 失敗2件はいずれも base 5d89b9df 時点で再現する既存失敗（git stash により本変更を除外して同一失敗を確認済み）。本 PR の変更ファイルを直接カバーするテスト（TS-003/004/005、追加正規化テスト、check_extensions 全テスト）は全て合格 — Findings に記録のうえ合格判定

### docs-integrity gate

- check_changed_docs.ts --workflow case-run --base-ref origin/main --json: files_checked 1件（integrity-contracts.md）、failures 0 / warnings 0
- src/opencode/{commands,skills}/** は未変更のため check_distribution_boundary は対象外

### 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 変更ファイル対象テスト | 全合格 | 全合格 | ✅ |
| full integrity suite | 2030 pass / 2 fail（既存失敗、本変更無関係） | 対象基準違反なし | ✅（Findings 記録） |
| check_changed_docs (case-run) | failures 0 | 0 | ✅ |
| worktree 実行の demotion 挙動 | 修正前後で同一（2/5/30） | 退行なし | ✅ |

## Findings / Capture候補

### docs-integrity

該当なし（check_changed_docs failures 0 / warnings 0）。

### intake

1. **IR-055 baseline drift（既存失敗、base 5d89b9df で再現確認）**: IR-055 runtime-unresolved-reference 実修復回帰 (Issue #1782) テストが失敗。src/opencode/skills/agentdev-artifact-graph/SKILL.md:268 と references/tim.md:5 の docs/specs/ 参照2件が ir-055-baseline.json の既知 bucket を超過（heuristic 違反。バッチ定義層 commit 由来と推定）。SPEC は heuristic 違反の bucket 再計算を許容するが、並列 Wave での同一 baseline 二重更新禁止（integrity-contracts「baseline 再生成分実行契約」）に従い本 PR では対処せず記録
2. **workflow-soft-guard 未宣言（既存失敗、base 5d89b9df で再現確認）**: checkWorkflowPreventive integration テストが失敗。agentdev-workflow-backlog-review、agentdev-workflow-case-auto 等 Workflow Skill SKILL.md が soft guard（単独起動抑制）を未宣言（src/opencode/skills/** の内容修正が必要なため本 Issue スコープ外）
3. **worktree 環境固有の new unmanaged NG 30件**: retired-req-primary-ref 19件等、docs/** 起因。修正前後で同一（30→30）であり本変更無関係。OU-0009（N16/N17 是正、Epic G）勢力圏

### learning

1. **ng-baseline.json の環境別表記重複 entry は正規化後に冗長化**: case-close.md command-capture-duty の src / .opencode 双 entry（Issue #2179 暫定措置）は、本正規化により同一 bucket へ衝突する。手書き削除は機械生成必須契約に反するため実施せず、次回 --update-ng-baseline --ng-baseline-additions 実行時に自然に単一 entry へ統合される見込み。並列 Wave 中の baseline 更新は避けるべき

## SPEC確定候補

1. **正規化衝突時の semantic**: baseline entries が正規化で同一 bucket key へ衝突する場合の扱い（同一論理 NG の環境別観測として count の大きい方を採用、加算しない）を checker アルゴリズム詳細として SPEC「NG baseline 運用手順」に確定候補。加算すると単一論理 NG の実数を超えて降格を許す（NG隠蔽リスク）、min は環境別観測の実数を下回る恐れがあるため max 採用
2. **check_extensions.ts の baseline 分岐**: SPEC L351 は「check_integrity.ts と check_extensions.ts は ... ng-baseline.json へ格納する」と記載するが、実装は check-extensions-baseline.json（現時点でファイル未作成 → baseline demotion が不活性）を使用し、updateExtensionsNgBaseline は additions manifest を要求しない無条件再生成となっている。SPEC 記述と実装のどちらを正とするかの確定が必要

Refs: #2206