### PR TITLE
agentdev: #2294 learning-promote 自律確定とHITLフォールバック実装

### DIFF
--- a/src/opencode/commands/agentdev/learning-promote.md
+++ b/src/opencode/commands/agentdev/learning-promote.md
@@ -1,10 +1,10 @@
 ---
-description: inbox.mdから正規化、分類、8軸評価、HITL確定を経て採用済み成果物を生成する
+description: inbox.mdから正規化、分類、8軸評価、自律確定・HITL確定を経て採用済み成果物を生成する
 ---
 
 # 学びの正規化、評価、昇華判定と採用済み成果物生成
 
-`.agentdev/learning/inbox.md` の学びエントリを読み込み、正規化、問題クラス分類、8軸評価、廃棄判定、既存対策確認、HITL承認を経て採用済み成果物を生成する。
+`.agentdev/learning/inbox.md` の学びエントリを読み込み、正規化、問題クラス分類、8軸評価、廃棄判定、既存対策確認、自律確定判定（一意に確定できる項目の自律確定）とユーザー判断が必要な項目のみの HITL 承認を経て採用済み成果物を生成する。
 
 **重要**: `.opencode/` への直接配置、直接反映は行わない。
 反映ルート: promoted → `/agentdev/backlog-review`（RU 生成）→ `/agentdev/req-define` → `/agentdev/req-save` → `/agentdev/case-open` → `/agentdev/case-run`。
@@ -44,8 +44,8 @@ description: inbox.mdから正規化、分類、8軸評価、HITL確定を経て
 | STEP-2 評価 | 正規化済み | 8軸評価スコア・問題クラス分類 | 評価根拠が各エントリに揃っていること |
 | STEP-3 判定 | 評価済み | 廃棄判定・既存対策確認・昇華可能性判定 | 恒久契約（REQ/Decision/SPEC）への昇華可能性が判定されていること |
 | STEP-4 review（経路D） | default-on（発動条件判定 → review 呼出） | review 結果と反映後の評価 | accepted finding 反映時は evaluation-report 生成工程から再実行していること |
-| STEP-5 HITL | 判定結果あり | ユーザー承認済みの判定・prune | 廃棄判定結果・8軸評価スコアの確認・修正・承認を経ていること |
-| STEP-6 永続化 | 承認済み | `promoted/{category}-{name}.md`・deferred.md 追記・inbox.md クリア・prune | 採用済み成果物・deferred 移動・prune が承認内容と一致していること |
+| STEP-5 判定確定（自律確定・HITL） | 判定結果あり | 判定確定（自律確定分はユーザー承認なし、ユーザー判断必要分はユーザー承認済み）・prune | 一意に確定できる項目はユーザー承認なしで確定し、ユーザー判断が必要な項目のみ廃棄判定結果・8軸評価スコアの確認・修正・承認を経ていること |
+| STEP-6 永続化 | 判定確定済み（自律確定またはユーザー承認） | `promoted/{category}-{name}.md`・deferred.md 追記・inbox.md クリア・prune | 採用済み成果物・deferred 移動・prune が確定内容と一致していること |
 | STEP-7 完了報告 | 永続化済み | 完了報告（次アクション） | 出力パスと次コマンド（`/agentdev/backlog-review`）が報告されていること |
 
 ## 不変条件
@@ -57,6 +57,7 @@ description: inbox.mdから正規化、分類、8軸評価、HITL確定を経て
 - 主入力は `inbox.md` とし、raw learning item の再分類は行わない
 - 既存対策を優先する（「新規X化」より「既存Xへ反映」を優先）
 - 学びは直接 REQ 化せず、恒久契約（REQ/Decision/SPEC）への昇華可能性を STEP-3 で評価し、昇華可能なもののみ `promoted/` へ出力する。昇華不能な知見は living pool（`deferred.md`）で維持する
+- 一意に確定できる項目は自律確定し、ユーザー判断が必要な項目のみ HITL 対象とする。自律確定可否の詳細判定表は横断契約SPEC「promote系判断確定とHITL境界」節が集約所有し、本コマンド定義と Workflow Skill は判定表を複製しない。自律確定はユーザー承認の擬制ではなく、deferred・未処理項目を自動削除しない安全境界は維持する
 - adversarial-review は default-on（経路D、REQ-{NNNN}-{NNN}）: workflow の review STEP（発動条件判定 → review 呼出）を経て原則発動する。skip 条件（inbox.md 1件で重複確実、inbox.md 空）該当時は HITL へ従来フローを維持し、ユーザー明示要求時は skip 条件にかかわらず必ず発動する。共通契約（任意性、副作用禁止、再 review 条件、停止条件、呼出失敗時取扱い）は `agentdev-adversarial-review` SPEC（REQ-{NNNN}）が正規所有する
 
 ## ガードレール
@@ -64,18 +65,18 @@ description: inbox.mdから正規化、分類、8軸評価、HITL確定を経て
 硬い境界（承認境界・state 破壊・書き込みスコープ等の否定規則）に限定する:
 
 - G01: `.opencode/` 直接反映は行わない（採用済み成果物は `.agentdev/learning/promoted/` のみに生成）
