### PR TITLE
feat(agentdev): CLI 引数解析実装を node:util.parseArgs へ移行（Issue #2354）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.test.ts
@@ -121,6 +121,103 @@ describe("parseArgs", () => {
   });
 });
 
+// 移行前受理・拒否挙動の固定（Issue #2354 / OU-003、REQ-044-003）。
+// 期待値は手書きループパーサの挙動であり、node:util.parseArgs 移行後も同一結果を要求する。
+describe("parseArgs acceptance data (pre-migration fix, OU-003)", () => {
+  it("consumes the next arg unconditionally as an option value (--root --profile)", () => {
+    const opts = parseArgs(["--root", "--profile", "nope"]);
+    expect(opts.root).toBe("--profile");
+    expect(opts.profile).toBe("source");
+    expect(opts.paths).toEqual(["nope"]);
+  });
+
+  it("ignores unknown options silently (--unknown v)", () => {
+    const opts = parseArgs(["--unknown", "v", "--json"]);
+    expect(opts.json).toBe(true);
+    expect(opts.paths).toEqual(["v"]);
+  });
+
+  it("ignores unknown short options (-x)", () => {
+    const opts = parseArgs(["-x", "src"]);
+    expect(opts.help).toBe(false);
+    expect(opts.paths).toEqual(["src"]);
+  });
+
+  it("ignores short option clusters (-hx keeps help false)", () => {
+    const opts = parseArgs(["-hx"]);
+    expect(opts.help).toBe(false);
+  });
+
+  it("ignores --option=value form for string options (--root=/x)", () => {
+    const opts = parseArgs(["--root=/x"]);
+    expect(opts.root).toBeUndefined();
+    expect(opts.paths).toEqual([]);
+  });
+
+  it("ignores --option=value form for boolean options (--json=true)", () => {
+    const opts = parseArgs(["--json=true"]);
+    expect(opts.json).toBe(false);
+  });
+
+  it("ignores --profile=release entirely (no archive requirement triggered)", () => {
+    const opts = parseArgs(["--profile=release", "--archive", "/tmp/x.zip"]);
+    expect(opts.profile).toBe("source");
+    expect(opts.archive).toBe("/tmp/x.zip");
+  });
+
+  it("treats -- as an inert arg and keeps parsing options after it (-- --json foo)", () => {
+    const opts = parseArgs(["--", "--json", "foo"]);
+    expect(opts.json).toBe(true);
+    expect(opts.paths).toEqual(["foo"]);
+  });
+
+  it("treats a lone -- before a path as inert (-- foo)", () => {
+    const opts = parseArgs(["--", "foo"]);
+    expect(opts.paths).toEqual(["foo"]);
+  });
+
+  it("consumes -- as an option value when it follows --root (--root -- x)", () => {
+    const opts = parseArgs(["--root", "--", "x"]);
+    expect(opts.root).toBe("--");
+    expect(opts.paths).toEqual(["x"]);
+  });
+
+  it("ignores a lone - as an unknown arg", () => {
+    const opts = parseArgs(["-", "foo"]);
+    expect(opts.paths).toEqual(["foo"]);
+  });
+
+  it("last occurrence wins for duplicate string options", () => {
+    expect(parseArgs(["--root", "a", "--root", "b"]).root).toBe("b");
+  });
+
+  it("duplicate boolean flags stay true", () => {
+    expect(parseArgs(["--json", "--json"]).json).toBe(true);
+  });
+
+  it("throws for an empty string value of --root", () => {
+    expect(() => parseArgs(["--root", ""])).toThrow(/--root requires a value/);
+  });
+
+  it("throws for an empty string value of --profile", () => {
+    expect(() => parseArgs(["--profile", ""])).toThrow(
+      /--profile requires a value/,
+    );
+  });
+
+  it("reports the first offending option in argv order (--profile nope --root)", () => {
+    expect(() => parseArgs(["--profile", "nope", "--root"])).toThrow(
+      /--profile must be one of/,
+    );
+  });
+
+  it("rejects an unknown --profile value passed after a valid --root", () => {
+    expect(() => parseArgs(["--root", "/r", "--profile", "nope"])).toThrow(
+      /--profile must be one of: source, installed, release \(got 'nope'\)/,
+    );
+  });
+});
+
 describe("printHelp", () => {
   it("outputs USAGE, OPTIONS, and EXIT CODES sections", () => {
     const logs: string[] = [];

--- a/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts
@@ -10,6 +10,8 @@
  * - Exit codes: 0 (ok), 1 (check failed), 2 (input error)
  * - No destructive operations
  */
+import { parseArgs as nodeParseArgs } from "node:util";
+
 export const EXIT_OK = 0;
 export const EXIT_NG = 1;
 export const EXIT_ERROR = 2;
@@ -93,53 +95,185 @@ export interface CliOptions {
   archive?: string; // WP-3: required when profile=release
 }
 
-export function parseArgs(args: string[]): CliOptions {
-  const options: CliOptions = {
-    help: false,
-    json: false,
-    dryRun: false,
-    classification: false, // REQ-0108-196
-    paths: [],
-    profile: DEFAULT_PROFILE,
-  };
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === "--help" || arg === "-h") {
-      options.help = true;
-    } else if (arg === "--json") {
-      options.json = true;
-    } else if (arg === "--dry-run") {
-      options.dryRun = true;
-    } else if (arg === "--classification") { // REQ-0108-196
-      options.classification = true;
-    } else if (arg === "--root") { // REQ-0145-014
-      const v = args[i + 1];
-      if (!v) throw new Error("--root requires a value");
-      options.root = v;
-      i++;
-    } else if (arg === "--profile") { // WP-3 (Issue #1928)
-      const v = args[i + 1];
-      if (!v) throw new Error("--profile requires a value (source|installed|release)");
-      if (!PROFILE_VALUES.includes(v as IntegrityProfile)) {
-        throw new Error(
-          `--profile must be one of: ${PROFILE_VALUES.join(", ")} (got '${v}')`,
-        );
-      }
-      options.profile = v as IntegrityProfile;
-      i++;
-    } else if (arg === "--archive") { // WP-3 (Issue #1928): release profile
-      const v = args[i + 1];
-      if (!v) throw new Error("--archive requires a value (path to release zip)");
-      options.archive = v;
-      i++;
-    } else if (!arg.startsWith("-")) {
-      options.paths.push(arg);
+// node:util.parseArgs への委譲（Issue #2354 / OU-003、DEC-019 決定1）。
+// 構文解析（オプションと値の結合、`=` 形式、短縮クラスタ、`--`）は標準 API が行い、
+// 許容値・必須性・プロファイル依存等の ADF 固有意味検証は後段に残留する。
+// 旧実装が未知引数として無視していた形式（`--opt=value`、短縮クラスタ、`--`）は
+// 標準 API が受理しても公開 CLI 仕様として新規保証しない（REQ-044-003）。
+// strict:false では値を持たない文字列オプションが true になるため、
+// token の value === undefined で値欠落を判別する。
+
+interface ParsedTokenOption {
+  kind: "option";
+  index: number;
+  name: string;
+  rawName: string;
+  value?: string;
+  inlineValue?: boolean;
+}
+interface ParsedTokenPositional {
+  kind: "positional";
+  index: number;
+  value: string;
+}
+interface ParsedTokenTerminator {
+  kind: "option-terminator";
+  index: number;
+}
+type ParsedToken =
+  | ParsedTokenOption
+  | ParsedTokenPositional
+  | ParsedTokenTerminator;
+
+interface ParsedSegment {
+  values: Record<string, string | boolean>;
+  tokens: ParsedToken[];
+}
+
+const CLI_PARSE_OPTIONS = {
+  help: { type: "boolean", short: "h" },
+  json: { type: "boolean" },
+  "dry-run": { type: "boolean" },
+  classification: { type: "boolean" },
+  root: { type: "string" },
+  profile: { type: "string" },
+  archive: { type: "string" },
+} as const;
+
+function parseSegment(args: readonly string[]): ParsedSegment {
+  return nodeParseArgs({
+    args: [...args],
+    options: CLI_PARSE_OPTIONS,
+    strict: false,
+    allowPositionals: true,
+    tokens: true,
+  }) as unknown as ParsedSegment;
+}
+
+function clusterArgIndexes(tokens: readonly ParsedToken[]): Set<number> {
+  const counts = new Map<number, number>();
+  for (const t of tokens) {
+    if (t.kind === "option" && !t.rawName.startsWith("--")) {
+      counts.set(t.index, (counts.get(t.index) ?? 0) + 1);
     }
   }
-  if (options.profile === "release" && !options.archive) {
+  const clustered = new Set<number>();
+  for (const [index, count] of counts) {
+    if (count > 1) clustered.add(index);
+  }
+  return clustered;
+}
+
+interface SegmentOptions {
+  help: boolean;
+  json: boolean;
+  dryRun: boolean;
+  classification: boolean;
+  paths: string[];
+  root?: string;
+  profile?: string;
+  archive?: string;
+}
+
+function buildSegmentOptions(segment: ParsedSegment): SegmentOptions {
+  const { values, tokens } = segment;
+  const clustered = clusterArgIndexes(tokens);
+  const ignored = new Set<string>();
+  for (const t of tokens) {
+    if (t.kind !== "option") continue;
+    if (t.inlineValue === true || clustered.has(t.index)) ignored.add(t.name);
+  }
+  for (const name of ignored) delete values[name];
+  for (const t of tokens) {
+    if (t.kind !== "option" || t.inlineValue === true || clustered.has(t.index))
+      continue;
+    if (t.value === undefined || t.value === "") {
+      if (t.name === "root") throw new Error("--root requires a value");
+      if (t.name === "profile")
+        throw new Error(
+          "--profile requires a value (source|installed|release)",
+        );
+      if (t.name === "archive")
+        throw new Error("--archive requires a value (path to release zip)");
+    }
+    if (
+      t.name === "profile" &&
+      !PROFILE_VALUES.includes(t.value as IntegrityProfile)
+    ) {
+      throw new Error(
+        `--profile must be one of: ${PROFILE_VALUES.join(", ")} (got '${t.value}')`,
+      );
+    }
+  }
+  const paths: string[] = [];
+  for (const t of tokens) {
+    if (t.kind === "positional" && !t.value.startsWith("-")) paths.push(t.value);
+  }
+  return {
+    help: values.help === true,
+    json: values.json === true,
+    dryRun: values["dry-run"] === true,
+    classification: values.classification === true,
+    paths,
+    root: typeof values.root === "string" ? values.root : undefined,
+    profile: typeof values.profile === "string" ? values.profile : undefined,
+    archive: typeof values.archive === "string" ? values.archive : undefined,
+  };
+}
+
+function mergeSegmentOptions(
+  pre: SegmentOptions,
+  post: SegmentOptions,
+): SegmentOptions {
+  return {
+    help: pre.help || post.help,
+    json: pre.json || post.json,
+    dryRun: pre.dryRun || post.dryRun,
+    classification: pre.classification || post.classification,
+    paths: [...pre.paths, ...post.paths],
+    root: post.root ?? pre.root,
+    profile: post.profile ?? pre.profile,
+    archive: post.archive ?? pre.archive,
+  };
+}
+
+function parseSegmentOptions(args: readonly string[]): SegmentOptions {
+  const segment = parseSegment(args);
+  const terminator = segment.tokens.find(
+    (t): t is ParsedTokenTerminator => t.kind === "option-terminator",
+  );
+  if (terminator) {
+    // 旧実装では `--` は不活性な未知引数であり、終端意味論を持たない
+    // （`--` 以降の引数も通常どおり解釈される）。標準 API の終端処理を適用しない
+    // ため、`--` の前後を再帰的に解析して旧の全 argv 走査順を再現する。
+    // ただし値を要求するオプションの直後の `--` は値として結合されるため
+    // 終端 token にはならない。
+    return mergeSegmentOptions(
+      parseSegmentOptions(args.slice(0, terminator.index)),
+      parseSegmentOptions(args.slice(terminator.index + 1)),
+    );
+  }
+  return buildSegmentOptions(segment);
+}
+
+export function parseArgs(args: string[]): CliOptions {
+  const merged = parseSegmentOptions(args);
+  // buildSegmentOptions が PROFILE_VALUES 外の値を拒否しているため、
+  // ここに到達する profile は必ず妥当な IntegrityProfile である。
+  const profile = (merged.profile ?? DEFAULT_PROFILE) as IntegrityProfile;
+  if (profile === "release" && !merged.archive) {
     throw new Error("--profile release requires --archive <zip-path>");
   }
-  return options;
+  return {
+    help: merged.help,
+    json: merged.json,
+    dryRun: merged.dryRun,
+    classification: merged.classification,
+    paths: merged.paths,
+    root: merged.root,
+    profile,
+    archive: merged.archive,
+  };
 }
 
 export function printHelp(

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/cli.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/cli.ts
@@ -16,6 +16,7 @@
 // validate itself, so the bootstrap report is produced by an independent
 // code path that reads base_oid only.
 
+import { parseArgs as nodeParseArgs } from "node:util";
 import { runLauncher } from "./launcher.ts";
 import { bootstrapDigestReport } from "./bootstrap-report.ts";
 import { ExitCode } from "./types.ts";
@@ -31,7 +32,84 @@ interface ParsedArgs {
   readonly bootstrap_mode: boolean;
 }
 
+// node:util.parseArgs への委譲（Issue #2354 / OU-003、DEC-019 決定1）。
+// 構文解析（値結合、`=` 形式、短縮クラスタ、`--`）は標準 API が行う。
+// 本 CLI は strict parser 契約（未知引数は無声受理しない）のため、未知 token を
+// 旧実装と同一のメッセージ・終了コードで拒否する。オプション間の必須検証は
+// mainInner 側の ADF 検証として残留する。
+// strict:false では値を持たない文字列オプションが true になるため、
+// token の value === undefined を値欠落（= 未指定）として扱う。
+
+const CLI_OPTIONS = {
+  "base-oid": { type: "string" },
+  "candidate-oid": { type: "string" },
+  "repo-root": { type: "string" },
+  "output-dir": { type: "string" },
+  "repository-identity": { type: "string" },
+  "default-branch": { type: "string" },
+  "bootstrap-report": { type: "string" },
+  "bootstrap-mode": { type: "boolean" },
+  "seed-mode": { type: "boolean" },
+  help: { type: "boolean", short: "h" },
+} as const;
+
+interface CliTokenOption {
+  kind: "option";
+  index: number;
+  name: string;
+  rawName: string;
+  value?: string;
+  inlineValue?: boolean;
+}
+interface CliTokenPositional {
+  kind: "positional";
+  index: number;
+  value: string;
+}
+interface CliTokenTerminator {
+  kind: "option-terminator";
+  index: number;
+}
+type CliToken = CliTokenOption | CliTokenPositional | CliTokenTerminator;
+
+function clusterArgIndexes(tokens: readonly CliToken[]): Set<number> {
+  const counts = new Map<number, number>();
+  for (const t of tokens) {
+    if (t.kind === "option" && !t.rawName.startsWith("--")) {
+      counts.set(t.index, (counts.get(t.index) ?? 0) + 1);
+    }
+  }
+  const clustered = new Set<number>();
+  for (const [index, count] of counts) {
+    if (count > 1) clustered.add(index);
+  }
+  return clustered;
+}
+
+function rejectUnknownArgument(a: string): never {
+  // Unknown args are an error: strict parser, no silent acceptance.
+  process.stderr.write(`cli.ts: unknown argument: ${a}\n`);
+  process.exit(ExitCode.InputContract);
+}
+
 function parseArgs(argv: readonly string[]): ParsedArgs {
+  const { tokens } = nodeParseArgs({
+    args: [...argv],
+    options: CLI_OPTIONS,
+    strict: false,
+    allowPositionals: true,
+    tokens: true,
+  }) as unknown as { tokens: CliToken[] };
+  const clustered = clusterArgIndexes(tokens);
+  const clusterShorts = new Map<number, string[]>();
+  for (const t of tokens) {
+    if (t.kind === "option" && clustered.has(t.index)) {
+      const shorts = clusterShorts.get(t.index) ?? [];
+      shorts.push(t.rawName.slice(1));
+      clusterShorts.set(t.index, shorts);
+    }
+  }
+
   const result: {
     mode: "run" | "report";
     base_oid?: string;
@@ -46,25 +124,57 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
     default_branch: "main",
     bootstrap_mode: false,
   };
-  for (let i = 0; i < argv.length; i++) {
-    const a = argv[i] ?? "";
-    switch (a) {
-      case "--base-oid": result.base_oid = argv[++i]; break;
-      case "--candidate-oid": result.candidate_oid = argv[++i]; break;
-      case "--repo-root": result.repo_root = argv[++i]; break;
-      case "--output-dir": result.output_dir = argv[++i]; break;
-      case "--repository-identity": result.repository_identity = argv[++i]; break;
-      case "--default-branch": result.default_branch = argv[++i] ?? "main"; break;
-      case "--bootstrap-mode": result.bootstrap_mode = true; break;
-      case "--seed-mode": result.bootstrap_mode = true; break;
-      case "--bootstrap-report": result.mode = "report"; result.base_oid = argv[++i]; break;
-      case "--help": case "-h":
-        printUsage();
-        process.exit(0);
-      default:
-        // Unknown args are an error: strict parser, no silent acceptance.
-        process.stderr.write(`cli.ts: unknown argument: ${a}\n`);
-        process.exit(ExitCode.InputContract);
+
+  for (const t of tokens) {
+    if (t.kind === "option" && clustered.has(t.index)) {
+      // 短縮クラスタ（-hx 等）は分割前の元引数として拒否する。
+      rejectUnknownArgument("-" + (clusterShorts.get(t.index) ?? []).join(""));
+    }
+    if (t.kind === "positional") {
+      rejectUnknownArgument(t.value);
+    }
+    if (t.kind === "option-terminator") {
+      rejectUnknownArgument("--");
+    }
+    // t is an option token, not a cluster member.
+    if (t.inlineValue === true) {
+      // `--opt=value` 形式は旧実装では未知引数のため、元引数として拒否する。
+      rejectUnknownArgument(`${t.rawName}=${t.value}`);
+    }
+    if (t.name === "help") {
+      printUsage();
+      process.exit(0);
+    }
+    if (!(t.name in CLI_OPTIONS)) {
+      rejectUnknownArgument(t.rawName);
+    }
+    switch (t.name) {
+      case "base-oid":
+        result.base_oid = t.value;
+        break;
+      case "candidate-oid":
+        result.candidate_oid = t.value;
+        break;
+      case "repo-root":
+        result.repo_root = t.value;
+        break;
+      case "output-dir":
+        result.output_dir = t.value;
+        break;
+      case "repository-identity":
+        result.repository_identity = t.value;
+        break;
+      case "default-branch":
+        result.default_branch = t.value ?? "main";
+        break;
+      case "bootstrap-mode":
+      case "seed-mode":
+        result.bootstrap_mode = true;
+        break;
+      case "bootstrap-report":
+        result.mode = "report";
+        result.base_oid = t.value;
+        break;
     }
   }
   return result;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/cli_args.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/cli_args.test.ts
@@ -1,0 +1,136 @@
+// CLI argument acceptance data for cli.ts, fixed before the node:util.parseArgs
+// migration (Issue #2354 / OU-003, REQ-044-003). Expectations pin the current
+// hand-written switch parser; the migrated parser must reproduce them exactly.
+// Spawns `bun cli.ts` directly (no PowerShell entry) and asserts exit code and
+// stderr/stdout contracts.
+
+import { describe, expect, test } from "bun:test";
+import { join } from "path";
+
+const CLI = join(import.meta.dir, "cli.ts");
+
+function runCli(args: readonly string[]): { stdout: string; stderr: string; code: number } {
+  const r = Bun.spawnSync(["bun", CLI, ...args]);
+  return {
+    stdout: r.stdout.toString(),
+    stderr: r.stderr.toString(),
+    code: r.exitCode,
+  };
+}
+
+describe("cli.ts argument acceptance data (pre-migration fix, OU-003)", () => {
+  test("--help prints usage to stdout and exits 0", () => {
+    const r = runCli(["--help"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("usage: bun cli.ts");
+  });
+
+  test("-h is the short form of --help", () => {
+    const r = runCli(["-h"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("usage: bun cli.ts");
+  });
+
+  test("no args reports missing required argument(s) with exit 8", () => {
+    const r = runCli([]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain("cli.ts: missing required argument(s)");
+  });
+
+  test("unknown long option is rejected with exit 8", () => {
+    const r = runCli(["--bogus"]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain("cli.ts: unknown argument: --bogus");
+  });
+
+  test("unknown short option is rejected with exit 8", () => {
+    const r = runCli(["-x"]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain("cli.ts: unknown argument: -x");
+  });
+
+  test("short option cluster is rejected as the original arg with exit 8", () => {
+    const r = runCli(["-hx"]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain("cli.ts: unknown argument: -hx");
+  });
+
+  test("positional argument is rejected as unknown with exit 8", () => {
+    const r = runCli(["foo"]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain("cli.ts: unknown argument: foo");
+  });
+
+  test("--option=value form is rejected as unknown with exit 8", () => {
+    const r = runCli(["--base-oid=x"]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain("cli.ts: unknown argument: --base-oid=x");
+  });
+
+  // bun's own CLI strips a leading `--` from the script argv, so a bare `--`
+  // is observable only in a non-leading position.
+  test("mid-position -- is rejected as unknown with exit 8", () => {
+    const r = runCli(["--candidate-oid", "c", "--"]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain("cli.ts: unknown argument: --");
+  });
+
+  test("--help wins when it appears before an unknown arg", () => {
+    const r = runCli(["--help", "--bogus"]);
+    expect(r.code).toBe(0);
+  });
+
+  test("unknown arg wins when it appears before --help", () => {
+    const r = runCli(["--bogus", "--help"]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain("cli.ts: unknown argument: --bogus");
+  });
+
+  test("--base-oid without a value (trailing) is treated as missing required (exit 8)", () => {
+    const r = runCli([
+      "--candidate-oid", "c",
+      "--repo-root", "r",
+      "--output-dir", "o",
+      "--repository-identity", "i",
+      "--base-oid",
+    ]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain("cli.ts: missing required argument(s)");
+  });
+
+  test("--base-oid consumes the next option name as its value, rejecting the orphaned value (exit 8)", () => {
+    const r = runCli([
+      "--base-oid",
+      "--candidate-oid", "c",
+      "--repo-root", "r",
+    ]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain("cli.ts: unknown argument: c");
+  });
+
+  test("empty string --base-oid is treated as missing required (exit 8)", () => {
+    const r = runCli([
+      "--base-oid", "",
+      "--candidate-oid", "c",
+      "--repo-root", "r",
+      "--output-dir", "o",
+      "--repository-identity", "i",
+    ]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain("cli.ts: missing required argument(s)");
+  });
+
+  test("-- consumed as an option value leaves the next arg rejected (exit 8)", () => {
+    const r = runCli(["--repo-root", "--", "x"]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain("cli.ts: unknown argument: x");
+  });
+
+  test("--bootstrap-report with a value but no --repo-root reports the report-mode requirement (exit 8)", () => {
+    const r = runCli(["--bootstrap-report", "oid"]);
+    expect(r.code).toBe(8);
+    expect(r.stderr).toContain(
+      "cli.ts: --bootstrap-report requires --base-oid and --repo-root",
+    );
+  });
+});

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/src/query_graph.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/src/query_graph.ts
@@ -7,11 +7,10 @@ import { PROFILE_KINDS, type ProfileKind } from "../lib/tim.ts"
 import { runTraceQuery } from "../lib/trace_query.ts"
 import { runDiagnostics } from "../lib/trace_diagnostics.ts"
 
-// node:util.parseArgs への委譲（Issue #2354 / OU-003、DEC-019 決定1）。
-// 構文解析（値結合、`=` 形式、`--`、未知オプションの切り分け）は標準 API が行う。
-// サブコマンド解釈、位置引数スロット（argv index 基準）、初回出現優先のフラグ値
-// 取得は ADF 固有の意味解釈として本ファイルに残留する
-// （agentdev-artifact-graph Design「スクリプト実装の標準API移行」）。
+// 引数構文解析は node:util.parseArgs（strict:false + tokens）へ委譲し、
+// 既存の受理・拒否契約を維持する。サブコマンド解釈、位置引数スロット
+// （argv index 基準）、フラグ値の初回出現優先は本 CLI 固有の意味解釈として
+// このファイルに残留する。
 // strict:false では値を持たない文字列オプションが true になるため、
 // token の value === undefined を値欠落として扱う。
 

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/src/query_graph.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/src/query_graph.ts
@@ -1,3 +1,4 @@
+import { parseArgs as nodeParseArgs } from "node:util"
 import { resolve } from "node:path"
 import { loadGraph } from "../lib/graph.ts"
 import { loadAugmentation, resolveConfig, resolveTraceModel } from "../lib/augmentation.ts"
@@ -6,41 +7,89 @@ import { PROFILE_KINDS, type ProfileKind } from "../lib/tim.ts"
 import { runTraceQuery } from "../lib/trace_query.ts"
 import { runDiagnostics } from "../lib/trace_diagnostics.ts"
 
-function value(args: readonly string[], name: string, fallback: string): string {
-  const index = args.indexOf(name)
-  return index < 0 ? fallback : (args[index + 1] ?? fallback)
+// node:util.parseArgs への委譲（Issue #2354 / OU-003、DEC-019 決定1）。
+// 構文解析（値結合、`=` 形式、`--`、未知オプションの切り分け）は標準 API が行う。
+// サブコマンド解釈、位置引数スロット（argv index 基準）、初回出現優先のフラグ値
+// 取得は ADF 固有の意味解釈として本ファイルに残留する
+// （agentdev-artifact-graph Design「スクリプト実装の標準API移行」）。
+// strict:false では値を持たない文字列オプションが true になるため、
+// token の value === undefined を値欠落として扱う。
+
+interface QueryTokenOption {
+  kind: "option"
+  index: number
+  name: string
+  rawName: string
+  value?: string
+  inlineValue?: boolean
+}
+interface QueryTokenPositional {
+  kind: "positional"
+  index: number
+  value: string
+}
+interface QueryTokenTerminator {
+  kind: "option-terminator"
+  index: number
+}
+type QueryToken = QueryTokenOption | QueryTokenPositional | QueryTokenTerminator
+
+const VALUE_FLAG_OPTIONS = {
+  graph: { type: "string" },
+  root: { type: "string" },
+  depth: { type: "string" },
+  "max-depth": { type: "string" },
+  augmentation: { type: "string" },
+  roots: { type: "string" },
+  limit: { type: "string" },
+} as const
+
+function isValueFlagToken(t: QueryToken): t is QueryTokenOption {
+  return t.kind === "option" && t.name in VALUE_FLAG_OPTIONS && t.inlineValue !== true
 }
 
-function option(args: readonly string[], name: string): string | undefined {
-  const index = args.indexOf(name)
-  return index < 0 ? undefined : args[index + 1]
+interface ArgView {
+  /** argv index of the subcommand (first non value-flag arg), or -1 when absent */
+  readonly commandIndex: number
+  /** first-occurrence value of a value flag (`--depth` 等)。`=` 形式と値欠落は undefined */
+  flag(name: string): string | undefined
+  /** whether the value flag appears at all (値欠落も出現扱い) */
+  has(name: string): boolean
 }
 
-const FLAGS_WITH_VALUE = new Set(["--graph", "--root", "--depth", "--max-depth", "--augmentation", "--roots", "--limit"])
-
-function findSubcommandIndex(args: readonly string[]): number {
-  let i = 0
-  while (i < args.length) {
-    const arg = args[i]
-    if (arg === undefined) break
-    if (FLAGS_WITH_VALUE.has(arg)) {
-      i += 2 // skip flag + value
-      continue
+function parseArgView(args: readonly string[]): ArgView {
+  const parsed = nodeParseArgs({
+    args: [...args],
+    options: VALUE_FLAG_OPTIONS,
+    strict: false,
+    allowPositionals: true,
+    tokens: true,
+  }) as unknown as { tokens: QueryToken[] }
+  const flags = new Map<string, string | undefined>()
+  let commandIndex = -1
+  for (const t of parsed.tokens) {
+    if (commandIndex < 0 && !isValueFlagToken(t)) commandIndex = t.index
+    if (isValueFlagToken(t) && !flags.has(t.name)) {
+      // 旧実装の indexOf セマンティクスに合わせ初回出現を優先する。
+      flags.set(t.name, t.value)
     }
-    return i // first non-flag argument is the subcommand
   }
-  return -1
+  return {
+    commandIndex,
+    flag: (name: string) => flags.get(name.replace(/^-+/, "")),
+    has: (name: string) => flags.has(name.replace(/^-+/, "")),
+  }
 }
 
-function parseQuery(args: readonly string[]): GraphQuery {
-  const commandIndex = findSubcommandIndex(args)
+function parseQuery(view: ArgView, args: readonly string[]): GraphQuery {
+  const commandIndex = view.commandIndex
   if (commandIndex < 0) throw new TypeError("query subcommand required")
   const command = args[commandIndex]
   if (command === "neighbors") {
     return {
       kind: "neighbors",
       node: args[commandIndex + 1] ?? "",
-      depth: Number(value(args, "--depth", "1")),
+      depth: Number(view.flag("--depth") ?? "1"),
     }
   }
   if (command === "path") {
@@ -48,7 +97,7 @@ function parseQuery(args: readonly string[]): GraphQuery {
       kind: "path",
       source: args[commandIndex + 1] ?? "",
       target: args[commandIndex + 2] ?? "",
-      maxDepth: Number(value(args, "--max-depth", "4")),
+      maxDepth: Number(view.flag("--max-depth") ?? "4"),
     }
   }
   if (command === "provenance") {
@@ -58,8 +107,8 @@ function parseQuery(args: readonly string[]): GraphQuery {
     return {
       kind: "discover",
       term: args[commandIndex + 1] ?? "",
-      roots: parseList(args, "--roots"),
-      rootDir: resolve(option(args, "--root") ?? "."),
+      roots: parseList(view),
+      rootDir: resolve(view.flag("--root") ?? "."),
     }
   }
   if (command === "index") {
@@ -68,58 +117,56 @@ function parseQuery(args: readonly string[]): GraphQuery {
   throw new TypeError(`query must be one of: ${[...PROFILE_KINDS, "neighbors", "path", "provenance", "discover", "index"].join(", ")}`)
 }
 
-function parseList(args: readonly string[], name: string): readonly string[] {
-  const index = args.indexOf(name)
-  if (index < 0) return []
-  const v = args[index + 1] ?? ""
-  return v.split(",").filter(Boolean)
+function parseList(view: ArgView): readonly string[] {
+  if (!view.has("--roots")) return []
+  return (view.flag("--roots") ?? "").split(",").filter(Boolean)
 }
 
-function parseLimit(args: readonly string[]): number | undefined {
-  const raw = option(args, "--limit")
+function parseLimit(view: ArgView): number | undefined {
+  const raw = view.flag("--limit")
   return raw === undefined ? undefined : Number(raw)
 }
 
-function parseDepth(args: readonly string[]): number | undefined {
-  const raw = option(args, "--depth")
+function parseDepth(view: ArgView): number | undefined {
+  const raw = view.flag("--depth")
   return raw === undefined ? undefined : Number(raw)
 }
 
 async function runHighLevel(
+  view: ArgView,
   args: readonly string[],
   profile: ProfileKind,
-  commandIndex: number,
 ): Promise<string> {
-  const root = resolve(option(args, "--root") ?? ".")
-  const augmentation = await loadAugmentation(root, option(args, "--augmentation"))
-  const graph = await loadGraph(resolve(value(args, "--graph", ".agentdev/graph")))
+  const root = resolve(view.flag("--root") ?? ".")
+  const augmentation = await loadAugmentation(root, view.flag("--augmentation"))
+  const graph = await loadGraph(resolve(view.flag("--graph") ?? ".agentdev/graph"))
   const model = resolveTraceModel(graph.manifest, augmentation)
-  const limit = parseLimit(args)
+  const limit = parseLimit(view)
   if (profile === "diagnostics") {
     return JSON.stringify(runDiagnostics(graph, model, limit))
   }
-  const node = args[commandIndex + 1] ?? ""
-  return JSON.stringify(runTraceQuery(graph, model, profile, node, limit, parseDepth(args)))
+  const node = args[view.commandIndex + 1] ?? ""
+  return JSON.stringify(runTraceQuery(graph, model, profile, node, limit, parseDepth(view)))
 }
 
 export async function main(args: readonly string[] = process.argv.slice(2)): Promise<void> {
-  const commandIndex = findSubcommandIndex(args)
-  if (commandIndex < 0) throw new TypeError("query subcommand required")
-  const command = args[commandIndex] ?? ""
+  const view = parseArgView(args)
+  if (view.commandIndex < 0) throw new TypeError("query subcommand required")
+  const command = args[view.commandIndex] ?? ""
 
   if ((PROFILE_KINDS as readonly string[]).includes(command)) {
-    console.log(await runHighLevel(args, command as ProfileKind, commandIndex))
+    console.log(await runHighLevel(view, args, command as ProfileKind))
     return
   }
 
-  const query = parseQuery(args)
+  const query = parseQuery(view, args)
   // discover doesn't need a loaded graph; others do
   if (query.kind === "discover") {
     let roots = query.roots
-    if (!args.includes("--roots")) {
+    if (!view.has("--roots")) {
       // REQ-{NNNN}-{NNN}/011: resolve discovery_roots from the applied config;
       // an explicit --roots flag overrides for this run only.
-      const augmentation = await loadAugmentation(query.rootDir, option(args, "--augmentation"))
+      const augmentation = await loadAugmentation(query.rootDir, view.flag("--augmentation"))
       roots = resolveConfig(augmentation).discovery_roots
     }
     const graph = { manifest: {} as never, nodes: [], edges: [], provenance: [], diagnostics: [] }
@@ -127,7 +174,7 @@ export async function main(args: readonly string[] = process.argv.slice(2)): Pro
     return
   }
 
-  console.log(JSON.stringify(await queryGraph(await loadGraph(resolve(value(args, "--graph", ".agentdev/graph"))), query)))
+  console.log(JSON.stringify(await queryGraph(await loadGraph(resolve(view.flag("--graph") ?? ".agentdev/graph")), query)))
 }
 
 if (import.meta.main) {

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/tests/query_cli_args.test.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/tests/query_cli_args.test.ts
@@ -1,0 +1,126 @@
+// Argument acceptance data for query_graph.ts, fixed before the
+// node:util.parseArgs migration (Issue #2354 / OU-003, REQ-044-003).
+// Expectations pin the current indexOf/skip-2 parser; the migrated parser must
+// reproduce them exactly. Normal-path regressions (related/discover/neighbors
+// with real graphs) are covered by trace_cli.test.ts.
+
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import {
+  createTraceFixture,
+  traceAugmentationYaml,
+  REQ1_NODE,
+  SRC_NODE,
+  SRC_PATH,
+} from "./trace_fixture.ts"
+
+const roots: string[] = []
+const scriptRoot = resolve(import.meta.dir, "..", "src")
+
+function runCli(args: readonly string[]) {
+  return Bun.spawnSync(["bun", join(scriptRoot, "query_graph.ts"), ...args])
+}
+
+async function cliFixture() {
+  const root = await mkdtemp(join(tmpdir(), "ag-cli-args-"))
+  roots.push(root)
+  await createTraceFixture(root, traceAugmentationYaml({ indexRole: true }))
+  const output = join(root, ".agentdev", "graph")
+  const build = Bun.spawnSync(["bun", join(scriptRoot, "build_graph.ts"), "--root", root, "--output", output])
+  expect(build.exitCode).toBe(0)
+  return { root, output }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe("query_graph argument acceptance data: syntax errors (pre-migration fix, OU-003)", () => {
+  it("empty argv reports query subcommand required", () => {
+    const r = runCli([])
+    expect(r.exitCode).toBe(2)
+    expect(r.stderr.toString()).toContain("query subcommand required")
+  })
+
+  it("unknown subcommand reports the accepted list", () => {
+    const r = runCli(["bogus"])
+    expect(r.exitCode).toBe(2)
+    expect(r.stderr.toString()).toContain("query must be one of")
+  })
+
+  it("unknown long option is treated as the subcommand and rejected", () => {
+    const r = runCli(["--bogus", "N"])
+    expect(r.exitCode).toBe(2)
+    expect(r.stderr.toString()).toContain("query must be one of")
+  })
+
+  it("unknown short option is treated as the subcommand and rejected", () => {
+    const r = runCli(["-x", "N"])
+    expect(r.exitCode).toBe(2)
+    expect(r.stderr.toString()).toContain("query must be one of")
+  })
+
+  it("--option=value form is treated as the subcommand and rejected", () => {
+    const r = runCli(["--limit=2", "related", "N"])
+    expect(r.exitCode).toBe(2)
+    expect(r.stderr.toString()).toContain("query must be one of")
+  })
+
+  it("a mid-arg -- after the subcommand operands is inert (exit 0)", async () => {
+    const { output } = await cliFixture()
+    const r = runCli(["--graph", output, "related", REQ1_NODE, "--", "extra"])
+    expect(r.exitCode).toBe(0)
+    expect(JSON.parse(r.stdout.toString()).profile).toBe("related")
+  })
+
+  it("a value flag consumes the next arg even when it is the subcommand", () => {
+    const r = runCli(["--graph", "related", "N"])
+    expect(r.exitCode).toBe(2)
+    expect(r.stderr.toString()).toContain("query must be one of")
+  })
+})
+
+describe("query_graph argument acceptance data: value binding (pre-migration fix, OU-003)", () => {
+  it("resolves the subcommand and reaches graph loading (arg syntax accepted)", async () => {
+    const missingGraph = join(await mkdtemp(join(tmpdir(), "ag-cli-missing-")), "gone")
+    const r = runCli(["--graph", missingGraph, "related", REQ1_NODE])
+    expect(r.exitCode).toBe(2)
+    expect(r.stderr.toString().length).toBeGreaterThan(0)
+    expect(r.stderr.toString()).not.toContain("query must be one of")
+  })
+
+  it("consumes -- as the value of a value flag and still resolves the subcommand", async () => {
+    const r = runCli(["--graph", "--", "related", "N"])
+    expect(r.exitCode).toBe(2)
+    expect(r.stderr.toString().length).toBeGreaterThan(0)
+    expect(r.stderr.toString()).not.toContain("query must be one of")
+  })
+
+  it("a trailing value flag without a value falls back (limit undefined, exit 0)", async () => {
+    const { output } = await cliFixture()
+    const r = runCli(["--graph", output, "related", REQ1_NODE, "--limit"])
+    expect(r.exitCode).toBe(0)
+    const parsed = JSON.parse(r.stdout.toString())
+    expect(parsed.candidates.length).toBeGreaterThan(0)
+  })
+
+  it("first occurrence wins for duplicate value flags (--graph)", async () => {
+    const { root, output } = await cliFixture()
+    const missing = join(root, "missing-graph")
+    const first = runCli(["--graph", missing, "--graph", output, "related", REQ1_NODE])
+    expect(first.exitCode).toBe(2)
+
+    const reversed = runCli(["--graph", output, "--graph", missing, "related", REQ1_NODE])
+    expect(reversed.exitCode).toBe(0)
+  })
+
+  it("extra positional args after the subcommand operand are ignored", async () => {
+    const { output } = await cliFixture()
+    const r = runCli(["--graph", output, "provenance", SRC_NODE, "extra-arg"])
+    expect(r.exitCode).toBe(0)
+    const parsed = JSON.parse(r.stdout.toString())
+    expect(parsed.provenance[0]?.path).toBe(SRC_PATH)
+  })
+})

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/tests/query_cli_args.test.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/tests/query_cli_args.test.ts
@@ -1,8 +1,8 @@
 // Argument acceptance data for query_graph.ts, fixed before the
-// node:util.parseArgs migration (Issue #2354 / OU-003, REQ-044-003).
-// Expectations pin the current indexOf/skip-2 parser; the migrated parser must
-// reproduce them exactly. Normal-path regressions (related/discover/neighbors
-// with real graphs) are covered by trace_cli.test.ts.
+// node:util.parseArgs migration. Expectations pin the current indexOf/skip-2
+// parser; the migrated parser must reproduce them exactly. Normal-path
+// regressions (related/discover/neighbors with real graphs) are covered by
+// trace_cli.test.ts.
 
 import { afterEach, describe, expect, it } from "bun:test"
 import { mkdtemp, rm } from "node:fs/promises"
@@ -37,7 +37,7 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
-describe("query_graph argument acceptance data: syntax errors (pre-migration fix, OU-003)", () => {
+describe("query_graph argument acceptance data: syntax errors (pre-migration fix)", () => {
   it("empty argv reports query subcommand required", () => {
     const r = runCli([])
     expect(r.exitCode).toBe(2)
@@ -82,7 +82,7 @@ describe("query_graph argument acceptance data: syntax errors (pre-migration fix
   })
 })
 
-describe("query_graph argument acceptance data: value binding (pre-migration fix, OU-003)", () => {
+describe("query_graph argument acceptance data: value binding (pre-migration fix)", () => {
   it("resolves the subcommand and reaches graph loading (arg syntax accepted)", async () => {
     const missingGraph = join(await mkdtemp(join(tmpdir(), "ag-cli-missing-")), "gone")
     const r = runCli(["--graph", missingGraph, "related", REQ1_NODE])


### PR DESCRIPTION
## 概要

Issue #2354（OU-003 / RU-0004、親 Epic #2351）。複雑な CLI 引数構文解析の3対象を `node:util.parseArgs` へ移行した（REQ-044-001/003/005、DEC-019 決定1・3・4）。

- `.opencode/skills/repo-agentdev-integrity/scripts/cli_utils.ts`（整合性検査共通 CLI 契約）
- `.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/cli.ts`
- `src/opencode/skills/agentdev-artifact-graph/scripts/src/query_graph.ts`

外部契約（受理・拒否入力、終了コード 0/1/2・8/9、stdout/stderr、サブコマンド解釈、共通 CLI 契約 `--help`/`--json`/`--dry-run`）は移行前と完全同一。`check_changed_docs.ts`、`check_test_impact.ts` のローカル引数解析は合意済み対象外（AG-006）のため未変更。

## 変更点

### 実装（3対象）

- **cli_utils.ts**: 手書きループパーサを削除し `node:util.parseArgs`（strict:false + tokens + allowPositionals）へ委譲。`--profile` 許容値検証、`--root`/`--profile`/`--archive` の値要求（値欠落・空文字列を含む）、`--profile release` 時の `--archive` 必須は ADF 側の後段検証として残留（エラーメッセージ文字列・検出順序も旧と同一）。全使用箇所（check_templates.ts、lint_skills.ts、generate_indexes.ts、check_integrity.ts ほか）はシグネチャ不変のため無変更。
- **trusted-distribution-gate/cli.ts**: switch パーサを削除し parseArgs トークン走査へ委譲。strict parser 契約（未知引数は `cli.ts: unknown argument: <元引数>` + exit 8）を維持。`--opt=value` 形式・短縮クラスタ（-hx 等）は元引数文字列を再構築して旧と同一のメッセージで拒否。必須検証（`missing required argument(s)`、`--bootstrap-report requires ...`）は mainInner 側に残留。
- **query_graph.ts**: `value`/`option`/`findSubcommandIndex`/`parseList`（indexOf・skip-2 スキャン）を削除し parseArgs トークンベースの `ArgView` へ置換。サブコマンド解釈（値フラグとその値の skip 後の最初の非フラグ引数）、位置引数スロット（argv index 基準の `args[commandIndex+N]`）、フラグ値の初回出現優先は ADF 固有の意味解釈として残留し、`query subcommand required` / `query must be one of: ...`・exit 2・stdout JSON 契約は不変。

### 互換性保持の設計（REQ-044-003「標準 API が受理できる形式の新規公開仕様化をしない」）

- `--opt=value` 形式: 3対象とも旧実装では未知引数（cli_utils は無視、cli.ts/query_graph は拒否）のため、inlineValue 付きトークンは値として採用しない
- 短縮クラスタ（`-hx` 等）: 旧実装では単一の未知引数のため、分割結果を採用せず元引数として扱う
- `--`: 旧実装はいずれも終端意味論を持たない（cli_utils は不活性、cli.ts は未知引数拒否、query_graph はサブコマンド候補）。値要求オプション直後の `--` は標準 API も値として結合するため挙動一致。cli_utils のみ `--` 前後の再帰解析で旧の全 argv 走査順を再現
- strict:false では値欠落の文字列オプションが `values.opt === true` になるため、トークンの `value === undefined` で値欠落を判別（Bun 1.3.10 実証済み）

### テスト（移行前の受理・拒否挙動の固定）

- `cli_utils.test.ts`: 受け入れデータ 17件追加（値の一括消費、未知オプション無視、`-x`/`-hx`、`--root=/x`・`--json=true` 無視、`--` 不活性・値結合、重複 last-wins、空文字列値エラー、エラー検出順序）
- `trusted-distribution-gate/cli_args.test.ts`: 新規 16件（--help/-h、未知 long/short/クラスタ/位置引数/`=`形式/`--`、help と未知の順序、値欠落・空文字列の required 扱い、`--bootstrap-report` モード）
- `tests/query_cli_args.test.ts`: 新規 12件（空 argv、未知サブコマンド/オプション/短縮/`=`形式、値フラグによるサブコマンド消費、`--` の値結合と不活性、trailing フラグのフォールバック、`--graph` 重複の初回出現優先、余分位置引数の無視）

いずれも移行前実装で green を確認後、移行後に同一結果（全 pass）を確認した（テストファースト）。

## テスト結果/検証証拠

TS-004（可用性）: `bun -e` 相当の実行確認で `typeof parseArgs === "function"`（bun 1.3.10、worktree 環境）。利用不能環境なしのため blocked 要件は不発火。

TS-003（外部契約回帰）: 固定テストデータの移行前後比較。

| 対象 | 移行前 | 移行後 | 判定 |
|---|---|---|---|
| cli_utils.test.ts（固定データ17件含む全68件） | 68 pass / 0 fail | 68 pass / 0 fail | 同一 |
| trusted-distribution-gate/cli_args.test.ts（16件） | 16 pass / 0 fail | 16 pass / 0 fail | 同一 |
| query_cli_args.test.ts（12件） | 12 pass / 0 fail | 12 pass / 0 fail | 同一 |

TS-001（二重経路不在）: 3対象から手書き構文解析（ループパーサ、indexOf スキャン、skip-2 走査）を削除済み。残存 `startsWith` はトークン分類（クラスタ検出、パス除外）と `findRepoRoot` の既存ディレクトリ走査のみで、argv 構文解析の独自実装は残存しない。

実行コマンドと結果:

```
# repo-agentdev-integrity/scripts（bun install 後）
bun test
  → 2090 pass / 0 fail / 86 files（cli_utils.test.ts、cli_args.test.ts、
     check_templates/lint_skills/generate_indexes/check_integrity、cli-e2e 含む）
bun x tsc --noEmit -p tsconfig.distribution-boundary.json  → exit 0
(cd trusted-distribution-gate) bun x tsc --noEmit -p tsconfig.json  → exit 0
bun x tsc --noEmit（cli_utils.test.ts 単体 strict 検査） → exit 0

# src/opencode/skills/agentdev-artifact-graph/scripts（bun install 後）
bun test
  → 169 pass / 0 fail / 20 files（query_cli_args、trace_cli、既存全体）
bun run typecheck（tsc --noEmit）  → exit 0

# 実表面の実行確認（移行後 parseArgs 経由の実入口）
bun check_templates.ts --help        → USAGE 出力
bun generate_indexes.ts --json --dry-run → dry-run レポート出力
bun lint_skills.ts -h                → USAGE 出力
```

経路G（adversarial-review、adapter 委譲内）: 実装方針形成後、最初の実装変更前に審議を実施し、受理 finding 4件（PR 本文への委譲境界の位置づけ明記、`inlineValue === true` 厳密比較と値欠落・クラスタの回帰テスト必須化、cli.ts の元引数再構築、typecheck ゲート組込み）を反映済み。unresolved 争点なし、blocked 条件なし（互換層は各対象の旧パーサより複雑でない）。

Closes #2354

## Findings / Capture候補

1. **bun 実行環境の argv 前処理**: bun 自身の CLI がスクリプト argv 先頭の `--` を削除する（実証: `Bun.spawnSync(["bun", script, "--", "a"])` → スクリプトは `["a"]` を受信、非先頭の `--` は保持）。そのため「先頭 `--`」は実 CLI 表面からは観測不可能で、テストは非先頭位置で固定した。query_graph では `-- related N`（先頭）が実際には `related N` として解釈される。標準 API 移行とは独立の実行基盤挙動。
2. **Bun の parseArgs トークン種別**: 位置引数トークンの kind が Bun では `"positional"`（Node の型定義上は `"argument"`）。移行実装は Bun 実装に合わせ `"positional"` で判別している。
3. **strict:false の値欠落表現**: 値を持たない文字列オプションがエラーにならず `values.opt === true` になる（Bun・Node 共通の strict:false 挙動）。トークンの `value === undefined` での判別が必要で、この依存は回帰テスト（値欠落ケース）で固定済み。
4. **worktree の依存未インストール**: worktree 内 scripts ディレクトリは node_modules が無く `bun test` が zod 解析エラーで大量 fail する状態から開始した（環境起因、移行と無関係）。`bun install`（bun.lock 変更なし）で解消。また `.opencode/skills/repo-agentdev-integrity/scripts/node_modules` は gitignore 対象外のため、コミット対象から明示的に除外した。

### distribution-boundary

- 検出内容: 配布依存境界の最終 gate（`check_distribution_boundary.ts --profile source`）が本 PR の worktree HEAD で不合格（ok=false、違反6件: concrete-id 2件・unclassified-entry 4件）。`src/opencode/skills/agentdev-artifact-graph/scripts/src/query_graph.ts` ヘッダーコメントと `tests/query_cli_args.test.ts` のヘッダー・describe 2件のコメント中に、producer 内部成果物の concrete ID 参照（REQ-044、DEC-019）と未分類 ID 類似トークン（OU-003）が残存していた。配布物（src/opencode/**）は consumer 環境で docs/ ツリーを持たないため、producer 内部 ID の配布物内参照は禁止される。
- 対応: 該当コメントを ID 参照なしの振る舞い記述へ一般化（コミット b1776d04）。機能コード・テスト期待値は不変で、コメントとテスト名（describe 表記）のみの修正。
- 再実行結果: gate 再実行 `ok=true` / exit 0（330 ファイル走査、違反0件）。`bun test`（agentdev-artifact-graph scripts 全体）169 pass / 0 fail。

## Design確定候補

1. checker-execution-contracts Design「再帰ファイル探索と CLI 引数解析の標準API移行」への補完候補: Bun 実行環境における parseArgs 移行の実装約束（a) 位置引数トークン kind は `"positional"`、b) strict:false で値欠落は `values.opt === true`、トークン `value === undefined` で判別、c) `--opt=value`・短縮クラスタを旧契約維持のために非採用とする判定表）。本 PR の実装はこの約束に基づく。
2. 「旧実装が `--` を終端として扱わない」3対象の差（cli_utils=不活性・cli.ts=未知引数拒否・query_graph=サブコマンド候補）は各 CLI の既存契約として明示的に保持した。この差分の正規記載先（各 Design の CLI 契約節）への反映可否は case-close の Design 確定チェックで判断を提案する。

