### PR TITLE
fix(integrity): IR-055 プレースホルダ免除をトークン近傍へ狭域化（OU-0015、Refs: #2210）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/baselines/ir-055-baseline.json
+++ b/.opencode/skills/repo-agentdev-integrity/baselines/ir-055-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "rule_id": "IR-055",
-  "generated_at": "2026-08-15",
+  "generated_at": "2026-08-18",
   "entries": [
     {
       "file": "src/opencode/commands/agentdev/README.md",
@@ -13,13 +13,13 @@
       "file": "src/opencode/commands/agentdev/inspect-docs.md",
       "pattern": "docs/guides/",
       "severity": "heuristic",
-      "count": 2
+      "count": 1
     },
     {
       "file": "src/opencode/commands/agentdev/inspect-docs.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 6
+      "count": 5
     },
     {
       "file": "src/opencode/commands/agentdev/inspect-skills.md",
@@ -40,18 +40,6 @@
       "count": 6
     },
     {
-      "file": "src/opencode/skills/agentdev-adversarial-review/SKILL.md",
-      "pattern": "docs/specs/",
-      "severity": "heuristic",
-      "count": 2
-    },
-    {
-      "file": "src/opencode/skills/agentdev-adversarial-review/references/adversarial-review-protocol.md",
-      "pattern": "docs/specs/",
-      "severity": "heuristic",
-      "count": 1
-    },
-    {
       "file": "src/opencode/skills/agentdev-artifact-graph/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
@@ -61,6 +49,18 @@
       "file": "src/opencode/skills/agentdev-artifact-graph/SKILL.md",
       "pattern": "repo-*",
       "severity": "strict",
+      "count": 1
+    },
+    {
+      "file": "src/opencode/skills/agentdev-artifact-graph/SKILL.md",
+      "pattern": "src/opencode/",
+      "severity": "strict",
+      "count": 1
+    },
+    {
+      "file": "src/opencode/skills/agentdev-artifact-graph/references/augmentation.md",
+      "pattern": "docs/specs/",
+      "severity": "heuristic",
       "count": 1
     },
     {
@@ -79,13 +79,13 @@
       "file": "src/opencode/skills/agentdev-backlog-integration/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 1
+      "count": 3
     },
     {
       "file": "src/opencode/skills/agentdev-command-authoring/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 1
+      "count": 3
     },
     {
       "file": "src/opencode/skills/agentdev-command-authoring/SKILL.md",
@@ -100,16 +100,22 @@
       "count": 3
     },
     {
+      "file": "src/opencode/skills/agentdev-doc-diagnostics/SKILL.md",
+      "pattern": "docs/specs/",
+      "severity": "heuristic",
+      "count": 2
+    },
+    {
       "file": "src/opencode/skills/agentdev-doc-writing/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 1
+      "count": 3
     },
     {
       "file": "src/opencode/skills/agentdev-doc-writing/SKILL.md",
       "pattern": "src/opencode/",
       "severity": "strict",
-      "count": 1
+      "count": 2
     },
     {
       "file": "src/opencode/skills/agentdev-doc-writing/references/document-boundaries.md",
@@ -127,7 +133,7 @@
       "file": "src/opencode/skills/agentdev-doc-writing/references/document-boundaries.md",
       "pattern": "src/opencode/",
       "severity": "strict",
-      "count": 2
+      "count": 4
     },
     {
       "file": "src/opencode/skills/agentdev-doc-writing/references/japanese-replacement-dictionary.md",
@@ -139,7 +145,7 @@
       "file": "src/opencode/skills/agentdev-epic-tracker/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 1
+      "count": 3
     },
     {
       "file": "src/opencode/skills/agentdev-git-worktree/references/worktree-operations.md",
@@ -157,13 +163,13 @@
       "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 2
+      "count": 4
     },
     {
       "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
       "pattern": "src/opencode/",
       "severity": "strict",
-      "count": 6
+      "count": 7
     },
     {
       "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
@@ -193,7 +199,7 @@
       "file": "src/opencode/skills/agentdev-learning-capture/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 1
+      "count": 3
     },
     {
       "file": "src/opencode/skills/agentdev-learning-pipeline/references/disposition-and-artifact-schema.md",
@@ -205,7 +211,7 @@
       "file": "src/opencode/skills/agentdev-quality-gates/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 1
+      "count": 3
     },
     {
       "file": "src/opencode/skills/agentdev-quality-gates/references/qg-4-final-acceptance.md",
@@ -217,7 +223,7 @@
       "file": "src/opencode/skills/agentdev-req-analysis/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 1
+      "count": 3
     },
     {
       "file": "src/opencode/skills/agentdev-req-analysis/references/analysis-viewpoints.md",
@@ -253,7 +259,7 @@
       "file": "src/opencode/skills/agentdev-req-file-manager/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 1
+      "count": 3
     },
     {
       "file": "src/opencode/skills/agentdev-req-file-manager/SKILL.md",
@@ -277,7 +283,7 @@
       "file": "src/opencode/skills/agentdev-req-structure-diagnostics/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 1
+      "count": 3
     },
     {
       "file": "src/opencode/skills/agentdev-req-structure-diagnostics/references/req-structure-review.md",
@@ -301,11 +307,23 @@
       "file": "src/opencode/skills/agentdev-skill-authoring/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 1
+      "count": 3
     },
     {
       "file": "src/opencode/skills/agentdev-skill-authoring/references/review-protocol.md",
       "pattern": "src/opencode/",
+      "severity": "strict",
+      "count": 1
+    },
+    {
+      "file": "src/opencode/skills/agentdev-workflow-case-close/SKILL.md",
+      "pattern": "repo-*",
+      "severity": "strict",
+      "count": 1
+    },
+    {
+      "file": "src/opencode/skills/agentdev-workflow-case-run/SKILL.md",
+      "pattern": "repo-*",
       "severity": "strict",
       "count": 1
     },
@@ -325,7 +343,7 @@
       "file": "src/opencode/skills/agentdev-workflow-orchestration/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 1
+      "count": 3
     },
     {
       "file": "src/opencode/skills/agentdev-workflow-orchestration/SKILL.md",
@@ -367,7 +385,7 @@
       "file": "src/opencode/skills/agentdev-workflow-spec-save/SKILL.md",
       "pattern": "docs/specs/",
       "severity": "heuristic",
-      "count": 6
+      "count": 7
     },
     {
       "file": "src/opencode/skills/agentdev-workflow-spec-save/references/placement-and-save.md",

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -1601,7 +1601,7 @@ describe("IR-053 gh-direct-invocation (REQ-0152-001/002)", () => {
 //   - strict pattern detection (REQ-NNNN, REQ-NNNN-NNN, ADR-NNNN, src/opencode/, /repo/, repo-*)
 //   - heuristic pattern detection (docs/specs/, docs/guides/, GitHub URL, line-number ref)
 //   - code-block exemption
-//   - template placeholder exemption
+//   - template placeholder exemption (token-neighborhood narrowing, CR-002)
 //   - exemption paths (vocabulary-registry.md, integrity-rule-catalog.md)
 //   - baseline-known vs new classification (REQ-0108-145)
 //   - report fields (file, line, evidence, expected, route)
@@ -1758,6 +1758,27 @@ function buildIr055Fixture(root: string): void {
       "# Placeholder command",
       "",
       "Replace REQ-{NNNN} with the actual requirement ID.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // CR-002 token-neighborhood narrowing: placeholder exemption is scoped to
+  // the placeholder-bearing token, not the whole line.
+  writeFileSync(
+    join(cmdDir, "placeholder-narrow-cmd.md"),
+    [
+      "---",
+      "description: placeholder narrowing command",
+      "agent: test-agent",
+      "---",
+      "",
+      "# Placeholder narrowing command",
+      "",
+      "Replace REQ-{NNNN}; see REQ-4321 for the concrete case.",
+      "Templated path docs/specs/<skills/agentdev-artifact-graph>.md stays exempt.",
+      "Brace-set glob docs/specs/{commands,skills}/** stays exempt.",
+      "Bare glob `docs/specs/**` next to `docs/specs/{a,b}/**` stays checked.",
       "",
     ].join("\n"),
     "utf-8",
@@ -2000,6 +2021,44 @@ describe("IR-055 runtime-unresolved-reference (REQ-0108-263/264)", () => {
         (res.file ?? "").includes("placeholder-cmd.md"),
     );
     expect(placeholderHits.length).toBe(0);
+  });
+
+  it("reports concrete references on placeholder-bearing lines (CR-002 narrowing)", () => {
+    const r = runScript(IR055_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hits = parsed.results.filter(
+      (res: { check: string; evidence?: string; file?: string }) =>
+        res.check === "runtime-unresolved-reference" &&
+        res.evidence === "REQ-4321" &&
+        (res.file ?? "").includes("placeholder-narrow-cmd.md"),
+    );
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("exempts placeholder-bearing path tokens (<...> and brace-set globs)", () => {
+    const r = runScript(IR055_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hits = parsed.results.filter(
+      (res: { check: string; evidence?: string; file?: string; line?: number }) =>
+        res.check === "runtime-unresolved-reference" &&
+        (res.file ?? "").includes("placeholder-narrow-cmd.md") &&
+        res.evidence === "docs/specs/" &&
+        (res.line === 9 || res.line === 10),
+    );
+    expect(hits.length).toBe(0);
+  });
+
+  it("keeps bare-glob references next to placeholder globs checked (CR-002 narrowing)", () => {
+    const r = runScript(IR055_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const hits = parsed.results.filter(
+      (res: { check: string; evidence?: string; file?: string; line?: number }) =>
+        res.check === "runtime-unresolved-reference" &&
+        (res.file ?? "").includes("placeholder-narrow-cmd.md") &&
+        res.evidence === "docs/specs/" &&
+        res.line === 11,
+    );
+    expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
   it("exempts vocabulary-registry.md (legitimate pattern documentation)", () => {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -7127,16 +7127,34 @@ function isIr055ExemptPath(relPath: string): boolean {
   return IR055_EXEMPT_PATH_PATTERNS.some((re) => re.test(relPath));
 }
 
-function isIr055ExemptLine(line: string): boolean {
-  // Template placeholder exemption: lines carrying {NNN} style placeholders where
-  // the match is a parameter rather than a concrete reference.
-  if (/\{[^}]*\}/.test(line)) {
-    // Only exempt when the placeholder is adjacent to the pattern kind; cheap
-    // heuristic: if the line contains any "{...}" we skip it to avoid noisy FPs
-    // on templated example text.
-    return true;
-  }
-  return false;
+// Token characters for path/identifier expressions: ASCII word chars plus
+// path punctuation, backticks, placeholder braces/angle brackets, brace-set
+// glob separators (","), and anchor/line-number signs. Token expansion stops
+// at whitespace and CJK characters adjacent to the token (same policy as
+// PATH_SEGMENT above).
+const IR055_TOKEN_CHAR = /[\w`{}<>.\/#:,-]/;
+
+/**
+ * IR-055 token-neighborhood placeholder exemption (CR-002 狭域化,
+ * integrity-rule-catalog.md "IR-055 template placeholder exemption
+ * （トークン近傍狭域化）"). A match is exempt only when the placeholder
+ * notation ({xxx} / <xxx>, incl. brace-set globs like {a,b}) sits in the
+ * same path/identifier token as the match. Concrete references elsewhere on
+ * a placeholder-bearing line remain reported. Placeholder notation follows
+ * the isTemplatePlaceholder convention ({...} plus <...> angle-bracket
+ * parameters, v2:REQ-0144-020).
+ */
+function isIr055PlaceholderAdjacentMatch(
+  line: string,
+  matchIndex: number,
+  matchLength: number,
+): boolean {
+  let start = matchIndex;
+  let end = matchIndex + matchLength;
+  while (start > 0 && IR055_TOKEN_CHAR.test(line[start - 1])) start--;
+  while (end < line.length && IR055_TOKEN_CHAR.test(line[end])) end++;
+  const token = line.slice(start, end);
+  return /\{[^}]*\}/.test(token) || /<[^<>]+>/.test(token);
 }
 
 interface Ir055RawViolation {
@@ -7171,7 +7189,6 @@ function collectIr055Violations(root: string): Ir055RawViolation[] {
     for (let i = 0; i < lines.length; i++) {
       if (isInsideCodeBlock(lines, i)) continue;
       const line = lines[i];
-      if (isIr055ExemptLine(line)) continue;
 
       const scanList: ReadonlyArray<{ name: string; pattern: RegExp; severity: "strict" | "heuristic" }> = [
         ...IR055_STRICT_PATTERNS.map((p) => ({ ...p, severity: "strict" as const })),
@@ -7188,6 +7205,13 @@ function collectIr055Violations(root: string): Ir055RawViolation[] {
             name === "ADR-NNNN" &&
             match.index >= 3 &&
             line.slice(match.index - 3, match.index) === "v2:"
+          ) {
+            continue;
+          }
+          // CR-002 狭域化: exempt only matches inside a placeholder-bearing
+          // token; concrete references elsewhere on the line stay reported.
+          if (
+            isIr055PlaceholderAdjacentMatch(line, match.index, match[0].length)
           ) {
             continue;
           }


### PR DESCRIPTION
Parent Epic: #2205（Epic EU-B Wave 2）
Refs: #2210

## 背景

OU-0015（source: RU-0060）。IR-055（runtime-unresolved-reference 検出）の template placeholder exemption は従来「`{...}` を含む行全体を実在確認対象外とする行単位免除」だった。行単位免除はプレースホルダ表記の残置を構造的に助長するため、CR-002 として「プレースホルダと同一トークン近傍」への狭域化が決定された。カタログ記載（docs/specs/integrity/integrity-rule-catalog.md「IR-055 template placeholder exemption（トークン近傍狭域化）」節、L241-249）は ACT-SPEC-013 として spec-save 済みのため本 PR は確認のみ行い、checker 実装の狭域化準拠更新を本体とする。

本 Issue は現行 full suite の pre-existing fail（IR-055 delta 2 件）の是正対象である。

## 変更内容

### checker 実装の狭域化準拠更新（.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts）

- `isIr055ExemptLine`（行単位免除: 行内に `{...}` があれば行全体を免除）を削除
- `isIr055PlaceholderAdjacentMatch`（トークン近傍免除）を新設:
  - マッチを含むパス・識別子トークン（ASCII word + パス句読点 + backtick + brace/angle bracket + brace-set glob 区切り。CJK 隣接で停止、PATH_SEGMENT と同一方針）を抽出し、トークン内にプレースホルダ表記がある場合のみ免除
  - プレースホルダを含む行の他の具体参照（プレースホルダを含まないパス・ID）は実在確認対象を維持
  - プレースホルダ表記の解釈は isTemplatePlaceholder 規約（`{...}` + `<...>`、v2:REQ-0144-020）に準拠

### 契約テスト追加（check_integrity.test.ts）

- プレースホルダ行の具体参照（REQ-4321）が検出されること（exempt 対象の縮小）
- プレースホルダトークン（`docs/specs/<...>.md`、`docs/specs/{commands,skills}/**`）が免除されること
- プレースホルダ隣接の bare glob（`docs/specs/**`）が検出維持されること

### baseline 再生成（baselines/ir-055-baseline.json）

- 狭域化により顕在化した delta（strict 6 件・heuristic 26 件）を baseline-known 化（66 entries / 147 violations、generated_at 2026-08-18）。triage_action（新規検出時は baseline に追加）に従う
- 既存 delta 2 件（agentdev-artifact-graph/SKILL.md:268・references/tim.md:5 の `docs/specs/<...>.md` パス参照）はトークン近傍免除により解消

## 検証結果（L2）

実行環境: Windows、worktree .worktrees/2210-feature（base 175a2047）、bun 1.3.10。起動コマンドと cwd を下表に記録する。

| コマンド | cwd | 結果・証拠 |
|---|---|---|
| `bun install` | scripts/ | 5 packages installed |
| `bun test ./check_integrity.test.ts` | scripts/ | 89 pass / 0 fail（修正前は IR-055 実修復回帰 1 fail、解消を確認） |
| `bun test ./`（full suite） | scripts/ | 2037 pass / 2 fail（2 fail は下記 pre-existing、IR-055 起因 fail なし） |
| `bun run ./.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts --json` | worktree root | IR-055 new violations (delta): 0 / baseline-known info: 147 |
| `bun run ./.opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref 175a2047` | worktree root | failures: 0 / exit 0 |
| `bun run ./.opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary_cli.ts --profile source` | worktree root | exit 0 |
| `bun run typecheck`（tsconfig.distribution-boundary.json） | scripts/ | exit 0 |

- TS-015: カタログ IR-055 記載がトークン近傍狭域化 + delta 顕在化挙動の注記（PR #2185/#2187 事例）を含むことを確認。checker の狭域化準拠更新と backticks 検出の挙動確認（契約テスト3件・実 repo 実行 delta 0）を実施
- TS-QC-001: 対象 document（integrity-rule-catalog.md）は本 case で無編集（ACT-SPEC-013 適用済み分の確認のみ）。新規の品質違反なし
- TS-QC-002: full suite 通過確認（pre-existing 2 fail を除く）と backticks 検出の挙動確認を実施
- full suite 残 2 fail は本変更と無関係の pre-existing: checkWorkflowPreventive（タスクコンテキストでスコープ外宣言）、checkExtensions real skill tree 分類（pristine main 175a2047 チェックアウトでも再現することを確認済みの環境依存既知事象。PR #2187 の commit message にも main 既知事象として記録）

## Findings / Capture候補

- 狭域化により顕在化し baseline-known 化した 33 件（`docs/specs/**` bare glob 参照等を含む）は、OU-0016（配布物プレースホルダ表記整理、本 Issue の checker 更新完了後に検出実施の前提）で段階解消される想定である
- check_integrity.ts は tsconfig.distribution-boundary.json の typecheck 対象外であり、既存 type error 3 件（L5448 JunctionIntegrity category、L7601 NgBaselineEntry missing fields、L8691 CliOptions unresolved）が存在する。本変更 hunk 外であり影響なし。typecheck 対象拡張の検討候補
- checkExtensions「classifies the real skill tree deterministically」が pristine main でも失敗する。タスクコンテキストの baseline 表記（2 fail: IR-055 delta + checkWorkflowPreventive）と現在環境の実測（checkWorkflowPreventive + checkExtensions）の乖離について要観測

## SPEC確定候補

- トークン近傍免除におけるプレースホルダ表記は、カタログ同節の例示（`REQ-{NNNN}`）を一般化し `{...}` に加え `<...>` 角括弧表記（isTemplatePlaceholder 規約、v2:REQ-0144-020 と整合）および brace-set glob（`{a,b}`）を含む実装とした。プレースホルダ表記の定義明記が SPEC 確定候補
