### PR TITLE
fix(integrity): AUTOGEN 計測日を実行時日付から最終コミット日付基準へ変更（OU-0013、Refs: #2211）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.ts
@@ -45,7 +45,8 @@ import {
   generateReqMetricsTable,
   generateSpecMetricsTable,
   generateReadmeReqSummaryCount,
-  formatMeasureDate,
+  deriveReqMetricsMeasureDate,
+  deriveSpecMetricsMeasureDate,
   CATALOG_PRE_BLOCK_ID,
   CATALOG_POST_BLOCK_ID,
   RULE_OWNERSHIP_BLOCK_ID,
@@ -389,21 +390,44 @@ function buildBlockTargets(root: string): BlockTarget[] {
 
   // DOC-MAP（docmap-inventory）検査は docs/DOC-MAP.md 廃止（DEC-009、REQ-013）に伴い除去。
 
-  // REQ / SPEC health-metrics（各1ブロック）。計測日は実行日のローカル日付（generate_indexes.ts と同一）。
-  const measureDate = formatMeasureDate(new Date());
+  // REQ / SPEC health-metrics（各1ブロック）。計測日は対象ドキュメント群の最終コミット日付（SC-002「計測日導出」）。
   if (fs.existsSync(reqDir)) {
     const reqMetrics = collectReqMetrics(reqDir);
+    const reqMeasureDate = deriveReqMetricsMeasureDate(
+      root,
+      reqDir,
+      reqMetrics,
+    );
+    if (reqMeasureDate === null) {
+      console.error(
+        `[check_autogen_freshness] measure date derivation failed for docs/requirements/REQ-*.md ` +
+          `(no commit history or git failure)`,
+      );
+      process.exit(EXIT_ERROR);
+    }
     targets.push({
       file: reqHealthMetricsPath,
       blockId: REQ_METRICS_BLOCK_ID,
-      expected: generateReqMetricsTable(reqMetrics, measureDate),
+      expected: generateReqMetricsTable(reqMetrics, reqMeasureDate),
     });
   }
   const specMetrics = collectSpecMetrics(specsDir);
+  const specMeasureDate = deriveSpecMetricsMeasureDate(
+    root,
+    specsDir,
+    specMetrics,
+  );
+  if (specMeasureDate === null) {
+    console.error(
+      `[check_autogen_freshness] measure date derivation failed for docs/specs/**/*.md ` +
+        `(no commit history or git failure)`,
+    );
+    process.exit(EXIT_ERROR);
+  }
   targets.push({
     file: specHealthMetricsPath,
     blockId: SPEC_METRICS_BLOCK_ID,
-    expected: generateSpecMetricsTable(specMetrics, measureDate),
+    expected: generateSpecMetricsTable(specMetrics, specMeasureDate),
   });
 
   // docs/README.md（1ブロック）。REQ ファイル群が存在しない場合は計測不能のため対象外。

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -59,7 +59,8 @@ import {
   collectSpecMetrics,
   generateReqMetricsTable,
   generateSpecMetricsTable,
-  formatMeasureDate,
+  deriveReqMetricsMeasureDate,
+  deriveSpecMetricsMeasureDate,
   README_REQ_SUMMARY_COUNT_BLOCK_ID,
   generateReadmeReqSummaryCount,
 } from "./generate_indexes.ts";
@@ -8412,8 +8413,20 @@ function checkIndexGenerationConsistency(root: string): CheckResult[] {
   const reqHealthMetricsPath = path.join(qualityDir, "req-health-metrics.md");
   const reqHealthMetricsContent = readText(reqHealthMetricsPath);
   if (reqHealthMetricsContent !== null && fs.existsSync(reqDir)) {
-    const measureDate = formatMeasureDate(new Date());
     const reqMetrics = collectReqMetrics(reqDir);
+    const measureDate = deriveReqMetricsMeasureDate(root, reqDir, reqMetrics);
+    if (measureDate === null) {
+      foundViolation = true;
+      results.push(
+        ng(
+          "IndexGenerationConsistency",
+          "index-generation-consistency",
+          `req-metrics measure date derivation failed (no commit history for docs/requirements/REQ-*.md or git failure). ` +
+            `Run: bun run .opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts (IR-061, SC-002)`,
+        ),
+      );
+      return results;
+    }
     const reqMetricsSpecs: AutogenBlockSpec[] = [
       {
         blockId: REQ_METRICS_BLOCK_ID,
@@ -8436,8 +8449,24 @@ function checkIndexGenerationConsistency(root: string): CheckResult[] {
   const specHealthMetricsPath = path.join(qualityDir, "spec-health-metrics.md");
   const specHealthMetricsContent = readText(specHealthMetricsPath);
   if (specHealthMetricsContent !== null) {
-    const measureDate = formatMeasureDate(new Date());
     const specMetrics = collectSpecMetrics(specsDir);
+    const measureDate = deriveSpecMetricsMeasureDate(
+      root,
+      specsDir,
+      specMetrics,
+    );
+    if (measureDate === null) {
+      foundViolation = true;
+      results.push(
+        ng(
+          "IndexGenerationConsistency",
+          "index-generation-consistency",
+          `spec-metrics measure date derivation failed (no commit history for docs/specs/**/*.md or git failure). ` +
+            `Run: bun run .opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts (IR-061, SC-002)`,
+        ),
+      );
+      return results;
+    }
     const specMetricsSpecs: AutogenBlockSpec[] = [
       {
         blockId: SPEC_METRICS_BLOCK_ID,

--- a/.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.test.ts
@@ -12,7 +12,11 @@
  * were misrecognized as real markers, causing generate_indexes.ts to stop.
  * This test locks the root-cause fix (whole-line matching).
  */
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, afterAll } from "bun:test";
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import {
   isAutogenBeginLine,
   isAutogenEndLine,
@@ -20,7 +24,11 @@ import {
   findAutogenBlocks,
   replaceAutogenBlock,
   countSpecBodyLines,
+  deriveMeasureDateFromLastCommit,
+  deriveReqMetricsMeasureDate,
+  deriveSpecMetricsMeasureDate,
 } from "./generate_indexes.ts";
+import { findRepoRoot } from "./cli_utils.ts";
 
 describe("isAutogenBeginLine", () => {
   it("returns true for a canonical marker line", () => {
@@ -266,4 +274,162 @@ describe("countSpecBodyLines", () => {
     const count = countSpecBodyLines(content);
     expect(count).toBe(8);
   });
+});
+
+// ─── 計測日導出（SC-002「計測日導出」、Issue #2211）───────────────────────
+// 対象ドキュメント群の最終コミット日付導出（実行時日付非依存）とメトリクス
+// ファイル自体の導出対象除外を固定する回帰テスト（IR-061 日次再検出の解消）。
+
+const TMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "genidx-measure-date-"));
+
+function commitAllWithDate(root: string, message: string, date: string): void {
+  execSync("git add -A", { cwd: root });
+  execSync(`git commit -q -m "${message}" --no-verify`, {
+    cwd: root,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: date,
+      GIT_COMMITTER_DATE: date,
+      GIT_AUTHOR_NAME: "test",
+      GIT_AUTHOR_EMAIL: "t@t",
+      GIT_COMMITTER_NAME: "test",
+      GIT_COMMITTER_EMAIL: "t@t",
+    },
+  });
+}
+
+describe("deriveMeasureDateFromLastCommit", () => {
+  it("returns YYYY-MM-DD for a tracked file with commit history", () => {
+    const root = findRepoRoot(import.meta.dir);
+    const date = deriveMeasureDateFromLastCommit(root, [
+      path.join(root, "docs", "README.md"),
+    ]);
+    expect(date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("returns a stable value across repeated calls", () => {
+    const root = findRepoRoot(import.meta.dir);
+    const p = path.join(root, "docs", "README.md");
+    expect(deriveMeasureDateFromLastCommit(root, [p])).toBe(
+      deriveMeasureDateFromLastCommit(root, [p]),
+    );
+  });
+
+  it("returns null for paths without commit history", () => {
+    const root = findRepoRoot(import.meta.dir);
+    expect(
+      deriveMeasureDateFromLastCommit(root, [
+        path.join(root, "docs", "__no_such_file__.md"),
+      ]),
+    ).toBe(null);
+  });
+
+  it("returns null for an empty path list", () => {
+    const root = findRepoRoot(import.meta.dir);
+    expect(deriveMeasureDateFromLastCommit(root, [])).toBe(null);
+  });
+});
+
+describe("deriveReq/SpecMetricsMeasureDate", () => {
+  const root = path.join(TMP_ROOT, "repo");
+  if (!fs.existsSync(root)) {
+    fs.mkdirSync(path.join(root, "docs", "requirements"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(root, "docs", "specs", "quality"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(root, "docs", "specs", "integrity"), {
+      recursive: true,
+    });
+    execSync("git init -q -b main", { cwd: root });
+    execSync('git config user.email "t@t"', { cwd: root });
+    execSync('git config user.name "t"', { cwd: root });
+
+    fs.writeFileSync(
+      path.join(root, "docs", "specs", "integrity", "index-auto-generation.md"),
+      "# spec A\n",
+    );
+    commitAllWithDate(root, "add spec A", "2026-01-01T12:00:00+09:00");
+    fs.writeFileSync(
+      path.join(root, "docs", "specs", "quality", "spec-health-metrics.md"),
+      "# metrics\n",
+    );
+    commitAllWithDate(
+      root,
+      "add spec-health-metrics",
+      "2026-02-02T12:00:00+09:00",
+    );
+    fs.writeFileSync(
+      path.join(root, "docs", "requirements", "REQ-001.md"),
+      "# req\n",
+    );
+    commitAllWithDate(root, "add REQ-001", "2026-03-03T12:00:00+09:00");
+  }
+
+  it("derives req measure date from the REQ file group last commit", () => {
+    expect(
+      deriveReqMetricsMeasureDate(
+        root,
+        path.join(root, "docs", "requirements"),
+        [{ id: "REQ-001", num: 1, lineCount: 1, signal: "+0", note: "" }],
+      ),
+    ).toBe("2026-03-03");
+  });
+
+  it("excludes metrics files themselves from spec measure date derivation", () => {
+    const metrics = [
+      {
+        relPath: "quality/req-health-metrics.md",
+        lineCount: 1,
+        status: "accepted",
+        domain: "quality",
+      },
+      {
+        relPath: "quality/spec-health-metrics.md",
+        lineCount: 1,
+        status: "accepted",
+        domain: "quality",
+      },
+      {
+        relPath: "integrity/index-auto-generation.md",
+        lineCount: 1,
+        status: "accepted",
+        domain: "integrity",
+      },
+    ];
+    // 除外なしの群最大値は spec-health-metrics.md の 2026-02-02 だが、メトリクスファイル自体は導出対象外。
+    expect(
+      deriveSpecMetricsMeasureDate(root, path.join(root, "docs", "specs"), metrics),
+    ).toBe("2026-01-01");
+  });
+
+  it("takes the max last-commit date of the non-excluded group", () => {
+    fs.writeFileSync(
+      path.join(root, "docs", "specs", "integrity", "other.md"),
+      "# spec B\n",
+    );
+    commitAllWithDate(root, "add spec B", "2026-04-04T12:00:00+09:00");
+    const metrics = [
+      {
+        relPath: "quality/spec-health-metrics.md",
+        lineCount: 1,
+        status: "accepted",
+        domain: "quality",
+      },
+      {
+        relPath: "integrity/other.md",
+        lineCount: 1,
+        status: "accepted",
+        domain: "integrity",
+      },
+    ];
+    expect(
+      deriveSpecMetricsMeasureDate(root, path.join(root, "docs", "specs"), metrics),
+    ).toBe("2026-04-04");
+  });
+});
+
+afterAll(() => {
+  fs.rmSync(TMP_ROOT, { recursive: true, force: true });
 });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts
@@ -1255,14 +1255,94 @@ export function generateSpecMetricsTable(
 }
 
 /**
- * 現在日付を YYYY-MM-DD 形式（ローカル時刻）で返す。
- * スクリプト実行環境のタイムゾーンに依存する（docs-check 実行環境と同一）。
+ * SPEC メトリクス計測日導出の対象外 relPath（specsDir 相対）。
+ *
+ * 計測例 AUTOGEN ブロックを持つメトリクスファイル自体を導出対象から除外する。
+ * 自身の AUTOGEN 更新コミットが SPEC 群の最終コミット日付を押し上げ、再生成と
+ * 検出が連鎖する自己増幅を防ぐ（「SPEC 行数計測の AUTOGEN ブロック除外」と同種の
+ * 計測器独立性原則）。
  */
-export function formatMeasureDate(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
+export const SPEC_METRICS_MEASURE_DATE_EXCLUDED: ReadonlySet<string> =
+  new Set([
+    "quality/req-health-metrics.md",
+    "quality/spec-health-metrics.md",
+  ]);
+
+/**
+ * 対象ドキュメント群の最終コミット日付（YYYY-MM-DD）を導出する（SC-002「計測日導出」）。
+ *
+ * `git log -1 --format=%cI -- <paths...>` で対象群のいずれかに触った最終コミット
+ * （= 各ファイル最終コミット日付の最大値）を取得し、その ISO 8601 日付部
+ * （コミットタイムゾーン基準）を返す。実行環境のタイムゾーンや実行時日付
+ * （`new Date()`）に依存しないため、ドキュメント群に実変更がない限り計測日を含む
+ * AUTOGEN ブロックは鮮度を失わない（IR-061 日次再検出の構造的解消）。
+ *
+ * 導出不能時（git コマンド失敗、対象パスへのコミット実績なし）は null を返す。
+ * 呼び出し元は null を検知した場合に生成・検査を失敗扱いとする。
+ */
+export function deriveMeasureDateFromLastCommit(
+  root: string,
+  absPaths: string[],
+): string | null {
+  if (absPaths.length === 0) return null;
+  const { execFileSync } = require("child_process") as typeof import("child_process");
+  const relPaths = absPaths.map((p) =>
+    path.relative(root, p).replace(/\\/g, "/"),
+  );
+  // パスを分割実行して Windows コマンドライン長制限を回避する。パスは OR 条件の
+  // ため、チャンクごとの最大値（ISO 日付の辞書順比較）の全体最大が群の最終コミット日付。
+  const CHUNK_SIZE = 100;
+  let latest: string | null = null;
+  for (let i = 0; i < relPaths.length; i += CHUNK_SIZE) {
+    const chunk = relPaths.slice(i, i + CHUNK_SIZE);
+    let out: string;
+    try {
+      out = execFileSync(
+        "git",
+        ["log", "-1", "--format=%cI", "--", ...chunk],
+        { cwd: root, encoding: "utf-8" },
+      ) as string;
+    } catch {
+      return null;
+    }
+    const match = out.trim().match(/^(\d{4}-\d{2}-\d{2})T/);
+    if (!match) continue;
+    if (latest === null || match[1] > latest) latest = match[1];
+  }
+  return latest;
+}
+
+/**
+ * req-metrics 計測日を導出する。対象は REQ メトリクスの計測対象ファイル群
+ * （docs/requirements/REQ-*.md、retired は含まない）と同一とする。
+ */
+export function deriveReqMetricsMeasureDate(
+  root: string,
+  reqDir: string,
+  metrics: ReqMetricInfo[],
+): string | null {
+  return deriveMeasureDateFromLastCommit(
+    root,
+    metrics.map((m) => path.join(reqDir, `${m.id}.md`)),
+  );
+}
+
+/**
+ * spec-metrics 計測日を導出する。対象は SPEC メトリクスの計測対象ファイル群から
+ * 計測例 AUTOGEN ブロックを持つメトリクスファイル自体
+ * （SPEC_METRICS_MEASURE_DATE_EXCLUDED）を除外した群とする。
+ */
+export function deriveSpecMetricsMeasureDate(
+  root: string,
+  specsDir: string,
+  metrics: SpecMetricInfo[],
+): string | null {
+  return deriveMeasureDateFromLastCommit(
+    root,
+    metrics
+      .filter((m) => !SPEC_METRICS_MEASURE_DATE_EXCLUDED.has(m.relPath))
+      .map((m) => path.join(specsDir, m.relPath)),
+  );
 }
 
 // ─── main ──────────────────────────────────────────────────────────────────
@@ -1415,11 +1495,33 @@ RELATED:
   const reqActiveTable = generateReqActiveTable(reqInfos);
   const reqRetiredTable = generateReqRetiredTable(reqRetiredInfos);
 
-  const measureDate = formatMeasureDate(new Date());
   const reqMetrics = collectReqMetrics(reqDir);
   const specMetrics = collectSpecMetrics(specsDir);
-  const reqMetricsTable = generateReqMetricsTable(reqMetrics, measureDate);
-  const specMetricsTable = generateSpecMetricsTable(specMetrics, measureDate);
+  const reqMeasureDate = deriveReqMetricsMeasureDate(root, reqDir, reqMetrics);
+  if (reqMeasureDate === null) {
+    console.error(
+      `[generate_indexes] measure date derivation failed for docs/requirements/REQ-*.md ` +
+        `(no commit history or git failure)`,
+    );
+    process.exit(EXIT_ERROR);
+  }
+  const specMeasureDate = deriveSpecMetricsMeasureDate(
+    root,
+    specsDir,
+    specMetrics,
+  );
+  if (specMeasureDate === null) {
+    console.error(
+      `[generate_indexes] measure date derivation failed for docs/specs/**/*.md ` +
+        `(no commit history or git failure)`,
+    );
+    process.exit(EXIT_ERROR);
+  }
+  const reqMetricsTable = generateReqMetricsTable(reqMetrics, reqMeasureDate);
+  const specMetricsTable = generateSpecMetricsTable(
+    specMetrics,
+    specMeasureDate,
+  );
 
   const readmeReqSummary = generateReadmeReqSummaryCount({
     activeReqCount: reqInfos.length,
@@ -1716,10 +1818,10 @@ RELATED:
       `[generate_indexes] REQ README: ${reqInfos.length} active, ${reqRetiredInfos.length} retired`,
     );
     console.log(
-      `[generate_indexes] req-health-metrics: ${reqMetrics.length} REQs (measure date ${measureDate})`,
+      `[generate_indexes] req-health-metrics: ${reqMetrics.length} REQs (measure date ${reqMeasureDate})`,
     );
     console.log(
-      `[generate_indexes] spec-health-metrics: ${specMetrics.length} SPECs (measure date ${measureDate})`,
+      `[generate_indexes] spec-health-metrics: ${specMetrics.length} SPECs (measure date ${specMeasureDate})`,
     );
     console.log(
       `[generate_indexes] docs/README.md: REQ summary active=${reqInfos.length} retired=${reqRetiredInfos.length}`,


### PR DESCRIPTION
## 背景

Issue #2211（OU-0013: 計測日導出の安定化（AUTOGEN 鮮度の構造的再発解消）、Epic #2205 EU-B W2、REQ-010）の実装 PR。

AUTOGEN 計測ブロック（`req-metrics-measurement-example` / `spec-metrics-measurement-example`）の計測日が実行時日付（`new Date()`）で導出されていたため、コミット済み AUTOGEN ブロックが日次で鮮度を失い、IR-061 が日次的に構造再検出する運用になっていた。ACT-SPEC-010/011（spec-save 適用済み）で確定した「計測日導出＝対象ドキュメント群の最終コミット日付基準」への実装修正が本 PR の対象。

前ドライバーが worktree で実装 commit（ba23ef30）まで完了していたが、infra 障害により PR 作成前に中断した。本 PR は同 commit をそのまま引き継ぎ、検証を完了した（既存 commit の改変なし・追加差分なし）。

## 変更内容

commit ba23ef30（4ファイル、+342/-21。すべて `.opencode/skills/repo-agentdev-integrity/scripts/` 配下、src/opencode 配下の変更なし）:

- **generate_indexes.ts**: `deriveMeasureDateFromLastCommit`（`git log -1 --format=%cI` の ISO 8601 日付部をコミットタイムゾーン基準で抽出、実行環境・実行時日付に非依存、Windows コマンドライン長制限回避のチャンク分割）と `deriveReq/SpecMetricsMeasureDate` を追加。計測日を実行時日付から対象ドキュメント群の最終コミット日付の最大値へ変更。導出不能時（git 失敗・コミット実績なし）は生成を失敗扱い（fail-closed）。`formatMeasureDate` は使用箇所消滅に伴い削除
- **check_integrity.ts / check_autogen_freshness.ts**: 検査側も生成側と同一の導出関数を共有（生成・検査の期待値一致）。導出失敗時は IR-061 NG / gate エラー扱い
- **自己増幅防止**: spec-metrics の導出対象から計測例 AUTOGEN ブロックを持つメトリクスファイル自体（`quality/req-health-metrics.md`、`quality/spec-health-metrics.md`）を除外（`SPEC_METRICS_MEASURE_DATE_EXCLUDED`）。自己の AUTOGEN 更新コミットが計測日を押し上げる連鎖を「SPEC 行数計測の AUTOGEN ブロック除外」と同種の計測器独立性原則で防止
- **generate_indexes.test.ts**: 導出関数の回帰テスト7件追加（固定日付コミットによる実行時日付非依存の検証、メトリクスファイル除外規則、群最大値計算、null ケース）

## 検証結果（L2・コマンドと証拠）

worktree: `.worktrees/2211-feature`（branch: `feature/issue-2211`、commit: ba23ef30）。

### 完了条件1: 計測日導出方式変更（最終コミット日付基準）の実装

- SPEC 2件の確定確認: `docs/specs/integrity/index-auto-generation.md`「計測日導出」節（対象ドキュメント群の最終コミット日付の最大値を用いる、実行時日付不使用、IR-061 日次陳腐化検出の解消を明記）と `docs/specs/integrity/autogen-freshness-gate.md`（計測日導出方式は index-auto-generation SPEC に従い最終コミット日付基準、日次再検出解消を gate 契約として明記）。ACT-SPEC-010/011 適用済み、本 PR での SPEC 変更なし
- 実装: 上記変更内容のとおり。生成（generate_indexes.ts）と検査（check_integrity.ts、check_autogen_freshness.ts）が同一導出関数を共有

### 完了条件2・TS-013: 計測日を含む AUTOGEN ブロックが日次で陳腐化せず IR-061 構造的再検出が解消

- `bun run ./.opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts --dry-run` → **WOULD UPDATE 0件**（出力なし）。導出された計測日は req/spec-metrics とも `2026-08-18`（対象文書群の最終コミット日付）に対し実行日は 2026-08-19。旧実装（実行時日付）であれば計測日 `2026-08-19` が導出され WOULD UPDATE が発生するはずが、差分ゼロ = 実行時日付非依存を本日実行で実証
- `bun run ./.opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.ts` → 検査索引ファイル数 7、**検出鮮度違反 0 件**「すべての AUTOGEN ブロックは鮮度が保たれています（再生成不要）」
- `bun run ./.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts --json` → summary **ok=240 / ng=0** / warning=15 / info=128。**IR-061 = ok「索引類自動生成整合性: All AUTOGEN blocks consistent」**

### TS-QC-001: SPEC 2件の文書品質

- 対象 SPEC は本 PR で変更なし（ACT-SPEC-010/011 適用済み分の確認のみ）。「計測日導出」節と gate 契約の記述が実装と整合することを確認

### TS-QC-002: full integrity suite 通過と AUTOGEN 再生成の整合

テスト結果表参照。full suite 2041 pass / 2 fail（2 fail は baseline の pre-existing 2 fail と一致）。AUTOGEN 再生成の整合は dry-run WOULD UPDATE 0件で確認。

## テスト結果

| 対象 | cwd | コマンド | 結果 |
|---|---|---|---|
| generate_indexes.test.ts | `.opencode/skills/repo-agentdev-integrity/scripts` | `bun test ./generate_indexes.test.ts` | 34 pass / 0 fail |
| check_autogen_freshness.test.ts | 同上 | `bun test ./check_autogen_freshness.test.ts` | 23 pass / 0 fail |
| check_integrity.test.ts | 同上 | `bun test ./check_integrity.test.ts` | 85 pass / 1 fail（pre-existing IR-055 delta） |
| full suite | 同上 | `bun test ./` | Ran 2043 tests / 84 files / 2041 pass / 2 fail（pre-existing） |

- 起動コマンド形式: AG-035 契約どおり ./ prefix 明示で対象を指定
- 2 fail は full suite baseline の pre-existing 2 fail と一致（IR-055 runtime-unresolved-reference delta = PR#2265 で解消予定、checkWorkflowPreventive = スコープ外）。いずれも src/opencode 配下を検査対象とする項目であり、本 PR は src/opencode 配下無変更（`git diff main...HEAD --name-only` で `.opencode/skills/repo-agentdev-integrity/scripts/` 4ファイルのみ）のため本変更起因ではない
- check_distribution_boundary.ts --profile source: 本 PR は src/opencode 配下の変更がないため対象外（同 diff で確認）
- 型検証: 本リポジトリは tsconfig を持たない bun 直実行構成のため、変更ファイルの全テスト合格を検証手段とする
- 環境整備: `bun install` を scripts 配下で実施（node_modules は untracked・commit 対象外）

## Findings / Capture候補

### intake

該当なし

### learning

該当なし

（pre-existing 2 fail の帰属は上記テスト結果に記録のとおり。本変更に起因する新規の本筋外検出事項なし）

## SPEC確定候補

該当なし（計測日導出の契約は index-auto-generation / autogen-freshness-gate SPEC に ACT-SPEC-010/011 で確定済み。実装は SPEC に従っており、新規に記載すべき SPEC レベル詳細なし）

## 関連Issue

Refs: #2211
