### PR TITLE
docs(specs): doc-diagnostics SPEC の中黒流動的並列2箇所を是正（OU-0040、Refs: #2250）

### DIFF
--- a/docs/specs/skills/agentdev-doc-diagnostics.md
+++ b/docs/specs/skills/agentdev-doc-diagnostics.md
@@ -2,7 +2,7 @@
 title: agentdev-doc-diagnostics SPEC
 status: draft
 created: 2026-07-22
-updated: 2026-08-18
+updated: 2026-08-19
 ---
 
 # agentdev-doc-diagnostics SPEC
@@ -56,7 +56,7 @@ inspect-docs の診断観点は正規の観点レジストリが所有する（R
 - **配置先**: `docs/specs/skills/agentdev-doc-diagnostics/references/perspective-registry.md`（本 SPEC の references 配下）
 - **schema**: 各観点エントリは観点ID（一意）、診断カテゴリ（SPLIT、MERGE、MOVE、DUPLICATE、RETIRE、DRIFT、残余参照、境界違反等）、適用文書種別、正規所有者 skill、詳細参照の項目を持つ
 - 移管対応表（integrity-rule-catalog.md の inspect-docs 移管記録）で名指しされた観点は当該レジストリへ登録する
-- レジストリの追加・変更は本 schema に従い、本 SPEC が schema の正規所有者となる
+- レジストリの追加、変更は本 schema に従い、本 SPEC が schema の正規所有者となる
 
 ## 参照する references
 
@@ -73,7 +73,7 @@ inspect-docs の診断観点は正規の観点レジストリが所有する（R
 
 ## 境界
 
-`agentdev-doc-writing`（文意品質）、`agentdev-req-structure-diagnostics`（REQ 固有 SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）、README 索引・トレーサビリティ派生索引 `agentdev-artifact-graph`（探索・導線）との責務重複がないこと。
+`agentdev-doc-writing`（文意品質）、`agentdev-req-structure-diagnostics`（REQ 固有 SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）、README 索引、トレーサビリティ派生索引 `agentdev-artifact-graph`（探索・導線）との責務重複がないこと。
 docs 横断診断は本 skill が正規の所有者となる（REQ-036-013 の diagnostics 許容例外境界、CR-001）。
 
 ## 対象外


### PR DESCRIPTION
Refs: #2250

## 背景

OU-0040（source: RU-0085、operation: update、scale: standard、Epic #2244 EU-G Wave 2）。廃止済み配布物スキル agentdev-doc-map（REQ-013-002/003 で廃止、実体不存在）の doc-diagnostics SPEC 参照4箇所（L18/L41/L69/L75）が現行の責務所在の記述へ更新されていること、CT-SPEC-026 として spec-save が適用済みであること、廃止済みスキル参照の grep 0件と旧パスリンクの解消を検証する確認系 Issue。前工程（spec-save: 3b8a42ff、ACT-SPEC-026）で本体是正は適用済み。

## 変更内容

docs/specs/skills/agentdev-doc-diagnostics.md のみ変更（1 file changed、+3 / -3、行数不変100行）。

TS-QC-001 査読（agentdev-doc-writing 参照基準）で中黒の流動的並列2箇所を検出し、on_failure（fix-and-reverify）に従い是正した:

- 観点レジストリ節: 「レジストリの追加・変更は」→「レジストリの追加、変更は」
- 境界節: 「README 索引・トレーサビリティ派生索引」→「README 索引、トレーサビリティ派生索引」
- frontmatter updated: 2026-08-18 → 2026-08-19

許容と判断し維持した中黒:

- 「探索・導線」（4箇所）: ACT-SPEC-026（spec-save）が確定導入した複合概念名。4箇所一貫使用であり、機械置換（読点）は概念名としての意味を壊すため文脈判断で許容
- 「提供する判断・操作」（見出し）: skill SPEC テンプレート（_template.md）由来の固定見出し（6ファイル使用）

## 検証結果

### TS-040（AG-040）: pass_criteria 充足、on_failure 未発動

