### PR TITLE
fix(integrity): NG baseline 暫定管理課題の是正と entry 除去（OU-0009、Refs: #2245）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/baselines/ng-baseline.json
+++ b/.opencode/skills/repo-agentdev-integrity/baselines/ng-baseline.json
@@ -148,24 +148,6 @@
       "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
     },
     {
-      "category": "CaptureBoundary",
-      "check": "command-capture-duty",
-      "file": "src/opencode/commands/agentdev/case-close.md",
-      "evidence": null,
-      "count": 1,
-      "provenance": "実欠陥",
-      "reason": "実欠陥: case-close.md の capture-boundaries 参照記述欠落。配布物コマンド編集を要し、OU-007（#2141）配布物是正で実施するまでの承認（NG21 分類 N17）"
-    },
-    {
-      "category": "CaptureBoundary",
-      "check": "command-capture-duty",
-      "file": ".opencode/commands/agentdev/case-close.md",
-      "evidence": null,
-      "count": 1,
-      "provenance": "実欠陥",
-      "reason": "実欠陥: case-close.md の capture-boundaries 参照記述欠落（junction 環境で checker が projection パス `.opencode/commands/agentdev/case-close.md` で検出する場合の同一承認分。src パス側 entry と対。OU-007（#2141）配布物是正で実施するまでの承認、NG21 分類 N17、Issue #2179 で路地合わせ）"
-    },
-    {
       "category": "Decision",
       "check": "accepted-adr-only-citation",
       "file": "docs/specs/commands/case-auto.md",
@@ -3017,15 +2999,6 @@
       "count": 1,
       "provenance": "v3-migration",
       "reason": "Stage 5 v2→v3 migration structural consequence (ADR-001 naming, v2: prefix range parsing, README table mismatch)"
-    },
-    {
-      "category": "integrity-rule-gap",
-      "check": "skill-category-gap",
-      "file": ".opencode/skills/repo-agentdev-integrity/SKILL.md",
-      "evidence": "Skill rename 対称性",
-      "count": 1,
-      "provenance": "実欠陥",
-      "reason": "実欠陥: 検査カテゴリ「Skill rename 対称性」が check_integrity.ts の categoryToCheckPattern map に未登録。checker 側変更（map 追加と check_skill_rename_symmetry.ts の対象スクリプト登録）として次回 checker 改修で解消するまでの承認（NG21 分類 N16）"
     }
   ]
 }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -2909,6 +2909,66 @@ describe("IR-055 runtime-unresolved-reference 実修復回帰 (Issue #1782)", ()
   });
 });
 
