### PR TITLE
docs(agentdev): ネイティブコマンド出力の安全な読み取り経路を手順書へ拡張（OU-0020、Refs: #2215）

### DIFF
--- a/src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md
+++ b/src/opencode/skills/agentdev-gh-cli/references/standard-procedures.md
@@ -45,6 +45,8 @@
 ### execSync バイパス
 
 - `gh` コマンドの出力取得には Node.js `child_process.execSync` を使用する（pwsh パイプラインをバイパスして gh CLI の生の UTF‑8 出力を直接取得するため）
+- **ネイティブコマンド全般への拡張**: 本バイパス経路は gh CLI に限定しない。pwsh 経由でネイティブコマンド（git CLI、bun、node 等）の出力を読み取る READ 操作全般に適用する（READ 手続き Section 3「適用範囲（gh CLI からネイティブコマンド全般への拡張）」参照）
+- **exit code が意味を持つコマンドは `spawnSync`**: 検証・検査コマンド等、非ゼロ exit が観測すべき結果として意味を持つコマンドは `execSync` ではなく `spawnSync`（status/ stdout 分離取得）を使用する（READ 手続き Section 3「exit code が意味を持つコマンドの stdout 退避形式」参照）
 
 ### PowerShell パイプライン READ の [Console]::OutputEncoding 前置
 
@@ -189,6 +191,38 @@ PowerShellがバッククォートをコマンド置換として解釈するた�
  **注**: 退避策（Section 3 項目7）による `.js` スクリプトファイル内では、テンプレートリテラルの使用は許可される。
 
  **パイプライン経由 READ の前置**: PowerShell パイプライン経由で日本語出力を読み取る READ 操作（`git show`、`Get-Content`、`Select-String` 等）は、パイプライン前の `[Console]::OutputEncoding` 前置、または Node.js `execSync` / `fs.readFileSync` 経路のいずれかを必須とする（「Windows 固有の制約」の「PowerShell パイプライン READ の [Console]::OutputEncoding 前置」節参照）。
+
+#### 適用範囲（gh CLI からネイティブコマンド全般への拡張）
+
+READ 安全手順（本 Section 3、Section 4）は gh CLI の READ に限定せず、pwsh（Windows PowerShell 5.x / pwsh 7）経由でネイティブコマンド（gh CLI、git CLI、bun、node 等）の出力を読み取る操作全般に適用する。適用経路は読み取り対象コマンドの性質により次の2つに分かれる。
+
+- **単発 READ（成功が見込めるもの）**: gh CLI の本文読込等、コマンド成功を前提とした単発 READ は従来どおり `execSync` 経路（項目1）を維持する
+- **exit code が意味を持つコマンド**: 検証・検査コマンド等、非ゼロ exit が観測すべき結果として意味を持つコマンドは次項の `spawnSync` 経路を標準とする
+
+#### exit code が意味を持つコマンドの stdout 退避形式
+
+**背景**: `execSync` は非ゼロ exit で例外を投げるため、stdout は例外オブジェクトのプロパティ経由でしか取得できず、例外処理を誤ると出力が失われる。検証・検査コマンド（integrity checker、test、`git diff --check` 等）では非ゼロ exit 時の stdout（JSON レポート、違反明細）こそが判定と証跡に必要となる（PR #1600/#2172 系、Epic #1719 Wave 4 の再発防止）。
+
+**標準形式**: `spawnSync` で status と stdout を分離取得し、`fs.writeFileSync` の第3引数に `'utf8'` を明示指定して UTF‑8（BOMなし）で一時ファイルへ退避する:
+
+```
+node -e "const{spawnSync}=require('child_process');const fs=require('fs');const r=spawnSync('bun',['run','.opencode/skills/<integrity-detector-skill>/scripts/check_changed_docs.ts','--workflow','case-run','--base-ref','origin/main','--json'],{encoding:'utf8'});fs.writeFileSync('.agentdev/tmp/cmd-stdout-{timestamp}.json',r.stdout,'utf8')"
+```
+
+- **status と stdout の分離判定**: exit code は `r.status` で判定する（`null` は起動失敗）。`r.status` の判定と stdout の解析（JSON レポートの読み取り）を分離して実施し、非ゼロ exit（違反検出等）時も stdout を証跡として保持する
+- **stderr の退避**: `r.stderr` は失敗診断に使用する。必要に応じて同一形式で退避する
+- **読み取りと cleanup**: 退避した一時ファイルを Read tool で読み取り、読み取り完了後に削除する（項目2〜3と同一）
+- **保存形式**: UTF‑8（BOMなし）、改行コード LF（項目4と同一）
+- **委譲時の配置先**: worktree 隔離境界により `.agentdev/**` への書き込みが禁止される場面では、Section 2 Step 1「委譲時の代替一時ファイル配置先」に従い `$env:TEMP` 配下へ退避する
+- **クォート競合**: コマンド引数にシングルクォートやパイプを含む場合は項目5〜8のクォート競合回避に従う
+- **`>` リダイレクトでの退避は禁止**: PowerShell の `>` リダイレクト、`2>&1` 等による stdout 退避は使用禁止（Section 4 と同一理由。パイプライン経由のエンコーディング変換で日本語が文字化けするため）
+
+#### execSync 維持境界
+
+`execSync` を全面禁止とはしない。維持境界は次のとおりとし、対象コマンドがどちらに該当するかを判定して経路を選択すること。
+
+- **維持（`execSync`）**: 成功が見込める単発 READ。gh CLI の本文読込・補助データ読込等、非ゼロ exit が例外的失敗のみを意味するコマンドの READ
+- **切替（`spawnSync`）**: exit code が意味を持つコマンド。非ゼロ exit が観測すべき結果として設計された検証・検査コマンド（integrity checker、test、`git diff --check` 等）の実行と stdout 取得
 
 ### 4. 読み取り禁止事項
 