-- G06: 判定、prune ともにユーザー承認なしには実行しない
+- G06: ユーザー判断が必要な項目の判定、prune ともにユーザー承認なしには実行しない。一意に確定できる項目（横断契約SPEC の詳細判定表に従う）はユーザー承認なしで自律確定する
 - G07: 管理用ファイル（`elevation-ledger.md` 等）は生成しない
-- G09: 破壊的変更（inbox.md 全体強制クリア、大量エントリ一括削除等）は STEP-5（HITL）承認とは別に明示承認を維持する（REQ）
+- G09: 破壊的変更（inbox.md 全体強制クリア、大量エントリ一括削除等）は STEP-5（判定確定）とは別に明示承認を維持する（REQ）。自律確定によっても迂回されない
 
 ## ユーザー確認ポイント、エラー処理
 
 ユーザー確認ポイント、エラー処理表、各成果物のライフサイクルは `agentdev-learning-pipeline` を参照。主要項目のみ本節に抜粋する:
 
-- **HITL（workflow STEP-5）**: 廃棄判定結果、8軸評価スコアの確認、修正、承認（判断の確定、REQ）
-- **prune（workflow 永続化 STEP）**: prune は HITL 承認と同時に承認済みとみなし自動実行（REQ）。staged/rejected/duplicate の追加確認は不要
+- **HITL（workflow STEP-5）**: ユーザー判断が必要な項目の廃棄判定結果、8軸評価スコアの確認、修正、承認（判断の確定、REQ）。一意に確定できる項目はユーザー承認なしで自律確定し、HITL 対象としない（判断確定の境界は横断契約SPEC「promote系判断確定とHITL境界」節の詳細判定表に従う）
+- **prune（workflow 永続化 STEP）**: prune は判定確定（自律確定またはユーザー承認）と同時に承認済みとみなし自動実行（REQ）。staged/rejected/duplicate の追加確認は不要
 - **inbox.md 不在**: エラー終了。「先に `agentdev-learning-capture` skill で学びを追加してください」
 - **git pull/push 失敗**: 構造化エラー表示して停止（push 失敗時は完了扱いにしない）
-- **learning-promote の責務**: normalize → classify → 8-axis eval → evaluation-report → disposal judgment → HITL → 採用済み成果物生成 → archive move → prune。採用済み成果物は `/agentdev/backlog-review` 経由で RU 化後に `/agentdev/req-define` に合流する
+- **learning-promote の責務**: normalize → classify → 8-axis eval → evaluation-report → disposal judgment → 自律確定判定（ユーザー判断が必要な項目のみ HITL）→ 採用済み成果物生成 → archive move → prune。採用済み成果物は `/agentdev/backlog-review` 経由で RU 化後に `/agentdev/req-define` に合流する
 
 

--- a/src/opencode/skills/agentdev-workflow-learning-promote/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-learning-promote/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: agentdev-workflow-learning-promote
-description: "learning-promote command の workflow 実装本体。inbox.md エントリの読込・正規化、問題クラス分類・8軸評価・evaluation-report 生成、廃棄判定・既存対策確認、adversarial-review 経路D、ユーザー承認（HITL）、採用済み成果物生成・deferred 移動・prune・git 永続化の各 STEP を独立 resume point として所有する。USE FOR: learning-promote 実行時の workflow 制御。DO NOT USE FOR: 学びの検知・抽出・inbox.md 蓄積、単独起動（対応する /agentdev/* コマンド経由で利用すること）。"
+description: "learning-promote command の workflow 実装本体。inbox.md エントリの読込・正規化、問題クラス分類・8軸評価・evaluation-report 生成、廃棄判定・既存対策確認、adversarial-review 経路D、自律確定判定とユーザー判断必要項目の HITL、採用済み成果物生成・deferred 移動・prune・git 永続化の各 STEP を独立 resume point として所有する。USE FOR: learning-promote 実行時の workflow 制御。DO NOT USE FOR: 学びの検知・抽出・inbox.md 蓄積、単独起動（対応する /agentdev/* コマンド経由で利用すること）。"
 ---
 
 # learning-promote workflow スキル
 
 learning-promote command の workflow 実装本体。
-`.agentdev/learning/inbox.md` の学びエントリを読み込み、正規化、問題クラス分類、8軸評価、廃棄判定、既存対策確認、HITL承認を経て採用済み成果物を生成する制御構造を所有する。
+`.agentdev/learning/inbox.md` の学びエントリを読み込み、正規化、問題クラス分類、8軸評価、廃棄判定、既存対策確認、自律確定判定（一意に確定できる項目の自律確定）とユーザー判断が必要な項目のみの HITL 承認を経て採用済み成果物を生成する制御構造を所有する。
 `.opencode/` への直接配置、直接反映は行わない（反映ルート: promoted → `/agentdev/backlog-review` → `/agentdev/req-define` → `/agentdev/req-save` → `/agentdev/case-open` → `/agentdev/case-run`）。
 
 learning-promote command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜{NNN}）。
