### PR TITLE
fix(integrity): ir035 worktree 誤検出の src fallback と check_extensions cwd 非依存化 (#2214)

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.test.ts
@@ -38,7 +38,8 @@ describe("checkExtensions (integration against real repo)", () => {
   });
 
   test("classifies the real skill tree deterministically", () => {
-    const classification = deriveSkillClassification();
+    // REQ-018 cwd-independence: explicit repoRoot, independent of bun test's cwd.
+    const classification = deriveSkillClassification(REPO_ROOT);
     expect(classification.workflowSkills.has("agentdev-workflow-case-run")).toBe(true);
     expect(classification.workflowSkills.has("agentdev-workflow-orchestration")).toBe(false);
     expect(classification.capabilitySkills.has("agentdev-workflow-orchestration")).toBe(true);

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
@@ -392,14 +392,14 @@ function parseSimpleYaml(text: string): any {
 /**
  * Known project-local skill locations for check #10 existence confirmation.
  * Returns true if a directory matching the skill name exists in any known
- * skills location.
+ * skills location. Paths are resolved against repoRoot (cwd-independent).
  */
-function projectLocalSkillExists(skillName: string): boolean {
+function projectLocalSkillExists(skillName: string, repoRoot: string): boolean {
   // Distributed skills
-  const distPath = path.join(SKILLS_DIR, skillName);
+  const distPath = path.join(repoRoot, SKILLS_DIR, skillName);
   if (dirExists(distPath)) return true;
   // Repo-local skills
-  const repoLocalPath = path.join(REPO_LOCAL_SKILLS_DIR, skillName);
+  const repoLocalPath = path.join(repoRoot, REPO_LOCAL_SKILLS_DIR, skillName);
   if (dirExists(repoLocalPath)) return true;
   return false;
 }
@@ -414,10 +414,13 @@ export interface SkillClassification {
  * Workflow Skill  = agentdev-workflow-{X} where src/opencode/commands/agentdev/{X}.md exists.
  * Capability Skill = every other agentdev-* skill directory under src/opencode/skills
  * (including cross-cutting agentdev-workflow-* skills without a corresponding command).
+ * Paths are resolved against repoRoot when given, process.cwd() otherwise
+ * (cwd-independent: REQ-018 worktree test fallback).
  */
-export function deriveSkillClassification(): SkillClassification {
+export function deriveSkillClassification(repoRoot?: string): SkillClassification {
+  const root = repoRoot ?? process.cwd();
   const workflowSkills = new Set<string>();
-  const commandFiles = listMarkdownFiles(PUBLIC_COMMAND_DIR, false).filter(
+  const commandFiles = listMarkdownFiles(path.join(root, PUBLIC_COMMAND_DIR), false).filter(
     (f) => path.basename(f) !== "README.md",
   );
   for (const cf of commandFiles) {
@@ -425,8 +428,9 @@ export function deriveSkillClassification(): SkillClassification {
     workflowSkills.add(`agentdev-workflow-${base}`);
   }
   const capabilitySkills = new Set<string>();
-  if (dirExists(SKILLS_DIR)) {
-    const dirs = fs.readdirSync(SKILLS_DIR, { withFileTypes: true }) as any[];
+  const skillsAbs = path.join(root, SKILLS_DIR);
+  if (dirExists(skillsAbs)) {
+    const dirs = fs.readdirSync(skillsAbs, { withFileTypes: true }) as any[];
     for (const d of dirs) {
       if (!d.isDirectory() || !d.name.startsWith("agentdev-")) continue;
       if (!workflowSkills.has(d.name)) capabilitySkills.add(d.name);
@@ -583,10 +587,13 @@ function walkExtension(parsed: any, rawText: string, rcFile: string): ExtensionW
 
 export function checkExtensions(repoRoot: string): CheckReport {
   const failures: CheckFailure[] = [];
-  const origCwd = process.cwd();
-  process.chdir(repoRoot);
-  try {
-    const classification = deriveSkillClassification();
+  // cwd-independent (REQ-018): resolve every scan target against repoRoot.
+  // No process.chdir() mutation — immune to (and no source of) order-dependent
+  // cwd pollution in the shared test process.
+  const toRepoRel = (p: string): string => path.relative(repoRoot, p).replace(/\\/g, "/");
+  const extensionsSkillsAbs = path.join(repoRoot, EXTENSIONS_SKILLS_DIR);
+  {
+    const classification = deriveSkillClassification(repoRoot);
     const stats = {
       workflow_extensions: 0,
       internal_workflow_extensions: 0,
@@ -604,7 +611,7 @@ export function checkExtensions(repoRoot: string): CheckReport {
     };
 
     // Check #7: .agentdev/extensions/commands/** residual (classification: migration-required)
-    const commandsDirFiles = listFilesRecursive(EXTENSIONS_COMMANDS_DIR);
+    const commandsDirFiles = listFilesRecursive(path.join(repoRoot, EXTENSIONS_COMMANDS_DIR));
     stats.commands_dir_files = commandsDirFiles.length;
     if (commandsDirFiles.length > 0) {
       failures.push({
@@ -617,11 +624,10 @@ export function checkExtensions(repoRoot: string): CheckReport {
       });
     }
 
-    const extFiles = listYamlFilesRecursive(EXTENSIONS_SKILLS_DIR);
-
     // Checks 1, 2-6, 9-11, 13: per-extension validation
-    for (const rc of extFiles) {
-      const rcText = readText(rc) ?? "";
+    for (const rcAbs of listYamlFilesRecursive(extensionsSkillsAbs)) {
+      const rc = toRepoRel(rcAbs);
+      const rcText = readText(rcAbs) ?? "";
       const resolution = resolveExtensionState(rcText);
 
       if (resolution.state === "malformed") {
@@ -670,7 +676,7 @@ export function checkExtensions(repoRoot: string): CheckReport {
       else if (kind === "internal-workflow-extension") stats.internal_workflow_extensions++;
       else stats.capability_extensions++;
 
-      const relPath = path.relative(EXTENSIONS_SKILLS_DIR, rc).replace(/\\/g, "/");
+      const relPath = path.relative(extensionsSkillsAbs, rcAbs).replace(/\\/g, "/");
       const segments = relPath.split("/");
 
       // Check #2: kind-path consistency
@@ -715,7 +721,7 @@ export function checkExtensions(repoRoot: string): CheckReport {
             message: `internal-workflow-extension 'id' (${id || "<missing>"}) must match the parent directory Workflow Skill name (${parent})`,
           });
         }
-        if (id && !projectLocalSkillExists(id)) {
+        if (id && !projectLocalSkillExists(id, repoRoot)) {
           failures.push({
             check: 3,
             check_name: "id-target-consistency",
@@ -736,7 +742,7 @@ export function checkExtensions(repoRoot: string): CheckReport {
             message: `extension 'id' (${id || "<missing>"}) must match the target skill name derived from the filename (${fileBase})`,
           });
         }
-        if (id && !projectLocalSkillExists(id)) {
+        if (id && !projectLocalSkillExists(id, repoRoot)) {
           failures.push({
             check: 3,
             check_name: "id-target-consistency",
@@ -794,7 +800,8 @@ export function checkExtensions(repoRoot: string): CheckReport {
 
       // Check #9: context.paths existence
       for (const p of walk.pathsReferenced) {
-        if (!fileExists(p) && !dirExists(p)) {
+        const pAbs = path.resolve(repoRoot, p);
+        if (!fileExists(pAbs) && !dirExists(pAbs)) {
           failures.push({
             check: 9,
             check_name: "context-paths-existence",
@@ -808,7 +815,7 @@ export function checkExtensions(repoRoot: string): CheckReport {
 
       // Check #10: rules.skill / checks.skill project-local skill existence (warning)
       for (const skillName of walk.skillsReferenced) {
-        if (!projectLocalSkillExists(skillName)) {
+        if (!projectLocalSkillExists(skillName, repoRoot)) {
           failures.push({
             check: 10,
             check_name: "delegated-skill-existence",
@@ -822,8 +829,9 @@ export function checkExtensions(repoRoot: string): CheckReport {
     }
 
     // Check #12: legacy .agentdev/doc-inputs/** residual detection (warning)
-    if (dirExists(LEGACY_DOC_INPUTS_DIR)) {
-      const legacyFiles = listFilesRecursive(LEGACY_DOC_INPUTS_DIR);
+    const docInputsAbs = path.join(repoRoot, LEGACY_DOC_INPUTS_DIR);
+    if (dirExists(docInputsAbs)) {
+      const legacyFiles = listFilesRecursive(docInputsAbs);
       stats.doc_inputs_residual_files = legacyFiles.length;
       if (legacyFiles.length > 0) {
         failures.push({
@@ -849,13 +857,14 @@ export function checkExtensions(repoRoot: string): CheckReport {
     ).length;
 
     // Stats: public commands/skills counts (informational)
-    const commandFiles = listMarkdownFiles(PUBLIC_COMMAND_DIR, false).filter((f) => {
+    const commandFiles = listMarkdownFiles(path.join(repoRoot, PUBLIC_COMMAND_DIR), false).filter((f) => {
       const base = path.basename(f);
       return base !== "README.md";
     });
     stats.public_commands = commandFiles.length;
-    if (dirExists(SKILLS_DIR)) {
-      const skillDirs = (fs.readdirSync(SKILLS_DIR, { withFileTypes: true }) as any[])
+    const publicSkillsAbs = path.join(repoRoot, SKILLS_DIR);
+    if (dirExists(publicSkillsAbs)) {
+      const skillDirs = (fs.readdirSync(publicSkillsAbs, { withFileTypes: true }) as any[])
         .filter((d) => d.isDirectory() && d.name.startsWith("agentdev-"));
       stats.public_skills = skillDirs.length;
     }
@@ -900,8 +909,6 @@ export function checkExtensions(repoRoot: string): CheckReport {
       failures,
       stats,
     };
-  } finally {
-    process.chdir(origCwd);
   }
 }
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -8856,7 +8856,9 @@ function checkSkillSeeAlsoReference(skillsDir: string, root: string): CheckResul
     while ((m = seeAlsoPattern.exec(seeAlsoSection)) !== null) {
       const refName = m[1];
       if (!refName.startsWith("agentdev-")) continue;
-      const refDir = path.join(skillsDir, refName);
+      // REQ-018: worktree（junction 未伝播）環境の誤検出防止。原本 src/opencode/skills/ への
+      // fallback 存在判定（v2:REQ-0108-189 と同一規則）。
+      const refDir = resolvePathWithFallback(path.join(skillsDir, refName));
       if (!fs.existsSync(refDir)) {
         results.push(
           warn(


### PR DESCRIPTION
## 変更概要

Issue #2214（OU-0007: worktree・実行形態環境差の検査失敗の帰属確認手順の明文化と環境依存失敗の是正、Epic #2213 EU-C Wave 1）の実装。中断された前ドライバーの部分作業を全て維持し、main (27e8d199) を取り込んで検証を完了した。

- **check_integrity.ts（ir035）**: checkSkillSeeAlsoReference の See Also 参照先存在判定を resolvePathWithFallback 経由に変更。worktree（junction 未伝播）環境で実在スキルへの正常参照を誤検出しない（v2:REQ-0108-189 と同一規則、REQ-018）
- **check_extensions.ts**: process.chdir を廃止し全 scan target を repoRoot 基準で解決（cwd 非依存化）。フルスイート実行時の順序依存汚染の発生源・被災側の両方を除去。projectLocalSkillExists / deriveSkillClassification に repoRoot 引数を追加（未指定時は従来どおり process.cwd）
- **check_extensions.test.ts**: 実 repo 分類テストで deriveSkillClassification(REPO_ROOT) を明示し bun test の起動 cwd に依存しない

## 検証証拠

- **SPEC 明文化の確認（完了条件1）**: docs/specs/skills/agentdev-git-worktree-test-fallback.md に帰属確認二段階手順（単体再実行→base/main 再現）と main 等価再現手順（一時 junction / src 側代替経路 --profile source / bun install --cwd）の明文化を確認（ACT-SPEC-005 で spec-save 適用済み。本 PR での SPEC 変更なし）
- **ir035 誤検出解消の実証（完了条件2）**: worktree で .opencode/skills/agentdev-{req-file-manager, decision-file-manager, gh-cli, workflow-templates} が runtime 側不存在・src 側存在（repo-agentdev-integrity SKILL.md の See Also 参照4件が旧ロジックでは誤検出条件）。修正後は worktree・main とも check_integrity CLI で ir035 warning 0件。merge 後 worktree: NG=0 / Warning=15（main と完全一致）
- **checkExtensions テスト（完了条件3・worktree 対応）**: worktree 個別実行 10 pass / 0 fail。フルスイート内も合格。scan 対象は src/opencode/skills・.agentdev/extensions/skills・src/opencode/commands/agentdev（実ディレクトリ）で worktree 環境の junction 欠落の影響を受けない構成
- **両環境フルスイート（完了条件4）**: 下記テスト結果参照。2 fail はいずれも pre-existing（main でも同一 fail を再現、帰属確認手順の base/main 再現で恒常性確認済み）

## テスト結果

| 実行環境 | cwd | コマンド | 結果 |
|---|---|---|---|
| worktree（merge 後 31be68cd） | C:\\Users\\ogatay\\work\\agent-dev-flow\\.worktrees\\2214-feature | bun test ./.opencode/skills/repo-agentdev-integrity/scripts/ | Ran 2036 tests across 84 files / 2034 pass / 2 fail（pre-existing） |
| worktree（merge 前 5d89b9df+本変更） | 同上 | 同上 | Ran 2028 tests across 83 files / 2026 pass / 2 fail（直前実績 2028/83・2026 pass/2 fail と完全一致） |
| main（27e8d199） | C:\\Users\\ogatay\\work\\agent-dev-flow | 同上 | Ran 2040 tests across 84 files / 2038 pass / 2 fail（同一 pre-existing 2件） |

- 起動コマンド形式: AG-035 契約どおり ./ prefix 付き対象ディレクトリ明示指定
- 2036 vs 2040 の 4件差: skills_structure.test.ts の REQ-018-001 worktree fallback により scan 対象が projection（main: .opencode/skills）↔ source（worktree: src/opencode/skills）で切り替わるため。両ツリーの構成差（projection のみ: repo-agentdev-integrity / source のみ: agentdev-workflow-backlog-auto・main 側で junction 未張成）により生成テスト数が 462↔466 に変動。仕様通りの fallback 挙動でコード差ではない
- 環境整備: 前ドライバーが導入した scripts/node_modules（untracked・bun install 成果物）存在下では launcher-blockers（archive-builder）テストがフルスイート時のみ順序依存失敗したため、main と同一条件（未導入）で検証した。node_modules は commit 対象外
- 型検証: 本リポジトリに tsconfig を持たない bun 直実行構成のため、フルスイート実行（変更ファイルの全テスト合格）を検証手段とする

## Findings / Capture候補

1. **checkWorkflowPreventive integration fail（pre-existing）**: workflow-soft-guard で16 Workflow Skill が standalone skill launch suppression 宣言を持たない旨の strict failure。main でも同一 fail（本 PR 起因ではない）。src 側スキル本文のコンテンツ問題で本 Issue 対象外
2. **IR-055 runtime-unresolved-reference delta（pre-existing・#2210 対象）**: agentdev-artifact-graph SKILL.md / references/tim.md 由来の baseline 超過分。main でも同一 fail
3. **launcher-blockers archive-builder の順序依存（環境起因・capture 候補）**: scripts/node_modules（untracked な bun install 成果物）が存在する worktree のフルスイート時のみ失敗。単体再実行では合格、node_modules 除去（main 等価環境）でも合格。SPEC 帰属確認二段階手順に基づき環境起因と判定。untracked 成果物がテスト列挙・実行順序に影響し得ることの learning 候補
4. **テスト数 drift の件数突合阻害（capture 候補）**: skills_structure の REQ-018-001 fallback は仕様どおりだが、projection/source の構成差（junction 未張成の agentdev-workflow-backlog-auto を含む）が main↔worktree の Ran N tests 突合を4件ずらす。AG-035 の件数突合運用時に環境差として考慮が必要

## SPEC確定候補

- 該当なし（SPEC docs/specs/skills/agentdev-git-worktree-test-fallback.md は ACT-SPEC-005 で適用済みであり、本 PR での追記事項は発生していない）

Refs: #2214