### PR TITLE
feat(agentdev): case-close 配布スキルへ統合先マージと実証最終クローズを適合（Issue 2313、OU-0023）

### DIFF
--- a/.agentdev/extensions/skills/agentdev-workflow-case-close.yaml
+++ b/.agentdev/extensions/skills/agentdev-workflow-case-close.yaml
@@ -16,7 +16,7 @@ context:
     when: "case-close 工程 SPEC 参照時"
     paths:
       - "docs/specs/commands/case-close.md"
-    purpose: "case-close の完了ゲートと QG-4 達成判定の確認"
+    purpose: "case-close の完了ゲート、QG-4 達成判定、統合先へのマージと実証最終クローズの実行詳細の確認"
   - id: index-auto-generation-spec
     when: "Step 3-3 AUTOGEN block 索引再生成差分検出（単一 Issue / Epic Wave E5b 前段）参照時"
     paths:

--- a/src/opencode/commands/agentdev/case-close.md
+++ b/src/opencode/commands/agentdev/case-close.md
@@ -76,6 +76,8 @@ OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため�
 - コメントテンプレートの【必須】セクションを確認してから投稿する
 - 学びの検知はエージェント自律で行う（ユーザーに問わない）
 - capture 責務は「回収・保存」である: PR 本文から intake/ learning を分離回収してドメイン状態に保存し、同一 commit に含める（capture 境界（capture-boundaries）は `agentdev-workflow-orchestration` 参照）。SPEC確定候補の処理は PR 本文の `## SPEC確定候補` を入力とし、`## Findings / Capture候補` とは区別する
+- squash merge 先と統合先ブランチ同期の対象は当該 Case の統合先を参照する（通常Caseは既定 main、実証Caseは対象評価ブランチ。統合先は Issue 本文の実証Case状態情報から確定）。通常Caseの squash merge 先は従来どおり main を基調とし、利用者向け操作と挙動を変更しない。統合先とブランチモデルの基盤契約は `agentdev-git-worktree` SPEC（extension 経由）参照
+- 実証全体の最終 case-close は新しい評価を始めず、事前の評価契約と蓄積済み証拠から最終評価結果を導出し、Issue 最終コメントを正規記録とする。実証Caseの最終 case-close は正式化経路として req-define <実証Issue> を利用者へ明示する（Standard では Standard Issue、Epic では Epic Issue を指定）。Epic 中間Waveでは正式化案内を出さない。case-close は後続 req-define を自動実行しない
 - 完了報告は結果状態を分離して報告する（`.agentdev` push 失敗時は完了扱いにしない）。今回の完了条件に含まれる未対応事項は intake 記録として明示し、完了扱いには含めない
 - ドメイン状態永続化の commit は並列実行安全ステージングプロシージャ（`agentdev-git-worktree`）に従い、明示パス（`git add <path>`/ `git rm <path>`）でステージし、`git commit -- <paths>`（--only pathspec 形式）で実行する
 
@@ -90,7 +92,7 @@ OpenCode 1.18.15 は skill 直接起動を機械的に防止できないため�
 - G17: ドメイン状態永続化の `git add` は capture 成果物の専用サブディレクトリ（`.agentdev/learning/`、`.agentdev/intake/`）または明示パスに限定し、`.agentdev/` 全体への一括スコープは行わない
 - G21: SPEC status 昇格（draft → accepted）は、対象 SPEC が `draft` かつ今回の実装が SPEC 内容を検証済みの場合のみ実行する（spec-save は accepted を付与しない）
 - G24: Epic Issue 本文ステータス追跡テーブルの更新は case-close のみが行う（単一書き手制約。case-run は読み取りのみ、case-auto は Wave 反復制御のみで直接書き込まない。last-write-wins 競合防止は case-close の単一書き手で維持する）。Epic Wave クローズ時の PR マージ・子Issue クローズは現在 Wave の `running` 子Issue のみを対象とし、`blocked`/ `failed` を `completed` に上書きしない（べき等性、`agentdev-epic-tracker` 準拠）
-- G27: squash merge 実行前に PR の mergeable 状態を事前確認し、UNKNOWN の場合は mergeable になるまでポーリング待機する（待機間隔・上限は `agentdev-gh-cli` の mergeable UNKNOWN ポーリング手続きが所有。上限超過時はマージ中止して構造化エラーで停止。ポーリング省略して UNKNOWN 状態のままマージ試行は禁止）。`git pull --ff-only` 実行前に worktree 状態（dirty tree）・並列実行による ref lock 競合・非 main ブランチ占有の3リスクを事前検出し、検出時は安全な代替同期手順を選択する
+- G27: squash merge 実行前に PR の mergeable 状態を事前確認し、UNKNOWN の場合は mergeable になるまでポーリング待機する（待機間隔・上限は `agentdev-gh-cli` の mergeable UNKNOWN ポーリング手続きが所有。上限超過時はマージ中止して構造化エラーで停止。ポーリング省略して UNKNOWN 状態のままマージ試行は禁止）。`git pull --ff-only` 実行前に worktree 状態（dirty tree）・並列実行による ref lock 競合・統合先以外のブランチ占有の3リスクを事前検出し、検出時は安全な代替同期手順を選択する（同期対象は当該 Case の統合先ブランチ）
 
 
 

--- a/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: agentdev-workflow-case-close
-description: "case-close command の workflow 実装本体。PR マージ（squash merge、mergeable UNKNOWN ポーリング、先行 commit 検出、コンフリクト Level 1 rebase）、QG-4 最終完了判定ゲート、docs 検証・SPEC 確定（SPEC status 昇格）、Capture 回収（PR 本文→intake/learning 分離）、Epic Wave クローズを所有する。USE FOR: case-close 実行時の workflow 制御（単一 Issue クローズ・Epic Wave クローズ・PR マージ・QG-4・SPEC 確定・Capture 回収）。DO NOT USE FOR: 単独起動（対応する /agentdev/* コマンド経由で利用すること）。"
+description: "case-close command の workflow 実装本体。PR マージ（squash merge 先の統合先解決、mergeable UNKNOWN ポーリング、先行 commit 検出、コンフリクト Level 1 rebase）、統合先ブランチ同期時のリスク事前検出、QG-4 最終完了判定ゲート、docs 検証・SPEC 確定（SPEC status 昇格）、Capture 回収（PR 本文→intake/learning 分離）、実証最終クローズ（最終評価結果の導出と Issue 最終コメント正規記録、正式化経路案内）、Epic Wave クローズを所有する。USE FOR: case-close 実行時の workflow 制御（単一 Issue クローズ・Epic Wave クローズ・PR マージ・QG-4・SPEC 確定・Capture 回収・実証最終クローズ）。DO NOT USE FOR: 単独起動（対応する /agentdev/* コマンド経由で利用すること）。"
 ---
 
 # case-close workflow スキル
 
 case-close command の workflow 実装本体。
 PR マージから Issue クローズ、Capture 回収、ドメイン状態永続化、完了報告までの制御構造、QG-4 最終完了判定ゲート（完了条件チェックボックス評価・更新）、SPEC 確定（draft → accepted 昇格）、Epic Wave クローズ（E1〜E6、単一書き手）を所有する。