@@ -56,16 +56,18 @@ learning-promote workflow は次の7 STEP で構成する。
 | STEP-2 | 評価（分類・8軸・evaluation-report） | 正規化済みエントリ確定 | 問題クラス分類、8軸評価スコア、evaluation-report.md 生成・更新 | [references/analysis-and-review.md](references/analysis-and-review.md) |
 | STEP-3 | 判定（廃棄判定・既存対策確認） | evaluation-report.md 反映済み | 処分区分判定（11カテゴリ + duplicate）、既存対策照合結果、昇華可能性評価 | [references/analysis-and-review.md](references/analysis-and-review.md) |
 | STEP-4 | review（adversarial-review 経路D） | evaluation-report.md に STEP-2/STEP-3 結果反映済み | review 結果反映（evaluation-report 戻しループ含む。skip 時は従来フロー継承） | [references/analysis-and-review.md](references/analysis-and-review.md) |
-| STEP-5 | HITL（判定結果提示・ユーザー承認） | STEP-3 完了、STEP-4 skip または反映済み | 判定確定（promote/defer/reject/duplicate、ユーザー承認済み） | [references/hitl-and-persistence.md](references/hitl-and-persistence.md) |
-| STEP-6 | 永続化（成果物生成・deferred 移動・prune・commit/push） | 判定確定 | 採用済み成果物、deferred 移動済み、prune 済み、クリア済み inbox.md、commit/push | [references/hitl-and-persistence.md](references/hitl-and-persistence.md) |
+| STEP-5 | 判定確定（自律確定・HITL） | STEP-3 完了、STEP-4 skip または反映済み | 判定確定（自律確定分はユーザー承認なし、ユーザー判断必要分はユーザー承認済み。promote/defer/reject/duplicate） | [references/hitl-and-persistence.md](references/hitl-and-persistence.md) |
+| STEP-6 | 永続化（成果物生成・deferred 移動・prune・commit/push） | 判定確定（自律確定またはユーザー承認） | 採用済み成果物、deferred 移動済み、prune 済み、クリア済み inbox.md、commit/push | [references/hitl-and-persistence.md](references/hitl-and-persistence.md) |
 | STEP-7 | 完了報告 | 永続化完了 | 8軸評価サマリ、判定結果、後続ルート、git 永続化結果を含む完了報告 | [references/hitl-and-persistence.md](references/hitl-and-persistence.md) |
 
 ### STEP 間の依存と分岐
 
 - **正常経路**: STEP-1 → STEP-2 → STEP-3 → STEP-4（skip 条件該当時は省略）→ STEP-5 → STEP-6 → STEP-7
+- **部分自律確定（STEP-5 内）**: 同一実行内に自律確定可能項目とユーザー判断必要項目が混在する場合、未決項目に依存しない自律確定可能項目を先行確定し、ユーザー判断必要項目のみ HITL 対象とする。自律確定可能項目を HITL 待ちにしない
+- **全項目自律確定時（STEP-5 内）**: ユーザー判断必要項目が残らない場合、HITL を発生させず STEP-6 へ進む
 - **evaluation-report 戻しループ（review 反映時）**: STEP-4 の accepted finding 反映で意味内容が変更された場合、STEP-2 → STEP-3 → STEP-4（発動条件判定）の順で再実行し、再 review 発動条件を満たす場合のみ再 review。停止条件（4点）を満たした時点でループを離脱し STEP-5 へ進む
-- **inbox.md 空または不在**: STEP-1 で終了（不在時はエラー終了）
-- **unresolved 残存時**: STEP-5（判定結果提示）、STEP-6（deferred 移動、prune、commit/push）等の不可逆処理へ進まない
+- **inbox.md 空または不在**: STEP-1 で終了（不在時はエラー終了）。HITL を発生させない
+- **unresolved 残存時**: STEP-5（判定確定）、STEP-6（deferred 移動、prune、commit/push）等の不可逆処理へ進まない
 
 ## Resume Protocol（durable state による再開）
 
@@ -89,7 +91,8 @@ learning-promote workflow は次の7 STEP で構成する。
 
 HITL（STEP-5）の承認状態は単独では durable state に記録されない。
 採用済み成果物（promoted/）、inbox.md クリア、deferred.md 追記のいずれかを承認証跡として扱い、証跡がない場合は未承認と解釈して STEP-5 をやり直す。
-不可逆処理（deferred 移動、prune、採用済み成果物生成）は承認確定後にのみ実行する。
+ただし自律確定分の証跡はユーザー承認ではなく evaluation-report.md の自律確定記録（判定結果、主要根拠、HITL 不要理由）であり、当該記録と永続化成果物の双方から再構成できる。
+不可逆処理（deferred 移動、prune、採用済み成果物生成）は判定確定（自律確定またはユーザー承認）後にのみ実行する。
 
 ## 主要 Capability Skill 連携
 
@@ -112,10 +115,11 @@ HITL（STEP-5）の承認状態は単独では durable state に記録されな�
 
 - **無条件の自動REQ化禁止**: 学びを直接 REQ 化しない。恒久契約（REQ/Decision/SPEC）への昇華可能性を STEP-3 で評価し、昇華可能なもののみ `promoted/` へ出力する。学びは昇華（`promoted/` → `/agentdev/backlog-review` → `/agentdev/req-define` → `/agentdev/req-save`）を経て初めて REQ 化される
 - **living pool 維持**: 昇華不能な知見（deferred 判定、情報が断片的、出現回数が少ない等）は `deferred.md` の living pool で維持し、REQ 化しない。`deferred.md` は deferred カテゴリのエントリだけでなく、未処理・保留中・再評価対象のエントリも保持する多状態の living pool である（AG-{NNN}）。終端保管ではなく、次回実行時に再評価の対象となる
