### PR TITLE
agentdev: #2295 inspect-promote 自律確定とHITLフォールバック実装

### DIFF
--- a/.agentdev/extensions/skills/agentdev-workflow-inspect-promote.yaml
+++ b/.agentdev/extensions/skills/agentdev-workflow-inspect-promote.yaml
@@ -4,10 +4,10 @@ id: agentdev-workflow-inspect-promote
 
 context:
   - id: workflow-contracts
-    when: ワークフロー契約（検出事項 lifecycle、capture 境界）参照時
+    when: ワークフロー契約（検出事項 lifecycle、capture 境界、promote系判断確定とHITL境界）参照時
     paths:
       - "docs/specs/workflows/workflow-contracts.md"
-    purpose: 検出事項の分類・昇格ワークフロー契約の確認
+    purpose: 検出事項の分類・昇格ワークフロー契約、自律確定可否の詳細判定表の確認
 
 rules: []
 

--- a/src/opencode/commands/agentdev/inspect-promote.md
+++ b/src/opencode/commands/agentdev/inspect-promote.md
@@ -25,6 +25,15 @@ description: 検出事項を分類、採用し、採用済み成果物として 
 `--auto` で自動 promote される高確信度カテゴリ、投入先、実行ログ、誤検知 revoke 手順の詳細は workflow-contracts SPEC（extension 経由で解決）の「inspect-promote 自動 promote」セクションに原本を置く。
 本コマンドはカテゴリ定義を重複保持しない。
 
+## 自律確定と HITL フォールバック
+
+分類・検証と必要な経路B review を経て、取得可能な根拠から promote / defer / reject を一意に確定できる検出事項は、ユーザー承認なしで確定する。ユーザー判断が必要な検出事項のみ HITL 対象とする。
+同一実行内に両者が混在する場合、未決項目に依存しない項目を先行確定し、ユーザー判断が必要な検出事項のみを提示する。
+自律確定可否の詳細判定表は workflow-contracts SPEC（extension 経由で解決）の「promote系判断確定とHITL境界」セクションに原本を置き、本コマンドは判定表を重複保持しない。
+自律確定した検出事項の判定結果、主要根拠、HITL不要と判断した理由は完了報告で報告する（新規永続成果物を必須としない）。
+
+`--auto` fast path（高確信度カテゴリの事前定義による早期処理、明示 opt-in）と通常経路の自律確定（レビュー・検証を経た最終確認省略）は別概念である。通常の実行によって `--auto` を暗黙的に有効化しない。
+
 ## project extensions
 
 本コマンドの workflow 実装本体を所有する Workflow Skill（`agentdev-workflow-inspect-promote`）が、対応する project extension（`.agentdev/extensions/skills/agentdev-workflow-inspect-promote.yaml`、kind: workflow-extension）を読み込む（ADR）。
@@ -47,8 +56,8 @@ durable state（`.agentdev/inspect/inbox/`、`.agentdev/inspect/promoted/`、`.a
 | STEP-2 inbox スキャン | 同期済み | 検出事項リスト | 読込失敗時はスキップ警告で継続していること |
 | STEP-3 検出事項分類（暫定分類） | スキャン済み | 暫定分類（promote/ defer/ reject） | 分類根拠が各検出事項に付いていること |
 | STEP-4 自動 promote（`--auto` opt-in 時のみ、fast path） | `--auto` 明示指定 | `.agentdev/intake/promoted/inspect-auto-*.md`・auto-promote-log 記録 | 自動 promote 対象カテゴリ（workflow-contracts SPEC 参照）合致のみであること |
-| STEP-5 adversarial-review（経路B） | ユーザー明示指定時 | review 結果と反映後の分類案 | accepted finding が分類案へ反映されていること |
-| STEP-6 HITL 確定（手動分類対象） | 分類案確定 | ユーザー確定済み分類 | ユーザーが分類を確認・修正する機会を経ていること |
+| STEP-5 adversarial-review（経路B） | review 挿入境界到達（default-on、skip 条件該当時は省略） | review 結果と反映後の分類案 | accepted finding が分類案へ反映されていること |
+| STEP-6 確定（自律確定判定と HITL 確定） | 分類案確定 | 確定済み分類（自律確定分とユーザー確定分） | 横断契約SPEC 詳細判定表に従い自律確定可能な検出事項が承認なしで確定され、ユーザー判断が必要な検出事項のみ提示されていること |
 | STEP-7 処理実行（promote / reject / defer） | 確定済み | promoted/ 保存・reject 即時削除・defer 残置 | 処理結果が分類確定内容と一致していること（全件 defer 時は残置報告） |
 | STEP-8 完了報告・永続化 | 処理実行済み | 完了報告・git 永続化 | push 失敗時は停止していること |
 
@@ -70,7 +79,7 @@ durable state（`.agentdev/inspect/inbox/`、`.agentdev/inspect/promoted/`、`.a
 
 硬い境界（承認境界・state 破壊等の否定規則）に限定する:
 