+squash merge 先は当該 Case の統合先（通常Caseは既定 main、実証Caseは対象評価ブランチ）に解決し、統合先ブランチ同期時のリスク事前検出を行う。
+実証全体の最終 case-close では新しい評価を始めず最終評価結果を導出して Issue 最終コメントへ正規記録し、正式化経路（req-define <実証Issue>）を案内する（実行詳細は case-close command SPEC（extension 経由）が所有する）。
 
 case-close command は公開 interface（入出力契約・ガードレール）と本スキルへの dispatch のみを持ち、本スキルが workflow 実装本体を提供する（DEC-{N}、REQ-{NNNN}-{NNN}〜{NNN}）。
 
@@ -55,9 +57,9 @@ Epic Wave クローズは STEP-1 のルーティングで分岐し、E1〜E6 と
 | STEP-1 | Issue 番号解決・ルーティング | Issue 番号受領 | 単一 Issue クローズ or Epic Wave クローズのルート確定 | [references/issue-resolution-and-qg4.md](references/issue-resolution-and-qg4.md) |
 | STEP-2 | QG-4 達成判定 | ルート確定（単一 Issue） | 完了条件チェックボックス評価・更新、観点8 評価スコープ確定 | [references/issue-resolution-and-qg4.md](references/issue-resolution-and-qg4.md) |
 | STEP-3 | docs 検証・SPEC 確定（配布依存境界 最終 gate 含む） | QG-4 合格 | targeted docs guard、IR-{NNN} check_extensions.ts、配布依存境界 最終 gate、full integrity suite 実行（bun test 実行形態契約）、SPEC status 昇格 | [references/docs-and-spec-promotion.md](references/docs-and-spec-promotion.md) |
-| STEP-4 | PR マージ・コンフリクト解消 | docs 検証合格（配布依存境界 最終 gate 含む） | マージ済みPR、HEAD commit hash 記録、コンフリクト Level 1 解消 or case-auto エスカレーション | [references/pr-merge-and-conflict.md](references/pr-merge-and-conflict.md) |
-| STEP-5 | Post-merge・Issue クローズ | PR マージ完了 | CI 通過確認、Issue 本文更新、Issue close | [references/cleanup-and-capture.md](references/cleanup-and-capture.md) |
-| STEP-6 | クリーンアップ・Capture 回収・永続化 | Issue クローズ完了 | worktree/branch 削除、親Epic 自動クローズ、実行前同期、Capture 回収、学び検知、`.agentdev/` 永続化、tmp/ 残存確認、完了報告 | [references/cleanup-and-capture.md](references/cleanup-and-capture.md) |
+| STEP-4 | PR マージ・コンフリクト解消 | docs 検証合格（配布依存境界 最終 gate 含む） | マージ済みPR（squash merge 先は当該 Case の統合先）、HEAD commit hash 記録、コンフリクト Level 1 解消 or case-auto エスカレーション | [references/pr-merge-and-conflict.md](references/pr-merge-and-conflict.md) |
+| STEP-5 | Post-merge・Issue クローズ | PR マージ完了 | CI 通過確認、Issue 本文更新、実証最終クローズ（最終評価結果導出・Issue 最終コメント正規記録）、Issue close | [references/cleanup-and-capture.md](references/cleanup-and-capture.md) |
+| STEP-6 | クリーンアップ・Capture 回収・永続化 | Issue クローズ完了 | worktree/branch 削除、親Epic 自動クローズ、実行前同期、Capture 回収、学び検知、実証最終クローズの正式化案内、`.agentdev/` 永続化、tmp/ 残存確認、完了報告 | [references/cleanup-and-capture.md](references/cleanup-and-capture.md) |
 | STEP-E1〜E6 | Epic Wave クローズ（E4-1 配布依存境界 最終 gate 含む） | Epic Issue 番号受領、ステータス追跡テーブル存在 | 現在 Wave の子Issue 一括マージ・クローズ（E4-1 gate 違反子Issue は `blocked` でマージ対象外）、Epic status table 更新、最終 Wave 判定 | [references/epic-wave-close.md](references/epic-wave-close.md) |
 
 ### STEP 間の依存と分岐
@@ -125,6 +127,8 @@ gate 違反時は両ルートとも PR マージを停止する。
 - **完了条件チェックボックス評価・更新は case-close の専任責務**: case-run/ driver/ 外部実行バックエンドは更新しない。case-close は別コンテキストで Issue 本文を再読込し、PR 本文を capture 入力源として最終完了判定する
 - **Epic Issue 本文ステータス追跡テーブルの更新は case-close 単一書き手**: case-run は読み取りのみ、case-auto は Wave 反復制御のみで直接書き込まない（last-write-wins 競合防止）
 - **Capture 境界**: intake/ learning を別々の成果物として扱い、PR 本文のみを capture 入力源とする（一時会話コンテキスト不入力）
+- **統合先基準（squash merge 先・同期基準）**: squash merge 先、統合先ブランチ同期の対象は当該 Case の統合先（通常Caseは既定 main、実証Caseは対象評価ブランチ）を参照する。統合先は Issue 本文の実証Case状態情報（対象評価ブランチ等の永続記録）から確定し、実証Case状態情報がない場合は通常Caseとして main を統合先とする。通常Case（評価を利用しない Standard / Epic Case）の squash merge 先は従来どおり main を基調とし、利用者向け操作と挙動を変更しない。QG-4 は Issue 完了条件の最終判定として意味を変更しない。統合先とブランチモデルの基盤契約は `agentdev-git-worktree` SPEC（extension 経由）を参照する
+- **実証最終クローズ**: 実証全体の最終 case-close は新しい評価を始めず、事前の評価契約と蓄積済み証拠（Issue 本文の評価契約、各 PR 本文の実行条件・測定結果・証拠・評価結果）から最終結果を導出する。導出した最終評価結果は Issue 最終コメントを正規記録として記録する。実証Caseの最終 case-close の完了報告では正式化経路として req-define <実証Issue> を利用者へ明示する（Standard では Standard Issue、Epic では Epic Issue を指定）。Epic 中間Wave（残 Wave が存在する Wave クローズ）では正式化案内を出さない。case-close は後続 req-define を自動実行しない
 - **`--delete-branch` 使用禁止**: PR マージ時に `--delete-branch` オプションを使用しない（アクティブ worktree で local 削除が失敗するため）。ブランチ削除は独立 STEP で実施
 - **GitHub auto-close 回避**: commit message でコマンド名と Issue 番号を分離し、`#` 記号による近接参照を避ける
 

