### PR TITLE
agentdev: #2310 req-define 実証Case判定と評価契約の配布スキル適合

### DIFF
--- a/.agentdev/extensions/skills/agentdev-workflow-req-define.yaml
+++ b/.agentdev/extensions/skills/agentdev-workflow-req-define.yaml
@@ -15,6 +15,11 @@ context:
     paths:
       - "docs/specs/quality/req-health-metrics.md"
     purpose: REQ 健全性メトリクス（肥大化、関心ズレ検出）の確認
+  - id: req-define-command-spec
+    when: 実証Case判定・評価契約の構成要素詳細、実証Issue 入力の入力優先規定、draft-data 実証情報出力形式参照時
+    paths:
+      - "docs/specs/commands/req-define.md"
+    purpose: 実証Case判定と評価契約セクションの実行詳細の確認
   - id: delegation-contracts
     when: サブエージェント委譲契約参照時
     paths:

--- a/src/opencode/commands/agentdev/req-define.md
+++ b/src/opencode/commands/agentdev/req-define.md
@@ -14,6 +14,7 @@ description: 要件を整理、定義する（機能追加、バグ修正共通�
 
 - ユーザーの自然言語による機能追加/バグ修正の説明
 - GitHub Issue URL（既存Issueの場合）
+- 実証Issue（`req-define <実証Issue>` 形式の明示指定時。当該実証の正式化を主たる入力とし、評価契約、最終評価結果、参照証拠を取り込む）
 - エラーログ（バグ修正の場合）
 - **ユーザーが明示した入力ファイル**: 設計メモ、調査メモ、RU（`.agentdev/backlog/req-units/RU-*.md`）等。全て参照専用入力（G04）
 - req-save SPLIT 検出時の検出事項（`.agentdev/drafts/requirements-review-finding-{topic-slug}.md`）
@@ -70,6 +71,10 @@ OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため�
 - Decision閾値以上の判断は `agentdev-decision-guidelines` で判定する。Decision 要否確認ゲートでは `agentdev-architecture-advisory` の助言を親エージェントが分類して採用し、未確認事項は要件本文と分離して扱う
 - work_type・Scale 判定は `agentdev-workflow-lifecycle` の基準に従う
 - draft は `operation_units` セクションを出力する（単一REQ操作も1件の OU として出力）。`depends_on` は必須依存のみ記録し、Issue 階層・Epic/Wave 構成の決定は case-open が担う
+- 実証必要性の推論・提案と評価契約の確定を要件展開工程の一部として実行する（実証Case判定と評価契約の意味論は評価ブランチ実証ワークフロー要件が所有する）。単なる追加調査だけを理由に実証Caseとしない
+- 実証Caseとして確定した後は評価ブランチ利用を別途確認せず、実証Caseなら評価ブランチ、通常Caseなら main と決定的に導出する
+- 評価契約と test strategy は分離する。test strategy は実証手段・計測手段・実証環境が正常に動作したかを扱い、評価契約は評価対象から得られた結果と採否を扱う
+- 本コマンドは実証Caseでも Git 副作用を持たない（評価ブランチ・worktree 準備の実行主体・手順は command SPEC が所有する）。評価ブランチ作成だけの新しい公開コマンドを追加しない
 - SPEC 分離基準に該当する要件行は `artifact_actions`（`artifact: spec`）へ分離する（安定契約例外は除く）。test strategy 項目は verification（検証手順）・pass_criteria（合格基準）・on_failure（不合格時の処置）の3要素を完全に持ち、欠落項目は保存前に QG fail として扱う
 
 ## ガードレール

--- a/src/opencode/skills/agentdev-workflow-req-define/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-req-define/SKILL.md
@@ -30,6 +30,7 @@ extension（`.agentdev/extensions/skills/agentdev-workflow-req-define.yaml`）�
 
 - ユーザーの自然言語による機能追加/バグ修正の説明
 - GitHub Issue URL（既存Issueの場合）、エラーログ（バグ修正の場合）
