### PR TITLE
agentdev: #2312 case-run 統合先基準の作業起点と実証実行の配布スキル適合

### DIFF
--- a/src/opencode/commands/agentdev/case-run.md
+++ b/src/opencode/commands/agentdev/case-run.md
@@ -79,6 +79,7 @@ OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため�
 工程上の選好を肯定形の不変条件として示す:
 
 - 本コマンドは orchestration に専念し、実装実行は実行担当サブエージェント経由で委譲する（work plan 生成・実装・乖離検出・specs 更新・PR 作成は委譲先の責務。adapter protocol は `agentdev-case-run-execution-adapter` 参照）
+- worktree の作成元と PR の base は当該 Case の統合先（既定 main。実証Caseは評価ブランチ）を参照する。同期基準・鮮度確認・Epic 後続 Wave の作業起点も同一の統合先を参照し、通常Caseの worktree 起点・PR base は従来どおり main を維持する。実証Caseの場合、実証手段の準備、実行、測定、観察、証拠生成、評価を評価ブランチ上で行い、PR 本文に実際の実行条件、測定結果、観察結果、証拠、評価結果を記録する（統合先とブランチモデルの基盤契約は `agentdev-git-worktree` SPEC 参照）
 - 処理単位は単一 Issue または単一 Wave（Epic 指定時: 現在 ready な Wave の子Issue を並列実行、最大5件）とする。Epic 全体（複数 Wave）の一括実行と Wave 境界（PR マージ）は case-close の責務であり、Epic Wave 実行モードでは1 Wave のみ実行して PR 作成で return する
 - Issue番号の省略は同一セッション内で作成済みの場合に限り、番号解決はユーザー入力またはセッション内会話から行う。work_type 判定基準は `agentdev-workflow-lifecycle` を参照する
 - result の4状態（completed-pr/blocked/failed/delegation-unavailable）は `agentdev-case-run-execution-adapter` の result 契約に従う。成功成果は PR 作成である。SSoT は状態別に PR 本文（成功）と Issue コメント（blocked/ failed）とし、一時会話コンテキスト・中間ファイルを SSoT としない

--- a/src/opencode/skills/agentdev-workflow-case-run/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/SKILL.md
@@ -151,6 +151,8 @@ Epic 全体（複数 Wave）の処理、Wave 境界（PR マージ）は case-cl
 ## 共通制約
 
 - **スコープ**: 単一 Issue または単一 Wave のみを処理する。Epic 全体（複数 Wave）の一括実行、Wave 境界（PR マージ）は扱わない（workflow-contracts SPEC SC-{NNN}、extension 経由で解決）
+- **統合先基準（作業起点・PR base）**: worktree の作成元と PR の base は、当該 Case の統合先（通常Caseは既定 main、実証Caseは評価ブランチ）を参照する。rebase・同期基準、鮮度確認、Epic 後続 Wave の作業起点も同一の統合先を参照する。通常Case（評価を利用しない Standard / Epic Case）の利用者向け操作と挙動は従来どおり維持する（統合先とブランチモデルの基盤契約は `agentdev-git-worktree` SPEC 参照）
+- **実証Caseの実行と PR 記録要素**: 実証Caseの場合、評価ブランチを作業起点および PR base とし、必要な実証手段の準備、実行、測定、観察、証拠生成、評価を評価ブランチ上で行う（詳細は委譲契約の実証Case指示を参照）。コード作成が不要な実証も許容する。実証Caseの PR 本文には実際の実行条件、測定結果、観察結果、証拠、評価結果を記録する
 - **実装実行の非所有**: case-run 本体は work plan 生成、実装、TDD、乖離検出、specs 更新、PR 本文作成、PR 作成を行わない（実行担当サブエージェント責務、adapter protocol 参照）
 - **SSoT**: blocked/failed の詳細本文 SSoT は Issue コメント。completed の SSoT は PR 本文。一時会話コンテキスト、中間ファイルは SSoT としない
 - **完了条件チェックボックス**: case-run、実行担当サブエージェントは完了条件チェックボックスを更新しない（case-close QG-4 の責務）

