### PR TITLE
refactor(repo): /repo/docs-check.md の前出出力検証表移行と EN. lettered prefix 規約節の整理（OU-0030、Issue #2229）

### DIFF
--- a/.opencode/commands/repo/docs-check.md
+++ b/.opencode/commands/repo/docs-check.md
@@ -22,13 +22,22 @@ agent-dev-flow リポジトリの自己監査コマンド。AgentDevFlow 管理�
 - `.agentdev/integrity/reports/YYYY-MM-DD-integrity-report.md` — 検出結果レポート（非永続、commit/push対象外）
 - `.agentdev/intake/inbox/YYYY-MM-DD-{topic-slug}.md` — 通常 intake item（NG/WARNING finding から自動生成、0件以上）
 
-## 手順
+## workflow
 
-### Step 1: スクリプト実行
+本コマンドは repo-local command であり、Workflow Skill への委譲を持たない（workflow 本体を command 本文が所有する）。各工程を前出出力検証表で示す（工程ラベルが推奨順）。
 
-**実行ランナー（REQ-0108-054）**: 本 command が呼び出す検査スクリプト群（`check_integrity.ts`、`check_command_format.ts`、`check_extensions.ts`、`check_distribution_boundary.ts`、`check_changed_docs.ts`、`check_templates.ts`、`lint_skills.ts`、`check_autogen_freshness.ts`）は TypeScript 直接実行と `require()` / `import` 混在構文、併設テストの `bun:test` 依存を前提とするため、実行ランナーは **Bun** とする。`node` 等の Bun 以外のランナーで直接起動すると `ReferenceError: require is not defined` 等 ESM 解釈エラーが発生する。スクリプトは `bun run <script-path>` 形式で起動すること。
+| 工程 | 前提条件 | 出力契約 | 検証基準 |
+|---|---|---|---|
+| STEP-1 スクリプト実行 | なし（コマンド実行時に全 artifact を自動スキャン） | 検査スクリプト群の実行結果（exit code・検出結果） | 検査スクリプト群をすべて `bun run` 形式で起動・実行していること。strict failure を示す終了コード1は docs-check 全体の失敗として扱っていること |
+| STEP-2 レポート確認・Finding整理 | 検査スクリプト実行済み | 重複・誤検出・根拠を確認した整理済み finding 群 | report の NG/WARNING finding のみを対象とし（INFO は対象外、REQ-0108-224）、同一是正方針で統合可能かの判断を経ていること（REQ-0108-222。固定単位での機械的分割を行っていないこと） |
+| STEP-3 Intake Item 自動生成 | finding 整理済み | `.agentdev/intake/inbox/` へ保存された通常 intake item（0件以上） | `/agentdev/intake-capture` の通常形式（frontmatter・route・dedup keyなし）に従い、各 item が自己完結（非永続 report への参照なしで後続処理成立）であること。原因分類が確認済/仮説/不明で区別されていること（実行＝保存承認、REQ-0108-225。採否は `intake-promote` へ委譲） |
+| STEP-4 Git 永続化（条件付き） | intake item 作成あり | commit・push（`.agentdev/intake/` 配下のみ） | intake item 作成時のみ commit/push を行い、`git add` が `.agentdev/intake/` 配下に限定されていること（integrity report は commit 対象外、REQ-0108-229） |
+| STEP-5 完了報告 | 永続化処理済み（intake item 未作成時は STEP-3 で 0 件確認済み） | 完了報告 | 完了報告 template（.opencode/commands/repo/templates/docs-check/standard.md）に従って出力していること |
 