+- 実証Issue（`req-define <実証Issue>` 形式の明示指定時。当該実証の正式化を主たる入力とし、評価契約、最終評価結果、参照証拠を取り込む）
 - ユーザーが明示した入力ファイル（設計メモ、調査メモ、RU `.agentdev/backlog/req-units/RU-*.md` 等、参照専用）
 - req-save SPLIT 検出時の検出事項、inspect-skills 診断結果の検出事項
 
@@ -39,7 +40,7 @@ extension（`.agentdev/extensions/skills/agentdev-workflow-req-define.yaml`）�
 
 ## 副作用
 
-- `.agentdev/drafts/**` 配下のファイル作成・更新のみ（G03）。`git` コマンドは実行しない（G08）
+- `.agentdev/drafts/**` 配下のファイル作成・更新のみ（G03）。`git` コマンドは実行しない（G08）。実証Caseでも Git 副作用（評価ブランチ作成等）を持たない
 - RU、promoted 成果物、inbox.md/deferred.md は読取のみ（参照専用入力）
 
 ## Control Plane（STEP 一覧）
@@ -50,12 +51,12 @@ req-define workflow は次の11 STEP で構成する。
 
 | STEP | 名称 | 開始条件 | 結果 | 詳細 reference |
 |---|---|---|---|---|
-| STEP-1 | セッションコンテキスト検知・入力解決 | req-define 起動 | 6項目推論（信頼度付き）、入力ソース確定 | [references/input-and-dialogue.md](references/input-and-dialogue.md) |
-| STEP-2 | 壁打ち対話（引き継ぎ判定含む） | 入力ソース確定 | 深掘り済み要件内容、`agentdev_handoff` 判定 | [references/input-and-dialogue.md](references/input-and-dialogue.md) |
+| STEP-1 | セッションコンテキスト検知・入力解決 | req-define 起動 | 6項目推論（信頼度付き）、入力ソース確定（実証Issue 明示指定時は正式化入力として確定、RU 自動検出と混在時はユーザー確認） | [references/input-and-dialogue.md](references/input-and-dialogue.md) |
+| STEP-2 | 壁打ち対話（引き継ぎ判定含む） | 入力ソース確定 | 深掘り済み要件内容、`agentdev_handoff` 判定、実証Case判定結果（実証/通常の別） | [references/input-and-dialogue.md](references/input-and-dialogue.md) |
 | STEP-3 | 既存REQ照合 | 壁打ち合意内容確定 | 操作分類結果（`artifact_actions` 記録用） | [references/requirement-development.md](references/requirement-development.md) |
-| STEP-4 | 要件展開 | 操作分類確定 | 変更影響候補、分類ゲート、Decision要否確認、test strategy 定義 | [references/requirement-development.md](references/requirement-development.md) |
+| STEP-4 | 要件展開 | 操作分類確定 | 変更影響候補、分類ゲート、Decision要否確認、test strategy 定義、評価契約確定（実証Case時） | [references/requirement-development.md](references/requirement-development.md) |
 | STEP-5 | Decision判断 | 要件展開完了 | Decision判断記録（`new:{topic-slug}` 形式） | [references/requirement-development.md](references/requirement-development.md) |
-| STEP-6 | 要件doc生成 | Decision判断完了 | 構造化 `draft-data`（operation_units、artifact_actions、test_strategy、review_dispositions） | [references/draft-generation.md](references/draft-generation.md) |
+| STEP-6 | 要件doc生成 | Decision判断完了 | 構造化 `draft-data`（operation_units、artifact_actions、test_strategy、review_dispositions。実証Case時は実証Caseであること、評価契約、評価ブランチ識別情報を含む） | [references/draft-generation.md](references/draft-generation.md) |
 | STEP-7 | work_type・Scale 判定 | 要件doc生成完了 | work_type 4値、scale（feature のみ） | [references/draft-generation.md](references/draft-generation.md) |
 | STEP-8 | adversarial-review（経路A） | STEP-7 完了後、STEP-9 前 | review 結果反映（skip 時は従来フロー継続） | [references/adversarial-review-path-a.md](references/adversarial-review-path-a.md) |
 | STEP-9 | ドラフト保存 | review 完了または skip | `.agentdev/drafts/req-draft-{topic-slug}.md` 保存 | [references/draft-generation.md](references/draft-generation.md) |
