### PR TITLE
docs(agentdev): workflow-templates SPEC の分解テーブル整合先用語を新4列形式へ修正（OU-0026、Refs: #2228）

### DIFF
--- a/docs/specs/skills/agentdev-workflow-templates.md
+++ b/docs/specs/skills/agentdev-workflow-templates.md
@@ -2,7 +2,7 @@
 title: `agentdev-workflow-templates` SPEC
 status: accepted
 created: 2026-06-21
-updated: 2026-08-18
+updated: 2026-08-19
 ---
 
 # `agentdev-workflow-templates` SPEC
@@ -186,7 +186,7 @@ Epic Issue・子 Issue テンプレートの次の正規形を本 SPEC が正規
 
 ### Epic 分解テーブルの正規形
 
-- 分解テーブル（Epic 本文の子 Issue 一覧）は `| {wave}-{seq} | #{child_issue} | {status} | {child_title} |` 形式とする（agentdev-epic-tracker V4形式と整合）
+- 分解テーブル（Epic 本文の子 Issue 一覧）は `| {wave}-{seq} | #{child_issue} | {status} | {child_title} |` 形式とする（agentdev-epic-tracker 新4列形式と整合）
 - 行 ID は `{wave}-{seq}` 形式（例: `1-1`）。Issue 列は `#N` のみ（OU ID の接尾は内容欄へ置く）
 - ステータス初期値は `pending`（更新は agentdev-epic-tracker が単一書き手として行う）
 - テンプレート選定規則は本 SPEC が、Wave 構成（wave 番号の付番）は epic-wave-model SPEC がそれぞれ所有する責務分担を維持する


### PR DESCRIPTION
## 背景

Issue #2228（OU-0026、Epic #2223 EU-E Wave 2）。ACT-SPEC-021 により workflow-templates SPEC へ正典化された「Parent 先頭行配置・Epic 分解テーブル {wave}-{seq} 形式」の正規形について、テンプレートコメント（issue_desc_child.md / issue_desc_epic.md）と agentdev-epic-tracker references との一致確認（検証中心 Issue）。

## 変更内容

`docs/specs/skills/agentdev-workflow-templates.md` の2箇所のみ。

1. 「Epic 分解テーブルの正規形」節の整合先表記修正（1行）:
   - 修正前: `` | {wave}-{seq} | #{child_issue} | {status} | {child_title} | `` 形式とする（agentdev-epic-tracker **V4形式**と整合）
   - 修正後: 同（agentdev-epic-tracker **新4列形式**と整合）
   - 理由: SPEC が整合先として挙げる「V4形式」という名称は agentdev-epic-tracker（SKILL.md・references）のどこにも存在せず、実体の定義名は references/regex-and-merge-conflict.md「新4列形式（#/ Issue/ ステータス/ 内容）」。`git log -S "V4形式"` により当該用語は ACT-SPEC バッチ SPEC 保存コミット 3b8a42ff で導入された dangling な参照先用語と確認（テンプレート issue_desc_epic.md L30 のコメントは当初から「新4列形式」を使用）
2. frontmatter `updated: 2026-08-18` → `2026-08-19`

行数は 222→222 で不変（generate_indexes 不要、check_autogen_freshness で鮮度違反 0 件を確認）。

## 検証結果（L2・コマンドと証拠）

Issue 本文のテスト戦略を全項目処理（test-fix ループ）。

### TS-026（正規形の SPEC 記載とテンプレート・references の一致）

初回検証で Parent 配置・分解テーブル・Wave テーブルの実体一致と責務分割は全て確認済みだが、SPEC L189 の整合先用語「V4形式」が dangling（乖離）と判定 → on_failure「fix-and-reverify」に従い SPEC 側を整合させ再確認。

一致確認の根拠（3成果物の突合）:

- SPEC L181-185「Parent 配置の正規形」（先頭行 `Parent: #N`、case-open が配置、旧「## 親Issue」配置は後方互換）
  = issue_desc_child.md L7（先頭行 `Parent: #{epic_number}`）+ L9 コメント
  = references/regex-and-merge-conflict.md L52（一元化表の「Parent 配置」行）
- SPEC L189-191「Epic 分解テーブルの正規形」（`{wave}-{seq}` 行 ID、Issue 列 `#N` のみ、初期値 pending）
  = issue_desc_epic.md L30-34（分解テーブル正規形コメント + 4列テーブル雛形）
  = references L53（一元化表の「分解テーブル」行）+ L24-33（新4列形式の定義と実例）