-- **prune 対象**: staged（採用済み成果物生成済み）/ rejected / duplicate のエントリのみ。deferred / 未処理のエントリは残す。staged エントリ除去時に採用済み成果物の「元learning item/ 根拠」セクションに証拠を保存する。STEP-5 のユーザー承認（判定確定）と同時に prune も承認済みとみなし、追加確認なしで削除する
+- **自律確定と HITL フォールバック**: 問題クラス分類、8軸評価、廃棄判定、昇華可能性、既存対策との関係の評価（STEP-2〜STEP-4）を経て、取得可能な根拠で処置を一意に確定できる項目はユーザー承認なしで確定し、ユーザー判断が必要な項目のみ HITL 対象とする。自律確定はユーザー承認の擬制ではなく、モデルの自己申告による確信度や固定パーセンテージのみで可否を判定しない。自律確定可否の詳細判定表（自律確定可能要件、HITL移送条件、判定と運用の共通規則）は横断契約SPEC `<workflows/workflow-contracts>`「promote系判断確定とHITL境界」節が集約所有し、本スキルは判定表を複製しない（extension 経由で解決）。deferred・未処理項目を自動削除しない既存の安全境界は自律確定によって迂回しない。自律確定項目の証跡（判定結果、主要根拠、HITL 不要理由）は evaluation-report.md 等の既存成果物を優先利用し、新規永続成果物を必須としない
+- **prune 対象**: staged（採用済み成果物生成済み）/ rejected / duplicate のエントリのみ。deferred / 未処理のエントリは残す。staged エントリ除去時に採用済み成果物の「元learning item/ 根拠」セクションに証拠を保存する。STEP-5 の判定確定（自律確定またはユーザー承認）と同時に prune も承認済みとみなし、追加確認なしで削除する
 - **直接反映禁止**: 採用済み成果物は `.agentdev/learning/promoted/` のみに生成する。`.opencode/` 直接書込、`case-run` への直接受け渡しは禁止（`/agentdev/backlog-review` 経由のみ）
 - **evaluation-report.md**: 本 workflow が生成、管理する（外部コマンドの事前生成に依存しない）。毎回上書きされ長期履歴ではない
-- **破壊的変更の明示承認**: inbox.md 全体強制クリア、大量エントリ一括削除等は STEP-5 の承認とは別に明示承認を維持する
+- **破壊的変更の明示承認**: inbox.md 全体強制クリア、大量エントリ一括削除等は STEP-5 の確定（自律確定を含む）とは別に明示承認を維持する
 - **git 永続化**: `git add` は `.agentdev/learning/` 配下のみを対象とする（明示パス、`git commit -- <paths>` の --only pathspec 形式）。`.agentdev/` 全体の一括スコープ、スイープ操作は禁止。commit message は `chore(agentdev): promote learning findings`。変更なし時は commit/push せず「変更なし」と報告。push 失敗時は構造化エラー形式で停止（完了扱いにしない）
 - **実行前同期**: `git pull --ff-only` 失敗時は共通 template（`.opencode/commands/agentdev/templates/common/git-error-messages.md`）の該当形式で表示して停止する（自動解消しない）
 - **完了報告**: template は `.opencode/commands/agentdev/templates/learning-promote/standard.md` に従う。8軸評価サマリ、判定結果（promote/defer/reject/duplicate 件数）、後続ルート（`/agentdev/backlog-review`）、git 永続化結果を含める

--- a/src/opencode/skills/agentdev-workflow-learning-promote/references/analysis-and-review.md
+++ b/src/opencode/skills/agentdev-workflow-learning-promote/references/analysis-and-review.md
@@ -162,7 +162,7 @@ inbox → deferred 移動、prune、commit/push 等の不可逆処理は未実�
 5. **evaluation-report 戻しループ**: review 反映時（review 対象の意味内容が変更された場合）は STEP-2 へ戻り、STEP-2（evaluation-report 生成・更新）→ STEP-3（廃棄判定）→ STEP-4 発動条件判定 → 再 review 発動条件（新たな本質的争点が生じ得る場合）を満たす場合のみ再 review、の順で再実行する。
 停止条件（4点）を満たした時点でループを離脱し STEP-5 へ進む。
 新証拠、新前提、異なる failure condition、未評価範囲のいずれも伴わない同一 finding の再起票を禁止する
-6. **unresolved 扱い**: unresolved な本質的争点またはユーザー判断事項が残る場合、STEP-5（判定結果提示）、STEP-6（deferred 移動、prune、commit/push）等の不可逆処理へ進まない。unresolved は既存の HITL（STEP-5 ユーザー承認）または blocker 扱いへ振り向ける
+6. **unresolved 扱い**: unresolved な本質的争点またはユーザー判断事項が残る場合、STEP-5（判定確定）、STEP-6（deferred 移動、prune、commit/push）等の不可逆処理へ進まない。unresolved は既存の HITL（STEP-5 のユーザー承認）または blocker 扱いへ振り向ける
 7. **呼出失敗時**: silent skip を禁止し、利用不能を報告した上で従来フロー（STEP-5 以降）と既存 HITL を維持する
 
 ### Result