@@ -120,6 +121,7 @@ req-define workflow は次の11 STEP で構成する。
 - **draft-data 形式**: 出力は構造化 `draft-data`（`# draft-data` fenced YAML block）。`operation_units` を出力し、`execution_groups` は出力しない。`workflow_route` は派生値として保存しない（後続工程の分岐は `artifact_actions` の存在で決定）
 - **Issue 階層非決定**: req-define は Issue 階層を決定しない。`depends_on` は case-open の execution_unit 構成が使用する依存情報であり、最終 Issue 構成は case-open が決定する
 - **session由来RU 消費契約**: 正規原本（一時成果物ライフサイクル要件 + artifact-contracts SPEC）へ委譲し、本スキルで再定義しない
+- **実証Case判定・評価契約確定**: 実証必要性の推論・提案と評価契約の確定を要件展開工程の一部として実行する。実証Caseと評価契約の意味論は評価ブランチ実証ワークフロー要件が正規所有し、本スキルは実行位置と手順を提供する。実証Caseでも Git 副作用を持たない（評価ブランチ・worktree 準備の実行主体・手順は req-define command SPEC（extension 経由）が所有する）
 
 ## See Also
 

--- a/src/opencode/skills/agentdev-workflow-req-define/references/draft-generation.md
+++ b/src/opencode/skills/agentdev-workflow-req-define/references/draft-generation.md
@@ -35,13 +35,14 @@
 原本は構造化された `# draft-data` fenced YAML block である。
 STEP-5 の Decision禁止ゲート・STEP-4 の文書分類妥当性検証で分離した SPEC 候補は `artifact_actions`（`artifact: spec`）として統合し、`## SPEC候補` 補助セクションは出力しない。
 保存対象は単一の `artifact_actions` 配列に統合する。
+実証Caseの場合、draft-data に実証Caseであること、評価契約、評価ブランチ識別情報を出力する。下流コマンドは Issue 等の永続情報または draft-data の当該情報から実証Caseを認識する。
 
 各副ステップ（定義完全性ゲート QG-1、operation_units 生成、depends_on/recommended_order 定義、artifact_actions 生成、target_area/content 形式、SPEC action 分類根拠出力、test_strategy 生成、review_dispositions 生成）の詳細、フィールドスキーマ、委譲接続点は `agentdev-req-analysis` の req-define detailed gates、および req-define command SPEC（extension 経由）の各フィールドスキーマを参照。
 `target_spec`、`spec_logical_division`、`canonical_owner`、`on_failure`、`review_dispositions` の出力形式も同 SPEC を正とする。
 
 ### Result
 
-- 構造化 `draft-data`（`work_type`, `scale`, `summary`, `auto_gate`, `agreed_items`, `artifact_actions`, `conflict_resolutions`, `operation_units`, `test_strategy`, `review_dispositions`, `case_open_hints`）
+- 構造化 `draft-data`（`work_type`, `scale`, `summary`, `auto_gate`, `agreed_items`, `artifact_actions`, `conflict_resolutions`, `operation_units`, `test_strategy`, `review_dispositions`, `case_open_hints`。実証Case時は実証Caseであること、評価契約、評価ブランチ識別情報を含む）
 
 ### Evidence
 
@@ -49,7 +50,7 @@ STEP-5 の Decision禁止ゲート・STEP-4 の文書分類妥当性検証で分
 
 ### Completion Verification
 
-- 必須 fields が揃い、`execution_groups` を含まないこと。SPEC 候補が `artifact_actions` へ統合済みであること
+- 必須 fields が揃い、`execution_groups` を含まないこと。SPEC 候補が `artifact_actions` へ統合済みであること。実証Case時は実証Caseであること、評価契約、評価ブランチ識別情報が出力済みであること
 
 ### Resume-Idempotency
 
