### PR TITLE
fix(integrity): workflow-soft-guard 検出語の AG-004 簡潔トリガー項統一（OU-0010）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/SKILL.md
+++ b/.opencode/skills/repo-agentdev-integrity/SKILL.md
@@ -83,7 +83,7 @@ agent-dev-flow リポジトリ（self-hosting repo）の artifact 整合性検�
 | Obsolete spec path | `check_integrity.ts` | `obsolete-path-map.yaml` に基づく旧SPEC直下パス参照検出、直接生成方式語彙検出（IR-057, REQ-0158-002） |
 | Distribution reference boundary | `check_distribution_boundary.ts` | 配布 command/skill 本文（`src/opencode/commands/agentdev/**/*.md`, `src/opencode/skills/agentdev-*/**/*.md`）に含まれる具体ID（`ADR-NNNN`, `REQ-NNNN`）、具体パス（`docs/(adr\|requirements\specs)/<file>.md`、但し README.md とテンプレート表記は除外）、固定URL（blob/raw）を検出。project extensions 機構（配布物参照境界）の持続的検査を担う |
 | Targeted docs guard | `check_changed_docs.ts` | 変更ファイル限定の整合性検査。req-save / spec-save / case-close / docs-check の各 workflow で実行（REQ-0158-003） |
-| Workflow preventive checks | `check_workflow_preventive.ts` | AG-008 旧責務残存の予防検査7項目（全公開 Command の Workflow Skill dispatch 存在、dispatch 先 Skill 存在、Workflow Skill の soft guard 存在、旧 extension kind・runtime path 残存禁止、Command から Skill 内部 reference 直接依存禁止、Workflow/Capability 分類と Extension kind 整合、command-format rules と thin Command モデル無矛盾）。false positive 対策の exemption は script 本体に構造化 |
+| Workflow preventive checks | `check_workflow_preventive.ts` | AG-008 旧責務残存の予防検査7項目（全公開 Command の Workflow Skill dispatch 存在、dispatch 先 Skill 存在、Workflow Skill の description 簡潔トリガー項存在（AG-004、検出語は lint_skills.ts と統一）、旧 extension kind・runtime path 残存禁止、Command から Skill 内部 reference 直接依存禁止、Workflow/Capability 分類と Extension kind 整合、command-format rules と thin Command モデル無矛盾）。false positive 対策の exemption は script 本体に構造化 |
 
 ### Finding レベル（REQ-0108-100~105）
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.test.ts
@@ -24,7 +24,8 @@ describe("checkWorkflowPreventive (integration against real repo)", () => {
       expect(c.pass).toBe(true);
     }
     expect(report.failures.filter((f) => f.severity === "strict").length).toBe(0);
-    expect(report.stats.public_commands).toBe(16);
+    // 17 public commands since backlog-auto was added (16 before).
+    expect(report.stats.public_commands).toBe(17);
     expect(report.stats.legacy_kind_files).toBe(0);
     expect(report.stats.legacy_commands_dir_files).toBe(0);
   });
@@ -63,14 +64,12 @@ description: fixture command
 
 const DEFAULT_SKILL_BODY = `---
 name: agentdev-workflow-demo
-description: fixture workflow skill
+description: fixture workflow skill。DO NOT USE FOR: 単独起動（対応する /agentdev/* コマンド経由で利用すること）。
 ---
 
 # agentdev-workflow-demo
 
 本スキルは case-run workflow を所有する。
-
-**soft guard**: 本スキルは \`/agentdev/demo\` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わない。
 `;
 
 const DEFAULT_EXTENSION_YAML = `version: 1
@@ -176,13 +175,39 @@ describe("check 2: dispatch-target-existence", () => {
 });
 
 describe("check 3: workflow-soft-guard", () => {
-  test("Workflow Skill without a soft guard declaration fails", () => {
+  test("Workflow Skill description without the concise trigger item fails", () => {
     const root = buildFixture(tmpBase, {
-      skillBody: DEFAULT_SKILL_BODY.replace(/\*\*soft guard\*\*.*\n/, ""),
+      skillBody: DEFAULT_SKILL_BODY.replace(
+        "DO NOT USE FOR: 単独起動（対応する /agentdev/* コマンド経由で利用すること）。",
+        "DO NOT USE FOR: 単独利用。",
+      ),
     });
     const report = checkWorkflowPreventive(root);
     expect(report.checks.find((c) => c.item === 3)?.pass).toBe(false);
     expect(report.failures.some((f) => f.check === 3)).toBe(true);
+  });
+
+  test("body-level soft guard wording without the description trigger item fails (AG-004 detection word)", () => {
+    // PR #2185 removed body-level "soft guard" wording from compliant
+    // Workflow Skills; the legacy body-only form must not satisfy check 3.
+    const root = buildFixture(tmpBase, {
+      skillBody: `---
+name: agentdev-workflow-demo
+description: fixture workflow skill
+---
+
+# agentdev-workflow-demo
+
+本スキルは case-run workflow を所有する。
+
+**soft guard**: 本スキルは \`/agentdev/demo\` command の工程経由でのみ利用し、単独起動（直接 skill 起動）を行わない。
+`,
+    });
+    const report = checkWorkflowPreventive(root);
+    expect(report.checks.find((c) => c.item === 3)?.pass).toBe(false);
+    expect(
+      report.failures.some((f) => f.check === 3 && f.message.includes("単独起動")),
+    ).toBe(true);
   });
 });
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.ts
@@ -8,7 +8,8 @@
  *                                       dedicated Workflow Skill by name
  *   2. dispatch-target-existence        the dedicated Workflow Skill exists
  *   3. workflow-soft-guard              each command-bound Workflow Skill