--- a/src/opencode/skills/agentdev-gh-cli/references/verify.md
+++ b/src/opencode/skills/agentdev-gh-cli/references/verify.md
@@ -24,6 +24,7 @@ Windows 環境で WRITE 手続きを実行する場合、書き込み操作の�
 
 対象リソース（Issue/PR/コメント）の本文を取得する。
 読み取りは [standard-procedures.md](standard-procedures.md) の READ 手続き（Node.js `execSync` + 一時ファイル経由 + Read tool）に従う。
+READ 手続きは gh CLI 限定ではなくネイティブコマンド全般に適用される。検証で exit code が意味を持つコマンド（checker 等、非ゼロ exit が違反検出として観測対象になるコマンド）を実行して証跡を取る場合は、`spawnSync` による status/ stdout 分離取得 + `fs.writeFileSync` の UTF‑8 明示書き出しによる stdout 退避形式に従う（[standard-procedures.md](standard-procedures.md) READ 手続き「exit code が意味を持つコマンドの stdout 退避形式」参照）。
 
 - Issue本文: Issue 本文読込手続き
 - PR本文: PR 本文読込手続き

--- a/src/opencode/skills/agentdev-workflow-case-close/references/docs-and-spec-promotion.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/docs-and-spec-promotion.md
@@ -88,6 +88,8 @@ SPEC status 昇格タイミング（draft → accepted）の詳細、frontmatter
 - `check_distribution_boundary.ts`（`--profile source`、PR 変更ファイルが配布 command/skill ソース面に含まれる場合に実行）
 - test_strategy（QG-4 完了条件確認）
 
+**checker コマンドの stdout 退避形式**: 上記 checker コマンドは exit code が意味を持つコマンド（非ゼロ exit = 違反検出等の観測対象）であるため、実行と stdout 取得は `agentdev-gh-cli` READ 手続きの「exit code が意味を持つコマンドの stdout 退避形式」に従う（`spawnSync` による status/ stdout 分離取得 + `fs.writeFileSync` の UTF‑8 明示書き出し）。非ゼロ exit 時も JSON レポート（stdout）を Evidence として保持し、`>` リダイレクトや PowerShell 変数格納で退避しない。
+
 ## Evidence
 
 - targeted docs guard、check_extensions.ts、check_distribution_boundary.ts の各 JSON 結果、SPEC 確定フローの処理パターン（a/b/c）

