### PR TITLE
feat(agentdev): Project Extensions の YAML 解析・構造検証を Bun.YAML と Zod へ委譲する（Issue #2352）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
@@ -5,6 +5,13 @@
  * (DEC-012 migration: 3-kind enum, id binding, placement, classification) and the
  * REQ-002-030/031 load-time contract (fail-open applies to malformed only).
  *
+ * YAML syntax parsing and structural validation are delegated to the shared
+ * distribution-side implementation (agentdev-project-extensions skill scripts,
+ * lib/extension_state.ts): Bun.YAML.parse for syntax, Zod for structure
+ * (REQ-044, DEC-019). No hand-rolled YAML parser remains here. State
+ * semantics (classification, old/unknown kind judgment) stay ADF-side in
+ * the shared lib; this checker owns the deterministic NG reporting contract.
+ *
  * Extension schema:
  *   frontmatter: version: 1,
  *                kind: workflow-extension | internal-workflow-extension | capability-skill-extension,
@@ -68,21 +75,25 @@ const path = require("path") as typeof import("path");
 const fs = require("fs") as typeof import("fs");
 const os = require("os") as typeof import("os");
 
-export type ExtensionKind =
-  | "workflow-extension"
-  | "internal-workflow-extension"
-  | "capability-skill-extension";
+// Shared distribution-side state machine (Bun.YAML + Zod delegation,
+// REQ-044 / DEC-019). Relative import resolves identically in the main
+// checkout (junctioned skills) and in worktrees (junction not set up):
+// the src/opencode/ tree is the SoT in both environments (REQ-018).
+import {
+  NEW_EXTENSION_KINDS,
+  LEGACY_EXTENSION_KINDS,
+  parseExtensionYaml,
+  resolveExtensionState,
+  validateExtensionEntries,
+} from "../../../../src/opencode/skills/agentdev-project-extensions/scripts/lib/extension_state.ts";
 
-export const NEW_EXTENSION_KINDS: readonly ExtensionKind[] = [
-  "workflow-extension",
-  "internal-workflow-extension",
-  "capability-skill-extension",
-];
-
-export const LEGACY_EXTENSION_KINDS: readonly string[] = [
-  "command-extension",
-  "skill-extension",
-];
+// Re-export the shared contract under the historical module surface so
+// existing importers (tests, sibling checkers) keep working.
+export { NEW_EXTENSION_KINDS, LEGACY_EXTENSION_KINDS, resolveExtensionState };
+export type {
+  ExtensionKind,
+  ExtensionResolution,
+} from "../../../../src/opencode/skills/agentdev-project-extensions/scripts/lib/extension_state.ts";
 
 export type FailureClassification =
   | "malformed"