-`repo-agentdev-integrity` の検査スクリプト（`.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts`）を `bun run` で実行。検査カテゴリ・対象パス・検出結果の分類は SKILL.md（.opencode/skills/repo-agentdev-integrity/SKILL.md）の検査カテゴリ定義を authoritative source とする
+**STEP-1 検査スクリプト群の実行詳細**:
+
+- **実行ランナー（REQ-0108-054）**: 本 command が呼び出す検査スクリプト群（`check_integrity.ts`、`check_command_format.ts`、`check_extensions.ts`、`check_distribution_boundary.ts`、`check_changed_docs.ts`、`check_templates.ts`、`lint_skills.ts`、`check_autogen_freshness.ts`）は TypeScript 直接実行と `require()` / `import` 混在構文、併設テストの `bun:test` 依存を前提とするため、実行ランナーは **Bun** とする。`node` 等の Bun 以外のランナーで直接起動すると `ReferenceError: require is not defined` 等 ESM 解釈エラーが発生する。スクリプトは `bun run <script-path>` 形式で起動すること
+- `repo-agentdev-integrity` の検査スクリプト（`.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts`）を `bun run` で実行。検査カテゴリ・対象パス・検出結果の分類は SKILL.md（.opencode/skills/repo-agentdev-integrity/SKILL.md）の検査カテゴリ定義を authoritative source とする
 - **コマンド形式検査（IR-049）**: `check_command_format.ts` を `bun run` で併せて実行する。`--root` にリポジトリルートを指定し、終了コード1は docs-check 全体の失敗として扱う
 - Finding 分類・ルートは SKILL.md の定義に準拠
 - **実行 profile（Issue #1928 / WP-3）**: `check_integrity.ts` は `--profile source|installed|release` を取り、既定は `source`。docs-check は明示しない限り `source`（既定）で実行する。`installed` は配置後検査、`release` は配布アーカイブ検査（`--archive <zip>` 必須）で、いずれも `docs/specs/integrity/integrity-contracts.md`「実行プロファイル分離」と `scripts/package-release-archive.ps1` / `scripts/install-from-archive.ps1` を参照
@@ -36,22 +45,6 @@ agent-dev-flow リポジトリの自己監査コマンド。AgentDevFlow 管理�
 - **配布物参照境界（配布 command/skill 本文の具体参照禁止）**: `check_distribution_boundary.ts`（`.opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts`）を `bun run` で併せて実行する。配布 command/skill 本文（`src/opencode/commands/agentdev/**/*.md`、`src/opencode/skills/agentdev-*/**/*.md`）に含まれる具体ID（`ADR-NNNN`、`REQ-NNNN`）、具体パス（`docs/(adr|requirements|specs)/<file>.md`、但し README.md とテンプレート表記は除外）、固定URL（blob/raw）を検出し、厳格に取り扱う。check_distribution_boundary.ts の failure は docs-check 全体を fail とする
 - **AUTOGEN ブロック鮮度検出 gate（REQ-010-059、autogen-freshness-gate SPEC）**: `check_autogen_freshness.ts`（`.opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.ts`）を `bun run` で併せて実行する。AUTOGEN ブロック（`<!-- AUTOGEN:BEGIN:id=xxx -->`〜`<!-- AUTOGEN:END -->`）を含む索引ファイル群について、ソース（frontmatter / ファイル名 / status）の rename や status 変更後に AUTOGEN ブロックが陳腐化しているかを検出し、鮮度種別（rename / status_change / content_change）を分類して報告する。check_autogen_freshness.ts の strict failure（stale blocks 検出）は docs-check 全体を fail とする。不合格時は `bun run .opencode/skills/repo-agentdev-integrity/scripts/generate_indexes.ts` で AUTOGEN ブロックを再生成すること（自動修復は行わない、SPEC「不合格時の処置」）。IR-061（check_integrity.ts）と同一不整合を検出し得るが、両検査は独立して実施し、いずれか単独の実施要否にも他方の結果は影響しない
 - **full integrity suite（bun test 全件、QG-4 bun test 実行形態契約）**: `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/` を実行する。`./` prefix 付きで対象ディレクトリを明示指定する（必須ステップ）。実行結果の「Ran N tests across M files」の N/M 件数突合を実施し（必須ステップ）、直前実績と比較して件数が急減していないかの妥当性を検証する（固定値の期待値化は行わない）。実行 cwd と起動コマンド形式（prefix・パス指定を含む）をレポートの証拠記録に明記する。対象スイートには cwd 依存テストが混在するため、カレントディレクトトリビアな実行（`bun test` 単体等）で代替しない