--- a/src/opencode/skills/agentdev-workflow-case-close/references/epic-wave-close.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/epic-wave-close.md
@@ -49,6 +49,7 @@ Epic Issue 本文を読み込み、ステータス追跡テーブル（`agentdev
 各子Issue の PR マージへ進む前に、当該 PR の変更ファイルが `--profile source` の配布 command/skill ソース面に含まれる場合、配布依存境界の最終 gate を実行する。含まない PR（docs のみ等）ではスキップする。trigger 条件は detector の `--profile source` が分類する配布ソース面を基準とする（case-run command Step 7-1 と同一）。手続きの正規所有者は STEP-3-1（[docs-and-spec-promotion.md](docs-and-spec-promotion.md)）であり、本 STEP は同一手続きを Epic Wave の各子Issue に適用する。
 
 - **実行コマンド**: `bun run .opencode/skills/<integrity-detector-skill>/scripts/check_distribution_boundary.ts --profile source --json`。検査対象は当該子Issue PR の HEAD（マージ前の実際の PR ブランチ内容）。現在の main 状態ではなく、PR で提案されている実際の変更内容を検査する
+- **checker コマンドの stdout 退避形式**: 本 gate の checker コマンドは exit code が意味を持つコマンド（非ゼロ exit = 違反検出）であるため、実行と stdout 取得は `agentdev-gh-cli` READ 手続きの「exit code が意味を持つコマンドの stdout 退避形式」に従う（`spawnSync` による status/ stdout 分離取得 + `fs.writeFileSync` の UTF‑8 明示書き出し）。非ゼロ exit 時も JSON レポートを証跡として保持する（手続きの正規所有者は STEP-3-1 と同一）
 - **`--profile source`**: case-close は PR マージ前に実行され、配布ソース面を検査するため `source` を使用する（junction は原本への鏡像）
 - **検査エラーの扱い**: 読込不能、未分類エントリ、adapter 起動失敗は全て gate-not-passed として扱う。clean として通過させない
 - **gate 違反時**: 当該子Issue の PR マージを中止し、PR 本文の `## Findings / Capture候補` セクションに `### distribution-boundary` 小見出しで記録する（既に case-run command Step 7-1 で記録済みの場合は上書きせず、case-close で新たに検出された事項のみ追記）。当該子Issue は後続 E4-1 シーケンスへ進めず、E5 Epic status table で `blocked` 状態として記録する（`agentdev-epic-tracker` 準拠、`completed` へ上書きしない、べき等性）

--- a/src/opencode/skills/agentdev-workflow-case-run/references/delegation-and-result.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/references/delegation-and-result.md
@@ -78,6 +78,7 @@
 - **STEP-S5-1: 配布依存境界の最終変更経路 gate（実装後、command 公開順序の Step 7-1 に対応）**: result が `completed-pr` の場合、STEP-S6 に進む前に、実装後の実際の worktree HEAD に対して最終 gate を行う（実装担当サブエージェントが追加した変更も含めて検査する）
   - 実行条件: result が `completed-pr` であり、PR 対象ファイルに `src/opencode/{commands,skills}/**` 変更を含む場合。当該変更を含まない PR（docs のみ等）ではスキップする
   - 実行コマンド: `bun run .opencode/skills/<integrity-detector-skill>/scripts/check_distribution_boundary.ts --profile source --json`。現在の worktree（実装後 HEAD）の配布物ソースツリーを検査する
+  - **checker コマンドの stdout 退避形式**: 本 gate の checker コマンドは exit code が意味を持つコマンド（非ゼロ exit = 違反検出）であるため、実行と stdout 取得は `agentdev-gh-cli` READ 手続きの「exit code が意味を持つコマンドの stdout 退避形式」に従う（`spawnSync` による status/ stdout 分離取得 + `fs.writeFileSync` の UTF‑8 明示書き出し）。非ゼロ exit 時も JSON 実行結果（Evidence）を保持する
   - 検出結果の分類: 検査エラー（読込不能、未分類エントリ、adapter 起動失敗）は全て gate-not-passed として扱う。clean として通過させない
   - 違反検出時の停止契約（adapter result `blocked` とは区別）: 違反検出時は PR 本文の `## Findings / Capture候補` セクションに `### distribution-boundary` 小見出しで記録し、STEP-S6 へ進まず case-run を停止する。adapter result は `completed-pr` のまま変更せず、adapter result 契約の `blocked` へ上書きしない。停止理由は「配布依存境界 最終 gate 違反（PR 本文記録済み）」と報告し、SSoT は PR 本文とする。next action は同一 Issue で case-run を再実行し違反を修正する（worktree+ブランチ存活時は STEP-S3 をスキップし STEP-S4 から再開、べき等）。case-close へは進めない
 