+// ─── NG21 N16/N17 是正回帰テスト（Issue #2245, OU-0009, RU-0054） ──────────
+// N16（skill-category-gap: 「Skill rename 対称性」カテゴリの
+// categoryToCheckPattern map 未登録・check_skill_rename_symmetry.ts の
+// scriptFiles 対象未登録）と N17（command-capture-duty: case-close.md の
+// capture-boundaries 参照欠落）を実修復し、対応する baseline entry を
+// 除去した後の状態を保持することを検証する。baseline 更新だけで
+// gap/duty 違反を info へ降格していないことを回帰テストとして固定する。
+
+describe("NG21 N16/N17 是正回帰 (Issue #2245, OU-0009)", () => {
+  const REPO_ROOT = join(SCRIPT_DIR, "..", "..", "..", "..");
+
+  it("N16: 'Skill rename 対称性' カテゴリが gap で ng/warning にならないこと（map + scriptFiles 登録）", () => {
+    const proc = Bun.spawnSync(["bun", "run", SCRIPT_FILE, "--json"], {
+      cwd: REPO_ROOT,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = proc.stdout?.toString("utf-8") ?? "";
+    expect(stdout.length).toBeGreaterThan(0);
+
+    const parsed = JSON.parse(stdout) as {
+      results: Array<{ check: string; level: string; message?: string }>;
+    };
+
+    const gapNg = parsed.results.filter(
+      (r) =>
+        r.check === "skill-category-gap" &&
+        (r.level === "ng" || r.level === "warning"),
+    );
+    expect(gapNg.length).toBe(0);
+
+    const gapOk = parsed.results.find(
+      (r) => r.check === "skill-category-gap" && r.level === "ok",
+    );
+    expect(gapOk).toBeDefined();
+    expect(gapOk!.message).toContain("corresponding implementations");
+  });
+
+  it("N17: case-close.md の command-capture-duty が ok であること（capture-boundaries 参照）", () => {
+    const proc = Bun.spawnSync(["bun", "run", SCRIPT_FILE, "--json"], {
+      cwd: REPO_ROOT,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = proc.stdout?.toString("utf-8") ?? "";
+    const parsed = JSON.parse(stdout) as {
+      results: Array<{ check: string; level: string; message?: string }>;
+    };
+
+    const duty = parsed.results.find(
+      (r) =>
+        r.check === "command-capture-duty" &&
+        (r.message ?? "").includes("case-close.md"),
+    );
+    expect(duty).toBeDefined();
+    expect(duty!.level).toBe("ok");
+    expect(duty!.message).toContain("capture-boundaries reference");
+  });
+});
+
 // ─── WP-3 (Issue #1928): execution profile separation ───────────────────────
 // §7 exit-code contracts for source/installed/release.
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -4881,6 +4881,7 @@ function checkSkillCategoryGap(
     "check_integrity.ts",
     "check_templates.ts",
     "lint_skills.ts",
+    "check_skill_rename_symmetry.ts",
   ];
   for (const scriptFile of scriptFiles) {
     const scriptPath = path.join(scriptsDir, scriptFile);
@@ -4917,6 +4918,7 @@ function checkSkillCategoryGap(
     ["REQ verification basis", ["ReqVerificationBasis"]],
     ["Runtime reference", ["RuntimeUnresolvedReference"]],
     ["Distribution untracked skill", ["DistributionUntrackedSkillReference"]],
+    ["Skill rename 対称性", ["SkillRenameSymmetry"]],
   ]);
 
   let foundGap = false;

--- a/src/opencode/commands/agentdev/case-close.md
+++ b/src/opencode/commands/agentdev/case-close.md
@@ -75,7 +75,7 @@ OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため�
 - 機能追加で docs/ 更新がない場合は警告表示して停止確認する。テスト戦略チェックボックスは必ず更新する
 - コメントテンプレートの【必須】セクションを確認してから投稿する
 - 学びの検知はエージェント自律で行う（ユーザーに問わない）
-- capture 責務は「回収・保存」である: PR 本文から intake/ learning を分離回収してドメイン状態に保存し、同一 commit に含める（capture 境界は `agentdev-workflow-orchestration` 参照）。SPEC確定候補の処理は PR 本文の `## SPEC確定候補` を入力とし、`## Findings / Capture候補` とは区別する
+- capture 責務は「回収・保存」である: PR 本文から intake/ learning を分離回収してドメイン状態に保存し、同一 commit に含める（capture 境界（capture-boundaries）は `agentdev-workflow-orchestration` 参照）。SPEC確定候補の処理は PR 本文の `## SPEC確定候補` を入力とし、`## Findings / Capture候補` とは区別する
 - 完了報告は結果状態を分離して報告する（`.agentdev` push 失敗時は完了扱いにしない）。今回の完了条件に含まれる未対応事項は intake 記録として明示し、完了扱いには含めない
 - ドメイン状態永続化の commit は並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、明示パス（`git add <path>`/ `git rm <path>`）でステージし、`git commit -- <paths>`（--only pathspec 形式）で実行する
 


### PR DESCRIPTION
## 背景

Issue #2245（OU-0009、Epic #2244 EU-G Wave 1）。RU-0054 起点の NG baseline 暫定管理 3 課題（N01/N16/N17）を是正し、対応する baseline entry を除去する。N01（REQ-021-003 の v2:ADR-006→DEC-006 参照更新）は req-save 工程（ACT-REQ-001）で適用済みのため検証のみ（REQ-021.md の関連 Decision が DEC-006 表記であることを確認済み）。依存 OU-0008（#2206）はマージ済み。

## 変更内容

- N16: check_integrity.ts の checkSkillCategoryGap について、categoryToCheckPattern map へ「Skill rename 対称性」→ SkillRenameSymmetry を登録し、scriptFiles 対象へ check_skill_rename_symmetry.ts を追加した
- N17: src/opencode/commands/agentdev/case-close.md の capture 責務行へ capture-boundaries 参照を追加した（「capture 境界（capture-boundaries）は agentdev-workflow-orchestration 参照」の表記）
- NG baseline（ng-baseline.json）から N16/N17 の entry 計3件を除去した（skill-category-gap 1件、command-capture-duty 2件: src パス + projection パス）。N17 のパス bucket key 表記は AG-008（OU-0008）のパス正規化方針に従い、projection パス側 entry も対で除去した
- N16/N17 是正後の状態を固定する回帰テスト2件（「NG21 N16/N17 是正回帰 (Issue #2245, OU-0009)」）を check_integrity.test.ts へ追加した

## 完了条件

- [x] N01/N16/N17 の実是正が完了し、対応する baseline entry が除去されていること
- [x] QG-4 の機械 delta ノイズが解消されていること
- [x] check_skill_rename_symmetry が check_integrity 経由で実行されること（scriptFiles 対象登録の確認）
- [x] TS-009 の pass_criteria を満たしていること（不合格時は on_failure に従うこと）
- [x] 契約テスト期待値の更新と固定トークン確認: 実施済み（期待値更新対象: なし。構造様式変更なしのため既存契約テストの期待値変更は不要。回帰テスト2件を新規追加し、固定トークン "corresponding implementations"（skill-category-gap ok）・"capture-boundaries reference"（command-capture-duty ok）を検証で固定）

## 検証結果

テスト戦略 TS-009: 合格（N01/N16/N17 の実是正完了・対応 baseline entry 除去・機械 delta ノイズ解消を確認）。
TS-QC-001: 合格（check_command_format.ts OK・配布物記述基準 checker 通過）。TS-QC-002: 合格（full integrity suite + bun test 全件通過）。

- full suite: 2060 pass / 0 fail（4557 expect() calls、85 files、168.49s）— baseline 2058-2062 pass / 0 fail の範囲内
- 新規回帰テスト個別: `bun test ./check_integrity.test.ts -t "NG21 N16/N17"` → 2 pass / 0 fail（89 filtered out）
- check_integrity.ts --json: skill-category-gap=ok（All 25 SKILL.md categories have corresponding implementations）、command-capture-duty case-close.md=ok（has capture-boundaries reference and duty keyword「回収・保存」）。baseline 適用後の新規 ng（本変更由来）0 件
- check_distribution_boundary.ts --profile source: ok=true / exit 0（scanned_files=329、concrete_id_hits=0、concrete_path_hits=0、fixed_url_hits=0）
- check_command_format.ts: OK / exit 0
- tsc --noEmit -p tsconfig.distribution-boundary.json: exit 0（tsconfig の include は distribution-boundary 系のみ。check_integrity.ts は bun test による全件実行で実行時検証）
- **実行 cwd**: `.worktrees/2245-feature/.opencode/skills/repo-agentdev-integrity/scripts`（bun test・typecheck）、`.worktrees/2245-feature`（checker 各種）
- **起動コマンド形式**: `bun test ./`（./ prefix で当該ディレクトリ全体を明示指定）

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| full suite pass | 2060 | 2058-2062（環境差 baseline） | ✅ |
| full suite fail | 0 | 0 | ✅ |
| baseline entry 除去（N16/N17） | 3件 | 3件 | ✅ |
| 本変更由来の新規 ng | 0 | 0 | ✅ |

## Findings / Capture候補

### intake

- check_integrity 全体実行で warning 14件（REQ-028 retired 参照 11件: docs/specs 配下、DEC 引用 3件: DEC-017 proposed ×2・DEC-005 superseded ×1）が baseline 未管理 delta として検出される。いずれも本 PR の変更対象外パス（docs/specs・docs/specs/integrity/audits）で、worktree base f5b64d94 時点から存在する既存状態である（本 PR の diff は baseline・checker・case-close.md のみ）。既知の baseline drift 系課題（intake inbox の baseline-drift-bucket-recompute 等）と同系のため、本 PR では是正対象外とする

### learning

該当なし

## SPEC確定候補

該当なし（NG baseline 運用契約の明文化とパス正規化方針は依存 OU-0008（#2206）で確定済み。本 PR は checker 登録・参照追加・entry 除去のみで、SPEC レベルの新規契約はなし）

Refs: #2245