-- G01: ユーザーの明示的な承認なしに採用済み成果物を生成しない（`--auto` による自動 promote 対象を除く）
+- G01: ユーザーの明示的な承認なしに採用済み成果物を生成しない（`--auto` による自動 promote 対象、および詳細判定表（workflow-contracts SPEC 参照、extension 経由）に従い自律確定した検出事項を除く）
 - G02: promote された検出事項のみを `.agentdev/inspect/promoted/` へ保存する
 - G06: `--auto` は明示 opt-in の場合のみ有効。省略時は自動 promote を一切行わない
 

--- a/src/opencode/commands/agentdev/templates/inspect-promote/standard.md
+++ b/src/opencode/commands/agentdev/templates/inspect-promote/standard.md
@@ -6,6 +6,7 @@
  - 採用: {N}件（{file_list}）
  - 保留: {N}件
  - 却下: {N}件
+ - 自律確定: {N}件（判定・主要根拠・HITL不要理由は本文に記載）
 検証結果: ✅ OK
 git 永続化: commit: {hash}, push: {成功/失敗}
 次のコマンド:/agentdev/backlog-review

--- a/src/opencode/skills/agentdev-workflow-inspect-promote/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-promote/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentdev-workflow-inspect-promote
-description: "inspect-promote command の workflow 実装本体。検出事項（finding）の分類（promote/defer/reject）、自動 promote（--auto opt-in）、adversarial-review 経路B、HITL 確定、promote/reject/defer 処理実行、.agentdev 永続化を、独立 resume point を持つ STEP model（durable state から再開可能）として所有する。USE FOR: inspect-promote 実行時の workflow 制御（inbox スキャン・分類・経路B review・HITL 確定・処理実行・永続化）。DO NOT USE FOR: 検出事項の生成、REQ/Decision/SPEC 変更、単独起動（対応する /agentdev/* コマンド経由で利用すること）。"
+description: "inspect-promote command の workflow 実装本体。検出事項（finding）の分類（promote/defer/reject）、自動 promote（--auto opt-in）、adversarial-review 経路B、自律確定判定と HITL 確定、promote/reject/defer 処理実行、.agentdev 永続化を、独立 resume point を持つ STEP model（durable state から再開可能）として所有する。USE FOR: inspect-promote 実行時の workflow 制御（inbox スキャン・分類・経路B review・自律確定判定・HITL 確定・処理実行・永続化）。DO NOT USE FOR: 検出事項の生成、REQ/Decision/SPEC 変更、単独起動（対応する /agentdev/* コマンド経由で利用すること）。"
 ---
 
 # inspect-promote workflow スキル
@@ -69,13 +69,14 @@ inspect-promote workflow は次の8 STEP で構成する。
 | STEP-3 | 検出事項分類（暫定分類） | 検出事項一覧確定 | 暫定分類結果（promote/defer/reject と根拠） | [references/inbox-scan-and-classification.md](references/inbox-scan-and-classification.md) |
 | STEP-4 | 自動 promote（`--auto` fast path） | `--auto` 指定かつ暫定分類確定 | `.agentdev/intake/promoted/inspect-auto-*.md` 投入、auto-promote-log 記録 | [references/auto-promote-and-review.md](references/auto-promote-and-review.md) |
 | STEP-5 | adversarial-review（経路B） | 挿入境界（暫定分類後・HITL 前）到達、発動条件成立 | review 結果の暫定分類反映、または unresolved 停止、または従来フロー継続 | [references/auto-promote-and-review.md](references/auto-promote-and-review.md) |
-| STEP-6 | HITL 確定（手動分類対象） | review 完了または skip | ユーザー承認済み分類結果 | [references/hitl-and-disposition.md](references/hitl-and-disposition.md) |
-| STEP-7 | 処理実行（promote / reject / defer） | HITL 承認完了 | promoted/ 保存、inbox 削除（promote）、即時削除（reject）、inbox 残置（defer） | [references/hitl-and-disposition.md](references/hitl-and-disposition.md) |
+| STEP-6 | 確定（自律確定判定と HITL 確定） | review 完了または skip | 確定済み分類結果（自律確定分とユーザー承認分） | [references/hitl-and-disposition.md](references/hitl-and-disposition.md) |
+| STEP-7 | 処理実行（promote / reject / defer） | 確定完了（自律確定または HITL 承認） | promoted/ 保存、inbox 削除（promote）、即時削除（reject）、inbox 残置（defer） | [references/hitl-and-disposition.md](references/hitl-and-disposition.md) |
 | STEP-8 | 完了報告・永続化 | 処理実行完了 | 完了報告、`.agentdev/` 変更の commit/push | [references/hitl-and-disposition.md](references/hitl-and-disposition.md) |
 
 ### STEP 間の依存と分岐
 
 - **通常（手動分類）**: STEP-1 → STEP-2 → STEP-3 → （`--auto` 未指定時は STEP-4 を skip） → STEP-5（skip 条件該当時は省略） → STEP-6 → STEP-7 → STEP-8