--- a/src/opencode/skills/agentdev-workflow-case-run/references/single.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/references/single.md
@@ -121,6 +121,8 @@
 
 **case-run が使用する検査ツール**（integrity 契約 SPEC「Workflow × 使用ツールマトリックス」参照）: check_changed_docs.ts（--workflow case-run、docs/** 変更を含む場合に委譲前に実行）、check_extensions.ts（`.opencode/commands/agentdev/**/*.md`、`.opencode/skills/agentdev-*/SKILL.md`、`.opencode/skills/agentdev-*/references/**/*.md`、`.agentdev/extensions/**` のいずれかを変更した場合に実行）、check_distribution_boundary.ts（--profile source、STEP-S5 で実装後 worktree の実際の配布ソース面を検査）、test_strategy（Issue 完了条件検証）
 
+**checker コマンドの stdout 退避形式**: 上記 checker コマンドは exit code が意味を持つコマンド（非ゼロ exit = 違反検出等の観測対象）であるため、実行と stdout 取得は `agentdev-gh-cli` READ 手続きの「exit code が意味を持つコマンドの stdout 退避形式」に従う（`spawnSync` による status/ stdout 分離取得 + `fs.writeFileSync` の UTF‑8 明示書き出し）。非ゼロ exit 時も JSON レポート（stdout）を Evidence として保持し、`>` リダイレクトや PowerShell 変数格納で退避しない。
+
 ### Result
 
 - worktree+ブランチ作成済み（べき等）、前置 gate 群の判定結果、L2 タイムスタンプ記録済み


### PR DESCRIPTION
Refs: #2215

## 変更概要

OU-0020（Epic #2213 EU-C Wave 1）。pwsh 経由ネイティブコマンド出力の安全な読み取り経路を配布 skill references へ追記する（PR #1600/#2172 系、Epic #1719 Wave 4 の再発防止）。

- agentdev-gh-cli references（standard-procedures.md、verify.md）: 「execSync バイパス」節へネイティブコマンド全般への拡張と spawnSync 切替条件を追記。READ 手続き Section 3 へ「適用範囲（gh CLI からネイティブコマンド全般への拡張）」「exit code が意味を持つコマンドの stdout 退避形式」「execSync 維持境界」の3小節を新設
- agentdev-workflow-case-run references（single.md 検査ツール段落、delegation-and-result.md STEP-S5-1）: checker コマンドの stdout 退避形式適用を追記
- agentdev-workflow-case-close references（docs-and-spec-promotion.md 検査ツール、epic-wave-close.md STEP-E4-0）: 同一追記

## 検証証拠

### TS-020（合格）

- spawnSync + fs.writeFileSync（UTF-8 明示、第3引数 utf8 指定）の読み取り経路が standard-procedures.md「exit code が意味を持つコマンドの stdout 退避形式」へ明記済み（verify.md にも参照追記）
- case-run/case-close 検証手順 references 4ファイルへ stdout 退避形式の追記あり（single.md、delegation-and-result.md、docs-and-spec-promotion.md、epic-wave-close.md）
- execSync 維持境界が明確化済み（execSync を全面禁止とせず、維持=成功が見込める単発 READ / 切替=exit code が意味を持つコマンドの2分類。AG-020 確定内容どおり）
- 読み戻し確認: git diff 全追加行を確認、全6ファイルとも U+FFFD なし・BOM なし・LF 維持を Node 検証

### TS-QC-001（合格）

- check_distribution_boundary.ts（--profile source --json）: ok=true、failures=[]（332ファイル走査）
- check_extensions.ts: ok=true、failures 0件
- lint_skills.ts: NG=0、Warning=0（Info 1件は japanese-tech-writing prefix の既存情報で本事例無関係）
- 上記 checker 実行は今回文書化した spawnSync + fs.writeFileSync UTF-8 明示の stdout 退避形式で実施し、status と stdout を分離取得した（退避先: TEMP、リダイレクト不使用）

## Findings / Capture候補

該当なし。

## SPEC確定候補

- agentdev-gh-cli SPEC（docs/specs/skills 配下）「Windows 環境固有手続き」の READ 手続き関連記述へ、exit code が意味を持つコマンドの spawnSync 経路（status/ stdout 分離取得 + UTF-8 明示退避）追記の候補。現在 SPEC は READ 手続き扱いを references/standard-procedures.md へ委任しており矛盾はないが必須ではない。case-close Step 3 の判断対象。