-
-### Step 2: レポート確認・Finding整理
-
-reportのNG/WARNING findingについて重複・誤検出・根拠を確認し整理する。INFOは対象外（REQ-0108-224）。エージェントがfinding群を確認し、同一是正方針で統合可能かを判断する（REQ-0108-222）。固定単位での機械的分割は禁止。
-
-### Step 3: Intake Item 自動生成
-
-整理結果から通常intake itemを生成し、`.agentdev/intake/inbox/`に保存。形式は`/agentdev/intake-capture`の通常形式に従う（frontmatter・route・dedup keyなし）。各itemは自己完結（非永続reportへの参照なしで後続処理成立）。原因分類は確認済/仮説/不明を区別。実行＝保存承認（REQ-0108-225）。採否は`intake-promote`に委譲。learning/RU/REQの直接生成禁止（MUST NOT）。
-
-### Step 4: Git 永続化（条件付き）
-
-intake item作成時のみcommit/push。`git add`は`.agentdev/intake/`配下のみ。integrity reportはcommit対象外（REQ-0108-229）。
-
-### Step 5: 完了報告
-
-完了報告templateに従って出力。template: .opencode/commands/repo/templates/docs-check/standard.md
 
 ## ガードレール
 


### PR DESCRIPTION
## 背景

Issue #2229（OU-0030、source: RU-0075、operation: update、scale: standard、Epic #2223 EU-E「様式・構成 SPEC」Wave 2、Parent: #2223）。

- `/repo/*`（repo-local・配布対象外）の `docs-check.md` を前出出力検証表形式へ移行する
- `command-file-format` SPEC の EN. lettered prefix 規約節が `/repo/*` 限定へ明記されていることを確認する（ACT-SPEC-022 は spec-save 適用済みのため確認が本 Issue スコープ）
- 移行時に `check_command_format.ts` へ repo-local 向け表形式検査の対象拡張を検討し、結果を記録する

## 変更内容

### `.opencode/commands/repo/docs-check.md`（前出出力検証表移行、repo-local・配布対象外）

- `## 手順` セクション（`### Step 1`〜`### Step 5` 見出し列挙）を `## workflow` セクション + 前出出力検証表（`| 工程 | 前提条件 | 出力契約 | 検証基準 |`、STEP-1〜STEP-5 ラベル）へ移行した。様式は公開 `/agentdev/*` コマンドの移行済み形式（`case-close.md`、`intake-capture.md` 等）と同型
- 旧 Step 1 の検査スクリプト群の詳細（実行ランナー、IR-049/IR-056、配布物参照境界、AUTOGEN 鮮度 gate、full integrity suite）は表直下の `**STEP-1 検査スクリプト群の実行詳細**:` ボールド段落配下のリストとして保持し、情報の損失を回避した
- 旧 Step 2〜5 の本文は表の検証基準列へ集約した（REQ-0108-224/222/225/229 参照を保持）
- diff: 13 insertions / 20 deletions、1ファイル

### `docs/specs/authoring/command-file-format.md`（変更なし: 確認のみ）

EN. lettered prefix 規約節（「代替フロー内サブステップ表現 > 注意」3番目）に「本形式の採用は `/repo/*`（repo-local コマンド）限定とする」と明記済みであることを確認した（ACT-SPEC-022 の spec-save 適用済み分）。Issue の完了条件は「明記されていること」であり、SPEC の追加変更は不要。

## 検証結果（L2・コマンドと証拠）

実行 cwd: `.worktrees/2229-feature`（worktree root、branch `feature/issue-2229`、base `d9e351f9`）。

| # | コマンド | 結果 |
|---|---|---|
| 1 | `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_command_format.ts --root . --json` | status 0 / `"ok": true` / `"violations": []` |
| 2 | `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref origin/main --json` | status 0 / `failures: []`（`files_checked: []` — 変更ファイルは `.opencode/commands/repo/docs-check.md` のみで docs/ 配下変更なし） |
| 3 | `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts --profile source` | `ok: true` / failures 0 / scanned_files 329 |
| 4 | `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/check_command_format.test.ts` | 6 pass / 0 fail（期待件数 6: 実ファイル走査 1 + checker ユニットテスト 5。`./` prefix 明示） |
| 5 | `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/` | 2046 pass / 2 fail / 4530 expect() / Ran 2048 tests across 85 files [162.18s]。fail 2件は既知 baseline: IR-055 delta（PR #2265 は origin/main マージ済みだが worktree base `d9e351f9` には未反映のため残存）、archive-builder same-filesystem staging（環境依存）。本変更は Markdown 1ファイルのみでコード変更なし、両 fail と無関係 |

bun install: worktree 初回に `.opencode/skills/repo-agentdev-integrity/scripts` で実施（5 packages）。`node_modules/` は commit 対象外。