--- a/src/opencode/skills/agentdev-workflow-case-close/references/cleanup-and-capture.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/cleanup-and-capture.md
@@ -1,23 +1,24 @@
 # STEP-5/6: Post-merge・Issue クローズ・クリーンアップ・Capture 回収・永続化（cleanup-and-capture）
 
 > 本 reference は `agentdev-workflow-case-close` SKILL.md の Control Plane STEP-5, STEP-6 詳細である。
-> Post-merge テスト戦略検証、Issue クローズ、worktree/branch 削除、親Epic 自動クローズ判定、実行前同期、Capture 回収、学び検知、ドメイン状態永続化、完了報告を提供する。
+> Post-merge テスト戦略検証、実証最終クローズ（最終評価結果の導出と Issue 最終コメント正規記録）、Issue クローズ、worktree/branch 削除、親Epic 自動クローズ判定、実行前同期（統合先ブランチ）、Capture 回収、学び検知、ドメイン状態永続化、正式化経路案内、完了報告を提供する。
 
 ## 目次
 
-- STEP-5: Post-merge テスト戦略検証・Issue クローズ
+- STEP-5: Post-merge テスト戦略検証・実証最終クローズ・Issue クローズ
 - STEP-6: クリーンアップ・Capture 回収・永続化
 
-## STEP-5: Post-merge テスト戦略検証・Issue クローズ
+## STEP-5: Post-merge テスト戦略検証・実証最終クローズ・Issue クローズ
 
 ### Purpose
 
-マージ後のみ確認可能な項目（CI 通過等）を反映して Issue 本文を更新し、Issue をクローズする。
+マージ後のみ確認可能な項目（CI 通過等）を反映して Issue 本文を更新する。
+実証Caseで実証全体の最終 case-close に該当する場合は最終評価結果を導出して Issue 最終コメントへ正規記録し、Issue をクローズする。
 
 ### Input Resolution
 
-1. SSoT 再構成: PR の CI 状態、Issue 本文（テスト戦略チェックボックス）
-2. identifier 保持: Issue番号、PR番号
+1. SSoT 再構成: PR の CI 状態、Issue 本文（テスト戦略チェックボックス、実証Case状態情報、評価契約）、実証に属する PR 本文群（実行条件・測定結果・観察結果・証拠・評価結果）
+2. identifier 保持: Issue番号、PR番号、統合先ブランチ
 3. 最小 scalar: なし
 4. runtime artifact: なし
 
@@ -33,26 +34,35 @@
 マージ後のみ確認可能な項目（CI通過等）を反映。
 Issue 本文更新手続き（`agentdev-gh-cli`）で更新 → VERIFY。
 
-#### STEP-5-2: Issue クローズ
+#### STEP-5-2: 実証最終クローズ（実証Caseの最終 case-close 時のみ）
+
+Issue 本文の実証Case状態情報（対象評価ブランチ等の永続記録）から実証Caseと判定され、かつ当該 Issue が実証全体の最終 case-close に該当する場合に実行する。該当しない場合はスキップする（通常Caseの挙動を変更しない）。
+
+- **新しい評価を開始しない**: 最終 case-close で新しい評価を始めない。事前の評価契約（Issue 本文の正規記録）と蓄積済み証拠（各 PR 本文の実行条件・測定結果・観察結果・証拠・評価結果）から最終結果を導出する
+- **最終評価結果の正規記録**: 導出した最終評価結果（採用、不採用、判定不能、未確定の区別を含む）を Issue 最終コメントとして正規記録する（`agentdev-gh-cli` のコメント追加手続き → VERIFY）。評価ブランチ削除後も Issue/PR から結果と証拠を追跡できる構成とする
+- **評価契約の書き換え禁止**: 実証全体の最終完了後は当該実証の評価契約および最終結果を書き換えない
+
+#### STEP-5-3: Issue クローズ
 
 Issue close 手続き（理由: completed、`agentdev-gh-cli`）。
 
 ### Result
 
 - CI 通過確認、Issue 本文更新
+- 実証最終クローズ時: 最終評価結果の導出と Issue 最終コメント正規記録完了
 - Issue close 完了
 
 ### Evidence
 
-- CI 状態確認結果、Issue 本文更新の VERIFY 結果、Issue close 結果
+- CI 状態確認結果、Issue 本文更新の VERIFY 結果、実証最終クローズ実施時は最終評価結果の導出根拠（評価契約・蓄積済み証拠との対応）と Issue 最終コメントの VERIFY 結果、Issue close 結果
 
 ### Completion Verification
 
-- テスト戦略チェックボックスが更新済みであり（command 不変条件）、Issue がクローズ済みであること
+- テスト戦略チェックボックスが更新済みであり（command 不変条件）、Issue がクローズ済みであること。実証最終クローズ該当時は新しい評価を開始せず Issue 最終コメントへ最終評価結果が正規記録済みであること
 
 ### Resume-Idempotency
 
-- Issue の OPEN/CLOSED 状態（durable state）で再開点を判定する。クローズ済み Issue の再クローズは行わない
+- Issue の OPEN/CLOSED 状態（durable state）で再開点を判定する。クローズ済み Issue の再クローズは行わない。最終評価結果の正規記録済み Issue 最終コメント（durable state）の再記録を行わない
 
 ## STEP-6: クリーンアップ・Capture 回収・永続化
 
@@ -105,9 +115,10 @@ worktree/branch 削除、親Epic 自動クローズ判定、実行前同期、Ca
 `git pull --ff-only` 直前に、`agentdev-git-worktree` の「PR merge 前重複ファイルチェック」プロシージャを再実行する（L-013、PR #1128 由来、共有 main worktree で STEP-1-1 実行時点から STEP-6-3-1 実行までの間に並列セッションが加えた未コミット変更を検知するため）。
 重複ファイルを検出した場合、構造化エラーで停止しユーザーによる対応（stash/commit/checkout）を促すこと。
 
-##### STEP-6-3-2: git main 同期リスク事前検出・代替同期手順選択
+##### STEP-6-3-2: 統合先ブランチ同期リスク事前検出・代替同期手順選択
 
-`agentdev-git-worktree` の「git main 同期リスク事前検出プロシージャ」に従い、worktree 状態（dirty tree）・並列実行による ref lock 競合・非 main ブランチ占有の3リスク事前検出と代替同期手順選択を実行する。
+`git pull --ff-only` 直前に、`agentdev-git-worktree` の「git main 同期リスク事前検出プロシージャ」に従い、worktree 状態（dirty tree）・並列実行による ref lock 競合・統合先以外のブランチ占有の3リスク事前検出と代替同期手順選択を実行する。
+同期対象のブランチは当該 Case の統合先（通常Caseは既定 main、実証Caseは対象評価ブランチ）である。通常Caseの `main` 同期手続きは従来どおりである。
 `agentdev-git-worktree` に従い `git pull --ff-only` を実行（ローカル変更事前チェック、hash 検証、不一致時は評価・承認のやり直し）。
 
 #### STEP-6-4: 学びの検知・抽出・Capture 回収