- verification: 当該 SPEC において agentdev-doc-map 参照を grep（パターン: agentdev-doc-map / doc-map / doc_map / document-map / DOC-MAP、大文字小文字区別なし）→ すべて 0件
- 参照4箇所（現行 L18/L41/L70/L76）が現行の責務所在（README 索引、`agentdev-artifact-graph`、`agentdev-req-structure-diagnostics`、`agentdev-doc-writing`）の記述へ更新済みことを確認（3b8a42ff の diff で旧 L18/L41/L69/L75 相当の置換を確認）
- 旧パスリンクの解消確認: 現行ファイルに旧パス（docs/DOC-MAP.md、agentdev-doc-map 相対リンク等）への言及なし。相対リンク2件（agentdev-req-structure-diagnostics.md、agentdev-doc-writing.md）は実在確認
- CT-SPEC-026 spec-save 適用済み: コミット 3b8a42ff（ACT-SPEC-001〜026 一括反映、2026-08-18）で適用、frontmatter updated も同日

### TS-QC-001: 査読で中黒流動的並列2件を検出 → fix-and-reverify で是正 → 再査読で未解決違反なし

- SPEC 本文の合格基準（spec-writing-quality.md）: 現在形記述、検証可能構成要素（schema・配置先・判定表）、内部設計文書の位置づけ明記、他文書種別への移送対象なし
- 機械判定 4 規範（mechanical-replacement-rules.md）: em-dash 0件、一文一行違反 0行、LLM 表現（X5/X6 パターン）0件、英語混じり禁止表現 0件、中黒は違反2件を是正（残りは許容）

### check_changed_docs.ts（docs/ 変更時の必須検査）

- 起動コマンド: `bun run ./check_changed_docs.ts --workflow case-run --files docs/specs/skills/agentdev-doc-diagnostics.md`
- 実行 cwd: .worktrees/2250-feature/.opencode/skills/repo-agentdev-integrity/scripts
- 結果: failures 0 / warnings 0（files checked 1、coupled files checked 2、索引更新フラグすべて false）
- generate_indexes は docs/specs 行数変化なしのため対象外。check_distribution_boundary.ts は src/opencode/** 変更なしのため対象外

### 関連テスト（bun test・AG-035 記録様式）

- 起動コマンド（対象）: `bun test ./check_changed_docs.test.ts ./generate_indexes.test.ts ./check_integrity.test.ts`
- 実行 cwd: .worktrees/2250-feature/.opencode/skills/repo-agentdev-integrity/scripts
- 結果: 171 pass / 0 fail（Ran 171 tests across 3 files、453 expect() calls）
- 起動コマンド（full）: `bun test`
- 実行 cwd: 同上
- 結果: 2060 pass / 0 fail（Ran 2060 tests across 85 files、4557 expect() calls）— full suite baseline（2058-2062 pass / 0 fail）の範囲内
- 実行前に scripts ディレクトリで bun install 実施（5 packages installed）
- 対象根拠: docs 変更に直接関連する checker（check_changed_docs）、索引生成（generate_indexes）、整合検査本体（check_integrity）を主対象とし、full suite で回帰確認した

### check_integrity.ts（docs 整合の追加確認）

- 起動コマンド: `bun run ./check_integrity.ts --profile source --json`
- 実行 cwd: 同上
- 結果: NG 0 / Warning 14。Warning 14 はすべて pre-existing（REQ-028 retired 参照群、DEC 非 accepted 引用。PR #2282 時点と同数・同構成）

## Findings・Capture候補

### intake

- docs/specs/responsibilities/artifact-responsibilities.md L54・L60 に廃止済み `agentdev-doc-map` への参照が現役で残存（「操作 skill 正規所有者台帳」表の対外欄「探索順（agentdev-doc-map）」と責務重複記述）。TS-040 の grep 対象は doc-diagnostics SPEC のみであり本 Issue スコープ外。歴史記述（探索順の旧所有の表明）か廃止スキル参照の是正漏れかは inspect-docs / intake 経由での分類を推奨
- .opencode/skills/repo-agentdev-integrity/references/vocabulary-registry.md L107 に「agentdev-doc-map | DOC-MAP 管理」の語彙項目が残存。廃止済みスキルの語彙エントリ保持の要否は語彙レジストリ管理側での判断候補

### learning

該当なし

## SPEC確定候補

- 本 PR は既存 draft SPEC（agentdev-doc-diagnostics）の文書品質是正のみ。draft STATUS の accepted 昇格は case-close の SPEC 確定ステップが所管（Issue の scope-affecting impact candidate 宣言どおり）
- 新規の SPEC 確定候補なし