### PR TITLE
agentdev: #2317 workflow-lifecycle 配布スキルの実証Case例外適合

### DIFF
--- a/src/opencode/skills/agentdev-workflow-lifecycle/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-lifecycle/SKILL.md
@@ -63,6 +63,10 @@ Issue/PR をスキップする直接完了経路は存在しない。
 各コマンドの正式名は `/agentdev/<name>` である（例: `/agentdev/req-define`）。
 一覧は command README 参照。
 
+経路一覧の適用前提は通常Case（実証を利用しない Case）である。
+実証Caseは work_type にかかわらず scale と Issue 構造を選択できる。
+実証の判定は評価ブランチ実証ワークフローの定義による（詳細は「スケール判定基準」の実証Case例外参照）。
+
 feature が経由する req-save と spec-save は req_draft の `artifact_actions` により動的判定する。
 該当 entry がない場合は case-open から開始する。
 feature large の OU/ 子Issue 構成は `agentdev-workflow-orchestration` 参照。
@@ -83,7 +87,7 @@ docs 更新責務は全 work_type 共通である。
 
 ## スケール判定基準
 
-feature のスケール（standard/ large）判定基準。
+通常Case（実証を利用しない Case）の feature スケール（standard/ large）判定基準。
 req-define Step 8 が参照する。
 
 ### standard
@@ -100,6 +104,12 @@ req-define Step 8 が参照する。
  - 影響ファイル数が10ファイル超
  - 個別変更件数が30件超
  - シグナル対象: 修正候補リスト、検出事項カタログ、影響ファイル一覧等の実装詳細セクション
+
+### 実証Case例外
+
+- 通常Caseの scale は feature のみ standard / large とする
+- 実証Caseは work_type にかかわらず scale と Issue 構造を選択できる。実証の判定は評価ブランチ実証ワークフローの定義による
+- work_type・scale 判定の宣言的定義は通常Caseの判定規則として維持し、実証Case例外は当該宣言的定義に対する例外適用として扱う。実証を利用しない Case のスケール判定・工程分類の挙動は従来どおり維持する
 
 ## See Also
 


### PR DESCRIPTION
## 概要

Issue #2317（OU-0030、Epic B2 #2307 Wave 2）への対応。
`agentdev-workflow-lifecycle` SPEC に確定済みの「スケール判定と工程分類の実証Case例外」セクション（ACT-SPEC-012 相当、commit 3955170c）に基づき、workflow-lifecycle 配布スキル（SKILL.md）のスケール判定記述へ実証Case例外を適合させた。

Refs: #2317

## 変更内容

対象: `src/opencode/skills/agentdev-workflow-lifecycle/SKILL.md`（+11 行 / -1 行）

1. **経路一覧への適用前提明示**（`## work_type とコマンド経路` > `### 経路一覧`）
   - 経路一覧の適用前提は通常Case（実証を利用しない Case）であることを明示
   - 実証Caseは work_type にかかわらず scale と Issue 構造を選択できる旨と、実証の判定は評価ブランチ実証ワークフローの定義による旨を追記
   - workflow-contracts SPEC 経路制御節（OU-0019 適用分）と対称の記述

2. **スケール判定基準の通常Case前提の明示**（`## スケール判定基準` 冒頭）
   - 「feature のスケール判定基準」→「通常Case（実証を利用しない Case）の feature スケール判定基準」に修正（判定規則本文は無変更）

3. **実証Case例外の追加**（`## スケール判定基準` > `### 実証Case例外` 新設）
   - 通常Caseの scale は feature のみ standard / large とする（維持）
   - 実証Caseは work_type にかかわらず scale と Issue 構造を選択できる。実証の判定は評価ブランチ実証ワークフローの定義による
   - work_type・scale 判定の宣言的定義は通常Caseの判定規則として維持し、実証Case例外は当該宣言的定義に対する例外適用として扱う。実証を利用しない Case の挙動は従来どおり維持

### 適合上の判断

- **concrete REQ-ID 不使用**: 配布物参照境界（distribution boundary）に従い、SPEC 側の REQ 参照（REQ-005-005、REQ-005-012、REQ-043）はドメイン語参照（「評価ブランチ実証ワークフローの定義」等）に置換して記述。`check_distribution_boundary.ts --profile source` で concrete_id_hits=0 を機械検証
- **通常Caseの回帰なし**: 既存の standard/large 判定基準（3条件）、経路一覧テーブルの各行は変更なし。例外追加形式を維持
- **docs/specs は編集なし**: Phase 0 契約どおり SPEC は読み取りのみ（前工程 spec-save 適用済み分の検証を実施）

