### PR TITLE
docs(agentdev): gh-cli ローカル版へ git CLI 初期化要件を追記（OU-0019、Refs: #2246）

### DIFF
--- a/src/opencode-local/agentdev-gh-cli/references/local-procedures.md
+++ b/src/opencode-local/agentdev-gh-cli/references/local-procedures.md
@@ -1,10 +1,10 @@
 # ローカル版実装手順（Case ファイル版）
 
 agentdev-gh-cli の各手続きのローカル版（Case ファイル版）実装手順（REQ-0150-001, 002）。
-標準版（GitHub 版）の実装手順（[../../skills/agentdev-gh-cli/references/standard-procedures.md](../../../skills/agentdev-gh-cli/references/standard-procedures.md)）で扱う gh CLI 呼び出しを、Case ファイル（`.agentdev/cases/case-{NNNN}.md`）の読み書きに読み替える。
+標準版（GitHub 版）の実装手順（[standard-procedures.md](../../../opencode/skills/agentdev-gh-cli/references/standard-procedures.md)）で扱う gh CLI 呼び出しを、Case ファイル（`.agentdev/cases/case-{NNNN}.md`）の読み書きに読み替える。
 操作契約（手続き名、引数、戻り値）は [contracts.md](contracts.md) 参照。
 
-Case ファイルスキーマの意味仕様の正本は SPEC [local/local-case-file.md](../../../../../docs/specs/local/local-case-file.md)。操作用定義は [../case-schema/case-file.md](../case-schema/case-file.md)。
+Case ファイルスキーマの意味仕様の正本は SPEC [local/local-case-file.md](../../../../docs/specs/local/local-case-file.md)。操作用定義は [../case-schema/case-file.md](../case-schema/case-file.md)。
 
 ## 共通制約
 
