### PR TITLE
docs(agentdev): AG SPEC 旧見出し「利用上の防護」参照を「ワークフロー利用」へ追従更新（OU-0004、Refs: #2232）

### DIFF
--- a/docs/specs/commands/backlog-review.md
+++ b/docs/specs/commands/backlog-review.md
@@ -68,7 +68,7 @@ backlog-review は入力成果物に含まれる REQ, Decision, SPEC, canonical 
 
 Graph は候補提供者であり、統合, 分割, depends_on, 意味的重複の最終判断は正規成果物本文と独立探索手段での確認後に下す。
 promoted artifact 自体を Graph の正規 node とすることは必須でない。
-共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「利用上の防護」を参照。
+共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「ワークフロー利用」を参照。
 
 Graph 不在、stale、consumer 環境に対応 node type または relation type が存在しない場合は、従来の探索経路で継続し、workflow を停止しない（fail-open）。
 

--- a/docs/specs/commands/case-close.md
+++ b/docs/specs/commands/case-close.md
@@ -152,7 +152,7 @@ Graph defect と canonical defect を区別する。
 
 Graph 自体の生成または問い合わせ失敗のみを理由に case-close を失敗させず、fail-open して従来の検証経路で継続する。
 正規成果物側の実不整合が確認された場合は既存の品質ゲート, 受け入れ条件に従って fail とする。
-共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「利用上の防護」を参照。
+共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「ワークフロー利用」を参照。
 
 ## 参照する横断 SPEC
 

--- a/docs/specs/commands/case-open.md
+++ b/docs/specs/commands/case-open.md
@@ -211,7 +211,7 @@ Graph 候補は正規成果物または独立した探索手段で確認した�
 
 必須品質能力の導出は `artifact-quality-control-routing` SPEC が定める artifact type から品質能力キーへの変換に従い、Graph の delegates_to, governs 関係から必須 skill を直接決定しない。
 Graph は変更成果物候補と関連規則候補の探索のみを担当する。
-共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「利用上の防護」を参照。
+共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「ワークフロー利用」を参照。
 
 Graph 不在、stale、consumer 環境に対応 node type または relation type が存在しない場合は、従来の探索経路で継続し、workflow を停止しない（fail-open）。
 

--- a/docs/specs/commands/req-define.md
+++ b/docs/specs/commands/req-define.md
@@ -458,7 +458,7 @@ auto_gate:
 
 req-define は既存 REQ、関連 Decision と SPEC、canonical owner、構造的所有者重複、downstream 変更影響候補の探索に Artifact Graph を利用できる。
 Graph は候補提供者であり、CREATE, APPEND, UPDATE, SPLIT, MERGE, 意味的重複, canonical owner の最終判断は正規成果物本文と独立探索手段（`glob`, `grep`, `rg` 等）での確認後に下す。
-共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「利用上の防護」を参照。
+共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「ワークフロー利用」を参照。
 
 Graph 不在、stale、consumer 環境に対応 node type または relation type が存在しない場合は、従来の探索経路で継続し、workflow を停止しない（fail-open）。
 

--- a/docs/specs/commands/spec-save.md
+++ b/docs/specs/commands/spec-save.md
@@ -231,7 +231,7 @@ target_area 見出し検索は `agentdev-spec-file-manager/scripts/src/search-ta
 
 spec-save は対応 REQ、同一または関連 canonical owner を持つ SPEC、関連 command, skill, integrity rule の探索に Artifact Graph を利用できる。
 Graph は候補提供者であり、target_area, 正規配置先, SPEC 操作分類の最終判断は正規成果物本文と独立探索手段での確認後に下す。
-共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「利用上の防護」を参照。
+共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「ワークフロー利用」を参照。
 
 Graph 不在、stale、consumer 環境に対応 node type または relation type が存在しない場合は、従来の探索経路で継続し、workflow を停止しない（fail-open）。
 

--- a/docs/specs/skills/agentdev-adversarial-review.md
+++ b/docs/specs/skills/agentdev-adversarial-review.md
@@ -259,7 +259,7 @@ agentdev-adversarial-review は Artifact Graph をレビュー対象候補, evid
 
 Graph から得た情報は未検証 evidence として扱い、Reviewer または Reviewee の対論, 正規成果物確認を経ずに finding を確定しない。
 Graph はレビュー結論の確定ではなく evidence 探索に利用する。
-共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「利用上の防護」を参照。
+共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「ワークフロー利用」を参照。
 
 Graph 不在、stale、consumer 環境に対応 node type または relation type が存在しない場合は、従来のレビュー経路で継続し、review を停止しない（fail-open）。
 


### PR DESCRIPTION
Refs: #2232
Parent: #2231

## 背景

OU-0004（source: RU-0049、Epic #2231 EU-D1 W1、REQ-002: 配布成果物の責務境界・参照正規化）。AG SPEC（docs/specs/skills/agentdev-artifact-graph.md）の見出しは e73ba8e5（RU-0001 前工程の spec-save）で「利用上の防護」から「ワークフロー利用」へ改称された。src 側（src/opencode/）は PR #2197 で修正済みだが、docs 側6 SPEC が旧見出し「利用上の防護」を参照したまま残存していた。

## 変更内容

docs/specs/commands/ 配下5ファイルと docs/specs/skills/agentdev-adversarial-review.md の計6ファイルで、AG SPEC 参照の見出し名のみを置換した（参照形式・文脈は維持、各ファイル1行）。

| ファイル | 行 |
|---|---|
| docs/specs/commands/req-define.md | L461 |
| docs/specs/commands/spec-save.md | L234 |
| docs/specs/commands/case-open.md | L214 |
| docs/specs/commands/case-close.md | L155 |
| docs/specs/commands/backlog-review.md | L71 |
| docs/specs/skills/agentdev-adversarial-review.md | L262 |

置換: 「共通利用原則の防護事項は `agentdev-artifact-graph` SPEC「利用上の防護」を参照。」→「…SPEC「ワークフロー利用」を参照。」

- 参照先検証: 現行見出し `## ワークフロー利用` は docs/specs/skills/agentdev-artifact-graph.md L334 に存在し、防護原則（候補提供・最終判断としない・fail-open）は同セクション内 L347-352 にある
- 対象外: src/opencode/ 側（PR #2197 で修正済み）、AG SPEC 本文の内容確定（OU-0001、Epic A）
- scope-affecting impact candidate（docs/specs/skills/agentdev-artifact-graph.md）は確認のみ実施、変更不要と判断