+- **STEP-6 の内訳**: STEP-6 は自律確定判定と HITL 確定で構成する（後述「自律確定の判定位置とHITLフォールバック」）。全検出事項が自律確定可能な場合は HITL 提示なしで STEP-7 へ進む
 - **`--auto` 指定時**: STEP-4 で自動 promote 対象を fast path として投入し、手動分類対象のみ STEP-5 以降へ進む
 - **inbox 空**: STEP-2 で「対象なし」と報告して終了
 - **unresolved な本質的争点**: STEP-5 でユーザー判断事項として停止（STEP-6 へ進まない）
@@ -84,7 +85,7 @@ inspect-promote workflow は次の8 STEP で構成する。
 
 - 各 STEP の再開点は durable state から再構成する（`<workflows/input-resolution-and-durable-state>` SPEC の優先順位に従う）
 - **検出事項ごとの分類確定状態の再構成**: inbox に残存する検出事項は未確定（STEP-3 分類から再開）、`.agentdev/inspect/promoted/` に保存済みの検出事項は promote 確定（再保存しない）、auto-promote-log 記載済みかつ `.agentdev/intake/promoted/inspect-auto-*.md` 投入済みは自動 promote 確定（再投入しない）、inbox から削除済みは reject 確定（復元しない）、inbox 残置かつ処理実行済み報告があるものは defer 確定
-- **HITL 承認状態**: 承認は処理実行（STEP-7）の完了状態から逆算して再構成する。処理実行が済んでいない検出事項は承認未了と扱い、HITL 確定（STEP-6）から再開する
+- **HITL 承認状態**: 承認は処理実行（STEP-7）の完了状態から逆算して再構成する。処理実行が済んでいない検出事項は未確定と扱い、確定（STEP-6 の自律確定判定と HITL 確定）から再開する。自律確定項目にユーザー承認は存在しないため、再開時は詳細判定表に従い再判定する
 - 自然言語の前 STEP result のみに依存した再開を行わない
 
 ## 主要 Capability Skill 連携
@@ -107,18 +108,28 @@ Workflow Skill のみが読み、inspect-promote command は直接読まない�
 
 ## 共通制約
 
-- **HITL 承認必須**: 自動 promote 対象（`--auto`）を除き、ユーザーの明示的な承認なしに採用済み成果物を生成しない（G01）
+- **HITL 承認必須**: 自動 promote 対象（`--auto`）と自律確定対象（次節の詳細判定表に従う）を除き、ユーザーの明示的な承認なしに採用済み成果物を生成しない（G01）
 - **reject は即時削除**: `archive/rejected/` への移動は廃止。即時削除以外の取扱を禁止し、reject 時の commit message に却下理由を含める（command 不変条件）
 - **defer は inbox 残置**: defer となった検出事項を `.agentdev/inspect/inbox/` から移動しない（command 不変条件）
 - **`--auto` は明示 opt-in の場合のみ有効**: 省略時は自動 promote を一切行わない（G06）。自動 promote 対象は workflow-contracts SPEC（extension 経由）が定義する高確信度カテゴリのみとし、意味判断、曖昧な分類、ADR 要否判断を含む検出事項は手動分類へ回す（command 不変条件）
 - **実行ログ**: `--auto` 実行の都度、投入対象、根拠を `.agentdev/inspect/promoted/auto-promote-log.md` に記録する（command 不変条件）
 - **adversarial-review は任意助言手段**: 必須工程、QG、承認ゲート、統制ゲートとして導入しない。呼出失敗時は silent skip を禁止し、従来フロー（HITL 確定）を維持する
 