@@ -128,6 +139,7 @@ PR 本文の `## Findings / Capture候補` セクションから intake/ learnin
 - **Epic 横断回収**: Epic 単位で一括回収
 - **Capture 境界**: intake/ learning 境界は `agentdev-workflow-orchestration`（capture-boundaries）を参照。intake と learning を別々の成果物として扱う
 - **一時会話コンテキスト不入力**: case-run の一時会話コンテキスト（ローカル変数、中間ファイル等）を capture の入力として使用しない。capture 情報の入力源は PR 本文のみ
+- **実証Caseの capture 回収の扱い**: 実証Caseで評価ブランチ上で回収した intake/learning capture は、main 側パイプラインへ反映する（main 側の `.agentdev/` へ回収して永続化する）、または PR 本文記録を正として main 側から追跡可能な形で処理する。評価ブランチ削除によって capture が失われないことを確認する
 
 #### STEP-6-5: ドメイン状態永続化
 
@@ -157,24 +169,26 @@ learning と intake を同一 commit に含める。
 GitHub 完了後に `.agentdev` push 失敗の場合は standard 種別を使用してはならない。
 **結果状態の分離報告**: GitHub 側完了状態、`.agentdev` 永続化状態、ブランチ削除状態を独立して報告。
 
+**実証Caseの正式化経路案内（実証全体の最終 case-close 時）**: 実証Caseで実証全体の最終 case-close に該当する場合（Standard 実証では当該 Standard Issue の case-close）、正式化経路として `req-define <実証Issue>`（Standard では当該 Standard Issue を指定）を利用者へ明示する。Epic 実証の正式化案内は Epic Wave クローズの最終 Wave 判定（E6）で行い、Epic 中間Waveでは正式化案内を出さない。case-close は後続 req-define を自動実行しない。
+
 ### Result
 
 - worktree/branch 削除完了
 - 親Epic 自動クローズ判定・更新完了
-- 実行前同期完了（`git pull --ff-only`）
-- Capture 回収完了（intake/learning 分離）
+- 実行前同期完了（統合先ブランチへの `git pull --ff-only`）
+- Capture 回収完了（intake/learning 分離、実証Caseは main 側パイプラインへ反映または PR 本文記録を正として追跡可能）
 - 学び検知完了
 - `.agentdev/` 永続化完了
 - tmp/ 残存確認完了（残存時は対応結果を報告）
-- 完了報告出力
+- 完了報告出力（実証全体の最終 case-close 時は正式化経路案内を含む）
 
 ### Evidence
 
-- worktree・ブランチ削除結果、親Epic 更新の VERIFY 結果、重複ファイルチェックとリスク検出結果、Capture 回収ファイル群、`.agentdev/` commit hash と push 結果、tmp/ 残存確認結果、完了報告出力
+- worktree・ブランチ削除結果、親Epic 更新の VERIFY 結果、重複ファイルチェックとリスク検出結果、Capture 回収ファイル群、`.agentdev/` commit hash と push 結果、tmp/ 残存確認結果、完了報告出力（実証最終クローズ時は正式化経路案内を含む）
 
 ### Completion Verification
 
-- worktree/branch 削除が完了（失敗時は警告表示して停止）していること。Capture 回収が intake/learning 分離済みであること。結果状態の分離報告（GitHub 側、`.agentdev` 永続化、ブランチ削除）がなされていること。当該実行で `.agentdev/tmp/` に作成した一時ファイルが残存していないこと（残存時は対応結果を報告済みであること）
+- worktree/branch 削除が完了（失敗時は警告表示して停止）していること。Capture 回収が intake/learning 分離済みであること（実証Caseは評価ブランチ削除後も追跡可能であること）。結果状態の分離報告（GitHub 側、`.agentdev` 永続化、ブランチ削除）がなされていること。当該実行で `.agentdev/tmp/` に作成した一時ファイルが残存していないこと（残存時は対応結果を報告済みであること）
 
 ### Resume-Idempotency
 
@@ -183,10 +197,11 @@ GitHub 完了後に `.agentdev` push 失敗の場合は standard 種別を使用
 ## resume point
 
 - CI 通過状態、Issue close 状態
+- 実証最終クローズ状態（実証Case判定、最終評価結果の導出と Issue 最終コメント正規記録済み否か）
 - worktree/branch 削除状態
 - 親Epic 自動クローズ判定結果、子Issue 状態一覧
-- 実行前同期状態（重複ファイルチェック、リスク検出）
-- Capture 回収状態（intake/learning 分離）
+- 実行前同期状態（重複ファイルチェック、統合先ブランチ同期リスク検出）
+- Capture 回収状態（intake/learning 分離、実証Caseは main 側反映・追跡可能化の別）
 - 学び検知状態、`.agentdev/` commit/push 状態
 
 ## 関連 STEP
@@ -215,8 +230,9 @@ GitHub 完了後に `.agentdev` push 失敗の場合は standard 種別を使用
 - 不変条件（コメントテンプレートの【必須】セクション確認）
 - 不変条件（学びの検知はエージェント自律、ユーザーに問わない）
 - 不変条件（intake と learning を混合した単一成果物にしない、learning と intake を同一 commit に含める、今回の完了条件に含まれる未対応事項を intake に逃がして完了扱いにしない）
+- 不変条件（実証全体の最終 case-close は新しい評価を始めず評価契約と蓄積済み証拠から最終評価結果を導出し Issue 最終コメントへ正規記録する、実証Caseの最終 case-close の完了報告は正式化経路 req-define <実証Issue> を案内し後続 req-define を自動実行しない）
 - G17（STEP-6-5 の commit は並列実行安全ステージングプロシージャに従い、明示パスでステージ、`git add` は `.agentdev/` 全体の一括スコープにしない）
 - 不変条件（STEP-6-6 は当該実行で `.agentdev/tmp/` に作成した一時ファイルの残存なしを確認、残存時は cleanup 規定に従い処理して報告）
 - 不変条件（STEP-6-7 は結果状態を分離して報告、`.agentdev` push 失敗時は完了扱いにしない）
 - G21・不変条件（case-close の capture 責務は「回収・保存」、SPEC status 昇格は case-close の責務、SPEC 確定候補の処理は `## SPEC確定候補` を入力とし `## Findings / Capture候補` とは区別）