@@ -282,125 +293,6 @@ function listFilesRecursive(dirPath: string): string[] {
 }
 
 /**
- * Minimal YAML parser tailored to extension files (same constraints as the
- * earlier doc-input parser: top-level key: value, nested mapping by indent,
- * list of scalars, list of mappings with deeper-indent continuation,
- * inline arrays [a, b], inline empty mapping {}).
- */
-function parseSimpleYaml(text: string): any {
-  const lines = text.split(/\r?\n/);
-  const root: any = {};
-  const stack: { indent: number; node: any }[] = [{ indent: -1, node: root }];
-
-  function currentParent(indent: number): any {
-    while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
-      stack.pop();
-    }
-    return stack[stack.length - 1].node;
-  }
-
-  let i = 0;
-  while (i < lines.length) {
-    const rawLine = lines[i];
-    i++;
-    if (!rawLine.trim()) continue;
-    if (rawLine.trim().startsWith("#")) continue;
-    const indent = rawLine.length - rawLine.trimStart().length;
-    const line = rawLine.trim();
-
-    if (line.startsWith("- ")) {
-      const holder = currentParent(indent);
-      const owner = holder.__list_owner;
-      const key = holder.__list_key;
-      if (owner && key) {
-        if (!Array.isArray(owner[key])) owner[key] = [];
-        const rest = line.slice(2).trim();
-        const colonIdx = rest.indexOf(":");
-        if (
-          colonIdx !== -1 &&
-          !rest.startsWith("[") &&
-          !rest.startsWith('"') &&
-          !rest.startsWith("'")
-        ) {
-          const innerKey = rest.slice(0, colonIdx).trim().replace(/^["']|["']$/g, "");
-          const innerRaw = rest.slice(colonIdx + 1).trim();
-          const elem: any = {};
-          if (innerRaw === "") {
-            elem[innerKey] = null;
-          } else if (innerRaw.startsWith("[") && innerRaw.endsWith("]")) {
-            elem[innerKey] = innerRaw
-              .slice(1, -1)
-              .split(",")
-              .map((s) => s.trim().replace(/^["']|["']$/g, ""))
-              .filter((s) => s.length > 0);
-          } else {
-            elem[innerKey] = innerRaw.replace(/^["']|["']$/g, "");
-          }
-          owner[key].push(elem);
-          stack.push({ indent, node: elem });
-        } else {
-          owner[key].push(rest.replace(/^["']|["']$/g, ""));
-        }
-      }
-      continue;
-    }
-
-    const colonIdx = line.indexOf(":");
-    if (colonIdx === -1) continue;
-    const key = line.slice(0, colonIdx).trim().replace(/^["']|["']$/g, "");
-    const rawValue = line.slice(colonIdx + 1).trim();
-
-    let parent = currentParent(indent);
-
-    if (parent && parent.__list_owner !== undefined) {
-      const owner = parent.__list_owner;
-      const ownerKey = parent.__list_key;
-      const realNode: any = {};
-      owner[ownerKey] = realNode;
-      if (stack.length > 0 && stack[stack.length - 1].node === parent) {
-        stack[stack.length - 1].node = realNode;
-      }
-      parent = realNode;
-    }
-
-    if (rawValue === "") {
-      const holder: any = {
-        __list_owner: parent,
-        __list_key: key,
-      };
-      parent[key] = holder;
-      stack.push({ indent, node: holder });
-    } else if (rawValue.startsWith("[") && rawValue.endsWith("]")) {
-      parent[key] = rawValue
-        .slice(1, -1)
-        .split(",")
-        .map((s) => s.trim().replace(/^["']|["']$/g, ""))
-        .filter((s) => s.length > 0);
-    } else if (rawValue === "{}") {
-      parent[key] = {};
-    } else {
-      parent[key] = rawValue.replace(/^["']|["']$/g, "");
-    }
-  }
-
-  (function normalize(node: any): void {
-    if (node && typeof node === "object") {
-      for (const k of Object.keys(node)) {
-        const v = node[k];
-        if (v && typeof v === "object" && v.__list_owner !== undefined) {
-          node[k] = [];
-        } else if (Array.isArray(v)) {
-          for (const e of v) normalize(e);
-        } else if (v && typeof v === "object") {
-          normalize(v);
-        }
-      }
-    }
-  })(root);
-  return root;
-}
-
-/**
  * Known project-local skill locations for check #10 existence confirmation.
  * Returns true if a directory matching the skill name exists in any known
  * skills location. Paths are resolved against repoRoot (cwd-independent).
@@ -450,52 +342,6 @@ export function deriveSkillClassification(repoRoot?: string): SkillClassificatio
   return { workflowSkills, capabilitySkills };
 }
 
-export type ExtensionResolution =
-  | { state: "missing" }
-  | { state: "malformed"; reasons: string[] }
-  | { state: "migration-required"; kind: string }
-  | { state: "schema-violation"; kind: string }
-  | { state: "valid"; kind: ExtensionKind };
-
-/**
- * Load-time state classification shared by the runtime resolver contract and
- * the deterministic checks (UC-001 case 1). Judgment order matters: required
- * field problems (malformed, fail-open at runtime) are judged before the kind
- * value; legacy and unknown kinds are only classified once every required
- * field is syntactically present. parseSimpleYaml never throws, so YAML
- * syntax errors degrade into missing required fields (malformed).
- */
-export function resolveExtensionState(rawText: string | null): ExtensionResolution {
-  if (rawText === null) return { state: "missing" };
-  const parsed = parseSimpleYaml(rawText);
-  const reasons: string[] = [];
-  if (parsed.version === undefined || String(parsed.version) !== "1") {
-    reasons.push(`required field 'version' must be 1 (got: ${parsed.version})`);
-  }
-  if (typeof parsed.kind !== "string" || parsed.kind.length === 0) {
-    reasons.push("required field 'kind' is missing or not a string");
-  }
-  if (typeof parsed.id !== "string" || parsed.id.length === 0) {
-    reasons.push("required field 'id' is missing or not a string");
-  }
-  for (const sec of ["context", "rules", "checks", "acceptance_gates", "must_not"]) {
-    if (parsed[sec] === undefined || parsed[sec] === null) {
-      reasons.push(`required section '${sec}' is missing (use an empty array if no entries)`);
-    } else if (!Array.isArray(parsed[sec])) {
-      reasons.push(`required section '${sec}' must be an array`);
-    }
-  }
-  if (reasons.length > 0) return { state: "malformed", reasons };
-  const kind = parsed.kind as string;
-  if (LEGACY_EXTENSION_KINDS.includes(kind)) {
-    return { state: "migration-required", kind };
-  }
-  if (!NEW_EXTENSION_KINDS.includes(kind as ExtensionKind)) {
-    return { state: "schema-violation", kind };
-  }
-  return { state: "valid", kind: kind as ExtensionKind };
-}
-
 interface ExtensionWalkResult {
   pathsReferenced: string[];
   skillsReferenced: string[];
@@ -506,74 +352,49 @@ interface ExtensionWalkResult {
 /**
  * Walk context/rules/checks sections to collect path strings, skill names,
  * and detect override-intent phrases (check #13 heuristic). Called only for
- * extensions whose load-time state is "valid".
+ * extensions whose load-time state is "valid". Entry structure violations
+ * (check #11) come from the shared Zod validation in extension_state.ts.
  */
-function walkExtension(parsed: any, rawText: string, rcFile: string): ExtensionWalkResult {
+function walkExtension(parsedDoc: unknown, rawText: string, rcFile: string): ExtensionWalkResult {
   const pathsReferenced: string[] = [];
   const skillsReferenced: string[] = [];
   const failures: CheckFailure[] = [];
 
-  // context: array of {id, when?, paths?, purpose?}
-  if (Array.isArray(parsed.context)) {
-    for (let idx = 0; idx < parsed.context.length; idx++) {
-      const e = parsed.context[idx];
-      if (!e || typeof e !== "object") {
-        failures.push({
-          check: 11,
-          check_name: "extension-structure",
-          severity: "strict",
-          classification: "malformed",
-          file: rcFile,
-          message: `context[${idx}] must be an object`,
-        });
-        continue;
-      }
-      if (typeof e.id !== "string") {
-        failures.push({
-          check: 11,
-          check_name: "extension-structure",
-          severity: "strict",
-          classification: "malformed",
-          file: rcFile,
-          message: `context[${idx}] missing 'id' string`,
-        });
-      }
-      if (Array.isArray(e.paths)) {
-        for (const p of e.paths) {
-          if (typeof p === "string") pathsReferenced.push(p);
+  for (const message of validateExtensionEntries(parsedDoc)) {
+    failures.push({
+      check: 11,
+      check_name: "extension-structure",
+      severity: "strict",
+      classification: "malformed",
+      file: rcFile,
+      message,
+    });
+  }
+
+  const doc =
+    parsedDoc !== null && typeof parsedDoc === "object" && !Array.isArray(parsedDoc)
+      ? (parsedDoc as Record<string, unknown>)
+      : null;
+  if (doc) {
+    if (Array.isArray(doc.context)) {
+      for (const e of doc.context) {
+        if (!e || typeof e !== "object" || Array.isArray(e)) continue;
+        const entry = e as Record<string, unknown>;
+        if (Array.isArray(entry.paths)) {
+          for (const p of entry.paths) {
+            if (typeof p === "string") pathsReferenced.push(p);
+          }
         }
       }
     }
-  }
-
-  // rules / checks: array of {id, when?, skill?}
-  for (const sec of ["rules", "checks"] as const) {
-    if (Array.isArray(parsed[sec])) {
-      for (let idx = 0; idx < parsed[sec].length; idx++) {
-        const e = parsed[sec][idx];
-        if (!e || typeof e !== "object") {
-          failures.push({
-            check: 11,
-            check_name: "extension-structure",
-            severity: "strict",
-            classification: "malformed",
-            file: rcFile,
-            message: `${sec}[${idx}] must be an object`,
-          });
-          continue;
-        }
-        if (typeof e.id !== "string") {
-          failures.push({
-            check: 11,
-            check_name: "extension-structure",
-            severity: "strict",
-            classification: "malformed",
-            file: rcFile,
-            message: `${sec}[${idx}] missing 'id' string`,
-          });
-        }
-        if (typeof e.skill === "string" && e.skill.length > 0) {
-          skillsReferenced.push(e.skill);
+    for (const sec of ["rules", "checks"] as const) {
+      if (Array.isArray(doc[sec])) {
+        for (const e of doc[sec]) {
+          if (!e || typeof e !== "object" || Array.isArray(e)) continue;
+          const entry = e as Record<string, unknown>;
+          if (typeof entry.skill === "string" && entry.skill.length > 0) {
+            skillsReferenced.push(entry.skill);
+          }
         }
       }
     }
@@ -715,8 +536,17 @@ export function checkExtensions(repoRoot: string): CheckReport {
         }
       }
 
-      const parsed = parseSimpleYaml(rcText);
-      const id = typeof parsed.id === "string" ? parsed.id : "";
+      // resolution.state === "valid" guarantees the parse succeeded, so the
+      // re-parse below cannot fail; it exists because resolveExtensionState
+      // returns only the state, not the parsed document.
+      const reparsed = parseExtensionYaml(rcText);
+      const parsedDoc = reparsed.ok ? reparsed.data : null;
+      const id =
+        parsedDoc !== null &&
+        typeof parsedDoc === "object" &&
+        typeof (parsedDoc as Record<string, unknown>).id === "string"
+          ? ((parsedDoc as Record<string, unknown>).id as string)
+          : "";
 
       // Check #3: id-target consistency
       const fileBase = segments[segments.length - 1]?.replace(/\.ya?ml$/, "") ?? "";
@@ -806,7 +636,7 @@ export function checkExtensions(repoRoot: string): CheckReport {
       }
 
       // Walk sections: collect paths/skills, check structure, override phrases
-      const walk = walkExtension(parsed, rcText, rc);
+      const walk = walkExtension(parsedDoc, rcText, rc);
       failures.push(...walk.failures);
 
       // Check #9: context.paths existence

--- a/src/opencode/skills/agentdev-project-extensions/scripts/.gitignore
+++ b/src/opencode/skills/agentdev-project-extensions/scripts/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/opencode/skills/agentdev-project-extensions/scripts/README.md
+++ b/src/opencode/skills/agentdev-project-extensions/scripts/README.md
@@ -1,0 +1,30 @@
+# agentdev-project-extensions scripts
+
+Project Extensions の読込時状態機械（runtime resolver と deterministic checker の共有実装）。
+
+YAML 構文解析は `Bun.YAML.parse` へ委譲し、構造検証は Zod へ委譲する（REQ-044、DEC-019、基盤 Design「YAML 解析と構造検証の実装契約」）。
+状態分類（missing / malformed / migration-required / schema-violation / valid）と旧kind・未知kind の意味判定は ADF 側に残留する。
+
+## 構成
+
+| パス | 役割 |
+|------|------|
+| `lib/extension_state.ts` | 共有実装。`parseExtensionYaml`（Bun.YAML 委譲）、`resolveExtensionState`（状態機械）、`validateExtensionEntries`（配列要素の構造検証） |
+| `tests/extension_state.test.ts` | TS-002 回帰ケース（構文エラー、必須フィールド欠落、旧kind、未知kind、有効、空入力、型不正、クォート内コロン・`#`、CRLF、入れ子、配列） |
+
+保証 YAML 機能はマッピング、配列、文字列、数値、真偽値、null、入れ子構造、通常のクォート文字列に限定する。
+anchor、alias、カスタムタグ、複数ドキュメントは保証対象外である。
+
+## 依存
+
+`zod` は本 `package.json` / `bun.lock` で管理する（実行時パッケージ境界、agentdev-artifact-graph scripts と同一経路）。
+利用時は本ディレクトリで `bun install` を実行して `node_modules/` を生成する。
+
+```powershell
+cd src/opencode/skills/agentdev-project-extensions/scripts
+bun install
+bun test
+```
+
+repo-local deterministic checker（`.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts`）は
+本ディレクトリの `lib/extension_state.ts` を相対 import で参照する。配布側実装から repo-local 成果物への依存は持たない。

--- a/src/opencode/skills/agentdev-project-extensions/scripts/README.md
+++ b/src/opencode/skills/agentdev-project-extensions/scripts/README.md
@@ -2,7 +2,7 @@
 
 Project Extensions の読込時状態機械（runtime resolver と deterministic checker の共有実装）。
 
-YAML 構文解析は `Bun.YAML.parse` へ委譲し、構造検証は Zod へ委譲する（REQ-044、DEC-019、基盤 Design「YAML 解析と構造検証の実装契約」）。
+YAML 構文解析は `Bun.YAML.parse` へ委譲し、構造検証は Zod へ委譲する。
 状態分類（missing / malformed / migration-required / schema-violation / valid）と旧kind・未知kind の意味判定は ADF 側に残留する。
 
 ## 構成
@@ -10,7 +10,7 @@ YAML 構文解析は `Bun.YAML.parse` へ委譲し、構造検証は Zod へ委�
 | パス | 役割 |
 |------|------|
 | `lib/extension_state.ts` | 共有実装。`parseExtensionYaml`（Bun.YAML 委譲）、`resolveExtensionState`（状態機械）、`validateExtensionEntries`（配列要素の構造検証） |
-| `tests/extension_state.test.ts` | TS-002 回帰ケース（構文エラー、必須フィールド欠落、旧kind、未知kind、有効、空入力、型不正、クォート内コロン・`#`、CRLF、入れ子、配列） |
+| `tests/extension_state.test.ts` | 回帰ケース（構文エラー、必須フィールド欠落、旧kind、未知kind、有効、空入力、型不正、クォート内コロン・`#`、CRLF、入れ子、配列） |
 
 保証 YAML 機能はマッピング、配列、文字列、数値、真偽値、null、入れ子構造、通常のクォート文字列に限定する。
 anchor、alias、カスタムタグ、複数ドキュメントは保証対象外である。

--- a/src/opencode/skills/agentdev-project-extensions/scripts/bun.lock
+++ b/src/opencode/skills/agentdev-project-extensions/scripts/bun.lock
@@ -1,0 +1,29 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "agentdev-project-extensions-scripts",
+      "dependencies": {
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
+        "typescript": "^5.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+  }
+}

--- a/src/opencode/skills/agentdev-project-extensions/scripts/lib/extension_state.ts
+++ b/src/opencode/skills/agentdev-project-extensions/scripts/lib/extension_state.ts
@@ -1,9 +1,7 @@
 /**
  * Shared Project Extensions load-time state machine (distribution side).
  *
- * Canonical contract: docs/designs/foundations/project-extensions.md
- * "YAML 解析と構造検証の実装契約" (REQ-044, DEC-019).
- *
+ * Contract summary:
  * - YAML syntax parsing is delegated to Bun.YAML.parse. Parse exceptions
  *   are converted into ADF states (malformed); they never crash runtime
  *   processing directly.
@@ -156,7 +154,7 @@ function buildMalformedReasons(data: unknown, failedKeys: Set<string>): string[]
 
 /**
  * Load-time state classification shared by the runtime resolver contract
- * and the deterministic checker (UC-001 case 1). Judgment order matters:
+ * and the deterministic checker. Judgment order matters:
  * required field problems (malformed, fail-open at runtime) are judged
  * before the kind value; legacy and unknown kinds are only classified
  * once every required field is structurally present. Bun.YAML.parse

--- a/src/opencode/skills/agentdev-project-extensions/scripts/lib/extension_state.ts
+++ b/src/opencode/skills/agentdev-project-extensions/scripts/lib/extension_state.ts
@@ -1,0 +1,236 @@
+/**
+ * Shared Project Extensions load-time state machine (distribution side).
+ *
+ * Canonical contract: docs/designs/foundations/project-extensions.md
+ * "YAML 解析と構造検証の実装契約" (REQ-044, DEC-019).
+ *
+ * - YAML syntax parsing is delegated to Bun.YAML.parse. Parse exceptions
+ *   are converted into ADF states (malformed); they never crash runtime
+ *   processing directly.
+ * - Structural validation is delegated to Zod (structure only): version,
+ *   kind, id, context, rules, checks, acceptance_gates, must_not and the
+ *   array element shapes. Zod owns no state semantics.
+ * - State classification (missing / malformed / migration-required /
+ *   schema-violation / valid) and the old-kind / unknown-kind judgment
+ *   stay on the ADF side (this module). The official kind enum is owned
+ *   by the Project Extensions Design ("Extension kind enum（公式）").
+ * - Guaranteed YAML feature scope: mappings, arrays, strings, numbers,
+ *   booleans, null, nesting, plain quoted strings. Anchors, aliases,
+ *   custom tags and multiple documents are NOT guaranteed.
+ *
+ * This module is the distribution-side base implementation shared by the
+ * runtime resolver contract and the repo-local deterministic checker
+ * (check_extensions.ts). It must not depend on repo-local artifacts.
+ */
+
+import { z } from "zod";
+
+export type ExtensionKind =
+  | "workflow-extension"
+  | "internal-workflow-extension"
+  | "capability-skill-extension";
+
+export const NEW_EXTENSION_KINDS: readonly ExtensionKind[] = [
+  "workflow-extension",
+  "internal-workflow-extension",
+  "capability-skill-extension",
+];
+
+export const LEGACY_EXTENSION_KINDS: readonly string[] = [
+  "command-extension",
+  "skill-extension",
+];
+
+export type ExtensionResolution =
+  | { state: "missing" }
+  | { state: "malformed"; reasons: string[] }
+  | { state: "migration-required"; kind: string }
+  | { state: "schema-violation"; kind: string }
+  | { state: "valid"; kind: ExtensionKind };
+
+// ---------------------------------------------------------------------------
+// YAML syntax parsing (Bun.YAML delegation)
+// ---------------------------------------------------------------------------
+
+export type ExtensionYamlResult =
+  | { ok: true; data: unknown }
+  | { ok: false; error: string };
+
+/**
+ * Delegates YAML syntax parsing to Bun.YAML.parse and converts exceptions
+ * into a value so callers classify them as malformed instead of crashing.
+ */
+export function parseExtensionYaml(text: string): ExtensionYamlResult {
+  try {
+    return { ok: true, data: Bun.YAML.parse(text) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: message.split("\n")[0] ?? message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Zod structural schemas (structure only; no state semantics)
+// ---------------------------------------------------------------------------
+
+const ExtensionDocumentSchema = z.object({
+  // Legacy acceptance: both the YAML number 1 and the quoted string "1"
+  // pass, mirroring the pre-migration String(version) === "1" check.
+  version: z.union([z.literal(1), z.literal("1")]),
+  // kind is validated as a non-empty string here; the legacy / unknown /
+  // official-3-value judgment is ADF-side state semantics.
+  kind: z.string().min(1),
+  id: z.string().min(1),
+  context: z.array(z.unknown()),
+  rules: z.array(z.unknown()),
+  checks: z.array(z.unknown()),
+  acceptance_gates: z.array(z.unknown()),
+  must_not: z.array(z.unknown()),
+});
+
+const ContextEntrySchema = z.object({
+  id: z.string(),
+  when: z.string().optional(),
+  paths: z.array(z.string()).optional(),
+  purpose: z.string().optional(),
+});
+
+const DelegatedEntrySchema = z.object({
+  id: z.string(),
+  when: z.string().optional(),
+  skill: z.string().optional(),
+});
+
+const ExtensionEntriesSchema = z.object({
+  context: z.array(ContextEntrySchema),
+  rules: z.array(DelegatedEntrySchema),
+  checks: z.array(DelegatedEntrySchema),
+  acceptance_gates: z.array(z.string()),
+  must_not: z.array(z.string()),
+});
+
+const REQUIRED_KEYS = [
+  "version",
+  "kind",
+  "id",
+  "context",
+  "rules",
+  "checks",
+  "acceptance_gates",
+  "must_not",
+] as const;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Rebuilds the pre-migration malformed reason wording from a failed key so
+ * existing checker failure messages (and their baseline keys) stay stable.
+ */
+function malformedReasonFor(key: string, value: unknown): string {
+  if (key === "version") {
+    return `required field 'version' must be 1 (got: ${value})`;
+  }
+  if (key === "kind" || key === "id") {
+    return `required field '${key}' is missing or not a string`;
+  }
+  if (value === undefined || value === null) {
+    return `required section '${key}' is missing (use an empty array if no entries)`;
+  }
+  return `required section '${key}' must be an array`;
+}
+
+function buildMalformedReasons(data: unknown, failedKeys: Set<string>): string[] {
+  const record = isPlainObject(data) ? data : {};
+  const targets =
+    failedKeys.size > 0
+      ? REQUIRED_KEYS.filter((key) => failedKeys.has(key))
+      : [...REQUIRED_KEYS];
+  return targets.map((key) => malformedReasonFor(key, record[key]));
+}
+
+// ---------------------------------------------------------------------------
+// Load-time state machine (ADF-side semantics; shared implementation)
+// ---------------------------------------------------------------------------
+
+/**
+ * Load-time state classification shared by the runtime resolver contract
+ * and the deterministic checker (UC-001 case 1). Judgment order matters:
+ * required field problems (malformed, fail-open at runtime) are judged
+ * before the kind value; legacy and unknown kinds are only classified
+ * once every required field is structurally present. Bun.YAML.parse
+ * exceptions and structural violations are converted into malformed
+ * instead of crashing the caller.
+ */
+export function resolveExtensionState(rawText: string | null): ExtensionResolution {
+  if (rawText === null) return { state: "missing" };
+  const parsed = parseExtensionYaml(rawText);
+  if (!parsed.ok) {
+    return { state: "malformed", reasons: [`YAML syntax error: ${parsed.error}`] };
+  }
+  const result = ExtensionDocumentSchema.safeParse(parsed.data);
+  if (!result.success) {
+    const failedKeys = new Set<string>();
+    for (const issue of result.error.issues) {
+      const head = issue.path[0];
+      if (typeof head === "string") failedKeys.add(head);
+    }
+    return {
+      state: "malformed",
+      reasons: buildMalformedReasons(parsed.data, failedKeys),
+    };
+  }
+  const kind = result.data.kind;
+  if (LEGACY_EXTENSION_KINDS.includes(kind)) {
+    return { state: "migration-required", kind };
+  }
+  if (!NEW_EXTENSION_KINDS.includes(kind as ExtensionKind)) {
+    return { state: "schema-violation", kind };
+  }
+  return { state: "valid", kind: kind as ExtensionKind };
+}
+
+// ---------------------------------------------------------------------------
+// Entry structure validation (deterministic checker support, check #11)
+// ---------------------------------------------------------------------------
+
+function entryFieldShape(field: string): string {
+  if (field === "paths") return "an array of strings";
+  return "a string";
+}
+
+/**
+ * Structural validation of the five section entries (the deterministic
+ * checker's extension-structure check). Returns violation messages in the
+ * legacy checker wording. Which failure classification these map to
+ * (malformed) stays with the checker: Zod owns structure only.
+ */
+export function validateExtensionEntries(data: unknown): string[] {
+  const result = ExtensionEntriesSchema.safeParse(data);
+  if (result.success) return [];
+  const messages: string[] = [];
+  for (const issue of result.error.issues) {
+    const [head, index, field] = issue.path;
+    if (typeof head === "string" && typeof index === "number") {
+      if (field === undefined) {
+        if (head === "acceptance_gates" || head === "must_not") {
+          messages.push(`${head}[${index}] must be a string`);
+        } else {
+          messages.push(`${head}[${index}] must be an object`);
+        }
+      } else if (field === "id") {
+        messages.push(`${head}[${index}] missing 'id' string`);
+      } else {
+        messages.push(
+          `${head}[${index}] field '${String(field)}' must be ${entryFieldShape(String(field))}`,
+        );
+      }
+    } else if (typeof head === "string") {
+      messages.push(`section '${head}' has invalid structure (${issue.message})`);
+    } else {
+      messages.push(`extension entries have invalid structure (${issue.message})`);
+    }
+  }
+  return messages;
+}

--- a/src/opencode/skills/agentdev-project-extensions/scripts/package.json
+++ b/src/opencode/skills/agentdev-project-extensions/scripts/package.json
@@ -2,7 +2,7 @@
   "name": "agentdev-project-extensions-scripts",
   "version": "0.1.0",
   "private": true,
-  "description": "Shared Project Extensions load-time state machine: YAML parsing via Bun.YAML and structural validation via Zod (REQ-044, DEC-019). Referenced by the repo-local deterministic checker; no repo-local dependencies.",
+  "description": "Shared Project Extensions load-time state machine: YAML parsing via Bun.YAML and structural validation via Zod. Referenced by the repo-local deterministic checker; no repo-local dependencies.",
   "type": "module",
   "scripts": {
     "test": "bun test",

--- a/src/opencode/skills/agentdev-project-extensions/scripts/package.json
+++ b/src/opencode/skills/agentdev-project-extensions/scripts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "agentdev-project-extensions-scripts",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared Project Extensions load-time state machine: YAML parsing via Bun.YAML and structural validation via Zod (REQ-044, DEC-019). Referenced by the repo-local deterministic checker; no repo-local dependencies.",
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/bun": "^1.3.0"
+  },
+  "dependencies": {
+    "zod": "^4.0.0"
+  }
+}

--- a/src/opencode/skills/agentdev-project-extensions/scripts/tests/extension_state.test.ts
+++ b/src/opencode/skills/agentdev-project-extensions/scripts/tests/extension_state.test.ts
@@ -1,9 +1,7 @@
 /**
  * Regression tests for the shared extension load-time state machine.
  *
- * Covers the TS-002 cases required by docs/designs/foundations/
- * project-extensions.md "YAML 解析と構造検証の実装契約" (REQ-044,
- * DEC-019): YAML syntax error, missing required fields, legacy kind,
+ * Covered cases: YAML syntax error, missing required fields, legacy kind,
  * unknown kind, valid extension, empty input, type mismatch, colon/#
  * inside quotes, CRLF, nesting, arrays.
  *
@@ -21,7 +19,7 @@ import {
 const validDoc = (kind: string) =>
   `version: 1\nkind: ${kind}\nid: agentdev-workflow-demo\n\ncontext: []\nrules: []\nchecks: []\nacceptance_gates: []\nmust_not: []\n`;
 
-describe("parseExtensionYaml (Bun.YAML delegation, TS-004 availability evidence)", () => {
+describe("parseExtensionYaml (Bun.YAML delegation, availability evidence)", () => {
   test("Bun.YAML.parse is available and handles the guaranteed YAML scope", () => {
     const result = parseExtensionYaml(
       'num: 1\nstr: "x"\nplain: y\nflag: true\nnil: null\nlist: [1, a, "b"]\nnested:\n  - id: e1\n    paths:\n      - "docs/a.md"\n',
@@ -48,7 +46,7 @@ describe("parseExtensionYaml (Bun.YAML delegation, TS-004 availability evidence)
   });
 });
 
-describe("resolveExtensionState (TS-002 regression cases)", () => {
+describe("resolveExtensionState (regression cases)", () => {
   test("missing when the input is null", () => {
     expect(resolveExtensionState(null)).toEqual({ state: "missing" });
   });
@@ -151,7 +149,7 @@ describe("resolveExtensionState (TS-002 regression cases)", () => {
       "  - id: must-1",
       "    when: always",
       "    paths:",
-      "      - \"docs/designs/foundations/project-extensions.md\"",
+      "      - \"docs/foundation-guide/nested-path.md\"",
       "    purpose: shared state machine contract",
       "rules:",
       "  - id: rule-1",

--- a/src/opencode/skills/agentdev-project-extensions/scripts/tests/extension_state.test.ts
+++ b/src/opencode/skills/agentdev-project-extensions/scripts/tests/extension_state.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Regression tests for the shared extension load-time state machine.
+ *
+ * Covers the TS-002 cases required by docs/designs/foundations/
+ * project-extensions.md "YAML 解析と構造検証の実装契約" (REQ-044,
+ * DEC-019): YAML syntax error, missing required fields, legacy kind,
+ * unknown kind, valid extension, empty input, type mismatch, colon/#
+ * inside quotes, CRLF, nesting, arrays.
+ *
+ * Guaranteed YAML scope only: anchors, aliases, custom tags and multiple
+ * documents are intentionally NOT tested (not guaranteed features).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  parseExtensionYaml,
+  resolveExtensionState,
+  validateExtensionEntries,
+} from "../lib/extension_state.ts";
+
+const validDoc = (kind: string) =>
+  `version: 1\nkind: ${kind}\nid: agentdev-workflow-demo\n\ncontext: []\nrules: []\nchecks: []\nacceptance_gates: []\nmust_not: []\n`;
+
+describe("parseExtensionYaml (Bun.YAML delegation, TS-004 availability evidence)", () => {
+  test("Bun.YAML.parse is available and handles the guaranteed YAML scope", () => {
+    const result = parseExtensionYaml(
+      'num: 1\nstr: "x"\nplain: y\nflag: true\nnil: null\nlist: [1, a, "b"]\nnested:\n  - id: e1\n    paths:\n      - "docs/a.md"\n',
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const data = result.data as Record<string, unknown>;
+      expect(data.num).toBe(1);
+      expect(data.str).toBe("x");
+      expect(data.plain).toBe("y");
+      expect(data.flag).toBe(true);
+      expect(data.nil).toBe(null);
+      expect(data.list).toEqual([1, "a", "b"]);
+      expect(Array.isArray(data.nested)).toBe(true);
+    }
+  });
+
+  test("converts syntax errors into a value instead of throwing", () => {
+    const result = parseExtensionYaml(":\n\t- ][{ ::\n\tversion: [[[\n");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("resolveExtensionState (TS-002 regression cases)", () => {
+  test("missing when the input is null", () => {
+    expect(resolveExtensionState(null)).toEqual({ state: "missing" });
+  });
+
+  test("malformed on YAML syntax error", () => {
+    const resolution = resolveExtensionState(":\n\t- ][{ ::\n\tversion: [[[\n");
+    expect(resolution.state).toBe("malformed");
+  });
+
+  test("malformed on empty input", () => {
+    const resolution = resolveExtensionState("");
+    expect(resolution.state).toBe("malformed");
+    if (resolution.state === "malformed") {
+      expect(resolution.reasons.some((r) => r.includes("'version'"))).toBe(true);
+    }
+  });
+
+  test("malformed on missing required fields", () => {
+    const resolution = resolveExtensionState("version: 1\nkind: workflow-extension\n");
+    expect(resolution.state).toBe("malformed");
+    if (resolution.state === "malformed") {
+      expect(resolution.reasons.some((r) => r.includes("'id'"))).toBe(true);
+      expect(resolution.reasons.some((r) => r.includes("'context'"))).toBe(true);
+    }
+  });
+
+  test("malformed on type mismatch (wrong version value, numeric kind, non-array section)", () => {
+    expect(resolveExtensionState(validDoc("workflow-extension").replace("version: 1", "version: 2")).state).toBe("malformed");
+    expect(resolveExtensionState(validDoc("workflow-extension").replace("version: 1", "version: true")).state).toBe("malformed");
+    expect(resolveExtensionState(validDoc("workflow-extension").replace("kind: workflow-extension", "kind: 123")).state).toBe("malformed");
+    expect(resolveExtensionState(validDoc("workflow-extension").replace("context: []", "context: not-an-array")).state).toBe("malformed");
+    expect(resolveExtensionState(validDoc("workflow-extension").replace("context: []", "context: {}")).state).toBe("malformed");
+  });
+
+  test("malformed when the document root is not a mapping (all required keys reported)", () => {
+    const listRoot = resolveExtensionState("- a\n- b\n");
+    expect(listRoot.state).toBe("malformed");
+    if (listRoot.state === "malformed") {
+      expect(listRoot.reasons.some((r) => r.includes("'version'"))).toBe(true);
+    }
+    const scalarRoot = resolveExtensionState("hello\n");
+    expect(scalarRoot.state).toBe("malformed");
+  });
+
+  test("migration-required on legacy command-extension", () => {
+    expect(resolveExtensionState(validDoc("command-extension"))).toEqual({
+      state: "migration-required",
+      kind: "command-extension",
+    });
+  });
+
+  test("migration-required on legacy skill-extension", () => {
+    expect(resolveExtensionState(validDoc("skill-extension"))).toEqual({
+      state: "migration-required",
+      kind: "skill-extension",
+    });
+  });
+
+  test("schema-violation on unknown kind", () => {
+    expect(resolveExtensionState(validDoc("solar-extension"))).toEqual({
+      state: "schema-violation",
+      kind: "solar-extension",
+    });
+  });
+
+  test("valid for each official kind", () => {
+    for (const kind of [
+      "workflow-extension",
+      "internal-workflow-extension",
+      "capability-skill-extension",
+    ] as const) {
+      expect(resolveExtensionState(validDoc(kind))).toEqual({ state: "valid", kind });
+    }
+  });
+
+  test("valid with quoted version \"1\" (legacy acceptance kept)", () => {
+    const resolution = resolveExtensionState(validDoc("workflow-extension").replace("version: 1", 'version: "1"'));
+    expect(resolution).toEqual({ state: "valid", kind: "workflow-extension" });
+  });
+
+  test("valid with colon and # inside quoted strings", () => {
+    const doc =
+      'version: 1\nkind: workflow-extension\nid: "agentdev-workflow-demo"\n\ncontext:\n  - id: "ctx: one # two"\n    when: "a: b"\n    paths:\n      - "docs/x#y.md"\nrules: []\nchecks: []\nacceptance_gates: []\nmust_not: []\n';
+    const resolution = resolveExtensionState(doc);
+    expect(resolution).toEqual({ state: "valid", kind: "workflow-extension" });
+  });
+
+  test("valid with CRLF line endings", () => {
+    const resolution = resolveExtensionState(validDoc("workflow-extension").replace(/\n/g, "\r\n"));
+    expect(resolution).toEqual({ state: "valid", kind: "workflow-extension" });
+  });
+
+  test("valid with nesting and populated arrays", () => {
+    const doc = [
+      "version: 1",
+      "kind: workflow-extension",
+      "id: agentdev-workflow-demo",
+      "",
+      "context:",
+      "  - id: must-1",
+      "    when: always",
+      "    paths:",
+      "      - \"docs/designs/foundations/project-extensions.md\"",
+      "    purpose: shared state machine contract",
+      "rules:",
+      "  - id: rule-1",
+      "    when: implementation",
+      "    skill: agentdev-artifact-graph",
+      "checks:",
+      "  - id: check-1",
+      "    skill: repo-agentdev-integrity",
+      "acceptance_gates:",
+      "  - gate one",
+      "  - gate two",
+      "must_not:",
+      "  - prohibition one",
+      "",
+    ].join("\n");
+    const resolution = resolveExtensionState(doc);
+    expect(resolution).toEqual({ state: "valid", kind: "workflow-extension" });
+    if (resolution.state === "valid") {
+      const parsed = parseExtensionYaml(doc);
+      expect(parsed.ok).toBe(true);
+      if (parsed.ok) {
+        const data = parsed.data as Record<string, unknown>;
+        expect(validateExtensionEntries(data)).toEqual([]);
+        expect((data.acceptance_gates as string[]).length).toBe(2);
+      }
+    }
+  });
+});
+
+describe("validateExtensionEntries (entry structure validation)", () => {
+  test("accepts the legacy wording source shapes", () => {
+    const doc = parseExtensionYaml(
+      'version: 1\nkind: workflow-extension\nid: x\n\ncontext:\n  - id: c1\n    paths:\n      - "docs/a.md"\nrules: []\nchecks: []\nacceptance_gates:\n  - gate\nmust_not: []\n',
+    );
+    expect(doc.ok).toBe(true);
+    if (doc.ok) expect(validateExtensionEntries(doc.data)).toEqual([]);
+  });
+
+  test("rejects non-object section entries with the legacy message", () => {
+    const messages = validateExtensionEntries({
+      context: ["not-an-object"],
+      rules: [],
+      checks: [],
+      acceptance_gates: [],
+      must_not: [],
+    });
+    expect(messages).toContain("context[0] must be an object");
+  });
+
+  test("rejects entries missing the id string with the legacy message", () => {
+    const messages = validateExtensionEntries({
+      context: [{ when: "always" }],
+      rules: [{ when: "x" }],
+      checks: [],
+      acceptance_gates: [],
+      must_not: [],
+    });
+    expect(messages).toContain("context[0] missing 'id' string");
+    expect(messages).toContain("rules[0] missing 'id' string");
+  });
+
+  test("rejects non-string acceptance_gates / must_not elements", () => {
+    const messages = validateExtensionEntries({
+      context: [],
+      rules: [],
+      checks: [],
+      acceptance_gates: [1],
+      must_not: [true],
+    });
+    expect(messages).toContain("acceptance_gates[0] must be a string");
+    expect(messages).toContain("must_not[0] must be a string");
+  });
+
+  test("rejects wrong entry field shapes (when, paths)", () => {
+    const messages = validateExtensionEntries({
+      context: [{ id: "c1", when: 1, paths: "docs/a.md" }],
+      rules: [],
+      checks: [],
+      acceptance_gates: [],
+      must_not: [],
+    });
+    expect(messages.some((m) => m.startsWith("context[0] field 'when' must be a string"))).toBe(true);
+    expect(messages.some((m) => m.startsWith("context[0] field 'paths' must be an array of strings"))).toBe(true);
+  });
+});

--- a/src/opencode/skills/agentdev-project-extensions/scripts/tsconfig.json
+++ b/src/opencode/skills/agentdev-project-extensions/scripts/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["lib/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
# Project Extensions の YAML 解析・構造検証を Bun.YAML と Zod へ委譲する（OU-001）

Closes #2352

## 概要

Issue #2352（親 Epic #2351、OU-001 / RU-0002 / REQ-044-001〜005、DEC-019）。
Project Extensions の YAML 構文解析を `Bun.YAML.parse` へ、構造検証を Zod へ委譲し、`check_extensions.ts` の独自実装（parseSimpleYaml）を除去した。
状態分類（missing / malformed / migration-required / schema-violation / valid）と旧kind・未知kind の意味判定は ADF 側に残留させ、外部契約（状態分類、fail-open 挙動、checker NG 報告契約）を移行前と同一に維持する。

## 変更点

### 配布側（共有実装の基点。新規作成）

`src/opencode/skills/agentdev-project-extensions/scripts/` を新設（runtime-package-boundary Design の scripts 配布境界に従う構成）。

- `lib/extension_state.ts`: 共有状態機械。
  - `parseExtensionYaml`: `Bun.YAML.parse` へ委譲し、例外を値（`{ ok: false, error }`）へ変換。実行時処理を直接異常終了させない
  - `resolveExtensionState`: 読込時状態分類（旧 `check_extensions.ts` のシグネチャ・判定順序・reason 文言を維持）。Zod（`ExtensionDocumentSchema`: version / kind / id / 5セクションの構造検証）+ kind 値の意味判定（旧kind → migration-required、公式3値外 → schema-violation）
  - `validateExtensionEntries`: 5セクション配列要素の構造検証（check #11 相当。`context[{id, when?, paths?, purpose?}]`、`rules/checks[{id, when?, skill?}]`、`acceptance_gates[string]`、`must_not[string]`）。Zod は構造検証のみを所有
  - 型差異の吸収: `version` は `z.union([z.literal(1), z.literal("1")])` とし、旧 `String(version) === "1"` 判定と意味同等（数値 1 とクォート文字列 "1" の双方を受理）
- `tests/extension_state.test.ts`: TS-002 回帰ケース（構文エラー、必須フィールド欠落、旧kind、未知kind、有効、空入力、型不正、クォート内コロン・`#`、CRLF、入れ子、配列、ルート非 mapping、quoted version）。anchor / alias / カスタムタグ / 複数ドキュメントは保証対象外のためテスト不含
- `package.json` / `bun.lock`: `zod ^4.0.0` を追加（agentdev-artifact-graph scripts と同一の解決経路、DEC-014）
- `tsconfig.json` / `.gitignore`（node_modules 除外）/ `README.md`

### repo-local 側（配布側実装への参照）

`.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts`:

- `parseSimpleYaml`（独自 YAML 構文解析、約110行）を削除
- `ExtensionKind` / `NEW_EXTENSION_KINDS` / `LEGACY_EXTENSION_KINDS` / `ExtensionResolution` / `resolveExtensionState` を配布側 lib からの re-export に置換（既存 import 互換のため同一モジュール表面を維持。`check_workflow_preventive.ts` の `deriveSkillClassification` import は無影響）
- `walkExtension` の要素構造検査（check #11）を `validateExtensionEntries`（Zod）へ置換。paths / skills 収集と override 検出（check #13）は checker 側に維持
- 参照は src/opencode/ 相対 import（main の junction 環境・worktree の junction 未設定環境の双方で同一解決、REQ-018）
- 配布側実装から repo-local 成果物への依存は存在しない（依存方向は repo-local → 配布側のみ）

### 経路G（adversarial-review）省略について

adapter protocol 上の経路G review は省略した。実装方式（委譲先、例外→状態変換、Zod 適用範囲、状態意味論の ADF 残留、共有実装の配置方向、配布境界、回帰ケース）がすべて `docs/designs/foundations/project-extensions.md`「YAML 解析と構造検証の実装契約」・DEC-019・runtime-package-boundary Design により機械的に確定しており、Design 契約から自明であるため（委譲 prompt のスキップ条件に該当）。

## 完了条件

- [x] 対象スコープにおいて YAML 構文解析が `Bun.YAML.parse` へ委譲され、parseSimpleYaml 相当の独自実装が除去されていること（全使用箇所の確認証拠付き → テスト結果の残存検索参照）
- [x] 構造検証が Zod により行われ、`version`、`kind`、`id`、`context`、`rules`、`checks`、`acceptance_gates`、`must_not`、各配列要素が検証されていること
- [x] 状態分類と fail-open 挙動が移行前と同一の結果であること（回帰ケース全件 → テスト結果参照）
- [x] anchor、alias、カスタムタグ、複数ドキュメントを保証対象とする仕様・テストが追加されていないこと（配布側テストは保証範囲内のみ。保証外機能の挙動は下記「検証メモ」に記録のみ）
- [x] Zod 依存が package.json / bun.lock で管理され、自己適用環境と利用先相当環境の双方で対象テストが実行できること（REQ-044-004 → TS-005 結果参照）
- [x] 対応する ADF 実行環境（Bun）で Bun.YAML の可用性が実行検証されていること（REQ-044-005 → TS-004 結果参照。bun 1.3.10 で利用可）

## テスト結果 / 検証証拠

実行環境: bun 1.3.10、worktree `.worktrees/2352-feature`（ju則nction 未設定・src/opencode 直参照環境）。

### TS-004: Bun.YAML 可用性実行検証

```
bun -e "Bun.YAML.parse('version: 1\n...')"
→ パース成功: {"version":1,"kind":"workflow-extension","context":[]}
→ 構文エラー入力: throw "YAML Parse error: Unexpected token"（例外は parseExtensionYaml で値へ変換）
```

配布側テストの `parseExtensionYaml` describe（マッピング/配列/文字列/数値/真偽値/null/入れ子のパース実行を含む）も可用性の実行証拠。

### TS-002: YAML 状態分類回帰（配布側テスト）

```
cd src/opencode/skills/agentdev-project-extensions/scripts && bun test
→ 21 pass / 0 fail / 47 expect
```

カバー: 構文エラー→malformed、空入力→malformed、必須フィールド欠落→malformed、型不正（version: 2 / version: true / kind: 123 / context: 文字列 / context: {}）→malformed、ルート非 mapping→malformed、旧kind×2→migration-required、未知kind→schema-violation、公式3kind→valid、quoted "1"→valid、クォート内コロン・`#`→valid、CRLF→valid、入れ子・配列→valid、`validateExtensionEntries` の要素構造違反メッセージ（旧 checker 文言互換）。

### TS-002: repo-local checker 回帰

```
cd .opencode/skills/repo-agentdev-integrity/scripts
bun test check_extensions.test.ts       → 12 pass / 0 fail
bun check_extensions.ts --scenario      → 9/9 scenarios passed
bun test check_workflow_preventive.test.ts → 19 pass / 0 fail（check_extensions import 経由の間接影響なし）
```

```
bun .opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts .（worktree root から）
→ ok: true / failures: 0
→ workflow_extensions: 16, internal_workflow_extensions: 0, capability_extensions: 13
→ migration_required_entries: 0, schema_violation_entries: 0, malformed_entries: 0（exit 0）
```

現在有効な extension 29件がすべて移行前と同一の valid 分類、stats 同一、checker NG 報告契約（ok=true・exit 0）維持。

### TS-001: 独自実装残存の全使用箇所検索

```
rg -n "parseSimpleYaml" --no-ignore --hidden -g "!node_modules" .
→ コード出現 0 件（唯一のマッチは Design 契約文言 docs/designs/foundations/project-extensions.md の「残存させない」規定）
```

Project Extensions 入力処理（`.agentdev/extensions/**`）を扱うコードは `check_extensions.ts` のみで、当該ファイル内の独自 YAML 構文解析は消滅。同一入力に対する二重解析経路なし（resolveExtensionState 内と checker の walk 用に Bun.YAML.parse を標準 API として再呼出しする箇所はあるが、独自実装と標準 API の二重経路には該当しない）。

### TS-005: 依存解決（自己適用 + 利用先相当）

```
cd src/opencode/skills/agentdev-project-extensions/scripts
bun install                                  → zod 4.4.3 他 6 packages（bun.lock 生成）
bunx tsc --noEmit                            → 合格（exit 0）
bun test                                     → 21 pass / 0 fail
# fresh consumer 相当: node_modules 削除 → bun install → bun test
Remove-Item -Recurse -Force node_modules; bun install && bun test
→ 6 packages installed / 21 pass / 0 fail（bun.lock からの再現解決を確認）
```

repo-local checker テストは配布側 scripts の node_modules を介して zod を解決（importing file 位置基準。repo-local scripts の package.json への zod 追加は不要 — zod を直接 import するのは配布側 lib のみ）。

### 型チェック

```
cd src/opencode/skills/agentdev-project-extensions/scripts && bunx tsc --noEmit → exit 0
```

`Bun.YAML` の型は `@types/bun@1.3.14` に同梱（ambient 宣明不要）。

### 検証メモ（保証対象外機能の挙動、記録のみ・仕様化・テスト化なし）

- 複数ドキュメント（`---` 区切り）: `Bun.YAML.parse` は配列を返すため、本実装では schema 違反→malformed として分類される。クラッシュなし。保証対象外につき挙動を保証しない
- anchor / alias: `Bun.YAML.parse` は解決結果を返す（クラッシュなし）。保証対象外につき挙動を保証しない

## Findings / Capture候補

- check_workflow_preventive.ts の `extractYamlField`（正規表現 `^field:\s*(\S+)$` による単一トップレベルフィールド行抽出）が `.agentdev/extensions/skills/**` の YAML から kind / id を抽出している。ドキュメント全体を構造化する構文解析ではなく状態機械の入力でもないため本 Issue の移行対象からは除外したが、「Project Extensions YAML 入力からのフィールド抽出が正規表現と Bun.YAML の2経路」と見なせる余地がある。判定は ambiguous なため本 PR では対象化せず記録する。共有 lib の resolveExtensionState 再利用への統合は後続候補（移行の性質上 RU-0002 の「二重経路残存なし」の解釈次第）
- 宣言的データ YAML（`data/*.yaml`）の読み取り（check_integrity.ts、check_delegation_contract_residual.ts 等）は checker-execution-contracts Design「宣言的データ YAML の schema 原則」管轄であり Project Extensions 入力処理ではないため、本案スコープ外であることを確認済み

### distribution-boundary

- 検出内容: 配布依存境界 最終 gate（STEP-S5-1、`check_distribution_boundary.ts --profile source`）で concrete-id 8件・unclassified-entry 4件の計12件。いずれも本 PR で新規追加した配布物（`src/opencode/skills/agentdev-project-extensions/scripts/`）のコメント・description 中の producer 内部 ID 参照（REQ-044 / DEC-019 / TS-002 / TS-004 / UC-001）
- 対応: 該当箇所のコメント一般化（package.json description、README.md、lib/extension_state.ts、tests/extension_state.test.ts）。検出対象外だった `docs/designs` パス参照（コメント中の契約出所表記、テストフィクスチャ内パス文字列）も producer 内部参照となるため併せて除去・一般化。機能コードは無変更（コメント・description・テストデータのみ）
- 再実行結果: gate ok=true / exit 0（scanned_files 336、concrete_id_hits 0、concrete_path_hits 0、fixed_url_hits 0）、配布側テスト 21 pass / 0 fail、repo-local check_extensions テスト 12 pass / 0 fail

## Design確定候補

- 共有実装の物理構成: 配布側 `src/opencode/skills/agentdev-project-extensions/scripts/lib/extension_state.ts` が状態機械の単一実装（`parseExtensionYaml` / `resolveExtensionState` / `validateExtensionEntries` の3公開API）。repo-local checker は src/opencode/ 相対 import で参照（main junction 環境・worktree 環境の双方で同一解決）。OU-002（再帰探索移行 #2353）の共有実装配置の入力となる確定事項
- `resolveExtensionState` の公開契約は移行前のシグネチャ・戻り値型を維持（runtime resolver 契約と deterministic checker の接合点）。YAML 構文エラー時の reasons は `YAML syntax error: <message>`（旧実装は 構文エラーが必須フィールド欠落 reason に劣化していたが、状態は同一の malformed）
- 配列要素構造検証は読込時状態判定（`resolveExtensionState`）と区別し、deterministic checker の check #11 として維持（外部契約の状態分類タイミング不変）。この2段構成は lib 内で `ExtensionDocumentSchema`（load-time）と `ExtensionEntriesSchema`（check #11）の2スキーマとして表現

## 決定事項

- Issue 完了条件チェックボックスの更新は case-close の責務のため本 PR では行わない