+## 自律確定の判定位置とHITLフォールバック
+
+判断確定の境界は共通原則（REQ-{NNNN}-{NNN}）に従う。自律確定可否の詳細判定表（自律確定可能要件、HITL移送条件、判定と運用の共通規則）は横断契約SPEC（workflow-contracts SPEC「promote系判断確定とHITL境界」節、extension 経由で解決）が集約所有し、本スキルは判定表を重複保持しない（DEC-{N}）。
+
+- **判定位置**: 分類・検証（STEP-3）と必要な経路B review（STEP-5）を経た後、取得可能な根拠から promote / defer / reject を一意に確定できる検出事項は、ユーザー承認なしで確定する（REQ-{NNNN}-{NNN}）
+- **部分自律確定**: 同一実行内に自律確定可能項目とユーザー判断必要項目が混在する場合、未決項目に依存しない項目を先行確定し、ユーザー判断必要項目のみ HITL 対象とする（REQ-{NNNN}-{NNN}）
+- **`--auto` fast path との区別**: `--auto` fast path（高確信度カテゴリの事前定義による早期処理、明示 opt-in）と通常経路の自律確定（レビュー・検証を経た最終確認省略）は別概念とする。通常の実行によって `--auto` を暗黙的に有効化しない（REQ-{NNNN}-{NNN}）
+- **報告形式**: 判定結果、主要根拠、HITL不要と判断した理由は既存の分類結果と実行報告（STEP-8 完了報告）を優先利用して報告し、新規永続成果物を必須としない
+
 ## 終了条件（termination）
 
 - 全検出事項が promote（promoted/ 保存 + inbox 削除）/ reject（即時削除）/ defer（inbox 残置）/ 自動 promote（intake/promoted/ 投入 + ログ記録）のいずれかに確定している
 - `.agentdev/inspect/` と `.agentdev/intake/` 配下の変更が commit/push 済みである（変更なし時は「変更なし」報告済み）
 - 完了報告 template（`.opencode/commands/agentdev/templates/inspect-promote/standard.md`）に従い、promote/defer/reject/auto-promote の判定結果と後続 route（`--auto` 実行時は投入件数、投入先一覧、ログパスを含む）を報告した
+- 自律確定した検出事項の判定結果、主要根拠、HITL不要と判断した理由を完了報告に含めている（新規永続成果物を必須としない）
 
 ## See Also
 

--- a/src/opencode/skills/agentdev-workflow-inspect-promote/references/auto-promote-and-review.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-promote/references/auto-promote-and-review.md
@@ -23,7 +23,7 @@
   1. **発動条件判定**: inspect-promote は adversarial-review を原則実行する（default-on）。
 手動分類対象の検出事項（review 対象）が1件以上存在する場合に発動する。
 ユーザー明示指定は通常発動の必須条件ではない
-  2. **skip 条件**: `--auto` 経路（fast path）、または手動分類対象の検出事項が0件（inbox 空、全件 fast path 完了）の場合、省略して従来フロー（STEP-6 HITL 確定）を継続できる。skip 判断のためだけの新規 HITL、承認点は追加しない
+  2. **skip 条件**: `--auto` 経路（fast path）、または手動分類対象の検出事項が0件（inbox 空、全件 fast path 完了）の場合、省略して従来フロー（STEP-6 確定）を継続できる。skip 判断のためだけの新規 HITL、承認点は追加しない
   3. **ユーザー明示指定時の必須実行**: ユーザーが本コマンド起動時に adversarial-review を明示的に要求した場合、skip 条件の該当にかかわらず必ず発動する。ただし review 対象（手動分類対象）が存在しない場合は発動しない
   4. **review 呼出**: 手動分類対象の検出事項と暫定分類結果を入力コンテキストとして adversarial-review を呼び出す。
 adversarial-review は任意助言手段であり、必須工程、QG、承認ゲート、統制ゲートとして導入しない。
@@ -32,7 +32,7 @@ adversarial-review は任意助言手段であり、必須工程、QG、承認�
 - **Result**: review 結果反映済みの暫定分類、または unresolved 停止、または従来フロー継続
 - **Evidence**: review 呼出の実行記録、accepted finding の反映記録
 - **Completion Verification**: accepted finding の反映が完了していること、または unresolved 判定時に停止していること、または skip 条件該当時に従来フローへ遷移していること
-- **Resume-Idempotency**: `--auto` により STEP-4 で自動 promote された検出事項は HITL を経由しない fast path であり、本判定、本 review の対象外とする（review 挿入迂回）。skip 条件該当時、呼出失敗時は STEP-6 を実行せず従来フロー（HITL 確定）を維持する。unresolved な本質的争点が残る場合、STEP-6 へ進まずユーザー判断事項として停止する（adversarial-review 自体を恒久的な統制ゲートとしない）。呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し、利用不能を報告した上で従来フローを維持する
+- **Resume-Idempotency**: `--auto` により STEP-4 で自動 promote された検出事項は HITL を経由しない fast path であり、本判定、本 review の対象外とする（review 挿入迂回）。skip 条件該当時、呼出失敗時は review を実行せず従来フロー（STEP-6 確定）を維持する。unresolved な本質的争点が残る場合、STEP-6 へ進まずユーザー判断事項として停止する（adversarial-review 自体を恒久的な統制ゲートとしない）。呼出失敗時（スキル不在、起動異常、timeout 等）は silent skip を禁止し、利用不能を報告した上で従来フローを維持する
 
 ## 関連 STEP
 

