### PR TITLE
agentdev: #2315 agentdev-git-worktree 統合先基準のworktree操作の配布スキル適合

### DIFF
--- a/src/opencode/skills/agentdev-git-worktree/SKILL.md
+++ b/src/opencode/skills/agentdev-git-worktree/SKILL.md
@@ -32,14 +32,25 @@ extension（`.agentdev/extensions/skills/`）は標準 SKILL.md を前提とし�
 
 work_type判定は `agentdev-workflow-lifecycle` を参照。
 
-## origin/main 鮮度確認
+## 統合先基準の worktree 操作
 
-並列 Wave 実行時、PR merge 後再開時は、worktree 作成前に `git fetch origin` を実行し origin/main の鮮度を確認する。
+worktree の作成元は当該 Case の統合先（通常Caseは既定 main、実証Caseは対象評価ブランチ）を参照する。
+worktree の作成元、PR の base、rebase・同期基準、鮮度確認、squash merge 先、Epic 後続 Wave の作業起点は同一の統合先を参照する。
+通常Case（評価を利用しない Standard / Epic Case）の worktree 作成元は従来どおり main（既定）を維持する。
+統合先の解決と評価ブランチの作成・削除の手順は `references/worktree-operations.md` 参照。
+
+- **評価ブランチの再利用手順**: 評価ブランチの作成・削除には既存の Git/worktree 能力を再利用し、評価ブランチ専用の公開 Git コマンド体系は追加しない。評価ブランチは正規成果物ではなく一時的・非正規の成果物として扱う
+- **評価ブランチの命名**: 本スキルは評価ブランチの命名形式を固定しない。命名規則は実装設計で決定した形式に従う
+
+## 統合先の鮮度確認
+
+並列 Wave 実行時、PR merge 後再開時は、worktree 作成前に `git fetch origin` を実行し統合先の鮮度を確認する。
 古い commit 基準の worktree による DIRTY/CONFLICTING を防止するため。
+確認対象は当該 Case の統合先（通常Caseは `origin/main`、実証Caseは対象評価ブランチの remote ref）であり、worktree 作成元と同一の統合先を参照する。
 
-- **Wave 2 以降**: Wave 1 の PR merge 後に `git fetch origin` → `origin/main` の最新 commit を確認してから worktree 作成
+- **Wave 2 以降**: Wave 1 の PR merge 後に `git fetch origin` → 統合先の最新 commit を確認してから worktree 作成
 - **case-run 再開時**: 前回ケースの PR merge 後に再開する場合も同様
-- **確認手順**: `git fetch origin` 後、`git log --oneline origin/main -1` で最新 commit hash を確認。`git rev-parse HEAD` と比較し、差分がある場合は worktree を最新 origin/main から再作成（既存 worktree がある場合は削除して再作成）
+- **確認手順**: `git fetch origin` 後、`git log --oneline origin/{base_branch} -1` で最新 commit hash を確認。`git rev-parse HEAD` と比較し、差分がある場合は worktree を最新の統合先から再作成（既存 worktree がある場合は削除して再作成）
 
 ## stash 運用（worktree 検証時の一時退避）
 
@@ -52,6 +63,7 @@ detached worktree による baseline 比較を標準手順とする。
 | トピック | 参照先 |
 |----------|--------|
 | 作成、削除、ブランチ操作の詳細 | `references/worktree-operations.md` |
+| 統合先の解決、評価ブランチの作成・削除 | `references/worktree-operations.md` |
 | worktree 検証時の一時退避（stash 運用） | `references/worktree-operations.md` |
 | git pull/push/hash検証の共通手順 | `references/git-common-procedures.md` |
 

--- a/src/opencode/skills/agentdev-git-worktree/references/git-common-procedures.md
+++ b/src/opencode/skills/agentdev-git-worktree/references/git-common-procedures.md
@@ -542,7 +542,8 @@ squash merge がコンフリクトで失敗した場合（リトライ全失敗�
 
 ### rebase 実行
 
-`git fetch origin main` 後、`git rebase origin/main` を実行し機械的解消を試みる（rebase プロシージャは worktree-operations.md「Merge Conflict 対応パターン」参照）。
+`git fetch origin` 後、当該 Case の統合先（通常Caseは `main`、実証Caseは対象評価ブランチ）の remote ref を基準に `git rebase origin/{base_branch}` を実行し機械的解消を試みる（rebase プロシージャは worktree-operations.md「Merge Conflict 対応パターン」参照）。
+rebase 基準は PR の squash merge 先と同一の統合先を参照する。
 
 ### 分岐
 

--- a/src/opencode/skills/agentdev-git-worktree/references/worktree-operations.md
+++ b/src/opencode/skills/agentdev-git-worktree/references/worktree-operations.md
@@ -2,7 +2,14 @@
 
 ## 作成手順
 