-- G27・不変条件（`git pull --ff-only` 実行前に worktree 状態・ref lock 競合・非 main ブランチ占有の3リスクを事前検出し代替同期手順を選択）
+- G27・不変条件（`git pull --ff-only` 実行前に worktree 状態・ref lock 競合・統合先以外のブランチ占有の3リスクを事前検出し代替同期手順を選択、同期対象は当該 Case の統合先ブランチ）

--- a/src/opencode/skills/agentdev-workflow-case-close/references/epic-wave-close.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/epic-wave-close.md
@@ -1,16 +1,17 @@
 # STEP-E1〜E6: Epic Wave クローズ（epic-wave-close）
 
 > 本 reference は `agentdev-workflow-case-close` SKILL.md の Control Plane STEP-E1〜E6 詳細である。
-> Epic Issue 番号入力時（ステータス追跡テーブル存在時）の現在 Wave の一括クローズ、Epic status table 更新、最終 Wave 判定を提供する。
+> Epic Issue 番号入力時（ステータス追跡テーブル存在時）の現在 Wave の一括クローズ、Epic status table 更新、最終 Wave 判定、Epic 実証判定（共有評価ブランチ特定）と Epic 実証の最終 case-close（最終評価結果導出・正規記録、正式化案内）を提供する。
 
 ## Purpose
 
 Epic Issue 番号入力時（ステータス追跡テーブル存在時）に現在 Wave の子Issue を一括マージ・クローズし、Epic status table を更新、最終 Wave 判定を行う。
+Epic 実証（Epic Issue 本文の実証Case状態情報で共有評価ブランチが特定できる場合）は共有評価ブランチを統合先として各 Wave を連携させ、最終 Wave で実証全体の最終 case-close（最終評価結果の導出と Epic Issue 最終コメント正規記録、正式化経路案内）を実施する。
 
 ## Input Resolution
 
-1. SSoT 再構成: Epic Issue 本文（ステータス追跡テーブル）、現在 Wave の子Issue 本文・PR 本文群
-2. identifier 保持: Epic Issue番号、子Issue番号群、PR番号群
+1. SSoT 再構成: Epic Issue 本文（ステータス追跡テーブル、実証Case状態情報、評価契約）、現在 Wave の子Issue 本文・PR 本文群
+2. identifier 保持: Epic Issue番号、子Issue番号群、PR番号群、統合先ブランチ（通常 Epic Case は main、Epic 実証は共有評価ブランチ）
 3. 最小 scalar: なし
 4. runtime artifact: なし
 
@@ -24,15 +25,21 @@ Epic Issue 番号入力時（ステータス追跡テーブル存在時）に現
 - Epic status table 更新完了（単一書き手 case-close のみ）
 - Epic Issue 完了条件チェックボックス最終評価・更新（QG-4 観点8、中間 Wave vs 最終 Wave 評価スコープ切替）
 - 最終 Wave 判定結果（Epic クローズ または 残 Wave 通知）
+- Epic 実証の最終 Wave 判定時: 最終評価結果の導出と Epic Issue 最終コメント正規記録、正式化経路案内（中間Waveでは案内しない）
 
 ## Procedure
 
 現在 Wave の PR 作成済み子Issue を一括マージ、クローズし、Epic status table を更新する。
 最終 Wave 判定後に Epic Issue クローズ または 残 Wave 通知を行う。
 
-### E1: Epic Issue 本文読込・ステータス追跡テーブル解析
+### E1: Epic Issue 本文読込・ステータス追跡テーブル解析・Epic 実証判定
 
 Epic Issue 本文を読み込み、ステータス追跡テーブル（`agentdev-epic-tracker` の新4列/旧4列形式）を解析。
+
+**Epic 実証判定・統合先確定**: Epic Issue 本文の実証Case状態情報（対象評価ブランチ等の永続記録）から Epic 実証か否かを判定する。
+
+- **Epic 実証（実証Case状態情報あり）**: 共有評価ブランチを特定し、当該 Epic 実証の統合先（共有評価ブランチ）を確定する。本 Wave の子Issue PR の base、各 squash merge 先は同一の共有評価ブランチを参照する
+- **通常 Epic Case（実証Case状態情報なし）**: 従来どおり main を統合先とする
 
 ### E2: 現在 Wave 特定
 
@@ -67,7 +74,7 @@ trigger 条件は detector の `--profile source` が分類する配布ソース
 E4-1 を合格した子Issue について次を**準並列**で実行する。
 gate 違反子Issue は本シーケンスの対象外とする。
 
-- PR マージ（STEP-4 の PR マージ手続きに準拠、mergeable UNKNOWN ポーリング、squash merge、先行 commit 検出、コンフリクト Level 1 rebase）
+- PR マージ（STEP-4 の PR マージ手続き（squash merge 先の統合先解決を含む）に準拠、mergeable UNKNOWN ポーリング、squash merge、先行 commit 検出、コンフリクト Level 1 rebase）
 - 子Issue クローズ（Issue close 手続き）
 - 完了条件チェックボックス評価・更新（QG-4、観点8 PR対象範囲 vs 全体）
 - Capture 回収（PR 本文の `## Findings / Capture候補` から intake/learning 分離）
@@ -87,6 +94,15 @@ QG-4 観点8 に基づく評価スコープ切替（中間 Wave vs 最終 Wave�
 - **全子Issue completed** → Epic Issue クローズ
 - **以外** → 残 Wave 通知（次 Wave の case-run 実行をユーザーに促す）
 
+**Epic 実証の最終 case-close（全子Issue completed で Epic クローズする場合のみ）**:
+
+- **最終評価結果の導出**: 新しい評価を始めず、事前の評価契約（Epic Issue 本文の正規記録）と蓄積済み証拠（各子Issue の PR 本文の実行条件・測定結果・観察結果・証拠・評価結果）から最終評価結果を導出する
+- **最終評価結果の正規記録**: 導出した最終評価結果を Epic Issue の最終コメントとして正規記録する（`agentdev-gh-cli` のコメント追加手続き → VERIFY）
+- **正式化経路案内**: 正式化経路として `req-define <実証Issue>`（Epic 実証では Epic Issue を指定）を利用者へ明示する
+- **Epic 中間Waveでの案内抑制**: 残 Wave が存在する中間Wave（残 Wave 通知側）では正式化案内を出さない
+- **req-define 自動実行禁止**: case-close は後続 req-define を自動実行しない
+- 通常 Epic Case（Epic 実証でない場合）は従来どおりの最終 Wave 判定とし、本処理を実施しない
+
 ## 重要: 対象外・禁止事項
 
 - `pending`/ `ready`/ `blocked`/ `failed` 状態の子Issue は対象外
@@ -97,11 +113,11 @@ QG-4 観点8 に基づく評価スコープ切替（中間 Wave vs 最終 Wave�
 
 ## Evidence
 