--- a/src/opencode/skills/agentdev-workflow-learning-promote/references/hitl-and-persistence.md
+++ b/src/opencode/skills/agentdev-workflow-learning-promote/references/hitl-and-persistence.md
@@ -1,51 +1,59 @@
-# STEP 詳細: HITL / 永続化 / 完了報告（learning-promote）
+# STEP 詳細: 判定確定 / 永続化 / 完了報告（learning-promote）
 
 > 本 reference は `agentdev-workflow-learning-promote` SKILL.md の Control Plane STEP-5〜STEP-7 詳細である。
 > SKILL.md は control plane として STEP 遷移を管理し、本 reference は各 STEP の実行詳細を提供する。
 
 ## 目次
 
-- STEP-5: HITL（判定結果提示・ユーザー承認）
+- STEP-5: 判定確定（自律確定・HITL）
 - STEP-6: 永続化（成果物生成・deferred 移動・prune・commit/push）
 - STEP-7: 完了報告
 
-## STEP-5: HITL（判定結果提示・ユーザー承認）
+## STEP-5: 判定確定（自律確定・HITL）
 
 ### Purpose
 
-廃棄判定結果、8軸評価スコアをユーザーに提示し、確認、修正の機会を経て明示的な承認を得て判定を確定する（判断の確定）。
+各問題クラスについて自律確定可否を判定し、取得可能な根拠で処置を一意に確定できる項目をユーザー承認なしで確定する。ユーザー判断が必要な項目のみを提示し、確認、修正の機会を経て明示的な承認を得て確定する（判断の確定）。
 
 ### Input Resolution
 
 - STEP-2〜STEP-4 の評価・判定結果（中断時は evaluation-report.md と inbox.md 実ファイルから再構築する）
+- 自律確定可否の詳細判定表（自律確定可能要件、HITL移送条件、判定と運用の共通規則）は横断契約SPEC `<workflows/workflow-contracts>`「promote系判断確定とHITL境界」節が集約所有する（extension 経由で解決）。本 reference は判定表を複製しない
 - 提示形式、承認フローは `agentdev-learning-pipeline` の公開操作契約に従う
 
 ### Preconditions
 
 - STEP-3 完了、STEP-4 skip または反映済みであること
+- unresolved な本質的争点またはユーザー判断事項が残っていないこと（残る場合は本 STEP の判定確定へ進まない）
 
 ### Procedure
 
-1. 廃棄判定結果、8軸評価スコアを提示する
-2. ユーザーによる確認、修正を受け付ける
-3. ユーザー承認なしに採用済み成果物を生成しない。判定、prune ともに承認なしに実行しない
-4. 破壊的変更（inbox.md 全体強制クリア、大量エントリ一括削除等）は本 STEP の承認とは別に明示承認を維持する
+1. **自律確定判定**: 各問題クラスごとに、評価結果（問題クラス分類、8軸評価、廃棄判定、昇華可能性、既存対策照合）から処置を一意に確定できるかを横断契約SPEC の詳細判定表に従って判定する。モデルの自己申告による確信度や固定パーセンテージのみで可否を判定しない
+2. **自律確定の実行**: 一意に確定できる項目はユーザー承認なしで確定する（promote/defer/reject/duplicate）。自律確定はユーザー承認の擬制ではない。deferred・未処理項目を自動削除しない既存の安全境界は自律確定によって迂回しない
+3. **部分自律確定**: 自律確定可能項目とユーザー判断必要項目が混在する場合、未決項目に依存しない自律確定可能項目を先行確定する。自律確定可能項目を HITL 待ちにしない
+4. **HITL 提示（ユーザー判断必要項目のみ）**: 横断契約SPEC の HITL移送条件に該当する項目のみを対象に、廃棄判定結果、8軸評価スコアを提示する
+5. **ユーザーの確認、修正**: ユーザーによる確認、修正を受け付ける。判定の変更指示があれば廃棄判定、既存対策確認を再実行する
+6. **証跡記録**: 自律確定項目の判定結果、主要根拠、HITL 不要と判断した理由を evaluation-report.md に記録する（既存成果物を優先利用し、新規永続成果物を必須としない）
+7. **全項目自律確定時**: ユーザー判断必要項目が残らない場合、HITL を発生させず STEP-6 へ進む
+8. **破壊的変更の明示承認**: 破壊的変更（inbox.md 全体強制クリア、大量エントリ一括削除等）は本 STEP の確定とは別に明示承認を維持する
 
 ### Result
 
-- 判定確定（promote/defer/reject/duplicate、ユーザー承認済み）。STEP-6 は追加確認なしで自動実行する（prune も承認済みとみなす）
+- 判定確定（promote/defer/reject/duplicate）。自律確定分はユーザー承認なし、ユーザー判断必要分はユーザー承認済み。STEP-6 は追加確認なしで自動実行する（prune も判定確定と同時に承認済みとみなす）
 
 ### Evidence
 
