### PR TITLE
docs(agentdev): inspect 系3スキルへ document-model cleanup モデルへの適用経路を明示（OU-0033）

### DIFF
--- a/src/opencode/skills/agentdev-doc-diagnostics/SKILL.md
+++ b/src/opencode/skills/agentdev-doc-diagnostics/SKILL.md
@@ -49,6 +49,14 @@ extension（`.agentdev/extensions/skills/`）は標準 SKILL.md を前提とし�
 | 文意品質（LLM 表現、空虚語、英語混じり、実行主体分類） | `agentdev-doc-writing` | ルーティングのみ |
 | docs 横断診断カテゴリ、共通証拠構造、共通 finding 出力契約 | `agentdev-doc-diagnostics`（本スキル） | 一次所有 |
 
+## cleanup モデルへの適用経路
+
+document-model SPEC（extension 経由）「恒久基準と非規範情報の整理」は、非規範情報（移行情報、内部実装方式、fixture、regex、内部関数、テスト構成、未宣言 reference、draft SPEC、移行証跡、リリース証跡）を整理する cleanup モデル（6処置: KEEP、MERGE、REFERENCE、MOVE、RETIRE、INFERENCE）を所有し、処置の実行を inspect-docs / inspect-skills / 専用の cleanup 作業へ割り当てる。
+本スキルは inspect-docs の横断診断カテゴリの一次所有者として、この適用経路に組み込まれる。
+横断診断で cleanup モデルの対象カテゴリに該当する記述を検出した場合は、6処置の候補を検出事項の推奨 route に併記して提示する。
+処置に伴う文書変更は行わない（診断専用）。
+cleanup モデルと処置契約の SSoT は document-model SPEC であり、本スキルは再定義しない。
+
 ## 参考文献
 
 | ファイル | 内容 |

--- a/src/opencode/skills/agentdev-inspect-skills/SKILL.md
+++ b/src/opencode/skills/agentdev-inspect-skills/SKILL.md
@@ -43,6 +43,14 @@ extension（`.agentdev/extensions/skills/`）は標準 SKILL.md を前提とし�
 - 対象外（Out of Scope）
 - 推奨 intake/ learning route
 
+## cleanup モデルへの適用経路
+
+document-model SPEC（extension 経由）「恒久基準と非規範情報の整理」は、非規範情報を整理する cleanup モデル（6処置: KEEP、MERGE、REFERENCE、MOVE、RETIRE、INFERENCE）を所有し、処置の実行を inspect-docs / inspect-skills / 専用の cleanup 作業へ割り当てる。
+本スキルは配布物（Command/Skill 定義）の診断において、この適用経路に組み込まれる。
+配布物に cleanup モデルの対象カテゴリ（規範または非規範の地位が未宣言の references、移行証跡、リリース証跡等）に該当する記述を検出した場合は、6処置の候補を検出事項の推奨 route に併記して提示する。
+処置に伴うファイル変更は行わない（検査対象を直接修正しない制約に従う）。
+cleanup モデルと処置契約の SSoT は document-model SPEC であり、本スキルは再定義しない。
+
 ## 診断観点
 
 | 観点 | 確認内容 |

--- a/src/opencode/skills/agentdev-req-structure-diagnostics/SKILL.md
+++ b/src/opencode/skills/agentdev-req-structure-diagnostics/SKILL.md
@@ -31,6 +31,14 @@ extension（`.agentdev/extensions/skills/`）は標準 SKILL.md を前提とし�
 |----------|------|
 | inspect-docs | docs全体の意味整合性レビューにおける REQ 構造診断ロジックの提供（REQ参照ID整合性、第一参照導線、現行/廃止境界、SPEC分離基準違反検出、6観点診断、未処理成果物確認、問題候補出力スキーマ、配布物統合性検出（構文健全性、文意保持、責務整合、NG 分類）） |
 
+## cleanup モデル（6処置）と6観点診断の別軸性
+
+本スキルの6観点診断（SPLIT、MERGE、MOVE、DUPLICATE、RETIRE、DRIFT）と、document-model SPEC（extension 経由）「恒久基準と非規範情報の整理」の cleanup 6処置（KEEP、MERGE、REFERENCE、MOVE、RETIRE、INFERENCE）は別軸である。
+診断観点は REQ 体系の構造的問題を検出する軸であり、cleanup 6処置は非規範情報の整理処置を表す軸である。
+両者の対応関係は document-model SPEC が正規所有し、本スキルは再定義しない。
+REQ 内の内部実装方式（cleanup モデルの対象カテゴリ）の残留は SPEC 分離基準違反の検出シグナルとして扱い、検出事項には cleanup 6処置の候補を推奨 route に併記できる。
+処置に伴う文書変更は行わない（診断専用）。
+
 ## 参考文献
 
 | ファイル | 内容 |


### PR DESCRIPTION
Refs: #2249

## 背景

OU-0033（source: RU-0078、operation: update、scale: standard）。document-model SPEC「恒久基準と非規範情報の整理」（Issue 本文記載の L580 cleanup 実行契約）は、処置の実行を inspect-docs / inspect-skills / 専用の cleanup 作業へ割り当てる。
一方で推奨検討対象5スキル（agentdev-doc-diagnostics、agentdev-req-structure-diagnostics、agentdev-inspect-skills、agentdev-learning-pipeline、agentdev-intake-pipeline）の SKILL.md はいずれも当該 cleanup モデルへの参照・適用を持たず、実行契約と実行者（inspect 系スキル群）の間の適用経路が未確立だった。

## 変更内容

src/opencode/skills/ 配下の3ファイルのみ変更（3 files changed、+24 / -0）。document-model.md L580 自体の変更は含まない（SSoT は現行維持、Issue の対象外宣言どおり）。