--- a/src/opencode/skills/agentdev-workflow-inspect-promote/references/hitl-and-disposition.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-promote/references/hitl-and-disposition.md
@@ -1,27 +1,30 @@
-# STEP-6 / STEP-7 / STEP-8: HITL 確定・処理実行・完了報告と永続化（hitl-and-disposition）
+# STEP-6 / STEP-7 / STEP-8: 確定（自律確定判定と HITL 確定）・処理実行・完了報告と永続化（hitl-and-disposition）
 
 > 本 reference は `agentdev-workflow-inspect-promote` SKILL.md の Control Plane STEP-6〜STEP-8 詳細である。
 > 各 STEP は resume point を持つ（`<workflows/step-reference-contract>` SPEC）。
 
-## STEP-6: HITL 確定（手動分類対象）
+## STEP-6: 確定（自律確定判定と HITL 確定）
 
-- **Purpose**: 自動 promote 対象外の検出事項について、ユーザーの明示的な承認を得て分類を確定する
-- **Input Resolution**: STEP-5 の反映済み暫定分類結果（skip 時は STEP-3 の暫定分類結果）。検出事項本文は inbox ファイル（durable state）から読み取る
-- **Preconditions**: STEP-5 完了または skip 条件該当、手動分類対象が1件以上存在
-- **Procedure**: 自動 promote 対象外の検出事項はユーザーの明示的な承認なしに採用済み成果物を生成しない。分類結果を提示し、承認を得る
-- **Result**: ユーザー承認済み分類結果（promote/defer/reject の確定）
-- **Evidence**: 分類提示内容とユーザー承認の応答
-- **Completion Verification**: 手動分類対象の全検出事項について承認応答を得たこと
-- **Resume-Idempotency**: 承認状態は処理実行（STEP-7）の完了状態から逆算して再構成する。処理実行が済んでいない検出事項は承認未了と扱い、本 STEP から再開する（未承認の推定で処理を実行しない）
+- **Purpose**: 分類・検証と必要な経路B review を経た検出事項について、自律確定判定と HITL 確定により分類を確定する
+- **Input Resolution**: STEP-5 の反映済み暫定分類結果（skip 時は STEP-3 の暫定分類結果）。検出事項本文は inbox ファイル（durable state）から読み取る。自律確定可否の判定基準は横断契約SPEC（workflow-contracts SPEC「promote系判断確定とHITL境界」節、extension 経由で解決）の詳細判定表を正とし、本 reference は判定表を複製しない
+- **Preconditions**: STEP-5 完了または skip 条件該当、確定対象の検出事項が1件以上存在
+- **Procedure**:
+  1. **自律確定判定**: 詳細判定表（自律確定可能要件、HITL移送条件）に従い、取得可能な根拠から promote / defer / reject を一意に確定できる検出事項をユーザー承認なしで確定する（REQ-{NNNN}-{NNN}）。モデルの自己申告による確信度や固定パーセンテージのみで可否を判定しない
+  2. **部分自律確定**: 自律確定可能項目とユーザー判断必要項目が混在する場合、未決項目に依存しない項目を先行確定し、ユーザー判断必要項目のみ HITL 対象とする（REQ-{NNNN}-{NNN}）。単純な意見差・形式的最終確認のみを理由とするHITL移送を行わない
+  3. **HITL 確定**: HITL移送条件に該当する検出事項のみ分類結果を提示して承認を得る。自律確定済み検出事項は確定内容の報告にとどめ、HITL 提示に含めない。全検出事項が自律確定可能な場合は HITL を発生させない
+- **Result**: 確定済み分類結果（自律確定分とユーザー承認分の promote/defer/reject 確定）
+- **Evidence**: 自律確定した検出事項ごとの判定と主要根拠、HITL不要と判断した理由、HITL 対象の分類提示内容とユーザー承認の応答（既存の分類結果・実行報告を利用し、新規永続成果物を必須としない）
+- **Completion Verification**: 全検出事項が自律確定またはユーザー承認のいずれかで確定していること
+- **Resume-Idempotency**: 確定状態は処理実行（STEP-7）の完了状態から逆算して再構成する。処理実行が済んでいない検出事項は未確定と扱い、本 STEP の自律確定判定から再開する（未承認の推定で処理を実行しない）。自律確定項目にユーザー承認は存在しないため、再開時は詳細判定表に従い再判定する
 
 ## STEP-7: 処理実行（promote / reject / defer）
 
