### PR TITLE
feat(integrity): TS-009 node_modules 除外と監査記録 retired 参照免除の実装

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -1470,6 +1470,24 @@ function checkSpecsExistence(specsDir: string, root: string): CheckResult[] {
   return results;
 }
 
+// ─── History record exemption (checker 実行契約 SPEC 検出対象除外規定) ────────
+// 監査記録・baseline は歴史記録として retired 参照系検出（retired-req-as-current、
+// retired-req-primary-ref 等）の免除対象とする。除外列挙は checker 実行契約 SPEC
+// （docs/specs/integrity/checker-execution-contracts.md「検出対象除外規定」）が
+// 正規所有し、列挙外の除外を本実装で追加しない（check_changed_docs.ts isSpecFile
+// と同一の判定規定）:
+//   - 配置ディレクトリ: docs/specs/integrity/audits/、baselines/（歴史記録領域）
+//   - frontmatter 信号キー: baseline_for / audit_for（snapshot・監査記録の起源標識）
+const SPEC_HISTORY_DIR_RE = /^docs\/specs\/integrity\/(audits|baselines)\//;
+const SPEC_HISTORY_FRONTMATTER_KEY_RE = /^(?:baseline_for|audit_for)\s*:/m;
+
+function isExemptHistoryRecord(relPath: string, content: string): boolean {
+  if (SPEC_HISTORY_DIR_RE.test(relPath)) return true;
+  const fmEnd = content.startsWith("---") ? content.indexOf("\n---", 3) : -1;
+  if (fmEnd === -1) return false;
+  return SPEC_HISTORY_FRONTMATTER_KEY_RE.test(content.slice(0, fmEnd));
+}
+
 // ─── Link integrity checks (v2:REQ-0108-013) ────────────────────────────────
 
 function collectAllArtifactPaths(root: string): string[] {
@@ -1743,6 +1761,7 @@ function checkLinkIntegrity(root: string): CheckResult[] {
         !relPath.startsWith("docs/adr/retired/") &&
         !relPath.startsWith("docs/adr/README.md") &&
         !relPath.startsWith("docs/adr/ADR-") && // ADRs discuss retired predecessors historically
+        !isExemptHistoryRecord(relPath, content) && // 監査記録・baseline は歴史記録として免除
         appearsOutsideRetired &&
         !(relPath.startsWith("docs/adr/ADR-") && isSupersededAdr(filePath, ref))
       ) {
@@ -1784,6 +1803,7 @@ function checkLinkIntegrity(root: string): CheckResult[] {
         !fs.existsSync(activePath) &&
         !relPath.startsWith("docs/requirements/retired/") &&
         !relPath.startsWith("docs/adr/ADR-") && // ADRs discuss REQ reorganization historically
+        !isExemptHistoryRecord(relPath, content) && // 監査記録・baseline は歴史記録として免除
         appearsOutsideRetired &&
         !isReqRangeContext // v2:REQ-0108-194: REQ range references like "REQ-0101 through REQ-0116"
       ) {
@@ -1984,6 +2004,7 @@ function checkLifecycleBoundary(root: string): CheckResult[] {
     if (relPath.startsWith("docs/adr/ADR-")) continue; // ADRs discuss REQ reorganization historically
     const content = readText(filePath);
     if (!content) continue;
+    if (isExemptHistoryRecord(relPath, content)) continue; // 監査記録・baseline は歴史記録として免除
     const contentLines = content.split("\n");
     const refs = content.match(/\bREQ-\d{3,4}\b/g) || [];
     const uniqueRefs = [...new Set(refs)];

--- a/.opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/commands_e2e.test.ts
@@ -16,6 +16,7 @@ import {
   expect,
 } from "bun:test";
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 
 const SCRIPT_DIR = import.meta.dir;
@@ -667,6 +668,33 @@ describe("TS-009: エンコーディング不整合検出", () => {
     }
     expect(findings).toEqual([]);
   });
+
+  it("契約: 再帰スキャンは node_modules 系ディレクトリを除外する", () => {
+    // checker 実行契約 SPEC「検出対象除外規定」: node_modules 系 git 管理外
+    // ディレクトリはスキャン対象から除外する。main 作業ディレクトリでは
+    // src/opencode/skills/*/scripts/node_modules/ 配下の依存パッケージ README
+    // （CRLF/LF 混在）が恒常 fail の原因となるため、除外を契約テストで固定する。
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ts009-node-modules-"));
+    try {
+      fs.mkdirSync(path.join(tempRoot, "skills", "normal"), { recursive: true });
+      fs.mkdirSync(
+        path.join(tempRoot, "skills", "demo", "scripts", "node_modules", "@types", "bun"),
+        { recursive: true },
+      );
+      fs.writeFileSync(path.join(tempRoot, "skills", "normal", "SKILL.md"), "# normal\n", "utf-8");
+      fs.writeFileSync(
+        path.join(tempRoot, "skills", "demo", "scripts", "node_modules", "@types", "bun", "README.md"),
+        "line1\r\nline2\nline3\r\n",
+        "utf-8",
+      );
+      const collected = collectMarkdownFiles(tempRoot);
+      expect(collected).toEqual([
+        path.join(tempRoot, "skills", "normal", "SKILL.md"),
+      ]);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 function collectMarkdownFiles(dir: string): string[] {
@@ -675,6 +703,9 @@ function collectMarkdownFiles(dir: string): string[] {
   for (const ent of entries) {
     const full = path.join(dir, ent.name);
     if (ent.isDirectory()) {
+      // checker 実行契約 SPEC「検出対象除外規定」: node_modules 系 git 管理外
+      // ディレクトリはスキャン対象から除外する。
+      if (ent.name === "node_modules") continue;
       result.push(...collectMarkdownFiles(full));
     } else if (ent.isFile() && ent.name.endsWith(".md")) {
       result.push(full);

--- a/.opencode/skills/repo-agentdev-integrity/scripts/regression_history_record_exemption.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/regression_history_record_exemption.test.ts
@@ -1,0 +1,231 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const SCRIPT_DIR = import.meta.dir;
+const CHECKER_PATH = join(SCRIPT_DIR, "check_integrity.ts");
+const TEMP_BASE = join("C:", "WINDOWS", "TEMP", "opencode");
+const RUN_ID = `history-record-exemption-${crypto.randomUUID().slice(0, 8)}`;
+const TEMP_ROOT = join(TEMP_BASE, RUN_ID);
+
+interface CheckerResult {
+  readonly category: string;
+  readonly check: string;
+  readonly level: string;
+  readonly message: string;
+  readonly file?: string;
+}
+
+interface CheckerReport {
+  readonly results: readonly CheckerResult[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseCheckerReport(stdout: string): CheckerReport {
+  const parsed: unknown = JSON.parse(stdout);
+  if (!isRecord(parsed) || !Array.isArray(parsed.results)) {
+    throw new Error("Checker JSON report must include a results array.");
+  }
+  const results: CheckerResult[] = [];
+  for (const value of parsed.results) {
+    if (
+      !isRecord(value) ||
+      typeof value.category !== "string" ||
+      typeof value.check !== "string" ||
+      typeof value.level !== "string" ||
+      typeof value.message !== "string"
+    ) {
+      throw new Error(
+        "Checker result must contain category, check, level, and message strings.",
+      );
+    }
+    results.push({
+      category: value.category,
+      check: value.check,
+      level: value.level,
+      message: value.message,
+      file: typeof value.file === "string" ? value.file : undefined,
+    });
+  }
+  return { results };
+}
+
+function runChecker(root: string): CheckerReport {
+  const processResult = Bun.spawnSync(
+    ["bun", "run", CHECKER_PATH, "--root", root, "--json"],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const stdout = processResult.stdout.toString("utf-8");
+  if (stdout.length === 0) {
+    throw new Error(
+      `Checker emitted no JSON (exit ${processResult.exitCode ?? -1}): ${processResult.stderr.toString("utf-8")}`,
+    );
+  }
+  return parseCheckerReport(stdout);
+}
+
+function writeFixtureFile(filePath: string, content: string): void {
+  mkdirSync(join(filePath, ".."), { recursive: true });
+  writeFileSync(filePath, content, "utf-8");
+}
+
+function buildFixture(root: string): void {
+  const reqDir = join(root, "docs", "requirements");
+  const retiredReqDir = join(reqDir, "retired");
+
+  writeFixtureFile(
+    join(reqDir, "REQ-001.md"),
+    [
+      "---",
+      "id: REQ-001",
+      "title: Active fixture requirement",
+      "created: 2026-07-26",
+      "updated: 2026-07-26",
+      "---",
+      "",
+      "# REQ-001",
+      "",
+      "Active requirement body.",
+      "",
+    ].join("\n"),
+  );
+  writeFixtureFile(
+    join(reqDir, "README.md"),
+    [
+      "# Requirements",
+      "",
+      "| ID | Title |",
+      "|----|-------|",
+      "| REQ-001 | Active fixture requirement |",
+      "",
+    ].join("\n"),
+  );
+  writeFixtureFile(
+    join(retiredReqDir, "REQ-9999.md"),
+    [
+      "---",
+      "id: REQ-9999",
+      "title: Retired fixture requirement",
+      "created: 2026-07-26",
+      "updated: 2026-07-26",
+      "---",
+      "",
+      "# REQ-9999",
+      "",
+      "Retired requirement body.",
+      "",
+    ].join("\n"),
+  );
+  writeFixtureFile(
+    join(root, "docs", "adr", "README.md"),
+    "# ADR\n",
+  );
+  writeFixtureFile(join(root, "docs", "specs", "README.md"), "# SPEC\n");
+
+  // 監査記録（配置ディレクトリベースの免除対象）。表内の REQ-9999 参照は
+  // 行単位の退休語彙を持たないため、免除規定なしでは retired 参照系 warning となる。
+  writeFixtureFile(
+    join(root, "docs", "specs", "integrity", "audits", "retired-ref-audit-fixture.md"),
+    [
+      "---",
+      "id: AUDIT-RETIRED-REF-FIXTURE",
+      "title: retired 参照監査記録フィクスチャ",
+      "status: accepted",
+      "created: 2026-08-18",
+      "audit_for: REQ-001",
+      "---",
+      "",
+      "# retired 参照監査記録フィクスチャ",
+      "",
+      "| REQ | 判定 |",
+      "|-----|------|",
+      "| REQ-9999 | 履歴記録として記載 |",
+      "",
+    ].join("\n"),
+  );
+
+  // baseline snapshot（frontmatter 信号キー baseline_for ベースの免除対象）。
+  // 監査ディレクトリ外に配置し、信号キーのみで免除されることを固定する。
+  writeFixtureFile(
+    join(root, "docs", "specs", "integrity", "snapshot-fixture.md"),
+    [
+      "---",
+      "id: BASELINE-RETIRED-REF-FIXTURE",
+      "title: baseline snapshot フィクスチャ",
+      "status: accepted",
+      "created: 2026-08-18",
+      "baseline_for: REQ-001",
+      "---",
+      "",
+      "# baseline snapshot フィクスチャ",
+      "",
+      "| REQ | 状態 |",
+      "|-----|------|",
+      "| REQ-9999 | 計測時点の残存参照 |",
+      "",
+    ].join("\n"),
+  );
+
+  // 対照群: 履歴文脈のない通常 SPEC ファイル。免除を適用しない範囲の固定。
+  writeFixtureFile(
+    join(root, "docs", "specs", "integrity", "control-spec-fixture.md"),
+    [
+      "# 対照 SPEC フィクスチャ",
+      "",
+      "| 参照 | 用途 |",
+      "|------|------|",
+      "| REQ-9999 | 現行要件として参照 |",
+      "",
+    ].join("\n"),
+  );
+}
+
+beforeAll(() => {
+  rmSync(TEMP_ROOT, { recursive: true, force: true });
+  buildFixture(TEMP_ROOT);
+});
+
+afterAll(() => {
+  rmSync(TEMP_ROOT, { recursive: true, force: true });
+});
+
+describe("history record exemption for retired-reference detections", () => {
+  const RETIRED_REF_CHECKS = new Set([
+    "retired-req-as-current",
+    "retired-req-primary-ref",
+  ]);
+
+  it("監査記録（audits/ 配下）の retired 参照は警告されない", () => {
+    const report = runChecker(TEMP_ROOT);
+    const auditFindings = report.results.filter(
+      (r) =>
+        RETIRED_REF_CHECKS.has(r.check) &&
+        (r.file ?? "").includes("audits") &&
+        (r.file ?? "").includes("retired-ref-audit-fixture"),
+    );
+    expect(auditFindings).toEqual([]);
+  });
+
+  it("baseline_for 信号キーを持つファイルの retired 参照は警告されない", () => {
+    const report = runChecker(TEMP_ROOT);
+    const baselineFindings = report.results.filter(
+      (r) =>
+        RETIRED_REF_CHECKS.has(r.check) &&
+        (r.file ?? "").includes("snapshot-fixture"),
+    );
+    expect(baselineFindings).toEqual([]);
+  });
+
+  it("履歴文脈のない通常 SPEC ファイルの retired 参照は警告され続ける", () => {
+    const report = runChecker(TEMP_ROOT);
+    const controlFindings = report.results.filter(
+      (r) =>
+        RETIRED_REF_CHECKS.has(r.check) &&
+        (r.file ?? "").includes("control-spec-fixture"),
+    );
+    expect(controlFindings.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 変更概要

Issue #2209（OU-0014: checker 実行契約 SPEC の確定と除外実装、Epic #2205 EU-B Wave 1）の実装。

- **SPEC 2規定群の確定確認**: `docs/specs/integrity/checker-execution-contracts.md` の「パターンマッチ・網羅検査設計の標準規約」（行全体マッチ統一、列挙ベース網羅検査と件数整合の二重確認、階層 ID 検索の3点設計、宣言的データの silent skip 禁止 + 契約テスト固定）と「検出対象除外規定」（node_modules 除外、frontmatter 信号キー `baseline_for`/`audit_for` 正規列挙、監査記録・AUTOGEN 免除）が commit 3b8a42ff（ACT-SPEC-012、spec-save 適用済み）で反映済みであることを確認した。記載漏落なしのため本 PR での SPEC 編集はなし（draft から accepted への昇格は case-close 責務）。
- **TS-009 node_modules 除外**: `commands_e2e.test.ts` の `collectMarkdownFiles` 再帰スキャンに node_modules ディレクトリ除外を追加し、main 作業ディレクトリでの恒常 fail（`src/opencode/skills/*/scripts/node_modules/@types/bun/README.md` の CRLF/LF 混在4件）を解消した。除外仕様を契約テスト（fixture ベース）で固定した。
- **retired-req 免除（ファイル種別ベース）**: `check_integrity.ts` に `isExemptHistoryRecord` を追加し、監査記録・baseline（`docs/specs/integrity/audits/`・`baselines/` 配下、または frontmatter 信号キー `baseline_for`/`audit_for` 所持ファイル）を retired 参照系検出（`retired-req-as-current`、`retired-req-primary-ref`、`retired-adr-as-current`）の免除対象とした。`check_changed_docs.ts` isSpecFile と同一の判定規定。免除の正負例を固定する回帰テストを新規追加した。

### 除外方式の比較検討（完了条件の記録）

| 観点 | RETIREMENT_CONTEXT_RE 拡充 | ファイル種別ベース（採用） |
|---|---|---|
| 除外単位 | 行単位（退休語彙の正規表現マッチ） | ファイル単位（配置ディレクトリ + frontmatter 信号キー） |
| SPEC 整合 | 「除外は対象ファイル単位とし」に反する | 規定どおり（対象ファイル単位） |
| 誤検出耐性 | 監査記録の表細胞など語彙を欠く行で免除漏れ。語彙追加ごとにパターンが drift する | ディレクトリ・キーの列挙で決定的 |
| 実装一貫性 | check_integrity 独自の拡張になる | `check_changed_docs.ts` isSpecFile と同一規定（SPEC 正規列挙の実装由来） |

採用判定: ファイル種別ベース。RETIREMENT_CONTEXT_RE 拡充は行単位免除のため SPEC のファイル単位規定と不整合で、監査記録の表形式参照（行単位の退休語彙を欠く）に対して免除漏れが残る。

## 検証証拠

| 検証 | 結果 |
|---|---|
| TS-014: SPEC 2規定群の記載確認 | 合格（全要素の記載を確認、編集不要） |
| TS-009 恒常 fail 解消（main 作業ディレクトリ相当） | 合格。修正前 main で 1 fail（node_modules 配下4件検出）→ worktree 内で main と同一条件（`src/opencode` 配下に node_modules + CRLF/LF 混在 .md）を再現して実行し 120 pass / 0 fail |
| 追加契約テスト・回帰テスト | 合格（node_modules 除外契約テスト1件、免除正負例3件） |
| full integrity suite（bun test、worktree） | 2029 pass / 3 fail（残3 fail は事前存在・スコープ外、Findings 参照） |
| check_integrity --json（worktree） | audits/baselines の retired 参照 warning が修正前 11件 → 0件。対象外ファイルの警告は維持（回帰テストの対照群で固定） |
| TS-QC-001（agentdev-doc-writing 参照査読） | 合格。対象 SPEC に未解決違反なし（本 PR で SPEC 編集なし） |
| TS-QC-002 | 条件付き合格。TS-009 は解消。full suite の残3 fail は事前存在・別 Issue スコープのため Findings に記録（on_failure: record-in-findings） |

docs/** の変更なし（`check_changed_docs.ts` 対象外）、`src/opencode/{commands,skills}/**` の変更なし（`check_distribution_boundary.ts` 対象外）。

## 完了条件

- [x] SPEC の2規定群（パターンマッチ標準・検出対象除外規定）が確定していること（3b8a42ff 適用分の記載確認）
- [x] TS-009 の恒常 fail が解消していること（case 実施分）
- [x] 除外実装の方式選択（RETIREMENT_CONTEXT_RE 拡充 vs ファイル種別ベース）に比較検討の記録があること（本 PR「除外方式の比較検討」節）
- [x] TS-014 の pass_criteria を満たしていること
- 契約テスト期待値の更新と固定トークン確認: 実施済み（node_modules 除外の契約テストと免除回帰テストを新規追加。command/skill/template の構造変更なし）

## Findings / Capture候補

### intake

- 非監査系 SPEC ファイルの retired-req warning 11件が残存する（document-model、integrity-contracts、integrity-rule-catalog、rule-ownership、IR-044/055/062、req-impact-map、agentdev-doc-diagnostics、checker-execution-contracts 等）。大半は階層 ID（`REQ-028-0XX` 等）の前置一致に由来する誤検出で、SPEC「階層 ID 検索の3点設計」の前置一致除外の適用候補。AG-014 確定内容（既存 checker のマッチ実装の一括変更は要求しない）により本 Issue の対象外。NG baseline 運用は #2206、checker 準拠更新は #2210 の隣接スコープ。
- AUTOGEN ブロック単位の免除（SPEC「検出対象除外規定」に規定あり）は行領域判定を要するため本実装では未適用。本 PR はファイル種別ベース（監査記録・baseline）のみ実装した。`rule-ownership.md` の AUTOGEN ブロック内参照に由来する警告は残存する。

### learning

該当なし

### 事前存在 fail の記録（TS-QC-002 on_failure: record-in-findings）

full integrity suite（bun test）の残3 fail は修正前 main baseline でも同一:

1. IR-055 runtime-unresolved-reference delta（Wave 2 #2210 OU-0015 スコープ）
2. checkExtensions 実ツリー分類（OU-0007、Epic C。本 Issue の対象外に明記）
3. checkWorkflowPreventive（junction 未伝播に起因する環境依存。OU-0007 系）

## SPEC確定候補

該当なし（検出対象除外規定の正規列挙は 3b8a42ff で SPEC 確定済み。本 PR の比較検討結論は既存規定「除外は対象ファイル単位とし」への準拠であり、SPEC 追記を要する新規契約はなし）。

## 決定事項

- 除外実装の方式選択としてファイル種別ベースを採用（比較検討は「除外方式の比較検討」節）

## 関連Issue

Closes #2209

Refs: #2209