- 責務分割: SPEC L192 が「テンプレート選定規則は本 SPEC、Wave 構成（wave 番号の付番）は epic-wave-model SPEC」と明記。epic-wave-model SPEC は「Wave 構成ルール」「Wave 解析プロトコル」を所有しテンプレート選定を所有しないことを確認（逆方向も非侵入）

修正後の再確認コマンドと結果:

```
# 残存 dangling 用語の不在（docs/ + src/ 全 .md）
(Get-ChildItem -Recurse "<worktree>\docs","<worktree>\src" -Filter "*.md" | Select-String -Pattern "V4形式").Count
→ 0

# 3成果物の用語一致
SPEC L189: （agentdev-epic-tracker 新4列形式と整合）
issue_desc_epic.md L30: （agentdev-epic-tracker 新4列形式と整合）
regex-and-merge-conflict.md L24: ### 新4列形式（#/ Issue/ ステータス/ 内容）
→ 一致
```

判定: PASS（正規形が SPEC に記載され、テンプレート・references と乖離なし）。

### TS-QC-001（文書品質査読）

- 機械検査: `bun run ./check_changed_docs.ts --workflow case-run --files docs/specs/skills/agentdev-workflow-templates.md`（cwd: `.opencode/skills/repo-agentdev-integrity/scripts`）→ `failures: 0 / warnings: 0`、EXIT=0
- 査読: 変更は既存文の参照先用語1語の置換のみ。文書種別配置（SPEC の内容を SPEC に保持）、用語政策（「新4列形式」は references 既存の定義名）、配布物 ID 汚染なし、一文一行維持、LLM っぽい表現の追加なし → 未解決違反なし

判定: PASS。

### 機械検証（コマンド全文・実行環境）

- cwd: `.worktrees/2228-feature/.opencode/skills/repo-agentdev-integrity/scripts`（bun install 実施済み）
- `bun run ./check_changed_docs.ts --workflow case-run --files docs/specs/skills/agentdev-workflow-templates.md` → files checked: 1 / failures: 0 / warnings: 0、EXIT=0
- `bun run ./check_autogen_freshness.ts` → 検査索引ファイル数 7 / 検出鮮度違反 0 件（再生成不要）、EXIT=0
- `bun run ./check_templates.ts` → EXIT=0（worktree junction 未伝播による既知 WARNING 1件のみ、REQ-018 準拠の skip）
- `bun test ./check_changed_docs.test.ts ./check_autogen_freshness.test.ts ./check_templates.test.ts` → **83 pass / 0 fail**（206 expect() calls、3 files）
- `bun test ./check_integrity.test.ts` → 85 pass / 1 fail。fail は「IR-055 runtime-unresolved-reference 実修復回帰 > 配布物に新規（delta from baseline）runtime-unresolved-reference 違反がないこと」。本変更（docs/specs のみ、src/opencode/** 無変更）起因ではないことを `git stash` で本変更を除外して再実行し同一 fail を確認（BASE_EXIT=1）。既知 baseline（IR-055 delta は PR #2265 マージで解消予定）
- src/opencode/** は無変更のため check_distribution_boundary.ts は対象外（MUST DO 条件: src/opencode/** 変更時）

## Findings・Capture候補

- ACT-SPEC バッチ保存（3b8a42ff、ACT-SPEC-001〜026 一括反映）で、参照先成果物に実在しない用語（V4形式）を整合先として引用したまま SPEC 化された例が1件存在した。RU → draft → spec-save の経路で参照先用語の実在確認が行われていれば防止可能。learning Capture 候補（spec-save 工程の確認手順）
- 上記バッチ由来の他 SPEC への同種 dangling 用語の有無は本 Issue スコープ外（V4形式に限れば全 repo grep で残存 0 件を確認済み）。必要なら inspect-docs での横断確認が後続候補

## SPEC確定候補

- なし。本変更は既存 accepted SPEC（agentdev-workflow-templates）の整合是正のみで、新規 schema・enum・判定表・内部アルゴリズムの追加はない。正規形3要素（Parent 配置・分解テーブル・Wave テーブル）の正典は引き続き同 SPEC「テンプレート正規形」節が所有する

Refs: #2228