@@ -115,6 +116,8 @@ work_type（4値）と scale（feature のみ）を確定する。
 全 work_type（feature/bugfix/maintenance/docs_chore）で `.agentdev/drafts/req-draft-{topic-slug}.md` に保存する。
 STEP-6 の構造化 `draft-data` 形式（`# draft-data` fenced YAML block）で保存する。
 標準データモデル fields を保持する。
+実証Caseの場合、最初の保存処理より前に当該実証専用の評価ブランチと必要な worktree が準備されていることを前提とする。準備の実行主体・手順は req-define command SPEC（extension 経由）が所有し、本 workflow は Git 操作を実行しない。
+生成した draft は内容欠落なく評価環境へ引き継ぎ、req-save / spec-save を評価ブランチ上で継続実行できる。
 `workflow_route` は派生値として保存しない。
 後続工程の分岐は `artifact_actions` の存在で決定する（`artifact: req`/`adr` → req-save、`artifact: spec` → spec-save）。
 `summary` 等の人間可読セクションは補助的であり下流処理の正として扱われない。

--- a/src/opencode/skills/agentdev-workflow-req-define/references/input-and-dialogue.md
+++ b/src/opencode/skills/agentdev-workflow-req-define/references/input-and-dialogue.md
@@ -16,8 +16,8 @@
 
 ### Input Resolution
 
-1. SSoT 再構成: 明示入力ファイル（設計メモ、RU、検出事項）の実ファイル読込
-2. identifier 保持: RU-ID、Issue番号（URL 指定時）
+1. SSoT 再構成: 明示入力ファイル（設計メモ、RU、検出事項）および実証Issue 本文の実ファイル読込
+2. identifier 保持: RU-ID、Issue番号（URL 指定時、実証Issue 指定時）
 3. 最小 scalar: なし
 4. runtime artifact: セッション履歴・現在コンテキスト（推論の入力、権威情報源ではない）
 
@@ -30,12 +30,13 @@
 - **引数なし単体実行時**: `agentdev-req-analysis` に従い、当該セッション履歴・現在コンテキストから6項目（要件内容、work_type、scale、Decision、構造化、適用範囲）を推論し信頼度付きで表示する。Confirmed のみで要件doc自足可能なら STEP-3 以降へ、部分的不足で補足質問解消可能なら壁打ち（STEP-2）へ、有効な Requirement Source 構成不能なら RU 自動検出へ
 - **明示入力ファイル指定時**: Read tool で読み込み、壁打ちの初期コンテキストとして扱う。複数ファイル指定時は全て読み込む
 - **RU 自動検出**: 引数なしでセッションから有効な入力を構成できなかった場合のみ、`.agentdev/backlog/req-units/RU-*.md` の存在を確認し1件なら自動検出する。0件なら STEP-2 へ。2件以上なら候補一覧を表示し自動選択しない
+- **実証Issue 明示指定時**: 引数に実証Issue を指定された場合、当該実証の正式化を主たる入力として扱う。評価契約、最終評価結果、参照証拠を当該 Issue 本文と関連 PR から取り込む。実証Issue 明示指定時に RU 自動検出と混在する場合は、どちらを処理するかユーザーへ確認する（入力優先規定。詳細は req-define command SPEC（extension 経由）参照）
 - **session由来RU 受領時**: 読み込んだRU が `source_type: chat` かつ `generated_by: session` の場合、session由来RU 消費契約に従う。`session:...` 論理URI の解決、必須8セクション読み取り契約、`tentative_classification` → 最終分類の扱いは正規原本（一時成果物ライフサイクル要件、artifact-contracts SPEC）へ委譲する
 - セッション履歴、現在コンテキストおよび RU のいずれからも有効な入力を構成できない場合、壁打ち対話を開始する
 
 ### Result
 
-- 入力ソース確定（セッション推論 / 明示ファイル / RU / 対話開始）
+- 入力ソース確定（セッション推論 / 明示ファイル / RU / 実証Issue / 対話開始）
 
 ### Evidence
 
@@ -43,7 +44,7 @@
 
 ### Completion Verification
 
-- 入力ソースが一意に確定し、RU 複数候補時は自動選択していないこと
+- 入力ソースが一意に確定し、RU 複数候補時は自動選択していないこと。実証Issue 明示指定と RU 自動検出が混在した場合は処理対象をユーザー確認済みであること
 
 ### Resume-Idempotency
 