-- **Purpose**: 承認済み分類に従い、検出事項の配置変更（promote 保存、reject 削除、defer 残置）を実行する（finding disposition の出口 resume point）
-- **Input Resolution**: STEP-6 の承認済み分類結果、`--auto` 時は STEP-4 の自動 promote 確定状態（auto-promote-log との突合）
-- **Preconditions**: STEP-6 完了（手動分類対象）、STEP-4 完了（自動 promote 対象）
+- **Purpose**: 確定済み分類（自律確定分とユーザー承認分）に従い、検出事項の配置変更（promote 保存、reject 削除、defer 残置）を実行する（finding disposition の出口 resume point）
+- **Input Resolution**: STEP-6 の確定済み分類結果、`--auto` 時は STEP-4 の自動 promote 確定状態（auto-promote-log との突合）
+- **Preconditions**: STEP-6 完了（確定対象）、STEP-4 完了（自動 promote 対象）
 - **Procedure**:
-  - **promote 処理**: 承認された promote 対象検出事項を `.agentdev/inspect/promoted/` へ保存する。元の inbox file は削除する
-  - **reject 処理**: 承認された reject 対象検出事項は即時削除する。reject 時の commit message に却下理由を含める（監査証跡の補強）
+  - **promote 処理**: 確定済みの promote 対象検出事項（自律確定分を含む）を `.agentdev/inspect/promoted/` へ保存する。元の inbox file は削除する
+  - **reject 処理**: 確定済みの reject 対象検出事項（自律確定分を含む）は即時削除する。reject 時の commit message に却下理由を含める（監査証跡の補強）
   - **defer 処理**: defer となった検出事項は `.agentdev/inspect/inbox/` に残置する。intake/ learning 送付の推奨を報告する
 - **Result**: 全検出事項の配置確定（promoted/ 保存済み、削除済み、inbox 残置）
 - **Evidence**: 配置後のファイル構成（promoted/、inbox/）、reject を含む commit message
@@ -40,7 +43,7 @@
 commit message は `chore(agentdev): promote inspect findings`（reject を含む場合は却下理由を含める）。
 `git push` を実行する。
 push 失敗時は共通 template（`.opencode/commands/agentdev/templates/common/git-error-messages.md`）の該当形式で表示して停止する（完了扱いにしない）
-  4. 完了報告 template（`.opencode/commands/agentdev/templates/inspect-promote/standard.md`）に従い、promote/ defer/ reject/ auto-promote の判定結果と後続 route を提示する。`--auto` 実行時は投入件数、投入先一覧、ログパスを含める
+  4. 完了報告 template（`.opencode/commands/agentdev/templates/inspect-promote/standard.md`）に従い、promote/ defer/ reject/ auto-promote の判定結果と後続 route を提示する。`--auto` 実行時は投入件数、投入先一覧、ログパスを含める。自律確定した検出事項は判定結果、主要根拠、HITL不要と判断した理由を完了報告に含める（既存の実行報告を利用し、新規永続成果物を作成しない）
 - **Result**: 完了報告出力、`.agentdev/` 変更の commit/push
 - **Evidence**: commit hash、push 実行結果、完了報告
 - **Completion Verification**: 変更が commit/push 済みであること（または変更なし報告済み）、完了報告を出力したこと