--- a/src/opencode/skills/agentdev-workflow-case-run/references/delegation-and-result.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/references/delegation-and-result.md
@@ -18,7 +18,7 @@
 ### Input Resolution
 
 1. SSoT 再構成: Issue 本文（実行契約）、REQ/Decision/SPEC/docs/repository context（委譲先が再取得）
-2. identifier 保持: Issue番号、worktree root（相対パス、`.worktrees/{N}-{type}/`）、ブランチ名
+2. identifier 保持: Issue番号、worktree root（相対パス、`.worktrees/{N}-{type}/`）、ブランチ名、PR base（当該 Case の統合先）
 3. 最小 scalar: L2 タイムスタンプ（委譲起動直前・直後、JST）
 4. runtime artifact: なし（外部実行ハーネスの plan artifact 等は永続成果物としない）
 
@@ -31,7 +31,9 @@
 - 実装実行を adapter skill（`agentdev-case-run-execution-adapter`）を読み込んだ実行担当サブエージェントへ委譲する（委譲 prompt 内で実行 command を指定）。起動手段は AGENTS.md および references/<harness>.md 参照。adapter protocol は同 skill 参照
 - **L2 タイムスタンプ計測**: 委譲起動直前・直後に壁時計タイムスタンプ（JST）を記録し、実行担当サブエージェント実行時間を計測する。併せて STEP-S3（worktree 設置）と STEP-S6（クリーンアップ）の開始・終了時刻を記録する
 - 委譲プロンプト、staleness check 結果の引き渡し、test strategy 項目の test-fix ループ、実行担当サブエージェントの責務（目標分解、各 criterion に observable evidence を要求、品質ゲートの実行、test-fix ループ）、委譲起動失敗・異常終了時の扱い（即 `failed` とせず実装完了・検証未完了として扱う）の詳細は `agentdev-case-run-execution-adapter` スキルを参照
-- **引き渡し**: 割り当てられた1 Issue の Issue番号、worktree root（相対パス指定、worktree 内制約）、ブランチ名
+- **引き渡し**: 割り当てられた1 Issue の Issue番号、worktree root（相対パス指定、worktree 内制約）、ブランチ名、PR base（当該 Case の統合先。通常Caseは main、実証Caseは評価ブランチ。rebase・同期基準も同一の統合先を参照）
+- **実証Caseの委譲指示**: 実証Caseの場合、委譲プロンプトに評価ブランチを作業起点および PR base とすることと、評価ブランチ上で必要な実証手段の準備、実行、測定、観察、証拠生成、評価を行うことを含める。コード作成が不要な実証も許容し、実証コード・評価基盤・評価用データのみを変更対象とする PR、検証のみの PR を通常の Case と同一の経路で扱う（検証のみの PR は verification-only PR の既存経路に従う）。評価契約と test strategy は分離されており、test strategy は実証手段・計測手段・実証環境が正常に動作したかの検証を担う。実行側の自律判断で評価契約を変更しない
+- **実証Caseの PR 本文記録要素**: 実行担当サブエージェントが PR 本文に実際の実行条件、測定結果、観察結果、証拠、評価結果を記録するよう委譲プロンプトで指示する。評価ブランチ削除後も Issue/PR から必要な結果と証拠を追跡できる形式とする
 - **PR URL 受領**: 実行担当サブエージェントが直接 PR 作成を行い、PR URL を委譲 result として返却する（PR URL フォールバック検索は使用しない）
 - **case-run 本体は実装方針を生成・審査しない**: 実装方針の形成、adversarial-review 呼出、結果反映は委譲内で adapter の委譲契約に従い、最初の実装変更前に実施する。case-run 本体が実装方針を生成、保持、審査するステップを新設しない。委譲 result（4状態）のみで委譲内の結果を受領する
 - **経路G（adapter 委譲内 adversarial-review）**: 発動条件判定と review 呼出は adapter 委譲内で実行担当サブエージェントが分離して実施する。default-on、skip 条件（実装方針が自明の場合）該当時は省略して従来フローを継続、ユーザー明示指定時は強制発動。実装方針限定、blocked 遷移（(1) 既確定文書の変更・追加・撤回が必要、(2) 要件・仕様問題の検出、(3) unresolved な本質的争点またはユーザー判断事項が残る）の詳細は `agentdev-case-run-execution-adapter` 参照