-- 判定提示とユーザー承認の対話記録（確定した判定結果）
+- 自律確定項目: evaluation-report.md の自律確定記録（判定結果、主要根拠、HITL 不要理由）
+- HITL 対象項目: 判定提示とユーザー承認の対話記録（確定した判定結果）
 
 ### Completion Verification
 
-- 全問題クラスの判定がユーザー承認済みであること
+- 全問題クラスの判定が確定済みであること（自律確定またはユーザー承認のいずれか）
+- 自律確定分の証跡（判定結果、主要根拠、HITL 不要理由）が evaluation-report.md から確認できること
 
 ### Resume-Idempotency
 
-- 承認状態は単独では durable state に記録されない。promoted/ 成果物、inbox.md クリア、deferred.md 追記のいずれかを承認証跡として扱い、証跡がない場合は未承認と解釈して本 STEP をやり直す。承認前の再実行に副作用はない
+- 承認状態は単独では durable state に記録されない。promoted/ 成果物、inbox.md クリア、deferred.md 追記のいずれかを承認証跡として扱い、証跡がない場合は未承認と解釈して本 STEP をやり直す。自律確定分は evaluation-report.md の自律確定記録と永続化成果物の双方から再構成できる。承認前の再実行に副作用はない
 
 ## STEP-6: 永続化（成果物生成・deferred 移動・prune・commit/push）
 
@@ -61,7 +69,7 @@
 
 ### Preconditions
 
-- 判定確定済み（STEP-5 完了）
+- 判定確定済み（STEP-5 完了。自律確定またはユーザー承認）
 - 破壊的変更に該当する場合は明示承認済みであること
 
 ### Procedure
@@ -75,7 +83,7 @@
 対象は staged（採用済み成果物生成済み）/ rejected / duplicate のエントリのみ。
 deferred / 未処理のエントリは残す。
 staged エントリ除去時に採用済み成果物の「元learning item/ 根拠」セクションに証拠を保存する。
-追加確認なしで削除する（STEP-5 承認と同時に承認済みとみなす）
+追加確認なしで削除する（STEP-5 の判定確定と同時に承認済みとみなす）
 5. `git diff --name-only` で `.agentdev/learning/` 配下の変更を確認する。変更なし時は commit/push せず STEP-7 で「変更なし」と報告する
 6. 変更あり時、`git add` は `.agentdev/learning/` 配下のみを対象とする（明示パス指定、並列実行安全ステージングプロシージャ準拠）。
 `git commit -- <paths>`（--only pathspec 形式）でコミットする。
@@ -122,7 +130,7 @@ staged エントリ除去時に採用済み成果物の「元learning item/ 根�
 ### Procedure
 
 1. 完了報告 template（`.opencode/commands/agentdev/templates/learning-promote/standard.md`）に従って出力する
-2. 8軸評価サマリ、判定結果（promote/defer/reject/duplicate 件数）、後続ルート（`/agentdev/backlog-review`）、git 永続化結果（変更有無、ファイル一覧、commit hash、push 成否）を含める
+2. 8軸評価サマリ、判定結果（promote/defer/reject/duplicate 件数、自律確定と HITL 確定の内訳）、後続ルート（`/agentdev/backlog-review`）、git 永続化結果（変更有無、ファイル一覧、commit hash、push 成否）を含める
 
 ### Result
 


### PR DESCRIPTION
Refs: #2294

## 概要