-- Epic Issue 本文読取結果、E4-1 最終 gate の JSON 結果（子Issue 別）、マージ・クローズ結果、Epic status table 更新の VERIFY 結果、最終 Wave 判定根拠
+- Epic Issue 本文読取結果、Epic 実証判定根拠（実証Case状態情報と共有評価ブランチ）、E4-1 最終 gate の JSON 結果（子Issue 別）、マージ・クローズ結果、Epic status table 更新の VERIFY 結果、最終 Wave 判定根拠、Epic 実証最終クローズ時は最終評価結果の導出根拠と Epic Issue 最終コメントの VERIFY 結果
 
 ## Completion Verification
 
-- E4-2 対象が E4-1 合格子Issue のみであること。`blocked`/`failed` を `completed` に上書きしていないこと。Epic status table 更新後の再読込 VERIFY が合格であること
+- E4-2 対象が E4-1 合格子Issue のみであること。`blocked`/`failed` を `completed` に上書きしていないこと。Epic status table 更新後の再読込 VERIFY が合格であること。Epic 実証の最終 Wave では新しい評価を開始せず最終評価結果が Epic Issue 最終コメントへ正規記録済みであり、正式化経路案内を含むこと（中間Waveでは案内していないこと）
 
 ## Resume-Idempotency
 
@@ -109,11 +125,12 @@ QG-4 観点8 に基づく評価スコープ切替（中間 Wave vs 最終 Wave�
 
 ## resume point
 
-- Epic Issue 本文、ステータス追跡テーブル解析状態
+- Epic Issue 本文、ステータス追跡テーブル解析状態、Epic 実証判定・統合先確定状態（共有評価ブランチ）
 - 現在 Wave 特定状態
 - PR 作成済み子Issue 一覧、各子Issue の E4-1 最終 gate 結果（合格 / 違反 / スキップ）
 - 各子Issue のマージ・クローズ・評価状態（E4-2 対象は E4-1 合格子Issue のみ）
 - Epic status table 更新状態、Epic Issue 完了条件チェックボックス評価状態
+- Epic 実証の最終評価結果導出・Epic Issue 最終コメント正規記録状態、正式化案内実施状態
 - 最終 Wave 判定結果
 
 ## 関連 STEP
@@ -137,3 +154,4 @@ QG-4 観点8 に基づく評価スコープ切替（中間 Wave vs 最終 Wave�
 - G08・不変条件（未達チェックボックスが残る場合の構造化エラー停止、チェックボックス更新後の再読込 VERIFY 必須、完了条件チェックボックス評価・更新は case-close 専任責務）
 - G24・不変条件（Epic Issue 本文ステータス追跡テーブルの更新は case-close 単一書き手、case-run は読み取りのみ、case-auto は直接書き込まない、Epic Wave クローズは現在 Wave の `running` 子Issue のみ対象、`blocked`/ `failed` を `completed` に上書きしない、べき等性）
 - E4-1 gate 違反子Issue は `blocked` へ遷移し E4-2 マージ並列シーケンスの対象外、`completed` へ上書きしない（べき等性、case-close G24 準拠）
+- 不変条件（Epic 実証の最終 Wave は新しい評価を始めず最終評価結果を Epic Issue 最終コメントへ正規記録し正式化経路 req-define <実証Issue> を案内する、Epic 中間Waveでは正式化案内を出さない、後続 req-define を自動実行しない）

--- a/src/opencode/skills/agentdev-workflow-case-close/references/pr-merge-and-conflict.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/pr-merge-and-conflict.md
@@ -1,16 +1,16 @@
 # STEP-4: PR マージ・コンフリクト解消（pr-merge-and-conflict）
 
 > 本 reference は `agentdev-workflow-case-close` SKILL.md の Control Plane STEP-4 詳細である。
-> PR squash マージ、mergeable UNKNOWN ポーリング、先行 commit 検出、コンフリクト Level 1 rebase パスを提供する。
+> squash merge 先の統合先解決、PR squash マージ、mergeable UNKNOWN ポーリング、先行 commit 検出、コンフリクト Level 1 rebase パスを提供する。
 
 ## Purpose
 
-PR を squash マージし、mergeable UNKNOWN ポーリング、先行 commit 検出、コンフリクト Level 1 rebase パスを処理する。
+squash merge 先の統合先を解決し、PR を squash マージし、mergeable UNKNOWN ポーリング、先行 commit 検出、コンフリクト Level 1 rebase パスを処理する。
 
 ## Input Resolution
 
-1. SSoT 再構成: PR の mergeable 状態、ローカル/remote の commit 状態
-2. identifier 保持: PR番号、Issue番号
+1. SSoT 再構成: PR の mergeable 状態、ローカル/remote の commit 状態、Issue 本文の実証Case状態情報（対象評価ブランチ等の永続記録）
+2. identifier 保持: PR番号、Issue番号、統合先ブランチ
 3. 最小 scalar: ポーリング試行回数（上限は gh-cli 手続き側が所有）
 4. runtime artifact: なし
 
@@ -27,20 +27,29 @@ PR を squash マージし、mergeable UNKNOWN ポーリング、先行 commit �
 
 ## Procedure
 
-### STEP-4-1: squash merge 前の mergeable UNKNOWN ポーリング
+### STEP-4-1: squash merge 先の統合先解決
+
+squash merge 先は当該 Case の統合先とする。
+
+- **統合先の確定**: Issue 本文の実証Case状態情報（対象評価ブランチ等の永続記録）から当該 Case の統合先を確定する。実証Case状態情報がある場合は実証Caseとして対象評価ブランチを、ない場合は通常Caseとして既定 main を統合先とする
+- **通常Caseの回帰維持**: 通常Case（評価を利用しない Standard / Epic Case）の squash merge 先は従来どおり main であり、利用者向け操作と挙動を変更しない
+- **実証Case**: 対象評価ブランチを squash merge 先とする。PR の base が当該統合先であることを前提とし、PR base と squash merge 先が一致しない場合は処理を進めず構造化エラーとして扱う
+- 統合先とブランチモデルの基盤契約（worktree 作成元、PR の base、rebase・同期基準、鮮度確認、squash merge 先、Epic 後続 Wave の作業起点が同一の統合先を参照すること）は `agentdev-git-worktree` SPEC（extension 経由）を参照する
+
+### STEP-4-2: squash merge 前の mergeable UNKNOWN ポーリング
 
 `agentdev-gh-cli` の「squash merge 前の mergeable UNKNOWN ポーリング」手続きに従い、次を実行する。
 
 - 対象 PR の `mergeable` 状態事前確認
 - `UNKNOWN` ポーリング待機
 - 上限超過時の構造化エラー停止