@@ -75,17 +76,23 @@
 **前工程からの引き継ぎ判定**: 入力が AgentDevFlow 本体、配布 command、配布 skill、配布 template、配布 script の不具合または改善点を対象とする場合、`agentdev-workflow-lifecycle` に従い前工程からの引き継ぎ用 RU 入力として整理する。
 現在プロジェクトの通常要件docとして定義せず、出力に `agentdev_handoff: true` を含める。
 
+**実証Case判定**: 実証必要性を推論する。推論の観点は次の3つである: 調査・設計だけでは重要な採否判断を確定できないか、実行・測定・観察が必要か、単なる追加調査でないか。単なる追加調査だけを理由に実証Caseとしない。
+ユーザーが実証を明示している場合は再確認せず実証Caseとして扱う。明示していない場合は実証を推奨する理由を提示し、壁打ちにより実証Caseへの移行を確定する。
+実証Caseとして確定した後は評価ブランチ利用を別途確認せず、実証Caseなら評価ブランチ、通常Caseなら main と決定的に導出する。
+実証は work_type とは別の性質として扱い、work_type の値を実証のために増やさない。
+実証Case判定と評価契約の意味論は評価ブランチ実証ワークフロー要件が正規所有し、本 workflow は判定の実行位置を提供する。
+
 ### Result
 
-- 深掘り済み要件内容、`agentdev_handoff` 判定結果
+- 深掘り済み要件内容、`agentdev_handoff` 判定結果、実証Case判定結果（実証/通常の別）
 
 ### Evidence
 
-- draft-data 下書きの合意項目、引き継ぎ判定の根拠
+- draft-data 下書きの合意項目、引き継ぎ判定の根拠、実証Case判定の根拠（実証必要性推論、ユーザー明示の有無）
 
 ### Completion Verification
 
-- 合意内容が draft-data 下書きに反映されており、未解決質問・未解決衝突が残っていないこと（残る場合は対話継続）
+- 合意内容が draft-data 下書きに反映されており、未解決質問・未解決衝突が残っていないこと（残る場合は対話継続）。実証を推奨した場合は実証Caseへの移行の確定または却下が済んでいること
 
 ### Resume-Idempotency
 

--- a/src/opencode/skills/agentdev-workflow-req-define/references/requirement-development.md
+++ b/src/opencode/skills/agentdev-workflow-req-define/references/requirement-development.md
@@ -74,19 +74,21 @@
 - **文書分類妥当性検証**: REQ 要件行に SPEC 分離基準違反残留がないか検出する。検出時は SPEC 保存対象へ移送する（安定契約例外は対象外）
 - **Decision要否確認ゲート**: Decision候補・既存REQ/Decision/SPEC との衝突候補・責務境界変更を含む場合、`agentdev-architecture-advisory` へ委譲する。出力は4ラベル構造（確定事項/推定事項/ユーザー確認事項/ブロッカー）。soft-contract（Decision）。ブロッカーまたは未決事項残存時は壁打ち（STEP-2）へ差し戻す
 - **実行主体分類表**: 委譲契約を定義する場合、各委譲について実行主体分類表（adapter skill / command / subagent / harness）を必須とする（詳細は delegation-contracts SPEC（extension 経由）参照。委譲を含まない要件では省略可）