TS-030: verification（SPEC の EN. lettered prefix 規約節の `/repo/*` 限定明記確認、checker 対象拡張の検討結果確認）を実施し、pass_criteria 両項目を満たす（明記確認: 上記「変更内容」、検討記録: 下記「SPEC確定候補」）。

TS-QC-001: 変更後の `docs-check.md` について文書品質自查読を実施（表様式は公開コマンドと同型、用語は既存文書の使用語と同一、LLM っぽい空句なし、REQ 参照保持）。`command-file-format.md` は変更なしため新規違反の発生なし。

## Findings / Capture候補

- `docs/specs/authoring/command-file-format.md`「手順セクション形式」節の「前得出出力検証表」はタイポ（正: 前出出力検証表。同 SPEC「機械検査対象」節では「前出出力検証表様式」と正しく表記）
- 同 SPEC「代替フロー内サブステップ表現 > 代表例」（`case-close.md` の `**E1.**`〜`**E6.**`）が実態と陳腐化。公開 `/agentdev/*` コマンドの `src/opencode/commands/agentdev/` 配下で `**EN.**` 形式は grep 0件（W1 移行で消滅）
- 同 SPEC「注意」3番目の理由付け「公開 `/agentdev/*` コマンドでは主手順の手順列挙を `### Step N` 形式で表現する前提のため」が旧様式前提で陳腐化（公開コマンドは既に前出出力検証表へ移行済み）。`/repo/*` 限定という結論自体は本移行後も妥当
- `check_command_format.ts` の実装コメント「`/repo/* Command は従来形式を維持する`」（`PUBLIC_COMMAND_DIR_PATTERN` 定義部）が本移行で前提崩れ（`/repo/*` に `### Step` 見出しを使う command が存在しなくなる）。checker 本体の変更は本 Issue スコープ外（対象拡張の検討のみ）
- `.opencode/commands/repo/templates/docs-check/standard.md` の「失敗Step（{Step名}）」が旧様式の名残（template は本 Issue の変更対象成果物外のため未変更。工程ラベルを埋めれば機能は維持）

## SPEC確定候補

### check_command_format.ts への repo-local 向け表形式検査の対象拡張の検討記録（TS-030 完了条件の SSoT）

- **検討対象**: `check_command_format.ts` の前出出力検証表検査（`command-format-public-step-heading`: `### Step` 見出し禁止、`command-format-workflow-table`: `## workflow` セクションの表行必須）を公開 `/agentdev/*` 限定から `/repo/*` へも適用する拡張
- **結論: 本 Issue では実装しない**。理由:
  1. Issue の対象範囲が「repo-local 向け対象拡張の検討のみ」に限定されており（対象外: `check_command_format.ts` の配布物側検査の変更）、完了条件も「検討記録が残っていること」であって実装を要求しない
  2. `command-file-format` SPEC「thin Command モデル検査」節は「`/repo/*` Command は従来検査を維持し、公開 `/agentdev/*` Command と checker 上で区別する」と checker の区別方針を明記しており、拡張には先に SPEC 側の方針更新を要する
  3. `/repo/*` は repo-local・配布対象外で、checker の走査対象（`COMMAND_DIRS` の `.opencode/commands/repo` 直下 `.md`）は実ファイル `docs-check.md` の1ファイルのみ（`templates/` は走査対象外）。拡張の便益は将来の新規 `/repo/*` command 追加時に限られ、変更頻度は極めて低い
  4. EN. lettered prefix 形式の SPEC 記述（適用条件: 主手順 Step からの分岐・合流、代表例: case-close.md）が旧様式（`### Step N` 主手順）前提で陳腐化しており（Findings 参照）、checker 拡張の前に SPEC 側の整理が必要
- **残候補**: 拡張実装・checker コメント更新（「`/repo/* Command は従来形式を維持する`」の陳腐化解消）は、SPEC 陳腐化箇所の整理とセットで別途 Issue 化することが適切

## テスト戦略の処理状況

- TS-030: 合格（pass_criteria 両項目を満たす。EN. 形式規約の `/repo/*` 限定明記の確認、checker 対象拡張の検討記録＝本 PR の SPEC確定候補セクション）
- TS-QC-001: 合格（対象文書に未解決違反なし。`command-file-format.md` は変更なし、`docs-check.md` は品質自查読実施済み）

Refs: #2229
