### PR TITLE
docs(agentdev): project-extensions の DO NOT USE FOR へ extension 自体の作成・編集の除外項を反映（OU-0029、Refs: #2236）

### DIFF
--- a/src/opencode/skills/agentdev-project-extensions/SKILL.md
+++ b/src/opencode/skills/agentdev-project-extensions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentdev-project-extensions
-description: Resolves project-specific extensions (.agentdev/extensions/skills/**) for Workflow Skills and Capability Skills at runtime. USE FOR: extension discovery, load-time state classification (missing / malformed / migration-required / unknown), reading extension context/rules/checks, extracting project-local skill delegation targets. DO NOT USE FOR: defining extension schema, modifying distribution command/skill bodies, implementing project-local skills, migrating legacy extensions.
+description: Resolves project-specific extensions (.agentdev/extensions/skills/**) for Workflow Skills and Capability Skills at runtime. USE FOR: extension discovery, load-time state classification (missing / malformed / migration-required / unknown), reading extension context/rules/checks, extracting project-local skill delegation targets. DO NOT USE FOR: defining extension schema, modifying distribution command/skill bodies, implementing project-local skills, creating or editing extensions themselves, migrating legacy extensions.
 ---
 
 # Project Extensions


### PR DESCRIPTION
## 背景

Issue #2236（OU-0029、Epic #2231 EU-D1 W1、Parent: #2231、source: RU-0074、operation: update、docs_chore・軽微修正）。

agentdev-project-extensions の description（SKILL.md frontmatter）側 DO NOT USE FOR へ「extension 自体の作成・編集（プロジェクト側の責務）」除外項を反映する。
本文側 DO NOT USE FOR セクションは OU-003（PR #2186、commit f26bd757）で削除済みであり、削除前の本文5項目のうち description 側へ反映されたのは3項目（extension schema の定義 / 配布 command/skill 本文の変更 / project-local skill の実装）のみだった。
「extension 自体の作成、編集（プロジェクト側の責務）」は反映から漏れ、当該除外項がスキル契約上どこにも存在しない状態になっていた（「extension 構造の診断、検査」の未反映は本 Issue の対象外、Findings 参照）。

## 変更内容

- `src/opencode/skills/agentdev-project-extensions/SKILL.md`（1行変更）
  - description の DO NOT USE FOR へ `creating or editing extensions themselves` を追加
  - 配置は `implementing project-local skills` の直後（削除前本文 DO NOT USE FOR の項目順序「project-local skill の実装 → extension 自体の作成、編集」と同一）
  - 表現は agentdev-skill-authoring の description 記述基準（AG-004 簡潔トリガー項との整合）に従い、既存項目と同型の動名詞・カンマ区切り・括弧注記なし
- 変更後の DO NOT USE FOR は5項目（トリガー数 3〜7 の適正範囲内）、description 全体は524文字（単体600上限・OpenCode 仕様1024上限のいずれも下回る）

## 検証結果

L2（コマンドと証拠）:

| 検証 | コマンド（cwd） | 結果 |
|---|---|---|
| TS-029 内容確認 | PowerShell で frontmatter description を解析（worktree root） | DO NOT USE FOR 5項目中に `creating or editing extensions themselves` の存在を確認。USE FOR 4項目。description 524文字 |
| skill 構造 lint（AG-005 規則群） | `bun ./lint_skills.ts --root <worktree root>`（cwd: `.opencode/skills/repo-agentdev-integrity/scripts`） | agentdev-project-extensions は全カテゴリ OK。NG 1件は `agentdev-git-worktree/references/worktree-operations.md` の300行超過のみ（事前存在、Findings 参照） |
| 配布境界検査 | `bun ./check_distribution_boundary.ts --profile source <worktree root>`（cwd: 同上） | ok: true、scanned_files 329、concrete_id_hits 0、concrete_path_hits 0、fixed_url_hits 0、failures 0、rules findings 0 |
| workflow preventive | `bun ./check_workflow_preventive.ts <worktree root>`（cwd: 同上） | 7項目全 PASS（#3 workflow-soft-guard で AG-004 検出語整合を含む）、failures 0 |
| bun test（validator 自己検証） | `bun test ./lint_skills.test.ts ./check_workflow_preventive.test.ts`（cwd: `.opencode/skills/repo-agentdev-integrity/scripts`） | 45 pass / 0 fail（45 tests、150 expect() calls） |

TS-029: pass_criteria を満たす（description 側 DO NOT USE FOR に当該除外項が存在すること、authoring 規則 AG-004 簡潔トリガー項との整合が保たれていること）。

TS-QC-001: pass_criteria を満たす（対象 SKILL.md について lint_skills・checker 通過、未解決違反なし。検出 NG 1件は対象外ファイルの事前存在）。

- 契約テスト期待値の更新と固定トークン確認: 該当なし（構造変更なし。`*.test.ts`・checker を `agentdev-project-extensions` で事前 grep し、description 文言を期待値として固定するテスト・checker が存在しないことを確認。`check_workflow_preventive.test.ts` の当該スキル参照は fixture 内パスのみ）
- docs/ 配下の変更なし（`check_changed_docs.ts --workflow case-run` は対象外）。docs/specs 行数変更なし（generate_indexes は対象外）
- lsp_diagnostics: markdown ファイルのため LSP 対応なし（検証は上記 validator 実行で代替）

## Findings / Capture候補

- lint_skills NG 1件（事前存在・intake 採録候補）: `agentdev-git-worktree/references/worktree-operations.md` が336行で目次欠落（RU-0018 層2、300行超 references は目次必須）。merge-base 44c55d36（自変更前）と origin/main 2728a2a1 の双方で同一 blob であることを確認済み（`git diff --stat origin/main HEAD -- <file>` が空、`git log 44c55d36..origin/main -- <file>` が空）。本 PR のマージでは解消しないため、目次追加の軽微修正として intake 採録候補
- 旧本文 DO NOT USE FOR 5項目のうち「extension 構造の診断、検査（保守診断 command の責務）」も description 側へ未反映のまま残存（本 Issue の対象は「extension 自体の作成・編集」のみ）。対処要否は Epic #2231 側での確認候補。intake 採録候補

## SPEC確定候補

- `docs/specs/skills/agentdev-project-extensions.md` の「### DO NOT USE FOR」節（4項目）には「extension 自体の作成、編集」が含まれず、同 SPEC「対象外」節（5項目、当該項目を含む）と項目不一致が残存する。本 Issue の変更対象成果物は SKILL.md（description 更新）のみのため本 PR では SPEC を変更していない。SKILL.md description への反映後の SPEC「### DO NOT USE FOR」節への同項目追従追加を、case-close Step 3 の SPEC 確定チェックでの判断候補として記録する

Refs: #2236