## SPEC・REQ 適合の確認（context 再確認）

- `docs/specs/skills/agentdev-workflow-lifecycle.md`「スケール判定と工程分類の実証Case例外（新規セクション）」: 3規範（通常Case維持 / 実証Case選択自由 / 宣言的定義への例外適用）が存在し、SKILL.md 追記分と整合
- `docs/requirements/REQ-005.md` REQ-005-005（実証Caseは work_type にかかわらず scale と Issue 構造を選択できる）、REQ-005-012（workflow-lifecycle は宣言的定義のみ提供）: SKILL.md 追記は宣言的定義の範囲内で手続きを含まない
- `docs/specs/workflows/workflow-contracts.md` ワークフロー経路制御節: 「上記経路表の適用前提は通常Caseである」記述と SKILL.md 側追記が対称
- 矛盾なし

## 検証エビデンス

| 検証項目 | コマンド / 手段 | 結果 |
|---|---|---|
| 完了条件1: SPEC セクション存在 | docs/specs/skills/agentdev-workflow-lifecycle.md 44行目「スケール判定と工程分類の実証Case例外（新規セクション）」 | 存在確認 OK |
| 完了条件2: SKILL.md へ実証Case例外反映 | git diff（経路一覧注記 + 通常Case前提明示 + 実証Case例外節） | 反映 OK |
| 完了条件3: 通常Caseの回帰なし | git diff で standard/large 判定規則本文・経路一覧テーブル無変更を確認 | 回帰なし OK |
| 配布依存境界 gate（必須） | `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts --profile source --json` | **EXIT=0**（scanned 329 files、concrete_id_hits=0、concrete_path_hits=0、fixed_url_hits=0） |
| docs 整合性検査（TS-QC-001） | `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_changed_docs.ts --workflow case-run --base-ref origin/main` | **EXIT=0**（failures 0。変更ファイルは src/opencode 配下のみで docs 検査対象外、doc_map/spec_readme/requirements_readme 更新要求なし） |
| 契約テスト（TS-QC-002） | `bun test` skills_structure / lint_skills / check_reference_paths / check_extensions（4ファイル） | **528 pass / 0 fail**（構造様式変更に伴う期待値更新は不要: 当該テストに本スキル見出しの固定期待値なし） |
| TS-003（実証Caseの scale・Issue 構造選択に関わる条項） | SPEC / REQ-005 / workflow-contracts / SKILL.md の4文書間整合確認 | 合格: 経路一覧の適用前提が通常Caseと明示され実証Case確定後の決定的導出と整合、実証Caseの scale・Issue 構造選択の自由が例外として明記、宣言的定義と実証Case例外の関係（例外適用）が明示 |

### 補足（本変更と無関係な pre-existing 検出）

`check_integrity.ts`、`check_skill_rename_symmetry.ts`、`lint_skills.ts`（実スクリプト実行）は EXIT=1 だが、いずれも本変更と無関係の既存検出（後述の Findings 参照）。base commit（26a65341、変更なし状態）でも同一結果であることを stash 検証で確認済み。本変更ファイル（agentdev-workflow-lifecycle）は各レポートの failures に不登場。

## Findings / Capture候補

- **check_integrity.ts EXIT=1（pre-existing）**: 「14 new unmanaged NG (delta, exit code driver)」。内容は REQ-028 retired 参照まわりの既存 Warning 14 件（docs/specs 配下の既存ファイル由来）。base でも同一結果。intake 化候補
- **check_skill_rename_symmetry.ts EXIT=1（pre-existing）**: 17件の path-symmetry 違反（agentdev-workflow-backlog-review 等 16 スキルの SPEC 未対称、agentdev-git-worktree-test-fallback の draft SPEC 逆方向違反 + frontmatter title 不一致）。本変更と無関係。intake 化候補
- **lint_skills.ts EXIT=1（pre-existing）**: agentdev-git-worktree/references/worktree-operations.md が 340行で目次なし（AG-005、300行超）。intake 化候補

## SPEC確定候補

（なし）— SPEC 側（agentdev-workflow-lifecycle SPEC）は前工程 spec-save で適用済みであり、本 PR で新たに SPEC に確定すべき事項（schema、enum、判定表、内部アルゴリズム等）は検出していない

## 備考

- 完了条件チェックボックスの更新は実施していない（case-close QG-4 の責務）
- worktree: `.worktrees/2317-feature`（branch: feature/issue-2317、base: origin/main 26a65341）