--- a/src/opencode/skills/agentdev-workflow-case-run/references/epic-wave.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/references/epic-wave.md
@@ -35,17 +35,19 @@ Epic Issue 本文を読み込み（`agentdev-epic-tracker` 参照）、現在 re
 1 Wave の実行（PR作成まで）で return し、Wave 境界（マージ）は扱わない。
 同一コマンド再実行で次 Wave に進む（べき等、Epic Issue 本文から進行状況判定）。
 
+**Epic 実証判定（統合先確定）**: Epic Issue 本文の実証Case識別情報から、Epic 実証の場合は共有評価ブランチ（当該 Epic の統合先）を特定する。実証Case識別情報がない場合は通常 Epic として main（既定）を統合先とする。Epic 実証では全 Wave が同一の評価ブランチを統合先として継承する（評価ブランチ継承の実行詳細は epic-wave-model SPEC 参照）。
+
 **Epic Issue の入力ソース**: Epic Issue は本来の Epic flow（マルチREQ、`scale: large`）に加え、Standard flow 起因の独立 OU 自動 Epic 化（case-open が `depends_on` 空、L0 相当の独立 OU を検出して Epic 化）によるものも含む。
 入力ソースを区別せず、Epic Wave モデル（ADR、最大5件並列委譲）で一様に処理する。
 いずれのモードでも他Issue の実装履歴や Epic 全体の実装過程を前提としない。
 
 ### Result
 
-- 現在 ready な Wave の子Issue 群（子Issue番号、状態）確定
+- 現在 ready な Wave の子Issue 群（子Issue番号、状態）確定、Epic の統合先確定（通常 Epic は main、Epic 実証は共有評価ブランチ）
 
 ### Evidence
 
-- Epic Issue 本文読取結果、Wave 選択の根拠（子Issue 状態一覧）
+- Epic Issue 本文読取結果、Wave 選択の根拠（子Issue 状態一覧）、Epic 実証判定結果（実証Case識別情報の有無と共有評価ブランチ）
 
 ### Completion Verification
 
@@ -74,8 +76,8 @@ Epic Issue 本文を読み込み（`agentdev-epic-tracker` 参照）、現在 re
 
 ### Procedure
 
