### PR TITLE
docs(agentdev): docs/README.md の DEC-014 行を accepted 表記へ更新し旧名称二重リンクを解消（OU-0038、Refs: #2242）

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ REQ-024 の抽出規則と warning 分類は、後継の [agentdev-artifact-grap
 | [DEC-011](decisions/DEC-011.md) | STEP resume point と会話記憶非依存 |
 | [DEC-012](decisions/DEC-012.md) | Extension を file-kind から workflow/capability responsibility へ再編 |
 | [DEC-013](decisions/DEC-013.md) | IR 登録モデルの簡素化 — 現存 IR を実行可能な恒久統制に限定 |
-| [DEC-014](decisions/DEC-014.md) | 配布依存境界の多層 enforcement（proposed） |
+| [DEC-014](decisions/DEC-014.md) | 配布依存境界の多層 enforcement |
 | [DEC-015](decisions/DEC-015.md) | ADF決定論的実行中核と実行基盤実行機構の責務分界 |
 | [DEC-016](decisions/DEC-016.md) | 導入系スクリプトの副作用ゼロ原則（proposed） |
 | [DEC-017](decisions/DEC-017.md) | TIM 準拠トレーサビリティモデルの採用と4層分離（proposed） |
@@ -118,7 +118,6 @@ SPEC は 3 層構造（commands / skills / workflows）と基盤 6 ドメイン�
 - [ルール所有権マトリックス](specs/integrity/rule-ownership.md)
 - [実行時パッケージ境界](specs/local/runtime-package-boundary.md)
 - [ローカル Case ファイル](specs/local/local-case-file.md)
-- [ローカル版 OpenCode 生成](specs/local/runtime-package-boundary.md)
 - [コマンドファイルフォーマット規約](specs/authoring/command-file-format.md)
 
 ## ガイド


### PR DESCRIPTION
Refs: #2242

## 背景

OU-0038（source: RU-0083、operation: update、scale: standard、docs_chore 系）。docs/README.md の陳腐化是正を本 Issue のスコープとする。

- Decision 表 DEC-014 行の status 表記が proposed のままで、実体 DEC-014.md（2026-08-14 更新、status: accepted）と decisions/README.md の status 表（accepted、承認済み14件・提案中2件）に対して不一致だった。
- 基盤 SPEC 一覧の「実行時パッケージ境界」と「ローカル版 OpenCode 生成」が同一ファイル（specs/local/runtime-package-boundary.md）への二重リンクになっており、後者が旧名称残存だった。

## 変更内容

docs/README.md のみ変更（1 file changed、+1 / -2）。

- Decision 表 DEC-014 行の「（proposed）」注記を削除し、accepted 表記（注記なし。DEC-001〜013・015 と同一形式）へ更新した。実体 DEC-014.md・decisions/README.md の status と一致する。
- 基盤 SPEC 一覧から旧名称「ローカル版 OpenCode 生成」行（specs/local/runtime-package-boundary.md への重複リンク）を削除した。正名称「実行時パッケージ境界」行は維持する。

## 検証結果

### TS-038（pass_criteria 満たす。on_failure 未発動）

- verification: docs/README.md の DEC-014 行の status 表記と runtime-package-boundary.md の二重リンクを確認した。
- DEC-014 行が accepted 表記（注記なし）となり、実体 DEC-014.md（status: accepted、updated: 2026-08-14）・decisions/README.md の status 表（accepted）と一致することを確認した。
- docs/README.md 内の specs/local/runtime-package-boundary.md へのリンクが「実行時パッケージ境界」の1件のみに整理されていることを grep で確認した。旧名称「ローカル版 OpenCode 生成」は docs 配下で当該行のみの残存だった（grep 1件→0件）。
- Decision 節冒頭の散文（DEC-016、DEC-017 は proposed、DEC-005 は superseded）は DEC-014 を proposed に挙げておらず、更新後の表と一貫する。

### TS-QC-001（未解決違反なし）

- agentdev-doc-writing の査読観点を変更行と周辺へ適用した。
- DEC-014 行は DEC-014.md の title と完全一致し、他 accepted 行と同一形式である。LLM っぽい表現・中黒・em-dash の新規混入なし。残存リンクのリンク切れなし。

### check_changed_docs.ts（docs 変更時の必須検査）

- 起動コマンド形式: `bun run check_changed_docs.ts --workflow case-run --files docs/README.md`
- 実行 cwd: .worktrees/2242-feature/.opencode/skills/repo-agentdev-integrity/scripts
- 結果: files checked: 1（docs/README.md）、failures: 0、warnings: 0

### 回帰テスト（bun test・AG-035 記録形式）

- 起動コマンド形式: `bun test ./commands_error_cases.test.ts ./regression_decision_readme.test.ts ./check_autogen_freshness.test.ts`
- 実行 cwd: .worktrees/2242-feature/.opencode/skills/repo-agentdev-integrity/scripts
- 結果: 67 pass / 0 fail（Ran 67 tests across 3 files）
- 実行前に同一 cwd で bun install を実施した（5 packages installed）。
- 対象根拠: docs/README.md を参照するテスト（存在確認）と Decision README・AUTOGEN 鮮度の関連ドメイン。本変更は docs/README.md の2行のみで、src/opencode/** は無変更のため check_distribution_boundary.ts は対象外。

## Findings・Capture候補

### intake

該当なし

### learning

該当なし

## SPEC確定候補

該当なし（docs/README.md の索引表記是正のみで、SPEC が新たに所有すべき schema・enum・判定表・内部アルゴリズムの発見なし）