-- 待機中の `CONFLICTING` 遷移検出を自動分岐させ、コンフリクト解消パス（STEP-4-4）へ即時接続する
+- 待機中の `CONFLICTING` 遷移検出を自動分岐させ、コンフリクト解消パス（STEP-4-5）へ即時接続する
 
 ポーリング間隔・上限値は gh-cli 手続き側が所有する。
 
-### STEP-4-2: PR merge 実行
+### STEP-4-3: PR merge 実行
 
-PR merge 手続き（squash 方式、`agentdev-gh-cli`）を実行 → HEAD commit hash 記録（`agentdev-git-worktree` skill に従い）。
+STEP-4-1 で解決した当該 Case の統合先（PR の base）へ PR merge 手続き（squash 方式、`agentdev-gh-cli`）を実行 → HEAD commit hash 記録（`agentdev-git-worktree` skill に従い）。
 
 **Squash merge 失敗時のリトライ**: `agentdev-gh-cli` の「squash merge リトライ手続き」に従う（待機間隔・最大試行回数は gh-cli 手続き側が所有、各試行のログ記録、全試行失敗時のフォールバックは template `.opencode/commands/agentdev/templates/case-close/standard.md` 参照）。
 
@@ -49,28 +58,28 @@ PR merge 手続き（squash 方式、`agentdev-gh-cli`）を実行 → HEAD comm
 **`--delete-branch` 使用禁止**: PR マージ時に `--delete-branch` オプションを使用しない（アクティブ worktree に checkout されたブランチで local 削除が失敗し remote 削除フェーズへ到達しないため）。
 ブランチ削除は STEP-6 で独立実施する。
 
-### STEP-4-3: Squash merge 後のローカル先行 commit 検出・処理
+### STEP-4-4: Squash merge 後のローカル先行 commit 検出・処理
 
 squash merge 完了後、ローカルに remote 未 push の先行 commit が存在する場合、`agentdev-git-worktree` の「Squash merge 後分岐ハンドリング手続き」に従い、ローカル先行 commit 検出、内容重複確認、reset を実行する。
 本処理により `git pull --ff-only` 失敗を予防する。
 
-### STEP-4-4: コンフリクト解消 rebase パス（Level 1）
+### STEP-4-5: コンフリクト解消 rebase パス（Level 1）
 
-squash merge がコンフリクトで失敗した場合（STEP-4-2 のリトライ全失敗後、エラー原因がコンフリクトの場合）に実行する機械的解消パス（コンフリクト解消モデル Level 1）。
+squash merge がコンフリクトで失敗した場合（STEP-4-3 のリトライ全失敗後、エラー原因がコンフリクトの場合）に実行する機械的解消パス（コンフリクト解消モデル Level 1）。
 
 `agentdev-git-worktree` の「コンフリクト解消 rebase パス」に従い、rebase による機械的解消を試みる。
 
 - **実装変更は行わず** rebase のみ
-- **rebase 自動解決時**: squash merge（STEP-4-2）へ戻り再マージ
+- **rebase 自動解決時**: squash merge（STEP-4-3）へ戻り再マージ
 - **rebase コンフリクト発生時**: case-auto へエスカレーションして停止する（コンフリクト解消モデル Level 2/3 は case-auto の責務）
 
 ## Evidence
 
-- mergeable 状態とポーリング記録、merge 結果と HEAD commit hash、対応記録コメントの VERIFY 結果、先行 commit 検出・処理結果、rebase 試行結果
+- 統合先解決結果（通常Case main / 実証Case 対象評価ブランチの判定根拠）、mergeable 状態とポーリング記録、merge 結果と HEAD commit hash、対応記録コメントの VERIFY 結果、先行 commit 検出・処理結果、rebase 試行結果
 
 ## Completion Verification
 
-- PR がマージ済みであり、HEAD commit hash が記録されていること。Level 1 rebase 失敗時はエスカレーション停止していること
+- squash merge 先が当該 Case の統合先として解決済みであること。PR がマージ済みであり、HEAD commit hash が記録されていること。Level 1 rebase 失敗時はエスカレーション停止していること
 
 ## Resume-Idempotency
 
@@ -78,9 +87,10 @@ squash merge がコンフリクトで失敗した場合（STEP-4-2 のリトラ�
 
 ## resume point
 
+- 統合先解決状態（通常Case main / 実証Case 対象評価ブランチ）
 - mergeable 状態、ポーリング実行状態
 - PR merge 実行結果、HEAD commit hash
-- 先行 commit 検出・処理結果（STEP-4-3）
+- 先行 commit 検出・処理結果（STEP-4-4）
 - コンフリクト発生時の Level 1 rebase 試行結果、Level 2/3 エスカレーション状態
 
 ## 関連 STEP


### PR DESCRIPTION
## 概要

Issue 2313（OU-0023、Epic B2 2307 Wave 2）の実装。case-close command SPEC の確定済み「統合先へのマージと実証最終クローズ」セクション（squash merge 先の統合先解決、統合先ブランチ同期時のリスク事前検出、実証最終 case-close の評価結果導出、Issue 最終コメントへの最終評価結果正規記録、実証Case の capture 回収の扱い、正式化経路の案内と Epic 中間Waveでの案内抑制）に基づき、case-close 配布スキル・command を適合させた。

Refs: #2313

## 変更対象成果物と変更内容

### Skill: src/opencode/skills/agentdev-workflow-case-close 配下

- **SKILL.md**: frontmatter description へ「squash merge 先の統合先解決」「統合先ブランチ同期時のリスク事前検出」「実証最終クローズ」を追加。冒頭責務段落へ統合先解決と実証最終クローズの要約を追加。Control Plane 表の STEP-4/5/6 結果列へ反映。共通制約へ「統合先基準（squash merge 先・同期基準）」（統合先は Issue 本文の実証Case状態情報から確定、通常Caseは従来どおり main、QG-4 は意味不変）と「実証最終クローズ」（新しい評価を始めない、Issue 最終コメント正規記録、正式化経路案内、Epic 中間Wave抑制、req-define 自動実行禁止）を追加
- **references/pr-merge-and-conflict.md**: STEP-4-1「squash merge 先の統合先解決」を新設（通常Caseは既定 main、実証Caseは対象評価ブランチ、PR base と squash merge 先の不一致は構造化エラー、基盤契約は git-worktree SPEC extension 経由）。既存サブステップは STEP-4-2（mergeable ポーリング）〜 STEP-4-5（コンフリクト rebase）へ繰り下げ、内部参照を更新。Input Resolution・Evidence・Completion Verification・resume point に統合先解決を反映
- **references/cleanup-and-capture.md**: STEP-5-2「実証最終クローズ（実証Caseの最終 case-close 時のみ）」を新設（新しい評価を開始しない、評価契約と蓄積済み証拠から最終評価結果を導出、Issue 最終コメントを正規記録とする、評価契約の書き換え禁止）。Issue クローズは STEP-5-3 へ繰り下げ。STEP-6-3-2 を「統合先ブランチ同期リスク事前検出」へ一般化（非 main ブランチ占有 → 統合先以外のブランチ占有、同期対象は当該 Case の統合先ブランチ）。STEP-6-4 へ「実証Caseの capture 回収の扱い」（main 側パイプラインへ反映 or PR 本文記録を正として main 側から追跡、評価ブランチ削除による消失防止）を追加。STEP-6-7 へ「実証Caseの正式化経路案内」（req-define <実証Issue>、Standard は Standard Issue、Epic 中間Waveでは抑制、req-define 自動実行禁止）を追加
- **references/epic-wave-close.md**: E1 へ「Epic 実証判定・統合先確定」（Epic Issue 本文の実証Case状態情報から共有評価ブランチを特定、通常 Epic Case は main）を追加。E6 ほう「Epic 実証の最終 case-close」（最終評価結果の導出、Epic Issue 最終コメント正規記録、正式化経路案内、Epic 中間Waveでの案内抑制、req-define 自動実行禁止、通常 Epic Case は従来どおり）を追加。Input Resolution・Result・Evidence・Completion Verification・resume point・関連ガードレールへ反映