-- `git fetch origin` を実行しベースブランチの鮮度を確認する（Wave 実行時、PR merge 後再開時は必須）
-- 子Issue ごとに worktree とブランチを作成する（`agentdev-git-worktree` 参照。べき等チェック: 既存時はスキップ）
+- `git fetch origin` を実行し統合先（STEP-W1 で確定した Epic の統合先）の鮮度を確認する（Wave 実行時、PR merge 後再開時は必須）
+- 子Issue ごとに worktree とブランチを作成する（`agentdev-git-worktree` 参照。作成元は当該 Epic の統合先を明示的に指定する。通常 Epic は従来どおり main を起点とし、Epic 実証は共有評価ブランチを起点とする。Epic 後続 Wave の作業起点も同一の統合先を参照。べき等チェック: 既存時はスキップ）
 - 子Issue ごとに前置 gate 群（single.md STEP-S3 の STEP-S3-2〜S3-5 と同一契約: worktree precondition gate、QG-3 前置 staleness check、docs/** 変更時 targeted docs guard、配布依存境界 事前チェック）を適用する
 - 子Issue ごとの worktree 設置の L2 タイムスタンプを記録する
 

--- a/src/opencode/skills/agentdev-workflow-case-run/references/single.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/references/single.md
@@ -76,6 +76,7 @@ self-hosting リポジトリでは履歴メタデータとして通常の case w
 - Issue本文から要件docと受け入れ基準を抽出する（べき等性: worktree とブランチが既に存在する場合、STEP-S3 の作成処理をスキップする）。`agentdev-req-analysis` のチェックボックス品質基準で検証する
 - 関連Decision特定: `docs/decisions/README.md` を読み込み、関連Decisionがあれば個別に読み込み、実装がDecisionの決定事項に矛盾しないことを確認する
 - work_type 判定: `agentdev-workflow-lifecycle` に従い bugfix/feature/maintenance/docs_chore を判定する（scale は feature のみ standard/large、workflow_route は都度導出し保存しない）
+- **統合先判定（実証Case判定）**: Issue 本文の実証Case識別情報（対象評価ブランチ等の実証状態の永続記録）から当該 Case の統合先を確定する。実証Case識別情報がある場合は実証Caseとして評価ブランチを統合先とし、ない場合は通常Caseとして main（既定）を統合先とする。実証は work_type とは別の性質として扱い、work_type へ新値を追加しない
 - **execution contract 消費境界**: 完了条件、test strategy、必須品質統制を実行契約として扱う。不足・曖昧さ・矛盾・実現不能を検出した場合は自律補完せず blocked とする。test strategy を新規設計せず記録済み項目を実行する。必須品質統制の適用要否を再判断しない。work_type/scale/Issue structure を再分類して実行契約を変更しない
   - runtime-only 判断の維持: worktree 状態確認、QG-3 前置 staleness check、実 diff 検査、実装結果・test 実行結果は case-run の安全検査として維持する
   - blocked 遷移と case-update 連携: 完了条件の不足・曖昧さ・矛盾・実現不能、scope-affecting impact candidate の発見、関連 ADR への適合確認で新たな拘束の必要性検出、必須品質統制の追加変更必要性、Issue metadata・構造・実態の矛盾検出時は blocked とし、Issue 更新は case-update へ委譲する（case-run 単独では Issue 本文を書き換えない）
@@ -84,11 +85,11 @@ self-hosting リポジトリでは履歴メタデータとして通常の case w
 
 ### Result
 
-- 要件doc・受け入れ基準抽出済み、関連Decision確認済み、work_type metadata 整合確認済み、execution contract 消費境界適用済み
+- 要件doc・受け入れ基準抽出済み、関連Decision確認済み、work_type metadata 整合確認済み、統合先判定済み（通常Caseは main、実証Caseは評価ブランチ）、execution contract 消費境界適用済み
 
 ### Evidence
 
-- Issue 本文読取結果、関連Decision 一覧、消費境界判定結果（blocked 時はその理由）
+- Issue 本文読取結果、関連Decision 一覧、統合先判定結果（実証Case識別情報の有無と対象評価ブランチ）、消費境界判定結果（blocked 時はその理由）
 
 ### Completion Verification
 
@@ -117,7 +118,7 @@ self-hosting リポジトリでは履歴メタデータとして通常の case w
 
 ### Procedure
 
-- **Worktree 作成・ブランチ準備**: `agentdev-git-worktree` に従って実行する。ベースブランチを明示的に指定する。べき等チェック: worktree 既存時は作成をスキップする。Wave 実行時、PR merge 後再開時は worktree 作成前に `git fetch origin` を実行しベースの鮮度を確認する
+- **Worktree 作成・ブランチ準備**: `agentdev-git-worktree` に従って実行する。作成元は当該 Case の統合先（通常Caseは既定 main、実証Caseは評価ブランチ）を明示的に指定する。通常Caseの worktree 起点は従来どおり main を維持する。べき等チェック: worktree 既存時は作成をスキップする。Wave 実行時、PR merge 後再開時は worktree 作成前に `git fetch origin` を実行し統合先の鮮度を確認する（同期基準・鮮度確認も同一の統合先を参照）
 - **L2 タイムスタンプ計測**: 本 Step の開始時刻・終了時刻（JST）を記録し、worktree 設定時間を計測する（完了報告の L2 内訳に含める）
 - **STEP-S3-1 親Epic ステータス更新**: `agentdev-epic-tracker` 参照
 - **STEP-S3-2 worktree precondition gate**: `agentdev-git-worktree` の「worktree 内判定ヘルパー」に従い、当該 Issue の worktree+ブランチが作成済みであり、現在 worktree 内にいることを検証する。検証失敗時（worktree 未作成、メインリポジトリにいる）は実行担当サブエージェントを起動せず停止し、STEP-S3 へ戻るようユーザーに報告する


### PR DESCRIPTION
## 概要

Issue #2312（OU-0022、Epic B2 #2307 Wave 1）。docs/specs/commands/case-run.md「統合先基準の作業起点と実証実行」セクション（commit 3955170c 適用済み）と docs/specs/skills/agentdev-git-worktree.md「統合先基準のworktree操作」に基づき、case-run 配布スキル（agentdev-workflow-case-run 配下）と command case-run.md を統合先参照の作業起点・PR base、実証Caseの実証実行・PR 記録要素へ適合させる。

Refs: #2312

## 実装内容

- `src/opencode/skills/agentdev-workflow-case-run/references/single.md`: STEP-S2 に「統合先判定（実証Case判定）」を追加（Issue 本文の実証Case識別情報から通常Case=main／実証Case=評価ブランチを確定、実証は work_type とは別性情として扱い新値を追加しない）。STEP-S3 worktree 作成の作成元を統合先の明示指定へ変更（通常Caseは従来どおり main 維持）、fetch・鮮度確認を統合先参照へ汎化
- `references/epic-wave.md`: STEP-W1 に「Epic 実証判定（統合先確定）」を追加（Epic Issue 本文から共有評価ブランチ特定、通常 Epic は main）。STEP-W2 fan-out 準備の worktree 作成元・鮮度確認を Epic の統合先へ、Epic 後続 Wave の作業起点も同一統合先参照と明記
- `references/delegation-and-result.md`: STEP-S4 引き渡しに PR base（統合先）を追加。「実証Caseの委譲指示」（評価ブランチを作業起点・PR base、実証手段の準備・実行・測定・観察・証拠生成・評価、コード作成不要の実証許容、評価契約と test strategy の分離、実行側の自律判断で評価契約を変更しない）と「実証Caseの PR 本文記録要素」（実行条件・測定結果・観察結果・証拠・評価結果の記録、評価ブランチ削除後の追跡可能性）を追加
- `SKILL.md`: 共通制約に「統合先基準（作業起点・PR base）」「実証Caseの実行と PR 記録要素」を追加
- `src/opencode/commands/agentdev/case-run.md`: 不変条件へ統合先基準の公開契約投影を1項目追加
- 配布物参照境界適合: 初回最終 gate 検査で concrete REQ ID（concrete-id カテゴリ）違反を検出したため、追加文言から concrete ID を除去しドメイン語参照へ置換（fix-and-reverify 済み）

## 完了条件

- [ ] docs/specs/commands/case-run.md に「統合先基準の作業起点と実証実行」セクションが存在すること（識別子存在確認）→ 存在確認済み（L301、commit 3955170c）
- [ ] agentdev-workflow-case-run 配布スキルが統合先参照の作業起点・PR base と実証実行・PR 記録要素を実装していること → 実装内容のとおり
- [ ] 通常Caseの worktree 起点・PR base が従来どおり main（既定）であること（回帰なし）→ single.md「通常Caseの worktree 起点は従来どおり main を維持する」、epic-wave.md「通常 Epic は従来どおり main を起点とし」を明記。本 PR 自身も通常Caseとして worktree 起点 origin/main（40096376）・PR base main で作成
- [ ] TS-002 の worktree 起点・PR base の統合先切替に関わる条項と TS-004 の pass_criteria を満たしていること → 下記テスト結果のとおり
- 完了条件チェックボックスの評価は case-close QG-4 の責務のため本 PR では更新しない

## テスト結果

- 契約テスト: `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/` 配下の check_extensions / commands_structure / command_fixtures / check_reference_paths / lint_skills / commands_e2e / check_templates の7ファイル → 326 pass / 0 fail
  - 実行 cwd: worktree root（`.worktrees/2312-feature`）
  - 起動コマンド形式: `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/<file>.test.ts`
  - 構造様式変更（frontmatter、セクション構造型）は伴わないため契約テスト期待値更新は不要（全テスト合格で機械確認）
- check_changed_docs.ts（`--workflow case-run --base-ref origin/main --json`、TS-QC-001）: EXIT=0、failures なし（docs/** 変更なしのため対象ファイル検出警告のみ）
- check_extensions.ts（IR-056、src/opencode/skills 変更時）: EXIT=0、failures 0
- check_distribution_boundary.ts（`--profile source`、配布依存境界 最終 gate）: 初回 EXIT=1（concrete-id 違反: 追加文言の concrete REQ ID）→ concrete ID 除去へ修正し再実行 EXIT=0、failures 0（fix-and-reverify）
- TS-002 対象条項（worktree 起点・PR base の統合先切替関連）: (1) main 唯一の正規ブランチ（違反記述なし）(2) 通常 Standard Case の main 維持（記述 + 本 PR の実行で実証）(3) 通常 Epic Case の main 起点（記述）(4) 評価ブランチへの統合先設定（STEP-S2/W1 判定の実装）(5) 統合先の6項目一致（case-run 所管の作成元・PR base・rebase/同期基準・鮮度確認・Epic 後続 Wave 起点の同一統合先参照を明記。squash merge 先は case-close 所管 #2313）(6) 並行 Case での状態混入なし（統合先判定は当該 Case/Epic の Issue 本文から導出）(7) 新規公開Gitコマンドなし（文書変更のみ、既存 Git/worktree 能力の再利用）(8) QG-4 意味不変（変更記述なし）(9) main 以外統合先の完了を main 反映扱いにしない（該当記述なし）
- TS-004 pass_criteria: case-run スコープの条項（1実証単位=1評価ブランチ、評価ブランチ上文書の main 正式成果物誤認なし、RU 巻き戻し記述なし、Issue からの実証状態復元=STEP-S2 統合先判定、評価結果区分は case-close 側、blocked/failed 時のブランチ保持）について記述整合を確認。評価ブランチ上 req-save/spec-save 系の条項は req-save 側実装に依存し、case-run 差分に矛盾記述なし
- TS-QC-002（Skill 品質）/ TS-QC-003（Command 品質）: 既存セクションへの箇条書き追加・文修正のみで構造様式変更なし、skill-authoring / command-authoring 基準の自己査読合格（frontmatter 不変、段階的開示構造維持、責務境界維持: 実証実行の実体は委譲先で case-run 本体は委譲指示のみ）

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 配布依存境界（--profile source） | failures 0（fix-and-reverify 済み） | 0 件 | ✅ |
| check_extensions（IR-056） | failures 0 | 0 件 | ✅ |
| check_changed_docs（case-run profile） | failures 0 | 0 件 | ✅ |
| 契約テスト（7ファイル） | 326 pass / 0 fail | 0 fail | ✅ |

## Findings / Capture候補

### intake

- `src/opencode/skills/agentdev-git-worktree` 配下の統合先基準適合（worktree 作成元の統合先解決の詳細手順、SKILL.md「origin/main 鮮度確認」節の統合先汎化等）は Issue #2315（OU-0028、Epic #2307 Wave 2）が「配布スキル適合」として担当する。本 PR では case-run 側から `agentdev-git-worktree` への参照整合（作成元の明示指定、既存作成手順 `origin/{base_branch}` のパラメータ指定との機能整合確認済み）のみとし、git-worktree 配下は編集していない（Issue #2312 の対象範囲では scope-affecting impact candidate のみ）

### learning

該当なし

## SPEC確定候補

該当なし（docs/specs/commands/case-run.md「統合先基準の作業起点と実証実行」セクションは commit 3955170c で確定済みであり、本 PR は配布物適合のみ。配布物参照境界への concrete REQ ID 除去は既存契約に従い、新規確定事項なし）

## 決定事項

- 実証Caseの PR 記録要素は case-run 配布スキル側の委譲指示（delegation-and-result.md STEP-S4）で実装し、pr_desc.md（共通テンプレート）への実証Case専用セクション追加は行わなかった。case-run SPEC は「PR テンプレートと Issue 本文構造は workflow-templates の責務」としており、テンプレート変更を要求していないため（Issue 対象範囲の「必要時」条件に該当せず）

## 関連Issue

Closes #2312