@@ -13,6 +13,32 @@ Case ファイルスキーマの意味仕様の正本は SPEC [local/local-case-
 - 書き込みには OpenCode の Write tool、または `[System.IO.File]::WriteAllText` に `UTF8Encoding($false)` を指定する（標準版の WRITE 手続き Section 2 と共通）
 - `gh` コマンド、`gh issue`、`gh pr` は使用しない（REQ-0141-026, REQ-0150-008）
 - Windows PowerShell の `Out-File`, `Set-Content`, `>` リダイレクトによる Case ファイル書き込みは禁止（標準版と共通。BOM 付きや Shift-JIS になるため）
+- Windows 環境で git CLI 直接操作の WRITE（`git commit -F`、`git tag -F` 等のファイル引数に日本語を含む操作）を行う場合は、次節「git CLI 直接操作の初期化要件」の初期化を WRITE 実行前に必須前置する（標準版と共通）
+
+## git CLI 直接操作の初期化要件
+
+ローカル版も git 操作（commit 等）を行うため、git CLI 直接操作の WRITE には初期化要件を適用する（SPEC [agentdev-gh-cli](../../../../docs/specs/skills/agentdev-gh-cli.md)「WRITE 手続きの Windows encoding 初期化必須化」節「ローカル版の扱い」参照）。
+
+- **対象**: ファイル引数に日本語を含む git CLI 直接操作の WRITE（`git commit -F`、`git tag -F` 等）。Windows 環境では必須、Linux/ macOS/ WSL 等の Windows 以外の環境では不要（既定で UTF-8 コンソールのため）
+- **手順単位**: create（手順2のファイル書き出し） → git 実行 → VERIFY → cleanup を1手順ユニットとし、cleanup を省略不可とする（標準版の WRITE 手続きと共通）
+
+標準手順:
+
+1. **コンソールエンコーディング初期化（Windows 環境のみ）**: WRITE 実行前に、現在のセッションで以下の3行を実行する（標準版 [standard-procedures.md](../../../opencode/skills/agentdev-gh-cli/references/standard-procedures.md) Section 2 Step 0 と同一）:
+
+   ```powershell
+   [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+   $OutputEncoding = [System.Text.Encoding]::UTF8
+   cmd /c chcp 65001 | Out-Null
+   ```
+
+2. **BOM なし UTF-8 ファイル渡し**: メッセージ本文（commit メッセージ等）を一時ファイルへ UTF-8 (BOMなし)、LF で書き出し、`-F`（`--file`）オプションで渡す。書き出し手段は「共通制約」に従う
+3. **VERIFY**: 実行後に `git log -1 --pretty=%B` 等で読み戻し、書き出し時の本文と一致すること、および先頭バイトが UTF-8 BOM（`EF BB BF`）でないことを確認する
+4. **cleanup**: VERIFY が PASS した後に一時ファイルを削除する。VERIFY が FAIL の場合は cleanup を実行せず、一時ファイルを残して原因調査へ移行する
+
+worktree 隔離境界により `.agentdev/**` への書き込みが禁止される委譲の場面では、一時ファイル配置先をリポジトリ外の一時領域（`$env:TEMP` 配下）に変更する。本規定はローカル版へも適用できる。ただしローカル版は Case ファイル読み書きが主経路であるため、gh CLI 系の WRITE 手続き（一時ファイル配置先を含む）が必要になる場面は、ローカル版から gh CLI を直接利用する補助経路に限る（SPEC 同節「委譲時の一時ファイル代替配置先」「ローカル版の扱い」参照）。
+
+本要件は標準版 [standard-procedures.md](../../../opencode/skills/agentdev-gh-cli/references/standard-procedures.md)「commit メッセージ作成（BOM なし UTF-8 契約）」節の規定と矛盾しない。同節の詳細実装（実装手段、禁止事項）を本ファイルへ複製せず、ローカル版における本要件の正を本ファイル1ファイルへ維持する（`standard-procedures.md` のローカル版新設は行わない）。
 
 ## Case 番号の採番
 
@@ -23,7 +49,7 @@ Case ファイルスキーマの意味仕様の正本は SPEC [local/local-case-
 3. 欠番は再利用しない（過去に削除、リネームされた番号を再採番しない）
 4. 同一 Case 番号のファイルが既存の場合は上書きせず失敗とする
 
-採番規則の意味仕様は SPEC [local/local-case-file.md](../../../../../docs/specs/local/local-case-file.md) の「採番規則」セクション、運用参照資料は [../case-schema/case-file.md](../case-schema/case-file.md) の「採番規則」セクション参照。
+採番規則の意味仕様は SPEC [local/local-case-file.md](../../../../docs/specs/local/local-case-file.md) の「採番規則」セクション、運用参照資料は [../case-schema/case-file.md](../case-schema/case-file.md) の「採番規則」セクション参照。
 
 ## 各手続きのローカル版実装
 
@@ -95,7 +121,7 @@ YAML 前書きの各フィールド制約は [../case-schema/rules/frontmatter.y
 5. UTF-8 (BOMなし)、LF で保存
 6. VERIFY を直後に実行
 
-`## マージ結果` の記録方針は SPEC [local/local-case-file.md](../../../../../docs/specs/local/local-case-file.md) の「マージ結果の記録方針」セクション参照。
+`## マージ結果` の記録方針は SPEC [local/local-case-file.md](../../../../docs/specs/local/local-case-file.md) の「マージ結果の記録方針」セクション参照。
 
 ### Issue close（Case close）
 
@@ -107,11 +133,11 @@ YAML 前書きの各フィールド制約は [../case-schema/rules/frontmatter.y
 3. UTF-8 (BOMなし)、LF で保存
 4. VERIFY を直後に実行
 
-`closed_at` の値条件は SPEC [local/local-case-file.md](../../../../../docs/specs/local/local-case-file.md) の「closed_at の値条件」セクション参照。
+`closed_at` の値条件は SPEC [local/local-case-file.md](../../../../docs/specs/local/local-case-file.md) の「closed_at の値条件」セクション参照。
 
 ## status 状態遷移との協調
 
-本手続きは Case ファイルの status 状態遷移の一部を担う。状態遷移表の全体は SPEC [local/local-case-file.md](../../../../../docs/specs/local/local-case-file.md) の「状態遷移表」、運用参照資料は [../case-schema/case-file.md](../case-schema/case-file.md) の「status enum と状態遷移」参照。
+本手続きは Case ファイルの status 状態遷移の一部を担う。状態遷移表の全体は SPEC [local/local-case-file.md](../../../../docs/specs/local/local-case-file.md) の「状態遷移表」、運用参照資料は [../case-schema/case-file.md](../case-schema/case-file.md) の「status enum と状態遷移」参照。
 
 | 手続き | status 遷移 |
 |---|---|

--- a/src/opencode-local/agentdev-gh-cli/references/local-procedures.md
+++ b/src/opencode-local/agentdev-gh-cli/references/local-procedures.md
@@ -4,7 +4,8 @@ agentdev-gh-cli の各手続きのローカル版（Case ファイル版）実�
 標準版（GitHub 版）の実装手順（[standard-procedures.md](../../../opencode/skills/agentdev-gh-cli/references/standard-procedures.md)）で扱う gh CLI 呼び出しを、Case ファイル（`.agentdev/cases/case-{NNNN}.md`）の読み書きに読み替える。
 操作契約（手続き名、引数、戻り値）は [contracts.md](contracts.md) 参照。
 
-Case ファイルスキーマの意味仕様の正本は SPEC [local/local-case-file.md](../../../../docs/specs/local/local-case-file.md)。操作用定義は [../case-schema/case-file.md](../case-schema/case-file.md)。
+Case ファイルスキーマの意味仕様の正本は SPEC [local/local-case-file.md](../../../../docs/specs/local/local-case-file.md)。
+操作用定義は [../case-schema/case-file.md](../case-schema/case-file.md)。
 
 ## 共通制約
 
@@ -36,9 +37,12 @@ Case ファイルスキーマの意味仕様の正本は SPEC [local/local-case-
 3. **VERIFY**: 実行後に `git log -1 --pretty=%B` 等で読み戻し、書き出し時の本文と一致すること、および先頭バイトが UTF-8 BOM（`EF BB BF`）でないことを確認する
 4. **cleanup**: VERIFY が PASS した後に一時ファイルを削除する。VERIFY が FAIL の場合は cleanup を実行せず、一時ファイルを残して原因調査へ移行する
 
-worktree 隔離境界により `.agentdev/**` への書き込みが禁止される委譲の場面では、一時ファイル配置先をリポジトリ外の一時領域（`$env:TEMP` 配下）に変更する。本規定はローカル版へも適用できる。ただしローカル版は Case ファイル読み書きが主経路であるため、gh CLI 系の WRITE 手続き（一時ファイル配置先を含む）が必要になる場面は、ローカル版から gh CLI を直接利用する補助経路に限る（SPEC 同節「委譲時の一時ファイル代替配置先」「ローカル版の扱い」参照）。
+worktree 隔離境界により `.agentdev/**` への書き込みが禁止される委譲の場面では、一時ファイル配置先をリポジトリ外の一時領域（`$env:TEMP` 配下）に変更する。
+本規定はローカル版へも適用できる。
+ただしローカル版は Case ファイル読み書きが主経路であるため、gh CLI 系の WRITE 手続き（一時ファイル配置先を含む）が必要になる場面は、ローカル版から gh CLI を直接利用する補助経路に限る（SPEC 同節「委譲時の一時ファイル代替配置先」「ローカル版の扱い」参照）。
 
-本要件は標準版 [standard-procedures.md](../../../opencode/skills/agentdev-gh-cli/references/standard-procedures.md)「commit メッセージ作成（BOM なし UTF-8 契約）」節の規定と矛盾しない。同節の詳細実装（実装手段、禁止事項）を本ファイルへ複製せず、ローカル版における本要件の正を本ファイル1ファイルへ維持する（`standard-procedures.md` のローカル版新設は行わない）。
+本要件は標準版 [standard-procedures.md](../../../opencode/skills/agentdev-gh-cli/references/standard-procedures.md)「commit メッセージ作成（BOM なし UTF-8 契約）」節の規定と矛盾しない。
+同節の詳細実装（実装手段、禁止事項）を本ファイルへ複製せず、ローカル版における本要件の正を本ファイル1ファイルへ維持する（`standard-procedures.md` のローカル版新設は行わない）。
 
 ## Case 番号の採番
 
@@ -137,7 +141,8 @@ YAML 前書きの各フィールド制約は [../case-schema/rules/frontmatter.y
 
 ## status 状態遷移との協調
 
-本手続きは Case ファイルの status 状態遷移の一部を担う。状態遷移表の全体は SPEC [local/local-case-file.md](../../../../docs/specs/local/local-case-file.md) の「状態遷移表」、運用参照資料は [../case-schema/case-file.md](../case-schema/case-file.md) の「status enum と状態遷移」参照。
+本手続きは Case ファイルの status 状態遷移の一部を担う。
+状態遷移表の全体は SPEC [local/local-case-file.md](../../../../docs/specs/local/local-case-file.md) の「状態遷移表」、運用参照資料は [../case-schema/case-file.md](../case-schema/case-file.md) の「status enum と状態遷移」参照。
 
 | 手続き | status 遷移 |
 |---|---|
@@ -147,4 +152,6 @@ YAML 前書きの各フィールド制約は [../case-schema/rules/frontmatter.y
 | PR merge | `review` → `closed`（呼び出し元の責務。本手続きは `## マージ結果` 記録のみ） |
 | Issue close | `*` → `closed` または `cancelled` |
 
-status 遷移そのものは呼び出し元（各 command）の責務である。本手続きは対象セクションの読み書きと YAML 前書きの `updated_at` 更新のみを担う。ただし Issue close は例外的に `status` と `closed_at` を直接更新する。
+status 遷移そのものは呼び出し元（各 command）の責務である。
+本手続きは対象セクションの読み書きと YAML 前書きの `updated_at` 更新のみを担う。
+ただし Issue close は例外的に `status` と `closed_at` を直接更新する。


### PR DESCRIPTION
## 背景

Refs: #2246（OU-0019、Epic #2244「個別整備」Wave 1、source: RU-0064、CR-003）。
agentdev-gh-cli ローカル版（Case ファイル版）も git 操作（commit 等）を行う一方、git CLI 直接操作の初期化要件は標準版 standard-procedures.md にしか存在しなかった。
本 PR は SPEC agentdev-gh-cli「ローカル版の扱い」節（ACT-SPEC-014 適用済み）が規定する参照実体1ファイル構成に従い、初期化要件の正を local-procedures.md へ追記する。

## 変更内容

- src/opencode-local/agentdev-gh-cli/references/local-procedures.md へ「git CLI 直接操作の初期化要件」節を新設した（fcc8415c）
  - コンソールエンコーディング初期化3行（標準版 standard-procedures.md Section 2 Step 0 と同一）
  - BOM なし UTF-8 ファイル渡し（`-F`（`--file`）オプション）
  - VERIFY（`git log -1 --pretty=%B` 等での読み戻し一致、先頭バイトが UTF-8 BOM でないことの確認）
  - cleanup（VERIFY PASS 後のみ実行、省略不可）
  - 「委譲時の一時ファイル代替配置先」節のローカル版への適用（gh CLI 直接利用の補助経路に限定）
- 当該ファイル内の相対リンク切れ5箇所を是正した（標準版 standard-procedures.md 参照、SPEC local/local-case-file.md 参照の計算違い）
- 一文一行機械判定違反5行を文境界で行分割した（10409f9c、TS-QC-001 on_failure: fix-and-reverify に従う修正）
- standard-procedures.md のローカル版新設は行っていない（CR-003。参照実体を1ファイルへ維持し二重管理を回避）

## 検証結果

| 項目 | 結果 |
|---|---|
| 完了条件1: local-procedures.md へ git CLI 初期化要件の記載 | PASS（「git CLI 直接操作の初期化要件」節。初期化3行・BOM なし UTF-8 ファイル渡し・VERIFY・cleanup 全て記載） |
| 完了条件2: SPEC へローカル版 references 実体構成と代替配置先の適用可否の定義 | PASS（docs/specs/skills/agentdev-gh-cli.md「ローカル版の扱い」節で実体確認。ACT-SPEC-014 適用済み分） |
| 完了条件3: standard-procedures.md のローカル版新設を行っていないこと | PASS（ローカル版 references は contracts.md / local-procedures.md / retry.md / verify.md の4ファイル） |
| 完了条件4: TS-019 pass_criteria | PASS（下記 TS-019 検証） |
| TS-019 | PASS（SPEC「ローカル版の扱い」節の定義確認、local-procedures.md 追記内容の確認、src/opencode-local/ 実体編集の確認） |
| TS-QC-001 | PASS（機械判定4規範で未解決違反なし。fix-and-reverify 実施済み） |

- **bun test**: 2058 pass / 0 fail（4550 expect() calls、85 files、168.08s、baseline 2058-2062 pass / 0 fail の範囲内）
  - 実行 cwd: `.worktrees/2246-feature/.opencode/skills/repo-agentdev-integrity/scripts`（事前に同ディレクトリで `bun install` 実施）
  - 起動コマンド形式: `bun test ./`
- **check_distribution_boundary**: `bun run check_distribution_boundary.ts --profile source <worktree-root>` → ok: true（scanned_files 330、failures 0、concrete_id_hits 0、concrete_path_hits 0、fixed_url_hits 0、exit 0）
- **check_changed_docs**: 未実施（本 PR の docs/ 変更なし。実施条件不発）
- **TS-QC-001 機械判定**（agentdev-doc-writing 機械判定4規範、対象ファイルへ適用）: 中黒 0 件、em-dash 0 件、LLM 表現 0 件、一文一行 0 件（修正後再スキャンで確認）
- **エンコーディング検証**: 対象ファイルは BOM なし UTF-8（先頭バイト 23 20 E3）、LF のみ（CRLF 0 件）
- **変更ファイル**: src/opencode-local/agentdev-gh-cli/references/local-procedures.md のみ（src/opencode/**・docs/** は未変更）
- **契約テスト期待値**: 該当なし（command、skill、template の構造様式変更なし。変更は skill references の文書追記のみ）

## Findings・Capture候補

### intake

- src/opencode-local/agentdev-gh-cli/references/ の兄弟ファイル（contracts.md 2行、verify.md 3行、retry.md 1行）に一文一行機械判定違反が残存する。OU-0018 の機械是正（PR #2275）は src/opencode 側のみが適用範囲で、src/opencode-local 側は適用外だった。横断是正の実施候補。

### learning

該当なし

## SPEC確定候補

該当なし（本 PR は SPEC「ローカル版の扱い」節の実体確認を含むが、SPEC 本文へ追加確定すべき事項は発生していない）