-- **test strategy 定義**: 各合意項目（AG-*）の検証方法を test strategy として定義する。3要素構造（`verification` / `pass_criteria` / `on_failure`）を必須とし、`on_failure` を持たない検証項目は含めない。項目識別子は `TS-NNN`、`on_failure` アクション種別は `fix-and-reverify` / `record-in-findings` の2値。シリアライズ形式の詳細は req-define command SPEC（extension 経由）の draft-data test_strategy フィールドスキーマ参照
+- **評価契約確定（実証Case時）**: 実証Caseとして確定した場合、実証開始前に評価契約の構成要素を必要に応じて壁打ちで確定する。構成要素は評価対象・仮説、比較対象、比較条件、評価方法、評価観点、評価シナリオ、測定・観察項目、判定基準、必要証拠、採用条件、不採用条件、判定不能条件、中止条件、再実行条件、比較条件逸脱時の扱いとする。詳細は req-define command SPEC（extension 経由）「実証Case判定と評価契約」参照
+- **評価契約の変更管理**: 実証開始後、実行側の自律判断で評価契約を変更しない。ユーザーが評価契約の変更を明示的に指示した場合のみ変更でき、変更内容、変更理由、既存評価結果への影響を追跡可能にし、影響する既存評価について必要な再評価または再実行を行い、変更前の契約と結果を失わない。実証全体の最終完了後は当該実証の評価契約および最終結果を書き換えない。完了後に異なる条件で評価する場合は新しい実証として扱う
+- **test strategy 定義**: 各合意項目（AG-*）の検証方法を test strategy として定義する。3要素構造（`verification` / `pass_criteria` / `on_failure`）を必須とし、`on_failure` を持たない検証項目は含めない。項目識別子は `TS-NNN`、`on_failure` アクション種別は `fix-and-reverify` / `record-in-findings` の2値。シリアライズ形式の詳細は req-define command SPEC（extension 経由）の draft-data test_strategy フィールドスキーマ参照。test strategy と評価契約は分離する。test strategy は実証手段・計測手段・実証環境が正常に動作したかを扱い、評価契約は評価対象から得られた結果と採否を扱う。評価対象が採用基準を満たさなかったことを実装不具合として自動修正しない
 
 ### Result
 
-- 変更影響候補、最終分類、SPEC 分離結果、Decision要否確認結果、test strategy 定義
+- 変更影響候補、最終分類、SPEC 分離結果、Decision要否確認結果、test strategy 定義、評価契約（実証Case時）
 
 ### Evidence
 
-- 影響候補リスト、分類判定根拠、助言の4ラベル構造結果、test strategy 項目
+- 影響候補リスト、分類判定根拠、助言の4ラベル構造結果、test strategy 項目、評価契約の構成要素確定結果（実証Case時）
 
 ### Completion Verification
 
-- 全要件行候補の分類が確定し、SPEC 分離基準違反残留が0件であること。test strategy 項目が全て3要素を持つこと
+- 全要件行候補の分類が確定し、SPEC 分離基準違反残留が0件であること。test strategy 項目が全て3要素を持つこと。実証Case時は評価契約が実証開始前に確定していること
 
 ### Resume-Idempotency
 
@@ -149,3 +151,4 @@
 - 不変条件（SPEC 分離基準該当行の `artifact_actions` 分離）
 - 不変条件（アーキテクチャ助言サブエージェントの参照と未確認事項非混入）
 - 不変条件（test strategy 3要素完全、欠落時は QG-1 fail 扱い）
+- 不変条件（評価契約と test strategy の分離、評価対象が採用基準を満たさなかったことの実装不具合としての自動修正禁止）


### PR DESCRIPTION
## 概要

OU-0020（source: RU-0003、Epic B2 #2307 Wave 1）。req-define command SPEC に確定済みの「実証Case判定と評価契約」セクション（ACT-SPEC-002 適用分）に基づき、req-define 配布スキル（agentdev-workflow-req-define）・配布 command を実証Case判定・評価契約確定・実証Issue 入力・draft-data 実証情報出力へ適合させた。

Refs: #2310

## 変更内容