learning-promote command SPEC へ追加確定済みの「自律確定の判定位置とHITLフォールバック」セクション（commit 3955170c）および REQ-038-002/003、REQ-003-055/056、REQ-003-024 に基づき、learning-promote 配布スキル（agentdev-workflow-learning-promote）と command 定義へ自律確定判定・部分自律確定・安全境界維持・報告形式を実装した。詳細判定表（自律確定可能要件、HITL移送条件、共通規則）は横断契約SPEC `<workflows/workflow-contracts>`「promote系判断確定とHITL境界」節への参照とし、配布スキル内に複製しない（DEC-010）。deferred・未処理項目の自動削除禁止の安全境界は維持する。

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/opencode/skills/agentdev-workflow-learning-promote/SKILL.md` | description・リード文へ自律確定を反映、STEP-5 を「判定確定（自律確定・HITL）」へ改称、部分自律確定・全項目自律確定時の分岐を追記、Resume Protocol の証跡解釈を更新、共通制約へ「自律確定と HITL フォールバック」を追加、prune 承認解釈を判定確定（自律確定またはユーザー承認）へ更新 |
| `src/opencode/skills/agentdev-workflow-learning-promote/references/hitl-and-persistence.md` | STEP-5 を自律確定判定の本体（Procedure 8手順: 自律確定判定 → 自律確定の実行 → 部分自律確定 → HITL 提示（ユーザー判断必要項目のみ） → ユーザーの確認・修正 → 証跡記録 → 全項目自律確定時 → 破壊的変更の明示承認）へ再構成、Input Resolution へ詳細判定表の横断契約SPEC 参照を明記、STEP-6 の前提・prune 文言、STEP-7 の報告へ自律確定と HITL 確定の内訳を追記 |
| `src/opencode/skills/agentdev-workflow-learning-promote/references/analysis-and-review.md` | STEP-4 の unresolved 扱いにおける STEP-5 名称参照の整合（判定結果提示 → 判定確定）のみ |
| `src/opencode/commands/agentdev/learning-promote.md` | 公開契約投影: description、workflow 表 STEP-5/6 行、不変条件へ自律確定原則を追加、G06 を「ユーザー判断が必要な項目」限定へ更新、G09・ユーザー確認ポイント（HITL、prune、責務）を適合 |

## 完了条件検証

| # | 完了条件 | 判定 | 証拠 |
|---|---|---|---|
| 1 | docs/specs/commands/learning-promote.md に「自律確定の判定位置とHITLフォールバック」セクションが存在（識別子存在確認） | 合格 | docs/specs/commands/learning-promote.md 113〜131行目に存在。commit 3955170c が base (5ae61275) の祖先であることを `git merge-base --is-ancestor` で確認 |
| 2 | 配布スキルが自律確定判定（横断契約SPEC参照）、部分自律確定、安全境界維持、報告形式を実装 | 合格 | SKILL.md 共通制約「自律確定と HITL フォールバック」、references/hitl-and-persistence.md STEP-5 Procedure（自律確定判定: 手順1、部分自律確定: 手順3、安全境界: 手順2/8、報告形式: 手順6・Evidence・Completion Verification） |
| 3 | 配布スキルが詳細判定表を重複保持していない | 合格 | 自律確定可能要件8項・HITL移送条件8項・共通規則の表は src/opencode/skills/agentdev-workflow-learning-promote/ 配下に存在せず、`<workflows/workflow-contracts>`「promote系判断確定とHITL境界」節への参照のみ |
| 4 | TS-001 の pass_criteria を満たす | 合格 | 下記 TS-001 検証のとおり (1)〜(10) すべて合格 |

## テスト戦略検証

### TS-001（自律確定と HITL 移送の境界）— 合格

配布物は Markdown 指示文書であるため記述レベルの境界検証として実施した（worktree は junction 未伝播のため projection が空であり、実ワークフロー実行の検証環境はない。マージ後の実行で追試可能）。

pass_criteria 評価:

| # | pass_criteria | 判定 | 根拠 |
|---|---|---|---|
| (1) | 根拠から一意に確定できる item がユーザー承認なしで確定される | 合格 | STEP-5 Procedure 2、SKILL.md 共通制約、command 不変条件 |
| (2) | 単独実行と backlog-auto 経由で境界が同一 | 合格 | 経路による判定分岐なし。backlog-auto SKILL.md が「各子ワークフローの HITL 境界…を子ワークフロー側の所有として維持し、本スキルは新規の判断境界を追加しない」と宣言 |
| (3) | backlog-auto が子の判定を承認・上書きしない | 合格 | backlog-auto 側に承認・上書きロジックなし（同上） |
| (4) | 混在時、非依存の自律確定可能項目が HITL 待ちにならない | 合格 | STEP-5 Procedure 3、SKILL.md「部分自律確定（STEP-5 内）」 |
| (5) | 価値判断・矛盾・情報不足・未解決争点・対象範囲決定・明示承認安全境界では自律確定しない | 合格 | STEP-5 Procedure 4（HITL移送条件を詳細判定表参照で適用）、Preconditions（unresolved 非残存）、Procedure 2/8（安全境界） |
| (6) | 自律確定の結果・根拠・HITL不要理由が既存成果物から確認できる | 合格 | STEP-5 Procedure 6・Evidence・Completion Verification、Resume Protocol（evaluation-report.md の自律確定記録） |
| (7) | 空入力で HITL なしの正常完了 | 合格 | STEP-1 手順2（「分析対象の学びがありません」終了）、SKILL.md「inbox.md 空または不在…HITL を発生させない」 |
| (8) | --auto が明示 opt-in fast path のまま | 合格 | learning-promote に --auto は存在せず影響なし（--auto は inspect-promote 固有） |
| (9) | backlog-review の HITL 契約が不変 | 合格 | backlog-review 関連の記述は変更なし |
| (10) | REQ-003/036/037/038/041 と command SPEC・Workflow Skill の記述が相互に矛盾しない | 合格 | REQ-038-002/003、REQ-003-055/056、REQ-003-024 と配布物記述の整合を確認。SPEC 側旧 G06 文言との緊張は SPEC確定候補へ、Capability Skill 側旧記述は Findings へ記録 |

RU-0001 決定的受け入れ条件 1〜20 の個別評価:

| # | 条件（要約） | 評価 |
|---|---|---|
| 1 | intake-promote で一意確定 item が承認なしで確定できる | not applicable（本 Issue 対象外。REQ-037-003 は #2289 で確定済み） |
| 2 | learning-promote で一意確定できる学習項目が承認なしで確定できる | pass |
| 3 | inspect-promote 通常経路で同様 | not applicable（REQ-036-018 は #2288 で確定済み） |
| 4 | 単独実行と backlog-auto 経由で原則が変わらない | pass |
| 5 | backlog-auto が子の判定を承認・上書きしない | pass |
| 6 | 混在時、非依存項目まで HITL 待ちにしない | pass |
| 7 | 自律確定できなかった項目だけが提示される | pass |
| 8 | ユーザー固有の価値判断・優先順位が必要な場合自律確定しない | pass |
| 9 | 正規情報源に未解決の矛盾がある場合自律確定しない | pass |
| 10 | 判断に必要な情報が不足している場合自律確定しない | pass |
| 11 | レビュー未解決争点残存時自律確定しない | pass |
| 12 | 必須検証・外部依存の利用不能時、無視して自律確定しない | pass（HITL移送条件7を詳細判定表参照で適用） |
| 13 | 対象範囲の新規決定はユーザー判断を維持 | pass（HITL移送条件3を詳細判定表参照で適用） |
| 14 | 明示承認を安全境界と要求する操作は迂回されない | pass（deferred・未処理の自動削除禁止、破壊的変更の明示承認維持を明記） |
| 15 | 自己申告確信度・固定パーセンテージのみで可否判定しない | pass（STEP-5 Procedure 1、SKILL.md 共通制約に明記） |
| 16 | 自律確定項目の結果・主要根拠・HITL不要理由を後から確認できる | pass（evaluation-report.md の自律確定記録） |
| 17 | 空入力で HITL なしの正常完了 | pass |
| 18 | inspect-promote --auto が明示 opt-in のまま | not applicable（learning-promote に --auto なし、本変更も無関係） |
| 19 | backlog-review の HITL 契約に変更がない | pass |
| 20 | REQ-003/036/037/038/041 と command SPEC・Workflow Skill が相互に矛盾しない | pass（留意2件を Findings / SPEC確定候補に記録） |

### TS-QC-001（docs 整合性検査、TS-QC-001）— 合格

- `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref origin/main --root .` → failures 0、warnings 1（対象ファイル検出なし。本変更は docs/ 配下ではなく src/opencode 配下のため。doc_map/spec_readme/requirements_readme 更新不要、full_docs_check 推奨なし）

### TS-QC-002（Skill 品質査読）— 合格

- 契約テスト: `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/skills_structure.test.ts` → 462 pass / 0 fail、`lint_skills.test.ts` → 26 pass / 0 fail
- agentdev-skill-authoring 基準の記述査読: frontmatter（name、description）形式維持、USE FOR / DO NOT USE FOR 維持、progressive disclosure（SKILL.md control plane / references 詳細の分離）維持、責務境界（詳細判定表は SPEC 参照・複製なし）、構造様式変更なし（セクション構成・STEP 数・reference 構成は不変、STEP-5 名称変更のみ）
- 構造様式の変更（STEP-5 改称）に伴う契約テスト期待値更新: learning-promote を固定する期待値は存在せず（grep 確認）、更新不要

### TS-QC-003（Command 品質査読）— 合格

- 契約テスト: `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/commands_structure.test.ts` → 52 pass / 0 fail、`check_templates.test.ts` → 14 pass / 0 fail
- agentdev-command-authoring 基準の記述査読: frontmatter description 1行維持、workflow 表の列構造維持、ガードレールの否定規則形式維持（G06 は自律確定原則との整合形へ更新、G09 は明示承認維持を維持）

## エンコーディング検証

変更4ファイルとも UTF-8（BOM なし）valid を機械確認（edit ツールによる per-line 置換のみ、全面上書きなし）。

## Findings / Capture候補

1. **agentdev-learning-pipeline（Capability Skill）の追従未実施**: `src/opencode/skills/agentdev-learning-pipeline/references/promote-judgment-logic.md` 97行目「自動確定禁止: AI 単独で promote/ prune の最終確定を行ってはならない」が REQ-038-002（確定済み）と正面から矛盾する。同ファイル Phase 5「HITL承認」の全クラスタ提示・承認手順も旧原則のまま。learning-promote Workflow Skill の STEP-5 は「提示形式、承認フローは agentdev-learning-pipeline の公開操作契約に従う」と参照しており、両者の指示が衝突する状態になる。本 Issue の対象範囲（workflow-learning-promote 配下、command 定義）の外のため本 PR では変更せず、Capability Skill 側の追従を backlog 検討に回すことを提案する。

## SPEC確定候補

1. **learning-promote command SPEC の G06 系旧文言の更新提案**: docs/specs/commands/learning-promote.md「検証観点」（144行目「ユーザー承認必須（G06）: 判定、prune」）と「停止状態」（148行目「ユーザー承認（判定、prune）を得るまで実行フェーズへ進まない（G06）」）が、同 SPEC の新規セクション「自律確定の判定位置とHITLフォールバック」（REQ-038-002/003、一意に確定できる項目はユーザー承認なしで確定）と文面上の緊張を残す。本 PR の実装（配布物）は新セクションを境界の正として「ユーザー判断が必要な項目」に限定した G06 解釈で投影した。SPEC 側の旧文言も新原則に適合するよう更新することが望ましい（Phase 0 契約により本 PR では docs/specs/** を編集せず候補として記録する）。

## 実行記録（L2 timestamps）

- 2026-08-20 00:05 JST: 開始（worktree 自己検証、Issue 本文取得）
- 2026-08-20 00:05〜00:20 JST: context 再確認（command SPEC、REQ-003/037/038、横断契約SPEC、RU-0001、先行 PR #2323）、実装（4ファイル）、検証（check_changed_docs.ts、契約テスト4種、エンコーディング検証）
- 2026-08-20 00:20 JST: コミット・push・PR 作成