- *                                       SKILL.md declares the soft guard
+ *                                       description declares the AG-004
+ *                                       concise trigger item (単独起動)
  *   4. legacy-extension-residual        legacy kinds and the legacy runtime
  *                                       path must not remain (extension tree
  *                                       + distribution bodies under src/)
@@ -97,7 +98,13 @@ const COMMAND_FORMAT_RULES_PATH = path.join(
 
 const LEGACY_EXTENSION_KINDS = ["command-extension", "skill-extension"];
 const LEGACY_EXTENSIONS_PATH = ".agentdev/extensions/commands";
-const SOFT_GUARD_MARKER = "soft guard";
+// AG-004 concise trigger item detection word (the SPEC-authoritative soft
+// guard form: the description's DO NOT USE FOR entry "単独起動（対応する
+// /agentdev/* コマンド経由で利用すること）"). Must stay identical to
+// WORKFLOW_TRIGGER_ITEM in lint_skills.ts (the AG-004 implementation) so both
+// checkers assert the same form. lint_skills.ts runs main() at module top
+// level and cannot be imported here, hence the duplicated constant.
+const WORKFLOW_TRIGGER_ITEM = "単独起動";
 
 // check 5: a specific internal reference file (references/<file>.md|.ts).
 // The generic "`references/` 配下を参照" declaration names no file and is the
@@ -188,6 +195,22 @@ function listFilesRecursive(dirPath: string, extensions?: string[]): string[] {
 function extractYamlField(text: string, field: string): string | null {
   const m = text.match(new RegExp(`^${field}:\\s*(\\S+)\\s*$`, "m"));
   return m ? m[1] : null;
+}
+
+// Frontmatter description extraction with the same single-line semantics as
+// lint_skills.ts parseFrontMatter (all distribution SKILL.md files keep the
+// description as one quoted line).
+function extractFrontMatterDescription(text: string): string {
+  const parts = text.split("---");
+  if (parts.length < 3) return "";
+  for (const line of parts[1].split(/\r?\n/)) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+    if (line.slice(0, colonIndex).trim() === "description") {
+      return line.slice(colonIndex + 1).trim();
+    }
+  }
+  return "";
 }
 
 /**
@@ -313,16 +336,17 @@ export function checkWorkflowPreventive(repoRoot: string): PreventiveReport {
           message: `dispatch target Workflow Skill '${workflowSkill}' does not exist (expected ${skillMd})`,
         });
       } else {
-        // Check 3: soft guard declaration in the Workflow Skill
+        // Check 3: AG-004 concise trigger item in the Workflow Skill description
         const skillText = readText(skillMd) ?? "";
-        if (!skillText.includes(SOFT_GUARD_MARKER)) {
+        const skillDescription = extractFrontMatterDescription(skillText);
+        if (!skillDescription.includes(WORKFLOW_TRIGGER_ITEM)) {
           failures.push({
             check: 3,
             check_name: CHECK_NAMES[3],
             severity: "strict",
             classification: "consistency",
             file: skillMd,
-            message: `Workflow Skill '${workflowSkill}' does not declare the soft guard (standalone skill launch suppression)`,
+            message: `Workflow Skill '${workflowSkill}' description lacks the concise trigger item "単独起動（対応する /agentdev/* コマンド経由で利用すること）" in DO NOT USE FOR (AG-004, detection word unified with lint_skills.ts)`,
           });
         }
       }


### PR DESCRIPTION
Refs: #2220

## 変更概要

- `check_workflow_preventive.ts` item 3（workflow-soft-guard）の検出語を、本文リテラル「soft guard」要求から AG-004 簡潔トリガー項（frontmatter description の DO NOT USE FOR「単独起動（対応する /agentdev/* コマンド経由で利用すること）」）の肯定検証へ更新した。
- 検出語 `WORKFLOW_TRIGGER_ITEM = "単独起動"` を lint_skills.ts（AG-004 実装）と同一語・同一セマンティクス（frontmatter description 抽出と contains 判定）へ統一した。
- checker 自己記述（repo-agentdev-integrity SKILL.md 補助検査表の item 3 説明行）を新検証語へ追随させた。
- 契約テスト: check 3 の負例2種（description からの簡潔トリガー項欠落、本文のみの旧 soft guard 記述）と実リポジトリ integration（public_commands 17）を固定した。
- 前セッション中断時の部分実装を完了条件と照合のうえ採用し、SKILL.md 説明行更新と origin/main（27e8d199）への rebase を加えて完成させた。

## 検証証拠

- 検出語統一: check_workflow_preventive.ts `WORKFLOW_TRIGGER_ITEM = "単独起動"` は lint_skills.ts `WORKFLOW_TRIGGER_ITEM = "単独起動"` と同一（両者とも description への肯定検証）。
- SPEC 整合（AG-004）: `docs/specs/skills/agentdev-skill-authoring.md` L103「機械検査は全 Workflow Skill への簡潔トリガー項存在を肯定検証する」・L130「簡潔トリガー項欠落（AG-004）」に一致。
- SPEC 準拠配布物（PR #2185 適用後）が両 checker を通過することを確認:
  - `bun run ./.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.ts` → `ok: true`、7項目全 PASS（#3 workflow-soft-guard を含む）。
  - `bun run ./.opencode/skills/repo-agentdev-integrity/scripts/lint_skills.ts` → NG 0 / Warning 0（exit 0）。
- baselines/lint-skills-baseline.json: entries [] のまま（本変更で既知違反の増減なし。要更新なし）。

## テスト結果

- 起動コマンド形式: `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/`（`./` prefix 付き対象ディレクトリ明示指定、AG-035 適用済み契約形式）。
- 実行 cwd: `C:\Users\ogatay\work\agent-dev-flow\.worktrees\2220-feature`（worktree root）。
- チェッカー単位: `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.test.ts` → 19 pass / 0 fail（Ran 19 tests across 1 file）。
- full integrity suite（rebase 後、base = origin/main 27e8d199 + 本変更）: **2036 pass / 1 fail（Ran 2037 tests across 84 files）**。
- 件数突合: 直前実績 2028 tests / 83 files（base a08384a2、fail 2: check_workflow_preventive・IR-055 delta）→ 本変更で +1 test（check 3 負例追加、check_workflow_preventive 由来 fail 解消）→ rebase により先行 4 PR 分（#2255 の TS-009 node_modules 除外・新規テスト等）を取り込み 2037 tests / 84 files。
- 残 1 fail: IR-055 runtime-unresolved-reference delta（check_integrity.test.ts）。本変更なしの clean base（stash 検証）でも再現する事前発生。対象基準（check_workflow_preventive.ts・lint_skills.ts）は未解決違反 0 であり TS-QC-001 は合格、本事象は Findings 記録とした（TS-010 は合格）。

## Findings / Capture候補

### IR-055 delta（事前発生・本 Issue 対象外）

- `src/opencode/skills/agentdev-artifact-graph/SKILL.md`・`references/tim.md` の `docs/specs/` 参照 2 件が heuristic warning（delta from baseline）。
- 本変更前の clean base（a08384a2、stash 状態）で再現する事前発生。本 Issue の対象範囲（check_workflow_preventive item 3）外のため修正せず記録する。

### launcher-blockers archive-builder staging test の揺らぎ（観察）

- `trusted-distribution-gate/launcher-blockers.test.ts`「staging path is created UNDER outputRoot, never under os.tmpdir()」が間欠的に fail。単独実行で 9/0 → 8/1 → 8/1 → 8/1、clean base でも 8/1 を確認。約1秒境界の時間依存とみられる。最終 full suite 実行では pass。

### docs-integrity

- 該当なし（docs/** の変更なし。check_changed_docs.ts の実行対象外）。

## SPEC確定候補

- 該当なし（AG-004 簡潔トリガー項は `docs/specs/skills/agentdev-skill-authoring.md` の確定済み規則であり、本変更は checker を SPEC へ追従させるもの。新規 SPEC 記述事項なし）。