## 検証結果（L2・コマンドと証拠）

### TS-004: PASS

- 検証: 対象6 SPEC ファイルで旧見出し「利用上の防護」参照を grep（encoding-safe な Grep ツール出力で確認）
- 結果: 6ファイルとも旧見出し参照 0件。docs/specs 全体でも旧見出し「参照」は 0件（唯一の残存は docs/specs/local/artifact-graph.md L172 の superseded なローカル版 SPEC 自身の見出しであり参照ではない、スコープ外）
- 新参照「SPEC「ワークフロー利用」」が6ファイルすべてに出現することを確認

### TS-QC-001: PASS

- doc-writing の機械判定観点で本差分を査読: 中黒追加 0件、em-dash 追加 0件、LLM 空句 0件、Concrete ID（REQ-/DEC-/SPEC- 番号）追加 0件、backticks 識別子（`agentdev-artifact-graph`）維持、一文一行維持
- 参照解決: 参照先見出しが実在することを上記のとおり確認

### check_changed_docs.ts（docs 変更 gate）: PASS

- コマンド: `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref 8649c006`（cwd: .opencode/skills/repo-agentdev-integrity/scripts、コミット後の committed range）
- 結果: files checked 6 / coupled files checked 2（docs/README.md、docs/specs/README.md）/ failures 0 / warnings 0 / EXIT=0
- spec_readme_update_required=false、doc_map_update_required=false（docs/specs 行数変更なしのため generate_indexes 対象外）

### full suite（bun test）: 2047 pass / 1 fail / 2048 tests

- コマンド: `bun test ./`（cwd: .opencode/skills/repo-agentdev-integrity/scripts、AG-035 準拠の ./ prefix 明示）
- fail 1件は pre-existing: IR-055 runtime-unresolved-reference 実修復回帰（Issue #1782）の baseline delta テスト（PR #2265 で解消予定）
- 切り分け証拠: 本変更6ファイルを git stash で退避した clean base 状態でも `bun test ./check_integrity.test.ts`（同一 cwd）で同一 fail を再現（85 pass / 1 fail）。本 PR 由来の新規 fail なし
- src/opencode/ 配下は変更なしのため check_distribution_boundary.ts --profile source は本 PR 対象外

## Findings / Capture候補

- docs/specs/local/artifact-graph.md L172 に旧見出し「### 利用上の防護」が見出しとして残存する（status: superseded、後継 skills/agentdev-artifact-graph.md への移行表示あり）。参照ではないため本 Issue の完了条件（旧見出し参照 0件）には影響しない。superseded SPEC 本文の見出し追従は Epic A（OU-0001）側での扱い判断候補
- baseline 整合: 作業コンテキスト告知の baseline「2026 pass / 2 pre-existing fail」に対し、本 worktree（base 8649c006 = PR #2263 merge 直後）では 2047 pass / 1 fail（IR-055 のみ。junction 起因の checkExtensions fail は本実行では非再現）。総数差は base 以降のテスト追加に由来する可能性があり、起票時 baseline との乖離として記録する

## SPEC確定候補

- なし（見出し参照の追従のみ。SPEC レベルの新規契約・判定表・schema の発見なし）