### Command: src/opencode/commands/agentdev/case-close.md

- 不変条件へ統合先基準（squash merge 先と統合先ブランチ同期の対象は当該 Case の統合先、通常Caseは従来どおり main）と実証最終クローズ（新しい評価を始めない、Issue 最終コメント正規記録、正式化経路案内、中間Wave抑制、req-define 自動実行禁止）を公開契約として投影
- G27 のリスク事前検出を統合先一般化（「非 main ブランチ占有」→「統合先以外のブランチ占有」、同期対象は当該 Case の統合先ブランチ）

### scope-affecting impact candidate

- .agentdev/extensions/skills/agentdev-workflow-case-close.yaml: case-close-spec context の purpose を「case-close の完了ゲート、QG-4 達成判定、統合先へのマージと実証最終クローズの実行詳細の確認」へ拡張

## 実装方針の遵守

- 配布物（src/opencode 配下）への concrete REQ-ID（REQ-0xx 形式）の記述なし。内容ベース記述（「当該 Case の統合先（通常Caseは既定 main、実証Caseは対象評価ブランチ）」「Issue 本文の実証Case状態情報」等のドメイン語）と「SPEC（extension 経由）」参照形式のみ
- docs/specs/** の編集なし（Phase 0 契約）。SPEC 側の問題は発生せず SPEC確定候補は（なし）
- 通常Caseの回帰維持: 通常Caseの squash merge 先は従来どおり main、通常Caseの `main` 同期手続きは従来どおり、通常 Epic Case の最終 Wave 判定は従来どおり、を明記

## 検証エビデンス

### テスト戦略 TS-002（統合先切替に関わる条項）

- (2) 通常 Standard Case が従来どおり main へ squash merge: STEP-4-1「通常Caseの回帰維持」に明記。通常Caseのフロー変更なし（diff は追記のみ、既存手順の変更なし）
- (3) 通常 Epic Case が従来どおり main を介して Wave を進められる: E1「通常 Epic Case（実証Case状態情報なし）: 従来どおり main を統合先とする」
- (4) 統合先を評価ブランチへ設定できる: STEP-4-1（実証Caseは対象評価ブランチを squash merge 先）、E1（共有評価ブランチを統合先として確定）
- (5) 統合先の6項目が一致: SKILL.md 共通制約「統合先基準」、STEP-4-1 の基盤契約参照（worktree 作成元、PR の base、rebase・同期基準、鮮度確認、squash merge 先、Epic 後続 Wave の作業起点が同一の統合先を参照）
- (8) QG-4 の意味不変: SKILL.md 共通制約「QG-4 は Issue 完了条件の最終判定として意味を変更しない」

### テスト戦略 TS-005（最終 case-close・正式化案内に関わる条項）

- (1) Standard 実証が評価ブランチで完結: STEP-4-1（評価ブランチへ squash merge）+ STEP-5-2（最終評価結果導出・正規記録）+ STEP-6-7（正式化案内）
- (4) 評価ブランチを main へ merge せず完了: squash merge 先を評価ブランチに解決、main への merge 手続きは配布物に存在しない
- (5) 削除後も Issue/PR から結果と証拠を追跡可能: STEP-5-2「評価ブランチ削除後も Issue/PR から結果と証拠を追跡できる構成」、STEP-6-4 capture「評価ブランチ削除によって capture が失われないこと」
- (6) 最終 case-close が正式化経路を案内し中間Waveでは案内しない: STEP-6-7、E6「Epic 中間Waveでの案内抑制」

### 品質ゲート（worktree root で実行）

| 検証 | コマンド | 結果 |
|---|---|---|
| 配布依存境界 gate（MUST） | `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts --profile source --json` | **EXIT=0** |
| targeted docs guard | `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-close --files <変更6ファイル> --json` | **EXIT=0**、failures []、files_checked 6件、warnings [] |
| full integrity suite | `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/`（worktree root 実行、./ prefix 付き） | **EXIT=0**、2060 pass / 0 fail、Ran 2060 tests across 85 files（4569 expect() calls） |
| concrete REQ-ID 混入検査 | `Select-String -Pattern "REQ-\d"`（配布物5ファイル） | マッチなし |
| docs パス直接参照検査 | `Select-String -Pattern "docs/(specs\|requirements\|decisions)/"`（配布物5ファイルの追加行） | 追加行にマッチなし（既存プレースホルダ形式のみ） |
| 完了条件1（SPEC セクション存在確認） | `docs/specs/commands/case-close.md` 255行目「統合先へのマージと実証最終クローズ（新規セクション）」 | 存在確認済み |

### 契約テスト期待値更新

構造様式の変更（新規 STEP 構造の追加・削除）なし。STEP-4 のサブステップ番号繰り下げ（4-1 新設に伴う 4-2〜4-5 への変更）は reference 内部の整合を完結させており、bun test 全件合格（期待値更新不要）。

## Findings / Capture候補

- `agentdev-git-worktree` 配布スキルの「git main 同期リスク事前検出プロシージャ」（references/git-common-procedures.md）は手続き名・記述とも main 固定の文言のまま。case-close 配布スキル側は「同期対象のブランチは当該 Case の統合先」と一般化して参照したが、参照先の実行詳細（リスク3の非 main ブランチ占有の判定等）は main 固定のままのため、実証Caseの評価ブランチ同期時に手続き名と実体の間に表現のゆらぎが生じ得る。git-worktree スキル側の一般化は別 Issue のスコープと判断し、本 Issue では参照形式で接続した

## SPEC確定候補

（なし）docs/specs/commands/case-close.md の確定済みセクションに配布物実装上の矛盾・不足は検出されなかった