docs/specs/** は編集なし（Phase 0 契約）。配布物のみの変更。

| ファイル | 変更 |
|---|---|
| `src/opencode/skills/agentdev-workflow-req-define/references/input-and-dialogue.md` | STEP-1 に実証Issue 明示指定時の入力解釈（正式化の主たる入力、評価契約・最終評価結果・参照証拠の取込、RU 自動検出と混在時のユーザー確認＝入力優先規定）を追加。STEP-2 に実証Case判定（実証必要性推論3観点、追加調査除外、明示時再確認なし、未明示時理由提示と壁打ち確定、評価ブランチ/main の決定的導出、work_type との別概念）を追加。Result/Evidence/Completion Verification に実証Case判定結果を反映 |
| `src/opencode/skills/agentdev-workflow-req-define/references/requirement-development.md` | STEP-4 に評価契約確定（実証開始前、構成要素15項目）、評価契約の変更管理（自律変更禁止、ユーザー明示指示のみ、記録・追跡・再評価/再実行、最終完了後の書き換え禁止）を追加。test strategy 定義に評価契約との分離基準（test strategy は実証手段・計測手段・実証環境の正常動作、評価契約は結果と採否、採用基準不満足を不具合として自動修正しない）を追記 |
| `src/opencode/skills/agentdev-workflow-req-define/references/draft-generation.md` | STEP-6 に実証Case時の draft-data 出力（実証Caseであること、評価契約、評価ブランチ識別情報、下流コマンドの認識経路）を追加。STEP-9 に評価ブランチ・worktree 準備の前提（最初の保存処理より前、実行主体は SPEC 側、本 workflow は Git 操作しない）と draft の評価環境への引き継ぎ契約（内容欠落なく、req-save / spec-save を評価ブランチ上で継続）を追加 |
| `src/opencode/skills/agentdev-workflow-req-define/SKILL.md` | 入力に実証Issue を追加。副作用に「実証Caseでも Git 副作用を持たない」を明記。STEP 表の STEP-1/2/4/6 結果に実証Case関連を反映。共通制約に「実証Case判定・評価契約確定」（意味論は評価ブランチ実証ワークフロー要件が正規所有、本スキルは実行位置と手順）を追加 |
| `src/opencode/commands/agentdev/req-define.md` | 入力に実証Issue を追加（公開契約投影）。不変条件に実証Case関連4項目（要件展開工程の一部として実行・追加調査除外、評価ブランチ決定的導出、評価契約と test strategy の分離、Git 副作用なし・公開コマンド追加禁止）を追加 |
| `.agentdev/extensions/skills/agentdev-workflow-req-define.yaml` | context に `docs/specs/commands/req-define.md`（実証Case判定と評価契約セクション）への経路を追加。references から「req-define command SPEC（extension 経由）」参照の導線を解決 |

設計上の注意:
- 配布物の内部管理 ID 除去運用（src/opencode 配下に実 REQ-ID 不在）に従い、実 REQ-ID は記述せず内容ベースで規定した。SPEC 参照は既存パターンの「req-define command SPEC（extension 経由）」形式
- 評価ブランチ・worktree 準備の実行主体・手順は git-worktree skill SPEC（OU-0028 対応済み）が所有するため、req-define 配布スキルは前提契約と Git 操作禁止のみを記述
- 完了条件チェックボックスは更新していない（case-close QG-4 責務）

## 検証エビデンス

### 完了条件

1. **SPEC セクション存在**: `docs/specs/commands/req-define.md:476` に「実証Case判定と評価契約」セクション存在を grep で確認 → 合格
2. **配布スキル実装**: 実証Case判定・評価契約確定工程（STEP-2/4）、実証Issue 入力解釈（STEP-1）、draft-data 実証情報出力（STEP-6）を実装 → 合格
3. **Git 副作用なし**: 追加は自然言語記述のみ。`git` コマンド実行の追加なし（G08・評価ブランチ準備は前提契約のみ） → 合格
4. **TS-003**: 下表の通り全項目合格

### TS-003（pass_criteria 5項目の照合）

| # | pass_criteria | 実装箇所 | 判定 |
|---|---|---|---|
| (1) | 実証必要性を推論し未明示時は理由提示と合意後に確定 | input-and-dialogue.md STEP-2「実証Case判定」（推論3観点、単なる追加調査除外、明示時再確認なし、未明示時は理由提示し壁打ちで移行確定 + Completion Verification） | 合格 |
| (2) | 確定後に評価ブランチ利用を再確認しない | 同節「確定した後は評価ブランチ利用を別途確認せず、実証Caseなら評価ブランチ、通常Caseなら main と決定的に導出」+ command 不変条件 | 合格 |
| (3) | 評価契約が実証開始前に確定し実行側が自律変更しない | requirement-development.md STEP-4「評価契約確定（実証開始前に確定 + Completion Verification）」「評価契約の変更管理（実証開始後、実行側の自律判断で変更しない）」 | 合格 |
| (4) | ユーザー指示変更が記録され必要な再評価・再実行が行われる | 同「変更管理」（明示指示のみ変更可、変更内容・理由・影響を追跡可能、必要な再評価または再実行、変更前の契約と結果を保持） | 合格 |
| (5) | 完了済み実証の契約と結果が書き換えられない | 同「変更管理」（最終完了後は評価契約および最終結果を書き換えない、異条件評価は新しい実証として扱う） | 合格 |

RU-0003 の決定的受け入れ条件 1, 2, 8, 9, 10 の個別評価: RU ファイルは case-open 成功後の正常削除済みで本文参照不能のため、TS-003 pass_criteria (1)〜(5) を対応検証基準として全項目照合合格とした。

### TS-QC-001/002/003

| 検証 | 結果 |
|---|---|
| check_changed_docs.ts --workflow case-run --base-ref 40096376（コミット後実行） | failures 0 / warnings 1（検査対象0件: 本 PR の変更は src/opencode・extension のみで case-run profile の対象 docs/** に該当なし。docs 変更ゼロの正常系） |
| check_integrity.ts | NG 0 / Warning 14（全件 docs/** の既存指摘: REQ-028 retired 参照、DEC-017/005 proposed/superseded 引用等。今回変更ファイル由来の指摘ゼロ） |
| check_extensions.ts | failures 0（extension yaml 変更後: schema_violation_entries 0, malformed_entries 0） |
| check_command_format.ts | OK |
| bun test（skills_structure / commands_structure / check_extensions / templates_structure） | 557 pass / 0 fail（構造様式変更に伴う契約テスト期待値更新は不要: 既存見出し構造・Step 形式の変更なし） |
| lint_skills.ts（agentdev-workflow-req-define） | 違反なし（検出1件は agentdev-git-worktree/references/worktree-operations.md の既存 NG、本変更と無関係） |
| エンコーディング | 全変更ファイル BOM なし UTF-8 維持、git diff --check whitespace 0、diff 上文字化けなし |

## Findings / Capture候補

- check_integrity.ts の「14 new unmanaged NG (delta, exit code driver)」表示について: レポート本文上は NG 0 / Warning 14 で、全件 docs/** の既存指摘（RETIRE 済み REQ-028 参照、proposed/superseded Decision 引用）。本 PR と無関係だが、main ブランチでも同様に表示される可能性が高く、exit code 運用との整合確認を intake 化する価値があるかもしれない
- lint_skills の AG-005 既存 NG（agentdev-git-worktree/references/worktree-operations.md 340行・目次なし）は本 PR 無関係だが未解決のまま残存している

## SPEC確定候補

- SPEC「実証Case判定と評価契約」は実証Case の draft-data 出力形式について「実証Caseであること、評価契約、評価ブランチ識別情報を出力する」という要件水準に留まり、具体的なフィールド名・シリアライズ形式（draft-data YAML の当該キー構造）は規定していない。REQ-043 の適用範囲外に「評価ブランチ命名規則・draft引き継ぎ方式の詳細（実装設計）」とある通り意図的な残置と解釈したが、下流コマンド（case-open/case-run）が draft-data から実証Caseを機械的に認識するにはフィールド契約の確定が将来必要になる可能性がある
- 実証Issue 入力の入力優先規定（RU 自動検出と混在時のユーザー確認）は SPEC 上は一文規定のみ。確認プロンプトの形式・タイムアウト時の扱い等の実行詳細は SPEC に未規定（配布スキルは SPEC 参照に委譲する記述とした）
- 評価契約の変更管理（REQ-043-007/008 相当の内容）は req-define command SPEC「実証Case判定と評価契約」セクションに明示的な節を持たず、REQ 本文が直接所有する構成になっている。配布スキル側に実行規定を投影したが、SPEC 側にも「評価契約の変更管理」節を設けるかどうかは SPEC 整理の判断候補