### スキルごとの要否判断結果（TS-033 の判断記録）

| スキル | 判断 | 根拠 | 変更 |
|---|---|---|---|
| agentdev-doc-diagnostics | 明示参照: 必要 | inspect-docs（cleanup 処置実行者）の横断診断カテゴリ・ルーティングの一次所有者であり、document-model が割り当てた実行者側の知識基盤 | 「cleanup モデルへの適用経路」節を追加 |
| agentdev-req-structure-diagnostics | 明示参照: 必要 | 6観点診断（SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）が cleanup 6処置（KEEP/MERGE/REFERENCE/MOVE/RETIRE/INFERENCE）と同名値（MERGE/MOVE/RETIRE）を含み混同リスクが最大。REQ 内内部実装方式の検出は cleanup 対象カテゴリと直結 | 「cleanup モデル（6処置）と6観点診断の別軸性」節を追加 |
| agentdev-inspect-skills | 明示参照: 必要 | document-model が cleanup 処置実行者として inspect-skills を明示指定しているのに SKILL.md に参照が一切ない（適用経路欠落） | 「cleanup モデルへの適用経路」節を追加 |
| agentdev-learning-pipeline | 明示参照・実行時適用とも不要 | document-model の実行者列挙（inspect-docs / inspect-skills / 専用 cleanup 作業）に含まれない。処分区分（11カテゴリ + duplicate）は cleanup 6処置と語彙重複がなく、別分類であることを document-model SPEC が既に正規宣言済み | なし |
| agentdev-intake-pipeline | 明示参照・実行時適用とも不要 | 同上（intake 側も実行者外・語彙重複なし） | なし |

追記3節はいずれも、cleanup モデルと処置契約の SSoT が document-model SPEC（extension 経由）であること、検出事項には6処置の候補を推奨 route に併記できること、処置に伴う文書変更は行わないこと（診断専用）を明示する。モデルの再定義は行わない。

## 検証結果

### TS-033（pass_criteria 充足。on_failure 未発動）

- verification: 推奨検討対象5スキルの SKILL.md について、L580 cleanup モデルの明示参照または実行時適用の判断結果が確定していることを確認した。
- 5スキルすべてに要否判断を確定し、判断「必要」の3スキルへ明示参照節を追記した（上表）。判断「不要」の2スキルは実行者列挙外・別軸宣言済みの根拠とともに記録した。
- 適用経路: document-model SPEC（SSoT）→ inspect-docs / inspect-skills（処置実行者）→ doc-diagnostics / req-structure-diagnostics / inspect-skills（知識基盤側の明示参照）→ 検出事項の推奨 route へ6処置候補を併記 → 処置実行は専用の cleanup 作業。

### TS-QC-001（対象基準に未解決違反なし）

- lint_skills.ts --json: 変更前後で結果同一（ok=673、ng=1、info=1）。検出 ng 1件は agentdev-git-worktree/references/worktree-operations.md の既知 TOC 300行超（pre-existing、対象5スキル外）。対象5スキルに新規違反なし。
- check_integrity.ts --profile source --json: 変更前後で結果同一（ok=241、ng=0、warning=14、info=161）。warning 14件はすべて pre-existing（REQ-028 retired 参照、DEC-005/DEC-017 非 accepted 引用）。
- 文書品質査読: 追記3節は japanese-tech-writing 規範（一文一行、LLM 表現禁止、冗長排除）と agentdev-doc-writing の実行主体分類に適合。SKILL.md 見出しは日本語。

### check_distribution_boundary.ts（src/opencode/** 変更時の必須検査）

- 起動コマンド: `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts --profile source --json`
- 実行 cwd: .worktrees/2249-feature
- 結果: ok=true、failures: 0（scanned_files: 329、concrete_id_hits: 0、concrete_path_hits: 0、fixed_url_hits: 0）
- check_changed_docs.ts は docs/ 変更がないため対象外（本 PR の変更は src/opencode/skills/ 配下のみ）。generate_indexes も docs/specs 行数変化なしのため対象外。

### 関連テスト（bun test・AG-035 記録様式）

- 起動コマンド（対象）: `bun test ./skills_structure.test.ts ./lint_skills.test.ts ./check_integrity.test.ts`
- 実行 cwd: .worktrees/2249-feature/.opencode/skills/repo-agentdev-integrity/scripts
- 結果: 577 pass / 0 fail（Ran 577 tests across 3 files、1036 expect() calls）
- 起動コマンド（full）: `bun test`
- 実行 cwd: 同上
- 結果: 2058 pass / 0 fail（Ran 2058 tests across 85 files、4550 expect() calls）— full suite baseline（2058-2062 pass / 0 fail）の範囲内
- 実行前に scripts ディレクトリで bun install 実施（5 packages installed）
- 対象根拠: SKILL.md 構造（frontmatter・USE FOR・See Also）を検査する skills_structure、記述基準 lint の lint_skills、checker 本体の check_integrity を主対象とし、full suite で回帰確認した

## Findings・Capture候補

### intake

該当なし

### learning

該当なし

## SPEC確定候補

- agentdev-doc-diagnostics / agentdev-req-structure-diagnostics / agentdev-inspect-skills の各 skill SPEC（docs/specs/skills/）へ「cleanup モデルへの適用経路」相当の参照を反映する候補。本 PR は Issue の変更対象成果物（各 SKILL.md）に限定して SKILL.md 側へ明示参照を追記した。SKILL.md は原本 SPEC を正とする参照構造を取るため、SPEC 側への同一参照の正式反映は後続の spec-save / inspect 経路で確定判断する。
- document-model.md「恒久基準と非規範情報の整理」自体の変更は Issue の対象外宣言（SSoT は現行維持）どおり実施していない。