-### 1. ベースブランチの自動検出
+### 1. 統合先の解決（worktree 作成元）
+
+worktree の作成元は当該 Case の統合先（以下 `origin/{base_branch}`）である。
+通常Caseの統合先は既定 `main`、実証Caseは対象評価ブランチを指定する。
+呼出元（case-run 等）から統合先を明示指定された場合は当該ブランチを使用する。
+worktree の作成元、PR の base、rebase・同期基準、鮮度確認、squash merge 先、Epic 後続 Wave の作業起点は同一の統合先を参照する。
+
+明示指定がない場合（通常Case）はリポジトリのデフォルトブランチを検出して使用する（従来どおり）:
 
 ```bash
 git remote show origin | grep 'HEAD branch' | sed 's/.*: //'
@@ -11,6 +18,7 @@ git remote show origin | grep 'HEAD branch' | sed 's/.*: //'
 検出結果を `origin/{base_branch}` として使用。
 デフォルトは `main`。
 ローカルのベースブランチは古くなっている可能性があるため、常にリモートの最新状態を起点とする。
+実証Caseの指定する評価ブランチが remote に存在しない場合は、先に「評価ブランチの作成・削除」の作成手順を実行する。
 
 ### 2. worktree作成コマンド
 
@@ -34,6 +42,34 @@ git worktree add ".worktrees/{N}-{type}" -b "{type}/issue-{N}" origin/{base_bran
 | 同名worktree既存 | 既存worktreeを再利用（作成コマンド実行しない） |
 | ブランチのみ既存 | `git worktree add ".worktrees/{N}-{type}" "{type}/issue-{N}"` |
 | ダーティなworktree | 削除禁止。未コミット変更時はエラー停止 |
+
+## 評価ブランチの作成・削除（既存 Git 能力の再利用）
+
+実証Caseの評価ブランチは、専用の公開 Git コマンド体系を追加せず、既存の Git 能力で作成・削除する。
+評価ブランチは正規成果物ではなく一時的・非正規の成果物として扱う。
+命名形式は本スキルで固定せず、実装設計で決定した形式に従う。
+作成・削除の要否の判断（実証の開始・終了タイミング、再開可能性の考慮を含む）は呼出元が所有し、本手順は操作のみを提供する。
+
+### 1. 作成
+
+```bash
+git branch "{evaluation_branch}" origin/main
+git push origin "{evaluation_branch}"
+```
+
+- 作成元は main とする。評価ブランチ同士を依存・派生関係として扱わない
+- 作成後、作成手順の統合先として当該評価ブランチを指定する
+
+### 2. 削除
+
+```bash
+git push origin --delete "{evaluation_branch}"
+git branch -D "{evaluation_branch}"
+```
+
+- 評価ブランチは main へ merge しない前提で削除するため、マージ判定のある `-d` ではなく `-D` を使用する
+- リモートにブランチが存在しない場合はエラーを無視して続行（worktree 削除手順のリモートブランチ削除と同一の扱い）
+- 削除失敗時は警告表示して停止
 
 ## worktree 内判定ヘルパー
 


### PR DESCRIPTION
## 概要

Issue #2315（OU-0028、Epic B2 #2307 Wave 2）。docs/specs/skills/agentdev-git-worktree.md「統合先基準のworktree操作」セクション（commit 3955170c 適用済み、ACT-SPEC-010 適用分）と REQ-035（REQ-035-009 更新・REQ-035-012 追記分、commit 7b78d562）に基づき、agentdev-git-worktree 配布スキル（src/opencode/skills/agentdev-git-worktree/ 配下）を worktree 作成元の統合先解決（既定 main、実証Caseは評価ブランチ）と評価ブランチ作成・削除への既存 Git/worktree 能力再利用へ適合させる。

Refs: #2315

## 実装内容

- `SKILL.md`: 「統合先基準の worktree 操作」セクションを追加（作成元は当該 Case の統合先、作成元・PR base・rebase/同期基準・鮮度確認・squash merge 先・Epic 後続 Wave 起点の同一統合先参照、通常Caseは従来どおり main 維持、評価ブランチ専用公開 Git コマンド体系の追加禁止、命名形式は固定しない）。「origin/main 鮮度確認」を「統合先の鮮度確認」へ一般化（確認対象 = 当該 Case の統合先、通常Caseは `origin/main`）。参照先表へ統合先解決・評価ブランチ作成削除の行を追加
- `references/worktree-operations.md`: 作成手順「1. ベースブランチの自動検出」を「1. 統合先の解決（worktree 作成元）」へ一般化（呼出元からの統合先明示指定を優先、実証Caseは対象評価ブランチ、明示指定なしの通常Caseは従来どおりリポジトリデフォルトブランチ検出=main。評価ブランチ未存在時は作成手順を先に実行）。「評価ブランチの作成・削除（既存 Git 能力の再利用）」セクションを追加（`git branch`/`git push` による作成、作成元は main・評価ブランチ同士を依存派生関係として扱わない、削除は `-D` 使用・main へ merge しない前提、命名形式は実装設計に従い本スキルは固定しない、作成・削除の要否判断は呼出元が所有）
- `references/git-common-procedures.md`: 「コンフリクト解消 rebase パス」の rebase 実行を統合先基準へ一般化（`git fetch origin main` → `git rebase origin/main` 固定から、当該 Case の統合先の remote ref 基準へ。rebase 基準は PR の squash merge 先と同一の統合先を参照）

## 完了条件

- [ ] docs/specs/skills/agentdev-git-worktree.md に「統合先基準のworktree操作」セクションが存在すること（識別子存在確認）→ 存在確認済み（L45、commit 3955170c）
- [ ] agentdev-git-worktree 配布スキルが worktree 作成元の統合先解決と評価ブランチ作成・削除の再利用手順を実装していること → 実装内容のとおり
- [ ] 通常Caseの worktree 作成元が従来どおり main（既定）であること（回帰なし）→ worktree-operations.md「明示指定がない場合（通常Case）はリポジトリのデフォルトブランチを検出して使用する（従来どおり）」、SKILL.md「通常Caseの worktree 作成元は従来どおり main（既定）を維持する」を明記。本 PR 自身も通常Caseとして worktree 起点 origin/main（26a65341）・PR base main で作成
- [ ] TS-002 の pass_criteria のうち worktree 起点の統合先切替に関わる条項を満たしていること → 下記テスト結果のとおり
- 完了条件チェックボックスの評価は case-close QG-4 の責務のため本 PR では更新しない

## テスト結果

- 配布依存境界 gate（`check_distribution_boundary.ts --profile source --json`、MUST）: EXIT=0、ok=true、concrete_id_hits 0 / concrete_path_hits 0 / fixed_url_hits 0、rules findings 0
- check_changed_docs.ts（`--workflow case-run --base-ref origin/main --json`、TS-QC-001）: EXIT=0、failures なし（変更ファイルが src/opencode 配下のみのため docs 検査対象外、対象ファイル検出警告のみ）
- 契約テスト: `bun test` skills_structure / lint_skills / check_reference_paths / check_extensions の4ファイル → 528 pass / 0 fail（実行 cwd: worktree root `.worktrees/2315-feature`）
  - git-worktree スキルの構造・本文を固定する契約テストは存在せず（grep 確認済み）、セクション追加を伴う構造様式変更について期待値更新は不要（全テスト合格で機械確認）
- lint_skills.ts（TS-QC-002 機械検証）: Structure/Content/References/Namespace 全 OK。AG-005 1 NG は worktree-operations.md の 300 行超過（編集前 339 行 → 編集後 376 行、ともに超過）で編集前からの既存指摘であり、Issue #2315 の完了条件外（intake 済み別課題、本 PR では対応しない）
- TS-002 対象条項（worktree 起点の統合先切替関連）: (1) main 唯一の正規ブランチ（評価ブランチを一時的・非正規と明記、違反記述なし）(2) 通常 Standard Case の main 維持（明示指定なし時は従来どおりデフォルトブランチ検出=main、本 PR の実行で実証）(3) 通常 Epic Case の main 起点（SKILL.md 通常Case維持明記、Epic 後続 Wave 起点も同一統合先参照）(4) 評価ブランチへの統合先設定（作成手順の明示指定受け口を実装）(5) 統合先の6項目一致（作成元・PR base・rebase/同期基準・鮮度確認・squash merge 先・Epic 後続 Wave 起点の同一統合先参照を SKILL.md・worktree-operations.md・git-common-procedures.md に明記）(6) 複数評価ブランチ並行で混在なし（統合先は Case 単位で解決、worktree は `.worktrees/{N}-{type}` で Issue 単位隔離、評価ブランチ同士を依存派生関係として扱わない）(7) 新規公開Gitコマンドなし（追加は既存 git コマンドの再利用手順のみ）(8) QG-4 意味不変（QG-4 判定に触れる変更なし）(9) main 以外統合先の完了を main 反映扱いにしない（評価ブランチは main へ merge しない前提で削除、merge 昇格の記述なし）
- TS-QC-002（Skill 品質・文書品質）: frontmatter 不変、既存セクション一般化 + 新規セクション追加のみで段階的開示構造維持（SKILL.md は核心契約、手順詳細は references）、責務境界維持（評価ブランチ作成・削除の要否判断は呼出元、本スキルは Git 操作手順のみ提供）、japanese-tech-writing 規範の自己査読合格（一文一行、concrete REQ-ID 不使用）

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 配布依存境界（--profile source、MUST gate） | EXIT=0、failures 0 | EXIT=0 | ✅ |
| check_changed_docs（case-run profile） | failures 0 | 0 件 | ✅ |
| 契約テスト（4ファイル） | 528 pass / 0 fail | 0 fail | ✅ |
| lint_skills | 本変更起因の違反 0（AG-005 は既存・完了条件外） | 本変更起因 0 件 | ✅ |

## Findings / Capture候補

### intake

- AG-005「references TOC: worktree-operations.md 376 lines（> 300）目次なし」: 編集前（339 行）からの既存指摘で intake 済み別課題。本 PR の追記により 339 → 376 行へ増加。目次追加・分割の構造修正は Issue #2315 の完了条件外のため対応せず（AG-005 対応時の対処対象）

### learning

該当なし

## SPEC確定候補

該当なし（docs/specs/skills/agentdev-git-worktree.md「統合先基準のworktree操作」セクションは commit 3955170c で確定済みであり、本 PR は配布物適合のみ。docs/specs/** は編集していない）