@@ -67,6 +70,7 @@ push 失敗時は共通 template（`.opencode/commands/agentdev/templates/common
 
 ## 関連ガードレール（command 側で宣言、本 reference は詳細実装）
 
+- G01（ユーザーの明示的な承認なしに採用済み成果物を生成しない。`--auto` による自動 promote 対象、および詳細判定表に従い自律確定した検出事項を除く）
 - 不変条件（reject された検出事項は即時削除される。即時削除以外の取扱を禁止する）
 - 不変条件（defer された検出事項は `.agentdev/inspect/inbox/` に残す）
 - 不変条件（docs-check ルール／検査データ追加候補は独立 route とせず、採用済み成果物の要件化方向または受け入れ条件に含める）


### PR DESCRIPTION
## 概要

Issue #2295（OU-0027、Epic A #2286 Wave 3）。docs/specs/commands/inspect-promote.md「自律確定の判定位置とHITLフォールバック」セクション（commit 3955170c 適用分）および REQ-036-018 / REQ-003-055/056 / REQ-036-021 / REQ-041-016 に基づき、inspect-promote 配布物へ自律確定判定を実装した。--auto fast path（明示 opt-in）と通常経路の自律確定を別概念として区別し、--auto は明示 opt-in fast path のまま維持する。

Refs: #2295

## 変更内容

- `src/opencode/skills/agentdev-workflow-inspect-promote/SKILL.md`
  - STEP-6 を「HITL 確定（手動分類対象）」から「確定（自律確定判定と HITL 確定）」へ改称（STEP 数は 8 のまま、自律確定判定は SPEC 所定の挿入位置＝分類・検証・経路B review 後に STEP-6 内で実施）
  - 新規セクション「自律確定の判定位置とHITLフォールバック」追加（判定位置、部分自律確定、--auto fast path との区別、報告形式）。詳細判定表は横断契約SPEC（workflow-contracts「promote系判断確定とHITL境界」節、extension 経由）を参照し重複保持しない
  - 共通制約 G01 に自律確定対象の例外を明記、resume protocol・終了条件・description を整合更新
- `references/hitl-and-disposition.md`: STEP-6 を自律確定判定→部分自律確定→HITL 確定の3手順に拡張、STEP-7 の確定済み分類入力への整合、STEP-8 完了報告へ自律確定項目の判定・主要根拠・HITL不要理由の記載を追加
- `references/auto-promote-and-review.md`: STEP-5 内の STEP-6 名称参照を更新。あわせて「STEP-6 を実行せず従来フロー（HITL 確定）を維持する」を SPEC（「review 呼出を実行せず HITL 確定へ従来フローを維持する」）どおり「review を実行せず」へ是正（記述整合の副次修正）
- `src/opencode/commands/agentdev/inspect-promote.md`: 新規セクション「自律確定と HITL フォールバック」、STEP 表 STEP-6 行の更新、G01 例外明記。--auto の明示 opt-in 表示（G06、不変条件）は維持。STEP-5 行の前提条件「ユーザー明示指定時」を SPEC（default-on、REQ-015-002）どおり「review 挿入境界到達（default-on、skip 条件該当時は省略）」へ是正（記述整合の副次修正）
- `templates/inspect-promote/standard.md`: 完了報告へ「自律確定: {N}件（判定・主要根拠・HITL不要理由は本文に記載）」行を追加
- `.agentdev/extensions/skills/agentdev-workflow-inspect-promote.yaml`: workflow-contracts context の when/purpose に「promote系判断確定とHITL境界」詳細判定表参照を追加（scope-affecting impact candidate 対応）

### 完了条件チェックボックス

Issue 本文の完了条件チェックボックスは case-close 評価対象のため本 PR では更新しない。

## 検証エビデンス

### TS-QC-001（docs 整合性検査）

- docs/specs/commands/inspect-promote.md に「自律確定の判定位置とHITLフォールバック」セクション存在確認（L73-92、status: accepted、updated: 2026-08-19、commit 3955170c）
- check_changed_docs.ts（case-run profile、worktree 正規の --base-ref 5ae61275 指定）: **failures: 0**（src/opencode 配下のみの変更のため対象ファイル 0 は profile 仕様どおり。--files 指定は case-run profile の対象外で TARGET-EMPTY strict 出るがこれは配布物が docs 検査対象外であることに由来）
- docs/requirements/REQ-038.md（REQ-038-002/003）、REQ-003（REQ-003-055/056）、REQ-036（REQ-036-018/021）、workflow-contracts.md「promote系判断確定とHITL境界」節と配布物記述の矛盾なしを確認

### TS-QC-002（Skill 品質査読）

- lint_skills.ts: 変更対象ファイル（SKILL.md、references 2件）は **0 NG / 0 Warning**。exit=1 は未変更ファイル agentdev-git-worktree/references/worktree-operations.md の既存 NG（340行・目次なし、RU-0018 層2）のみ（Findings 参照）
- 判定表複製チェック: 横断契約SPEC 詳細判定表の表現（「適用すべき既存契約と判断根拠を特定できる」等）が src/opencode 配下に存在しないことを機械確認
- 実 ID 汚染チェック: 変更ファイルに実 REQ/DEC-ID なし（プレースホルダ REQ-{NNNN}-{NNN} 形式を遵守）
- エンコーディング: 変更 6 파일すべて UTF-8 BOM なし・LF 単一
- bun test（skills_structure / commands_structure / templates_structure）: **545 pass / 0 fail**（構造様式の変更なし、期待値更新不要）

### TS-QC-003（Command 品質査読）

- check_command_format.ts: **OK**（exit 0）
- check_templates.ts / check_extensions.ts / check_distribution_boundary_cli.ts: いずれも **exit 0**（check_templates の junction 未伝播 warning は worktree 環境の既知仕様、REQ-018）

### TS-001（自律確定と HITL 移送の境界検証）

RU-0001 は case-open の Issue 作成済みのため削除済み（.agentdev/backlog/req-units/ 空を確認）。Issue 本文 TS-001 pass_criteria (1)〜(10) を検証基準として、配布物 workflow 定義のシナリオ walkthrough を実施した。これらは workflow 定義（Markdown）であるため、実行検証は定義が各シナリオで要求どおり振る舞うかの文言・構造検証となる。

| # | pass_criteria | 判定 | 根拠 |
|---|---|---|---|
| 1 | 根拠から一意に確定できる item がユーザー承認なしで確定される | PASS | STEP-6 Procedure 1、SKILL 自律確定節「判定位置」、command 新規節 |
| 2 | 単独実行と backlog-auto 経由で境界が同一 | PASS | 自律確定判定は子ワークフロー内 STEP-6 に実装。backlog-auto は「既存再開契約に委譲」（stage-execution.md）で境界追加なし |
| 3 | backlog-auto が子の判定を承認・上書きしない | PASS | backlog-auto SKILL.md「本スキルは新規の判断境界を追加しない」、承認・上書き機構は存在せず（本 PR で backlog-auto 配下は無変更） |
| 4 | 混在時、非依存の自律確定可能項目がHITL待ちにならない | PASS | STEP-6 Procedure 2（部分自律確定、先行確定）+ Procedure 3（自律確定済みは HITL 提示に含めない） |
| 5 | 価値判断・矛盾・情報不足・未解決争点・対象範囲決定・明示承認安全境界では自律確定しない | PASS | Procedure 1 は詳細判定表（HITL移送条件 1-8）に従う。unresolved は STEP-5 で STEP-6 進行前に停止 |
| 6 | 自律確定の結果・根拠・HITL不要理由が既存成果物から確認できる | PASS | STEP-6 Evidence、STEP-8 Procedure 4、SKILL 終了条件、template 自律確定行（新規永続成果物なし） |
| 7 | 空入力でHITLなしの正常完了 | PASS | STEP-2「対象なし」終了、STEP-6 Procedure 3 全件自律確定時 HITL 発生なし |
| 8 | --auto が明示opt-in fast path のまま | PASS | 共通制約・G06・不変条件は無変更、「--auto fast path との区別」を新規明記（REQ-036-021/REQ-041-016） |
| 9 | backlog-review のHITL契約が不変 | PASS | 本 PR の diff に agentdev-workflow-backlog-review 配下は含まれない |
| 10 | REQ-003/036/037/038/041 と command SPEC・Workflow Skill の記述が相互に矛盾しない | PASS | REQ-003-055/056（共通原則・部分自律確定・証跡）、REQ-036-018（挿入位置）、REQ-036-021/REQ-041-016（--auto 維持）、REQ-037/038 は intake/learning 実装（OU-0025/0026 別 Issue）と同一横断契約SPEC 判定表を参照し矛盾なし |

TS-001 総合: **pass**（10/10）。on_failure（fix-and-reverify）発動なし。

## Findings / Capture候補

1. **lint_skills 既存 NG（pre-existing、本 PR 無関係）**: `agentdev-git-worktree/references/worktree-operations.md` が 300 行超（340 行）で目次なし（RU-0018 層2 AG-005）。本 PR で未変更のファイル。別途是正候補（intake 化候補）
2. **command STEP-5 前提条件の陈腐化（本 PR で是正済み・経緯記録）**: inspect-promote.md STEP 表の STEP-5 前提条件が「ユーザー明示指定時」となっており、SPEC の default-on 契約（REQ-015-002）と矛盾していた。本 PR の STEP 表更新に伴い「review 挿入境界到達（default-on、skip 条件該当時は省略）」へ是正した（経路B 実装 Issue 起点の取りこぼしと推定）
3. **auto-promote-and-review.md STEP-5 Resume-Idempotency の誤記（本 PR で是正済み・経緯記録）**: 「skip 条件該当時、呼出失敗時は STEP-6 を実行せず従来フロー（HITL 確定）を維持する」は SPEC「review 呼出を実行せず HITL 確定へ従来フローを維持する」の転記誤り（STEP-6 を実行しないと従来フロー維持が両立しない）。「review を実行せず」へ是正した

## SPEC確定候補

なし。docs/specs/commands/inspect-promote.md の新規セクションと横断契約SPEC 判定表で本実装は完結し、SPEC 側の追加確定事項（schema、enum、判定表の追加詳細）は発生しなかった。唯一の留意点として、SPEC「対象外」の G01 行（「ユーザーの明示的な承認なしの採用済み成果物生成（G01、--auto による自動 promote 対象を除く）」）は自律確定対象の例外が列挙されていないが、これは REQ-003-055（自律確定はユーザー承認の擬制ではなく、HITL移送条件 8「明示承認そのものを安全境界と要求する契約」が境界を担保する）により解釈確定しており、配布物側は G01 例外を明記する方式で対応済み。SPEC 本文の追記は必須と判断しないが、case-close の SPEC 確定チェックで G01 行の例外列挙の可否を確認することを推奨する。
