### PR TITLE
再帰ファイル探索実装を node:fs の glob へ移行する（OU-002）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_delegation_contract_residual.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_delegation_contract_residual.ts
@@ -153,7 +153,7 @@ function loadData(filePath: string): DelegationPatternData | null {
   return data;
 }
 
-function listMarkdownRecursive(dir: string): string[] {
+export function listMarkdownRecursive(dir: string): string[] {
   if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) return [];
   const out: string[] = [];
   for (const ent of fs.readdirSync(dir, { withFileTypes: true }) as any[]) {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_delegation_contract_residual.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_delegation_contract_residual.ts
@@ -13,6 +13,7 @@
 
 const path = require("path") as typeof import("path");
 const fs = require("fs") as typeof import("fs");
+import { globWalkRel } from "./lib/glob_walk.ts";
 
 export type DelegationRuleId = "IR-032" | "IR-033";
 
@@ -154,17 +155,9 @@ function loadData(filePath: string): DelegationPatternData | null {
 }
 
 export function listMarkdownRecursive(dir: string): string[] {
-  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) return [];
-  const out: string[] = [];
-  for (const ent of fs.readdirSync(dir, { withFileTypes: true }) as any[]) {
-    const full = path.join(dir, ent.name).replace(/\\/g, "/");
-    if (ent.isDirectory()) {
-      out.push(...listMarkdownRecursive(full));
-    } else if (ent.isFile() && ent.name.endsWith(".md")) {
-      out.push(full);
-    }
-  }
-  return out;
+  return globWalkRel(dir, { extensions: [".md"], filesOnly: true }).map(
+    (rel) => path.join(dir, ...rel.split("/")).replace(/\\/g, "/"),
+  );
 }
 
 function collectScanFiles(repoRoot: string, scanTargets: string[] | undefined): string[] {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_executor_notation.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_executor_notation.ts
@@ -12,6 +12,7 @@
 
 const path = require("path") as typeof import("path");
 const fs = require("fs") as typeof import("fs");
+import { globWalkRel } from "./lib/glob_walk.ts";
 
 export type ExecutorRuleId = "IR-050" | "IR-051";
 
@@ -44,19 +45,9 @@ function findRepoRoot(start: string): string {
 }
 
 export function listMarkdownRecursive(dir: string): string[] {
-  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) return [];
-  const out: string[] = [];
-  for (const ent of fs.readdirSync(dir, { withFileTypes: true }) as any[]) {
-    const full = path.join(dir, ent.name).replace(/\\/g, "/");
-    if (ent.isDirectory()) {
-      // Skip unrelated subtrees to keep the scan focused.
-      if (ent.name === "node_modules" || ent.name === ".git") continue;
-      out.push(...listMarkdownRecursive(full));
-    } else if (ent.isFile() && ent.name.endsWith(".md")) {
-      out.push(full);
-    }
-  }
-  return out;
+  return globWalkRel(dir, { extensions: [".md"], filesOnly: true, skipDirNames: ["node_modules", ".git"] }).map(
+    (rel) => path.join(dir, ...rel.split("/")).replace(/\\/g, "/"),
+  );
 }
 
 // IR-050: load_skills command argument must reference a Capability Skill

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_executor_notation.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_executor_notation.ts
@@ -43,7 +43,7 @@ function findRepoRoot(start: string): string {
   return cur;
 }
 
-function listMarkdownRecursive(dir: string): string[] {
+export function listMarkdownRecursive(dir: string): string[] {
   if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) return [];
   const out: string[] = [];
   for (const ent of fs.readdirSync(dir, { withFileTypes: true }) as any[]) {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
@@ -86,6 +86,7 @@ import {
   resolveExtensionState,
   validateExtensionEntries,
 } from "../../../../src/opencode/skills/agentdev-project-extensions/scripts/lib/extension_state.ts";
+import { globWalkRel } from "./lib/glob_walk.ts";
 
 // Re-export the shared contract under the historical module surface so
 // existing importers (tests, sibling checkers) keep working.
@@ -248,14 +249,15 @@ function readText(p: string): string | null {
 }
 
 export function listMarkdownFiles(dirPath: string, recursive: boolean): string[] {
+  // 再帰呼び出しは廃止（OU-002: 全呼び出し点が単一ディレクトリ列挙）。
+  // 単一ディレクトリ直下の列挙は移行対象外のため readdirSync のまま。
+  void recursive;
   const result: string[] = [];
   if (!dirExists(dirPath)) return result;
   const entries = fs.readdirSync(dirPath, { withFileTypes: true }) as any[];
   for (const ent of entries) {
     const full = path.join(dirPath, ent.name);
-    if (ent.isDirectory() && recursive) {
-      result.push(...listMarkdownFiles(full, true));
-    } else if (ent.isFile() && ent.name.endsWith(".md")) {
+    if (ent.isFile() && ent.name.endsWith(".md")) {
       result.push(full.replace(/\\/g, "/"));
     }
   }
@@ -263,33 +265,15 @@ export function listMarkdownFiles(dirPath: string, recursive: boolean): string[]
 }
 
 export function listYamlFilesRecursive(dirPath: string): string[] {
-  const result: string[] = [];
-  if (!dirExists(dirPath)) return result;
-  const entries = fs.readdirSync(dirPath, { withFileTypes: true }) as any[];
-  for (const ent of entries) {
-    const full = path.join(dirPath, ent.name);
-    if (ent.isDirectory()) {
-      result.push(...listYamlFilesRecursive(full));
-    } else if (ent.isFile() && (ent.name.endsWith(".yaml") || ent.name.endsWith(".yml"))) {
-      result.push(full.replace(/\\/g, "/"));
-    }
-  }
-  return result;
+  return globWalkRel(dirPath, { extensions: [".yaml", ".yml"], filesOnly: true }).map(
+    (rel) => path.join(dirPath, ...rel.split("/")).replace(/\\/g, "/"),
+  );
 }
 
 export function listFilesRecursive(dirPath: string): string[] {
-  const result: string[] = [];
-  if (!dirExists(dirPath)) return result;
-  const entries = fs.readdirSync(dirPath, { withFileTypes: true }) as any[];
-  for (const ent of entries) {
-    const full = path.join(dirPath, ent.name);
-    if (ent.isDirectory()) {
-      result.push(...listFilesRecursive(full));
-    } else if (ent.isFile()) {
-      result.push(full.replace(/\\/g, "/"));
-    }
-  }
-  return result;
+  return globWalkRel(dirPath, { filesOnly: true }).map(
+    (rel) => path.join(dirPath, ...rel.split("/")).replace(/\\/g, "/"),
+  );
 }
 
 /**

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts
@@ -247,7 +247,7 @@ function readText(p: string): string | null {
   }
 }
 
-function listMarkdownFiles(dirPath: string, recursive: boolean): string[] {
+export function listMarkdownFiles(dirPath: string, recursive: boolean): string[] {
   const result: string[] = [];
   if (!dirExists(dirPath)) return result;
   const entries = fs.readdirSync(dirPath, { withFileTypes: true }) as any[];
@@ -262,7 +262,7 @@ function listMarkdownFiles(dirPath: string, recursive: boolean): string[] {
   return result;
 }
 
-function listYamlFilesRecursive(dirPath: string): string[] {
+export function listYamlFilesRecursive(dirPath: string): string[] {
   const result: string[] = [];
   if (!dirExists(dirPath)) return result;
   const entries = fs.readdirSync(dirPath, { withFileTypes: true }) as any[];
@@ -277,7 +277,7 @@ function listYamlFilesRecursive(dirPath: string): string[] {
   return result;
 }
 
-function listFilesRecursive(dirPath: string): string[] {
+export function listFilesRecursive(dirPath: string): string[] {
   const result: string[] = [];
   if (!dirExists(dirPath)) return result;
   const entries = fs.readdirSync(dirPath, { withFileTypes: true }) as any[];

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -8,6 +8,7 @@ const CLI_UTILS_FILE = join(SCRIPT_DIR, "cli_utils.ts");
 const GEN_INDEXES_FILE = join(SCRIPT_DIR, "generate_indexes.ts");
 const HISTORY_EXEMPTION_FILE = join(SCRIPT_DIR, "ir057_history_exemption.ts");
 const CURRENT_REFS_FILE = join(SCRIPT_DIR, "current_refs.ts");
+const GLOB_WALK_FILE = join(SCRIPT_DIR, "lib", "glob_walk.ts");
 const TEMP_BASE = join("C:", "WINDOWS", "TEMP", "opencode");
 const RUN_ID = `integrity-test-${crypto.randomUUID().slice(0, 8)}`;
 const TEMP_ROOT = join(TEMP_BASE, RUN_ID);
@@ -62,6 +63,8 @@ function copyScripts(fixtureRoot: string): void {
   copyFileSync(GEN_INDEXES_FILE, join(dest, "generate_indexes.ts"));
   copyFileSync(HISTORY_EXEMPTION_FILE, join(dest, "ir057_history_exemption.ts"));
   copyFileSync(CURRENT_REFS_FILE, join(dest, "current_refs.ts"));
+  mkdirp(join(dest, "lib"));
+  copyFileSync(GLOB_WALK_FILE, join(dest, "lib", "glob_walk.ts"));
 }
 
 function buildValidFixture(root: string): void {
@@ -2383,6 +2386,8 @@ function copyScriptsComplete(fixtureRoot: string): void {
   }
   copyFileSync(HISTORY_EXEMPTION_FILE, join(dest, "ir057_history_exemption.ts"));
   copyFileSync(CURRENT_REFS_FILE, join(dest, "current_refs.ts"));
+  mkdirp(join(dest, "lib"));
+  copyFileSync(GLOB_WALK_FILE, join(dest, "lib", "glob_walk.ts"));
 }
 
 function buildNgBaselineFixture(root: string): void {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -71,6 +71,7 @@ import {
   extractCurrentDecRefs,
   extractCurrentReqRefs,
 } from "./current_refs.ts";
+import { globWalkRel } from "./lib/glob_walk.ts";
 
 const SCRIPT_NAME = "check_integrity.ts";
 const DESCRIPTION = "AgentDevFlow artifact integrity validator";
@@ -5451,25 +5452,14 @@ function checkBrokenJunctions(skillsDir: string, root: string, cmdsDir?: string)
 // to its source. Without this, content_mismatch would fire on every junction.
 export function collectMarkdownTree(dirRoot: string): string[] {
   if (!fs.existsSync(dirRoot)) return [];
-  const acc: string[] = [];
-  function walk(d: string): void {
-    let entries: import("fs").Dirent[];
-    try {
-      entries = fs.readdirSync(d, { withFileTypes: true }) as import("fs").Dirent[];
-    } catch {
-      return;
-    }
-    for (const ent of entries) {
-      const full = path.join(d, ent.name);
-      if (ent.isDirectory()) {
-        walk(full);
-      } else if (ent.isFile() && ent.name.endsWith(".md")) {
-        acc.push(full);
-      }
-    }
+  try {
+    return globWalkRel(dirRoot, { extensions: [".md"], filesOnly: true }).map((rel) =>
+      path.join(dirRoot, ...rel.split("/")),
+    );
+  } catch {
+    // 旧実装は走査中のディレクトリ単位エラーを黙ってスキップした（部分ツリー比較）
+    return [];
   }
-  walk(dirRoot);
-  return acc;
 }
 
 function readRealPath(filePath: string): string | null {
@@ -6856,16 +6846,10 @@ const IR053_EXEMPT_PATHS: RegExp[] = [
 
 export function walkMarkdown(dirPath: string, acc: string[]): void {
   if (!fs.existsSync(dirPath)) return;
-  for (
-    const entry of fs.readdirSync(dirPath, { withFileTypes: true }) as import("fs").Dirent[]
-  ) {
-    const full = path.join(dirPath, entry.name);
-    if (entry.isDirectory()) {
-      walkMarkdown(full, acc);
-    } else if (entry.name.endsWith(".md")) {
-      acc.push(full);
-    }
-  }
+  // .md 名のディレクトリも旧実装と同様に対象に含む（filesOnly を指定しない）。
+  acc.push(
+    ...globWalkRel(dirPath, { extensions: [".md"] }).map((rel) => path.join(dirPath, ...rel.split("/"))),
+  );
 }
 
 function collectAgentdevSkillMarkdown(skillRoot: string): string[] {
@@ -8555,16 +8539,11 @@ function truncateForLog(line: string | undefined): string {
 // walkAllFiles: walkMarkdown と同等だが .md に限定しない（.yaml/.yml 含む）
 export function walkAllFiles(dirPath: string, acc: string[]): void {
   if (!fs.existsSync(dirPath)) return;
-  for (
-    const entry of fs.readdirSync(dirPath, { withFileTypes: true }) as import("fs").Dirent[]
-  ) {
-    const full = path.join(dirPath, entry.name);
-    if (entry.isDirectory()) {
-      walkAllFiles(full, acc);
-    } else if (/\.(md|yaml|yml)$/.test(entry.name)) {
-      acc.push(full);
-    }
-  }
+  acc.push(
+    ...globWalkRel(dirPath, { extensions: [".md", ".yaml", ".yml"] }).map((rel) =>
+      path.join(dirPath, ...rel.split("/")),
+    ),
+  );
 }
 
 // ─── Release profile (Issue #1928 / WP-3 §7.5) ──────────────────────────────

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -5449,7 +5449,7 @@ function checkBrokenJunctions(skillsDir: string, root: string, cmdsDir?: string)
 
 // `realpath` follows Windows junctions, so a healthy projection compares equal
 // to its source. Without this, content_mismatch would fire on every junction.
-function collectMarkdownTree(dirRoot: string): string[] {
+export function collectMarkdownTree(dirRoot: string): string[] {
   if (!fs.existsSync(dirRoot)) return [];
   const acc: string[] = [];
   function walk(d: string): void {
@@ -6854,7 +6854,7 @@ const IR053_EXEMPT_PATHS: RegExp[] = [
   /src\/opencode\/skills\/agentdev-gh-cli\/references\/standard-procedures\.md$/,
 ];
 
-function walkMarkdown(dirPath: string, acc: string[]): void {
+export function walkMarkdown(dirPath: string, acc: string[]): void {
   if (!fs.existsSync(dirPath)) return;
   for (
     const entry of fs.readdirSync(dirPath, { withFileTypes: true }) as import("fs").Dirent[]
@@ -8553,7 +8553,7 @@ function truncateForLog(line: string | undefined): string {
 }
 
 // walkAllFiles: walkMarkdown と同等だが .md に限定しない（.yaml/.yml 含む）
-function walkAllFiles(dirPath: string, acc: string[]): void {
+export function walkAllFiles(dirPath: string, acc: string[]): void {
   if (!fs.existsSync(dirPath)) return;
   for (
     const entry of fs.readdirSync(dirPath, { withFileTypes: true }) as import("fs").Dirent[]

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_reference_paths.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_reference_paths.test.ts
@@ -23,6 +23,12 @@ function copyScripts(fixtureRoot: string): void {
       copyFileSync(join(SCRIPT_DIR, f), join(dest, f));
     }
   }
+  mkdirp(join(dest, "lib"));
+  for (const f of readdirSync(join(SCRIPT_DIR, "lib"))) {
+    if (f.endsWith(".ts") && !f.endsWith(".test.ts")) {
+      copyFileSync(join(SCRIPT_DIR, "lib", f), join(dest, "lib", f));
+    }
+  }
 }
 interface RunResult {
   exitCode: number;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_retired_artifact_residual.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_retired_artifact_residual.ts
@@ -193,7 +193,7 @@ function listMarkdown(dir: string): string[] {
     .map((f: string) => path.join(dir, f).replace(/\\/g, "/"));
 }
 
-function listMarkdownRecursive(dir: string): string[] {
+export function listMarkdownRecursive(dir: string): string[] {
   if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) return [];
   const out: string[] = [];
   for (const ent of fs.readdirSync(dir, { withFileTypes: true }) as any[]) {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_retired_artifact_residual.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_retired_artifact_residual.ts
@@ -16,6 +16,7 @@
 
 const path = require("path") as typeof import("path");
 const fs = require("fs") as typeof import("fs");
+import { globWalkRel } from "./lib/glob_walk.ts";
 
 export type RetiredKind = "IR-025" | "IR-037" | "IR-043";
 
@@ -194,17 +195,9 @@ function listMarkdown(dir: string): string[] {
 }
 
 export function listMarkdownRecursive(dir: string): string[] {
-  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) return [];
-  const out: string[] = [];
-  for (const ent of fs.readdirSync(dir, { withFileTypes: true }) as any[]) {
-    const full = path.join(dir, ent.name).replace(/\\/g, "/");
-    if (ent.isDirectory()) {
-      out.push(...listMarkdownRecursive(full));
-    } else if (ent.isFile() && ent.name.endsWith(".md")) {
-      out.push(full);
-    }
-  }
-  return out;
+  return globWalkRel(dir, { extensions: [".md"], filesOnly: true }).map(
+    (rel) => path.join(dir, ...rel.split("/")).replace(/\\/g, "/"),
+  );
 }
 
 // IR-025: 4-digit ADR filename must NOT exist under docs/decisions/.

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.test.ts
@@ -69,6 +69,9 @@ function setupTempRepo(): void {
   mkdirp(join(scriptDest, ".."));
   copyFileSync(SCRIPT_FILE, scriptDest);
   copyFileSync(CLI_UTILS_FILE, join(scriptDest, "..", "cli_utils.ts"));
+  const libDest = join(scriptDest, "..", "lib");
+  mkdirp(libDest);
+  copyFileSync(join(SCRIPT_DIR, "lib", "glob_walk.ts"), join(libDest, "glob_walk.ts"));
   // git init（--base-ref テスト用）。worktree ではなく main repo 形式で十分
   execSync("git init -q", { cwd: TEMP_ROOT });
   execSync('git config user.email "t@t"', { cwd: TEMP_ROOT });

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.ts
@@ -274,7 +274,7 @@ function globMatch(pattern: string, relPath: string): boolean {
   return new RegExp(`^${regexStr}$`).test(relPath);
 }
 
-function discoverTestFiles(root: string, testGlob: string): string[] {
+export function discoverTestFiles(root: string, testGlob: string): string[] {
   const results: string[] = [];
   function walk(dir: string): void {
     let entries: ReturnType<typeof fs.readdirSync>;

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_test_impact.ts
@@ -263,40 +263,72 @@ function shouldExclude(relPath: string): boolean {
   return SCAN_EXCLUDE_DIRS.some((d) => relPath.startsWith(d));
 }
 
-function globMatch(pattern: string, relPath: string): boolean {
-  // 最小限の glob 実装。**/*.test.ts 等の一般的なパターンをサポート。
-  // ** → 任意ディレクトリ階層、* → 単一階層の任意文字列。
-  const regexStr = pattern
-    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
-    .replace(/\*\*/g, "::DBLSTAR::")
-    .replace(/\*/g, "[^/]*")
-    .replace(/::DBLSTAR::/g, ".*");
-  return new RegExp(`^${regexStr}$`).test(relPath);
+// node:fs glob のワイルドカードはドット始まりディレクトリを列挙できないため、
+// リポジトリルート直下の隠しディレクトリ（.opencode 等）はトップレベルを
+// 単一階層 readdir で発見し、その内側を cwd 直指定の glob で列挙する。
+function patternForHiddenRoot(testGlob: string, hiddenDir: string): string | null {
+  if (testGlob.startsWith(`${hiddenDir}/`)) return testGlob.slice(hiddenDir.length + 1);
+  if (testGlob.startsWith("**/")) return testGlob;
+  return null;
 }
 
 export function discoverTestFiles(root: string, testGlob: string): string[] {
-  const results: string[] = [];
-  function walk(dir: string): void {
-    let entries: ReturnType<typeof fs.readdirSync>;
+  const relMatches = new Set<string>();
+
+  let standardMatches: string[] = [];
+  try {
+    standardMatches = fs.globSync(testGlob, { cwd: root }) as string[];
+  } catch (error) {
+    // ルート欠落（ENOENT）は空扱い。それ以外の走査エラーは握り潰さない
+    // （部分走査による不完全な tests_scanned を出さない）。
+    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+    standardMatches = [];
+  }
+  // 旧パターン解釈では "**/" 先頭パターンは必ず / を含む相対パスのみマッチする
+  // （リポジトリルート直下のファイルは対象外）。標準 API の受理範囲拡張を
+  // 公開仕様として追加しないため、この制約を明示的に維持する。
+  const requiresSeparator = testGlob.startsWith("**/");
+  for (const match of standardMatches) {
+    const rel = match.replace(/\\/g, "/");
+    if (requiresSeparator && !rel.includes("/")) continue;
+    relMatches.add(rel);
+  }
+
+  let topEntries: import("fs").Dirent[] = [];
+  try {
+    topEntries = fs.readdirSync(root, { withFileTypes: true }) as import("fs").Dirent[];
+  } catch {
+    topEntries = [];
+  }
+  for (const ent of topEntries) {
+    if (!ent.isDirectory() || !ent.name.startsWith(".")) continue;
+    const pattern = patternForHiddenRoot(testGlob, ent.name);
+    if (pattern === null) continue;
+    let hiddenMatches: string[] = [];
     try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
+      hiddenMatches = fs.globSync(pattern, { cwd: path.join(root, ent.name) }) as string[];
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+      hiddenMatches = [];
     }
-    for (const ent of entries) {
-      const abs = path.join(dir, ent.name);
-      const rel = path.relative(root, abs).replace(/\\/g, "/");
-      if (ent.isDirectory()) {
-        if (shouldExclude(rel + "/")) continue;
-        walk(abs);
-      } else if (ent.isFile()) {
-        if (shouldExclude(rel)) continue;
-        if (globMatch(testGlob, rel)) results.push(abs);
-      }
+    for (const match of hiddenMatches) {
+      relMatches.add(`${ent.name}/${match.replace(/\\/g, "/")}`);
     }
   }
-  walk(root);
-  return results.sort();
+
+  const results: string[] = [];
+  for (const rel of [...relMatches].sort()) {
+    if (shouldExclude(rel)) continue;
+    const abs = path.join(root, ...rel.split("/"));
+    let isFile = false;
+    try {
+      isFile = fs.lstatSync(abs).isFile();
+    } catch {
+      continue;
+    }
+    if (isFile) results.push(abs);
+  }
+  return results;
 }
 
 // ─── Layer 4: reference scanner ─────────────────────────────────────────────

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.ts
@@ -44,6 +44,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { deriveSkillClassification } from "./check_extensions.ts";
+import { globWalkRel } from "./lib/glob_walk.ts";
 
 export interface PreventiveFailure {
   check: number;
@@ -177,19 +178,9 @@ function listMarkdownFiles(dirPath: string): string[] {
 }
 
 export function listFilesRecursive(dirPath: string, extensions?: string[]): string[] {
-  const result: string[] = [];
-  if (!dirExists(dirPath)) return result;
-  for (const ent of fs.readdirSync(dirPath, { withFileTypes: true }) as any[]) {
-    const full = path.join(dirPath, ent.name);
-    if (ent.isDirectory()) {
-      result.push(...listFilesRecursive(full, extensions));
-    } else if (ent.isFile()) {
-      if (!extensions || extensions.some((e) => ent.name.endsWith(e))) {
-        result.push(full.replace(/\\/g, "/"));
-      }
-    }
-  }
-  return result.sort();
+  return globWalkRel(dirPath, { extensions, filesOnly: true }).map(
+    (rel) => path.join(dirPath, ...rel.split("/")).replace(/\\/g, "/"),
+  );
 }
 
 function extractYamlField(text: string, field: string): string | null {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_workflow_preventive.ts
@@ -176,7 +176,7 @@ function listMarkdownFiles(dirPath: string): string[] {
   return result.sort();
 }
 
-function listFilesRecursive(dirPath: string, extensions?: string[]): string[] {
+export function listFilesRecursive(dirPath: string, extensions?: string[]): string[] {
   const result: string[] = [];
   if (!dirExists(dirPath)) return result;
   for (const ent of fs.readdirSync(dirPath, { withFileTypes: true }) as any[]) {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/lib/glob_walk.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/lib/glob_walk.ts
@@ -1,0 +1,91 @@
+// node:fs glob ベースの再帰列挙共有ヘルパー（OU-002、checker-execution-contracts Design
+// 「再帰ファイル探索と CLI 引数解析の標準API移行」節）。
+//
+// 旧 readdirSync 再帰実装との外部契約維持:
+// - 列挙対象は走査ルート配下の全エントリ（拡張子フィルタは呼び出し側指定）
+// - symlink/junction ディレクトリは下降しない（lstat の reparse/symlink 判定で
+//   祖先ディレクトリを検査し、リンク経由のパスを除外）
+// - filesOnly 指定時は lstat の isFile 判定で通常ファイルのみ返す
+//   （Dirent.isFile() と同一 semantics: リンクファイルは除外）
+// - 存在しないディレクトリは空配列（エラー送出なし）
+// - 戻り値は forward slash 正規化済み相対パスの sort 順（列挙決定性）
+//
+// 既知の表現力上限（実行環境の node:fs glob 仕様に由来、文書化済み）:
+// - ワイルドカードはドット始まりパス要素を列挙できない。走査ルート直下の
+//   ドット名ディレクトリは単一階層 readdir で発見して cwd 直指定の glob で
+//   列挙する。それより深い位置のドット名ディレクトリ・ドットファイルは
+//   列挙不能（本リポジトリの走査対象ツリーに該当は存在しない）
+
+import * as path from "path";
+import * as fs from "fs";
+
+export interface GlobWalkOptions {
+  /** エントリ名の拡張子フィルタ（例: [".md", ".ts"]）。未指定時は全エントリ */
+  readonly extensions?: readonly string[];
+  /** 指定ディレクトリ名を含むサブツリーを列挙から除外（例: ["node_modules", ".git"]） */
+  readonly skipDirNames?: readonly string[];
+  /** lstat の isFile 判定で通常ファイルのみ返す（旧 Dirent.isFile() 相当） */
+  readonly filesOnly?: boolean;
+}
+
+function hasNoLinkAncestor(rootDir: string, segments: readonly string[]): boolean {
+  for (let i = 1; i < segments.length; i++) {
+    try {
+      if (fs.lstatSync(path.join(rootDir, ...segments.slice(0, i))).isSymbolicLink()) return false;
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+function collectGlobMatches(
+  rootDir: string,
+  cwd: string,
+  prefix: readonly string[],
+  opts: GlobWalkOptions | undefined,
+  out: string[],
+): void {
+  let matches: string[] = [];
+  try {
+    matches = fs.globSync("**/*", { cwd }) as string[];
+  } catch (error) {
+    // ENOENT（走査ルート欠落）は空扱い。それ以外は握り潰さず伝播させる
+    // （旧実装も readdirSync のエラーを握り潰さなかった）。
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+    throw error;
+  }
+  for (const match of matches) {
+    const segments = [...prefix, ...match.replace(/\\/g, "/").split("/")];
+    const name = segments[segments.length - 1];
+    if (opts?.skipDirNames?.some((d) => segments.slice(0, -1).includes(d))) continue;
+    if (opts?.extensions && !opts.extensions.some((e) => name.endsWith(e))) continue;
+    if (opts?.filesOnly) {
+      try {
+        if (!fs.lstatSync(path.join(rootDir, ...segments)).isFile()) continue;
+      } catch {
+        continue;
+      }
+    }
+    if (!hasNoLinkAncestor(rootDir, segments)) continue;
+    out.push(segments.join("/"));
+  }
+}
+
+export function globWalkRel(rootDir: string, opts?: GlobWalkOptions): string[] {
+  const out: string[] = [];
+  collectGlobMatches(rootDir, rootDir, [], opts, out);
+
+  // 走査ルート直下のドット名ディレクトリ（ワイルドカードで列挙不可）の補助列挙
+  let topEntries: import("fs").Dirent[] = [];
+  try {
+    topEntries = fs.readdirSync(rootDir, { withFileTypes: true }) as import("fs").Dirent[];
+  } catch {
+    topEntries = [];
+  }
+  for (const ent of topEntries) {
+    if (!ent.isDirectory() || !ent.name.startsWith(".")) continue;
+    collectGlobMatches(rootDir, path.join(rootDir, ent.name), [ent.name], opts, out);
+  }
+  return out.sort();
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/lint_skills.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/lint_skills.test.ts
@@ -72,6 +72,12 @@ function setupTempEnv(
       fs.copyFileSync(path.join(SCRIPTS_DIR, f), path.join(scriptsDir, f));
     }
   }
+  fs.mkdirSync(path.join(scriptsDir, "lib"), { recursive: true });
+  for (const f of fs.readdirSync(path.join(SCRIPTS_DIR, "lib"))) {
+    if (f.endsWith(".ts") && !f.endsWith(".test.ts")) {
+      fs.copyFileSync(path.join(SCRIPTS_DIR, "lib", f), path.join(scriptsDir, "lib", f));
+    }
+  }
   const scriptPath = path.join(scriptsDir, "lint_skills.ts");
 
   // Create .opencode/skills/ tree
@@ -111,6 +117,12 @@ function setupSrcEnv(
   for (const f of fs.readdirSync(SCRIPTS_DIR)) {
     if (f.endsWith(".ts") && !f.endsWith(".test.ts")) {
       fs.copyFileSync(path.join(SCRIPTS_DIR, f), path.join(scriptsDir, f));
+    }
+  }
+  fs.mkdirSync(path.join(scriptsDir, "lib"), { recursive: true });
+  for (const f of fs.readdirSync(path.join(SCRIPTS_DIR, "lib"))) {
+    if (f.endsWith(".ts") && !f.endsWith(".test.ts")) {
+      fs.copyFileSync(path.join(SCRIPTS_DIR, "lib", f), path.join(scriptsDir, "lib", f));
     }
   }
   const scriptPath = path.join(scriptsDir, "lint_skills.ts");

--- a/.opencode/skills/repo-agentdev-integrity/scripts/lint_skills.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/lint_skills.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_PROFILE,
 } from "./cli_utils.ts";
 import type { CheckResult, ScanSummary, IntegrityReport } from "./cli_utils.ts";
+import { globWalkRel } from "./lib/glob_walk.ts";
 
 const SCRIPT_NAME = "lint_skills.ts";
 const SCRIPT_DESCRIPTION = "Skill structure linter for AgentDevFlow";
@@ -283,19 +284,10 @@ function lintDescriptionAg005(
 }
 
 export function collectReferenceMarkdownFiles(refsDir: string): string[] {
-  const files: string[] = [];
-  if (!fs.existsSync(refsDir)) return files;
-  (function walk(dir: string): void {
-    for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
-      const full = path.join(dir, ent.name);
-      if (ent.isDirectory()) {
-        walk(full);
-      } else if (ent.isFile() && ent.name.endsWith(".md")) {
-        files.push(full);
-      }
-    }
-  })(refsDir);
-  return files;
+  if (!fs.existsSync(refsDir)) return [];
+  return globWalkRel(refsDir, { extensions: [".md"], filesOnly: true }).map((rel) =>
+    path.join(refsDir, ...rel.split("/")),
+  );
 }
 
 function lintReferencesTocAg005(skillDir: string, dirName: string): CheckResult[] {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/lint_skills.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/lint_skills.ts
@@ -282,11 +282,9 @@ function lintDescriptionAg005(
   return results;
 }
 
-function lintReferencesTocAg005(skillDir: string, dirName: string): CheckResult[] {
-  const results: CheckResult[] = [];
-  const refsDir = path.join(skillDir, "references");
-  if (!fs.existsSync(refsDir)) return results;
+export function collectReferenceMarkdownFiles(refsDir: string): string[] {
   const files: string[] = [];
+  if (!fs.existsSync(refsDir)) return files;
   (function walk(dir: string): void {
     for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
       const full = path.join(dir, ent.name);
@@ -297,6 +295,14 @@ function lintReferencesTocAg005(skillDir: string, dirName: string): CheckResult[
       }
     }
   })(refsDir);
+  return files;
+}
+
+function lintReferencesTocAg005(skillDir: string, dirName: string): CheckResult[] {
+  const results: CheckResult[] = [];
+  const refsDir = path.join(skillDir, "references");
+  if (!fs.existsSync(refsDir)) return results;
+  const files: string[] = collectReferenceMarkdownFiles(refsDir);
   for (const refPath of files.sort()) {
     const text = fs.readFileSync(refPath, "utf-8");
     const lineCount = text.split(/\r?\n/).length;
@@ -821,4 +827,6 @@ function main(): void {
   process.exit(determineExitCode(summary));
 }
 
-main();
+if (import.meta.main) {
+  main();
+}

--- a/.opencode/skills/repo-agentdev-integrity/scripts/tests/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/tests/check_integrity.test.ts
@@ -73,6 +73,12 @@ function copyScripts(fixtureRoot: string): void {
       copyFileSync(join(PARENT_SCRIPTS_DIR, f), join(dest, f));
     }
   }
+  mkdirp(join(dest, "lib"));
+  for (const f of readdirSync(join(PARENT_SCRIPTS_DIR, "lib"))) {
+    if (f.endsWith(".ts") && !f.endsWith(".test.ts")) {
+      copyFileSync(join(PARENT_SCRIPTS_DIR, "lib", f), join(dest, "lib", f));
+    }
+  }
 }
 
 /**

--- a/.opencode/skills/repo-agentdev-integrity/scripts/walk_enumeration_contract.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/walk_enumeration_contract.test.ts
@@ -1,0 +1,313 @@
+/**
+ * 再帰列挙契約の回帰テスト（OU-002、TS-003）。
+ *
+ * 再帰ファイル探索実装の移行（node:fs glob / globSync への委譲）に先立ち、
+ * 各検査器の再帰列挙の現在の受理・拒否挙動をテストデータとして固定する。
+ * 移行後も本テストが green であることが、列挙対象ファイル集合・リンク追跡・
+ * 隠しディレクトリ・欠落ディレクトリ挙動・列挙決定性の維持証拠となる
+ * （checker-execution-contracts Design「再帰ファイル探索と CLI 引数解析の標準API移行」節）。
+ *
+ * 固定する挙動:
+ * - 対象ファイル集合（拡張子フィルタ、単一ディレクトリと再帰の違い）
+ * - ディレクトリ単位のスキップ（node_modules / .git は実装ごとに異なる）
+ * - symlink / junction ディレクトリを下降しない、リンクファイルをファイルとして報告しない
+ * - リポジトリルート直下の隠しディレクトリ（.opencode 等）を列挙対象に含める
+ * - 存在しないディレクトリは空（エラー送出なし）
+ * - 列挙結果は正規化後パスの sort 順で決定的
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+import { listFilesRecursive, listYamlFilesRecursive, listMarkdownFiles } from "./check_extensions.ts";
+import { listFilesRecursive as listFilesRecursivePreventive } from "./check_workflow_preventive.ts";
+import { listMarkdownRecursive as listMarkdownRecursiveExecutor } from "./check_executor_notation.ts";
+import { listMarkdownRecursive as listMarkdownRecursiveDelegation } from "./check_delegation_contract_residual.ts";
+import { listMarkdownRecursive as listMarkdownRecursiveRetired } from "./check_retired_artifact_residual.ts";
+import { walkMarkdown, collectMarkdownTree, walkAllFiles } from "./check_integrity.ts";
+import { discoverTestFiles } from "./check_test_impact.ts";
+import { collectReferenceMarkdownFiles } from "./lint_skills.ts";
+
+const ROOTS: string[] = [];
+
+function buildFixture(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "adf-walk-contract-"));
+  ROOTS.push(root);
+  for (const d of ["sub/deep", "node_modules", ".git", "refs/nested"]) {
+    fs.mkdirSync(path.join(root, ...d.split("/")), { recursive: true });
+  }
+  const files: Record<string, string> = {
+    "a.md": "a",
+    "notes.md": "n",
+    "b.yaml": "b",
+    "c.yml": "c",
+    "t.ts": "t",
+    "skip.txt": "s",
+    "sub/x.md": "x",
+    "sub/deep/y.md": "y",
+    "sub/e.yml": "e",
+    "node_modules/nm.md": "nm",
+    ".git/gm.md": "gm",
+    "refs/r1.md": "r1",
+    "refs/nested/r2.md": "r2",
+    "refs/skip.txt": "st",
+  };
+  for (const [relPath, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(root, ...relPath.split("/")), content);
+  }
+  return root;
+}
+
+interface LinkFixture {
+  root: string;
+  junctionCreated: boolean;
+  fileLinkCreated: boolean;
+}
+
+function buildLinkFixture(): LinkFixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "adf-walk-links-"));
+  ROOTS.push(root);
+  fs.mkdirSync(path.join(root, "realdir"), { recursive: true });
+  fs.writeFileSync(path.join(root, "plain.md"), "p");
+  fs.writeFileSync(path.join(root, "realdir", "inner.md"), "i");
+  let junctionCreated = true;
+  try {
+    // junction は Windows で昇格不要。失敗時（非 Windows 等）は当該検証をスキップ。
+    fs.symlinkSync(path.join(root, "realdir"), path.join(root, "jdir"), "junction");
+  } catch {
+    junctionCreated = false;
+  }
+  let fileLinkCreated = true;
+  try {
+    fs.symlinkSync(path.join(root, "plain.md"), path.join(root, "slink.md"), "file");
+  } catch {
+    fileLinkCreated = false;
+  }
+  return { root, junctionCreated, fileLinkCreated };
+}
+
+function buildTestImpactFixture(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "adf-testimpact-"));
+  ROOTS.push(root);
+  const layout: Record<string, string> = {
+    "a.test.ts": "a",
+    "sub/b.test.ts": "b",
+    "sub/plain.ts": "p",
+    ".opencode/skills/demo/x.test.ts": "x",
+    "node_modules/d.test.ts": "d",
+    ".worktrees/e.test.ts": "e",
+    ".git/f.test.ts": "f",
+    "docs/requirements/retired/g.test.ts": "g",
+    "src/h.test.ts": "h",
+  };
+  for (const [relPath, content] of Object.entries(layout)) {
+    fs.mkdirSync(path.join(root, ...relPath.split("/").slice(0, -1)), { recursive: true });
+    fs.writeFileSync(path.join(root, ...relPath.split("/")), content);
+  }
+  return root;
+}
+
+function rel(root: string, files: readonly string[]): string[] {
+  return files.map((f) => path.relative(root, f).replace(/\\/g, "/"));
+}
+
+function sorted(values: readonly string[]): string[] {
+  return [...values].sort();
+}
+
+describe("再帰列挙契約: 対象ファイル集合と拡張子フィルタ（固定データ）", () => {
+  test("check_extensions listFilesRecursive: 全ファイル・forward slash・sort 済み", () => {
+    const root = buildFixture();
+    const out = listFilesRecursive(root);
+    expect(sorted(rel(root, out))).toEqual([
+      ".git/gm.md",
+      "a.md",
+      "b.yaml",
+      "c.yml",
+      "node_modules/nm.md",
+      "notes.md",
+      "refs/nested/r2.md",
+      "refs/r1.md",
+      "refs/skip.txt",
+      "skip.txt",
+      "sub/deep/y.md",
+      "sub/e.yml",
+      "sub/x.md",
+      "t.ts",
+    ]);
+  });
+
+  test("check_extensions listYamlFilesRecursive: yaml/yml のみ", () => {
+    const root = buildFixture();
+    const out = listYamlFilesRecursive(root);
+    expect(sorted(rel(root, out))).toEqual(["b.yaml", "c.yml", "sub/e.yml"]);
+  });
+
+  test("check_extensions listMarkdownFiles(recursive=false): 直下の .md のみ", () => {
+    const root = buildFixture();
+    const out = listMarkdownFiles(root, false);
+    expect(sorted(rel(root, out))).toEqual(["a.md", "notes.md"]);
+  });
+
+  test("check_workflow_preventive listFilesRecursive: 拡張子フィルタ付き", () => {
+    const root = buildFixture();
+    expect(sorted(rel(root, listFilesRecursivePreventive(root, [".md", ".ts"])))).toEqual([
+      ".git/gm.md",
+      "a.md",
+      "node_modules/nm.md",
+      "notes.md",
+      "refs/nested/r2.md",
+      "refs/r1.md",
+      "sub/deep/y.md",
+      "sub/x.md",
+      "t.ts",
+    ]);
+    expect(sorted(rel(root, listFilesRecursivePreventive(root)))).toEqual([
+      ".git/gm.md",
+      "a.md",
+      "b.yaml",
+      "c.yml",
+      "node_modules/nm.md",
+      "notes.md",
+      "refs/nested/r2.md",
+      "refs/r1.md",
+      "refs/skip.txt",
+      "skip.txt",
+      "sub/deep/y.md",
+      "sub/e.yml",
+      "sub/x.md",
+      "t.ts",
+    ]);
+  });
+
+  test("check_executor_notation listMarkdownRecursive: node_modules/.git をスキップ", () => {
+    const root = buildFixture();
+    expect(sorted(rel(root, listMarkdownRecursiveExecutor(root)))).toEqual([
+      "a.md",
+      "notes.md",
+      "refs/nested/r2.md",
+      "refs/r1.md",
+      "sub/deep/y.md",
+      "sub/x.md",
+    ]);
+  });
+
+  test("check_delegation/retired listMarkdownRecursive: スキップなしで全 .md", () => {
+    const root = buildFixture();
+    const expected = [
+      ".git/gm.md",
+      "a.md",
+      "node_modules/nm.md",
+      "notes.md",
+      "refs/nested/r2.md",
+      "refs/r1.md",
+      "sub/deep/y.md",
+      "sub/x.md",
+    ];
+    expect(sorted(rel(root, listMarkdownRecursiveDelegation(root)))).toEqual(expected);
+    expect(sorted(rel(root, listMarkdownRecursiveRetired(root)))).toEqual(expected);
+  });
+
+  test("check_integrity walkMarkdown / collectMarkdownTree / walkAllFiles", () => {
+    const root = buildFixture();
+    const mdAcc: string[] = [];
+    walkMarkdown(root, mdAcc);
+    const expectedMd = [
+      ".git/gm.md",
+      "a.md",
+      "node_modules/nm.md",
+      "notes.md",
+      "refs/nested/r2.md",
+      "refs/r1.md",
+      "sub/deep/y.md",
+      "sub/x.md",
+    ];
+    expect(sorted(rel(root, mdAcc))).toEqual(expectedMd);
+    expect(sorted(rel(root, collectMarkdownTree(root)))).toEqual(expectedMd);
+
+    const allAcc: string[] = [];
+    walkAllFiles(root, allAcc);
+    expect(sorted(rel(root, allAcc))).toEqual([
+      ".git/gm.md",
+      "a.md",
+      "b.yaml",
+      "c.yml",
+      "node_modules/nm.md",
+      "notes.md",
+      "refs/nested/r2.md",
+      "refs/r1.md",
+      "sub/deep/y.md",
+      "sub/e.yml",
+      "sub/x.md",
+    ]);
+  });
+
+  test("lint_skills collectReferenceMarkdownFiles: references 配下の .md を再帰収集", () => {
+    const root = buildFixture();
+    const out = collectReferenceMarkdownFiles(path.join(root, "refs"));
+    expect(sorted(rel(root, out))).toEqual(["refs/nested/r2.md", "refs/r1.md"]);
+  });
+});
+
+describe("再帰列挙契約: 欠落ディレクトリとリンク追跡", () => {
+  test("存在しないディレクトリは空を返し例外を送出しない", () => {
+    const root = buildFixture();
+    const missing = path.join(root, "does", "not", "exist");
+    expect(listFilesRecursive(missing)).toEqual([]);
+    expect(listYamlFilesRecursive(missing)).toEqual([]);
+    expect(listMarkdownFiles(missing, false)).toEqual([]);
+    expect(listFilesRecursivePreventive(missing)).toEqual([]);
+    expect(listMarkdownRecursiveExecutor(missing)).toEqual([]);
+    expect(listMarkdownRecursiveDelegation(missing)).toEqual([]);
+    expect(listMarkdownRecursiveRetired(missing)).toEqual([]);
+    const mdAcc: string[] = [];
+    walkMarkdown(missing, mdAcc);
+    expect(mdAcc).toEqual([]);
+    expect(collectMarkdownTree(missing)).toEqual([]);
+    const allAcc: string[] = [];
+    walkAllFiles(missing, allAcc);
+    expect(allAcc).toEqual([]);
+    expect(discoverTestFiles(missing, "**/*.test.ts")).toEqual([]);
+    expect(collectReferenceMarkdownFiles(missing)).toEqual([]);
+  });
+
+  test("junction/symlink ディレクトリを下降せず、リンクファイルを報告しない", () => {
+    const { root, junctionCreated, fileLinkCreated } = buildLinkFixture();
+    const rels = sorted(rel(root, listFilesRecursive(root)));
+    expect(rels).toContain("plain.md");
+    expect(rels).toContain("realdir/inner.md");
+    if (junctionCreated) {
+      expect(rels.some((r) => r.startsWith("jdir/"))).toBe(false);
+    }
+    if (fileLinkCreated) {
+      expect(rels).not.toContain("slink.md");
+    }
+  });
+});
+
+describe("再帰列挙契約: check_test_impact のテストファイル発見", () => {
+  test("隠しディレクトリ配下を含み、除外ディレクトリを除く（決定的 sort）", () => {
+    const root = buildTestImpactFixture();
+    const out = discoverTestFiles(root, "**/*.test.ts");
+    // 現行のパターン解釈では "**/" 先頭パターンは必ず / を含む相対パスのみ
+    // マッチする（リポジトリルート直下のファイルは対象外）。
+    expect(rel(root, out)).toEqual([
+      ".opencode/skills/demo/x.test.ts",
+      "src/h.test.ts",
+      "sub/b.test.ts",
+    ]);
+    // 決定性: 同一入力から同一順序
+    expect(discoverTestFiles(root, "**/*.test.ts")).toEqual(out);
+  });
+});
+
+process.on("exit", () => {
+  for (const r of ROOTS) {
+    try {
+      fs.rmSync(r, { recursive: true, force: true });
+    } catch {
+      // tmp クリーンアップはベストエフォート
+    }
+  }
+});

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/README.md
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/README.md
@@ -14,8 +14,9 @@ scripts/
 │   ├── config.ts          # デフォルト設定、graph_config_digest、path utility
 │   ├── augmentation.ts    # augmentation 読込・解析、resolveConfig、resolveTraceModel
 │   ├── parse.ts           # frontmatter、markdown link、extension field parser
-│   ├── provenance.ts      # provenance hashing
-│   ├── input.ts           # 入力収集 + digest
+│   ├── provenance.ts       # provenance hashing
+│   ├── glob_walk.ts        # node:fs glob ベースの再帰列挙（リンク非追跡）
+│   ├── input.ts            # 入力収集 + digest
 │   ├── nodes.ts           # config 駆動ノード抽出
 │   ├── edges.ts           # config 駆動エッジ抽出
 │   ├── graph.ts           # build + load（動的 schema）

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/lib/glob_walk.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/lib/glob_walk.ts
@@ -1,0 +1,72 @@
+// node:fs glob based recursive file enumeration shared by the graph scripts.
+//
+// Behavioral contract kept from the previous Dirent-based enumeration:
+// - regular files only (lstat), so link files are not reported
+// - link directories (junctions/symlinks) are not descended
+// - a missing scan root yields an empty result; ENOENT during enumeration
+//   skips that subtree while other errors propagate
+// - forward-slash, root-relative paths in sorted (deterministic) order
+//
+// Runtime limitation (documented): glob wildcards cannot enumerate dot-named
+// path components. Dot-named directories directly under the scan root are
+// enumerated via a single-level readdir plus a glob rooted inside them;
+// deeper dot-named directories and dot files are not enumerable.
+
+import { globSync, lstatSync, readdirSync } from "node:fs"
+import type { Dirent } from "node:fs"
+import { join } from "node:path"
+
+function hasNoLinkAncestor(rootDir: string, segments: readonly string[]): boolean {
+  for (let i = 1; i < segments.length; i += 1) {
+    try {
+      if (lstatSync(join(rootDir, ...segments.slice(0, i))).isSymbolicLink()) return false
+    } catch {
+      return false
+    }
+  }
+  return true
+}
+
+function collectMatches(
+  rootDir: string,
+  cwd: string,
+  prefix: readonly string[],
+  out: string[],
+): void {
+  let matches: string[]
+  try {
+    matches = globSync("**/*", { cwd }) as string[]
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return
+    throw error
+  }
+  for (const match of matches) {
+    const segments = [...prefix, ...match.replaceAll("\\", "/").split("/")]
+    let isFile = false
+    try {
+      isFile = lstatSync(join(rootDir, ...segments)).isFile()
+    } catch {
+      isFile = false
+    }
+    if (!isFile) continue
+    if (!hasNoLinkAncestor(rootDir, segments)) continue
+    out.push(segments.join("/"))
+  }
+}
+
+export function enumerateFilesRel(rootDir: string): readonly string[] {
+  const out: string[] = []
+  collectMatches(rootDir, rootDir, [], out)
+
+  let entries: Dirent[] = []
+  try {
+    entries = readdirSync(rootDir, { withFileTypes: true }) as Dirent[]
+  } catch {
+    entries = []
+  }
+  for (const ent of entries) {
+    if (!ent.isDirectory() || !ent.name.startsWith(".")) continue
+    collectMatches(rootDir, join(rootDir, ent.name), [ent.name], out)
+  }
+  return out.sort()
+}

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/lib/input.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/lib/input.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
-import { readdir, readFile } from "node:fs/promises"
-import type { Dirent } from "node:fs"
+import { readFile } from "node:fs/promises"
 import { join } from "node:path"
+import { enumerateFilesRel } from "./glob_walk.ts"
 import { isExcludedPath, isInputFile, type ResolvedConfig } from "./config.ts"
 import type { InputFile } from "./model.ts"
 
@@ -9,21 +9,12 @@ function normalizePath(path: string): string {
   return path.replaceAll("\\", "/")
 }
 
-async function walk(root: string, directory: string): Promise<readonly string[]> {
-  let entries: Dirent[]
-  try {
-    entries = await readdir(directory, { withFileTypes: true })
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") return []
-    throw error
-  }
+function walk(root: string, directory: string): readonly string[] {
   const paths: string[] = []
-  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
-    const fullPath = join(directory, entry.name)
-    const repoPath = normalizePath(fullPath.slice(root.length + 1).replace(/\\/g, "/"))
+  for (const rel of enumerateFilesRel(directory)) {
+    const repoPath = normalizePath(join(directory, rel).slice(root.length + 1).replace(/\\/g, "/"))
     if (isExcludedPath(repoPath)) continue
-    if (entry.isDirectory()) paths.push(...await walk(root, fullPath))
-    if (entry.isFile() && isInputFile(repoPath)) paths.push(repoPath)
+    if (isInputFile(repoPath)) paths.push(repoPath)
   }
   return paths
 }
@@ -31,7 +22,7 @@ async function walk(root: string, directory: string): Promise<readonly string[]>
 export async function collectInputs(root: string, config: ResolvedConfig): Promise<readonly InputFile[]> {
   const paths = new Set<string>()
   for (const indexedPath of config.indexed_paths) {
-    for (const path of await walk(root, join(root, indexedPath))) paths.add(path)
+    for (const path of walk(root, join(root, indexedPath))) paths.add(path)
   }
   return Promise.all([...paths].sort().map(async (path) => ({
     path,

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/lib/query.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/lib/query.ts
@@ -1,7 +1,7 @@
 import type { GraphData, GraphEdge } from "./model.ts"
-import { readdir, readFile, stat } from "node:fs/promises"
-import type { Dirent } from "node:fs"
+import { readFile, stat } from "node:fs/promises"
 import { join } from "node:path"
+import { enumerateFilesRel } from "./glob_walk.ts"
 import { relationsFor, evidenceFor, type QueryResult } from "./query_support.ts"
 import { runIndexQuery, runProfileQuery, type ProfileName } from "./profiles.ts"
 
@@ -79,23 +79,6 @@ function pathResult(graph: GraphData, source: string, target: string, maxDepth: 
   return { nodes: [], edges: [], relations: [], provenance: [] }
 }
 
-async function walkDir(root: string, dir: string, results: string[]): Promise<void> {
-  let entries: Dirent[]
-  try {
-    entries = await readdir(dir, { withFileTypes: true })
-  } catch {
-    return
-  }
-  for (const entry of entries) {
-    const full = join(dir, entry.name)
-    if (entry.isDirectory()) {
-      await walkDir(root, full, results)
-    } else if (entry.isFile()) {
-      results.push(full.slice(root.length + 1).replace(/\\/g, "/"))
-    }
-  }
-}
-
 async function discoverResult(query: { readonly term: string; readonly roots: readonly string[]; readonly rootDir: string }): Promise<QueryResult> {
   const term = query.term.toLowerCase()
   const matches: string[] = []
@@ -109,9 +92,14 @@ async function discoverResult(query: { readonly term: string; readonly roots: re
       exists = false
     }
     if (!exists) continue
-    const files: string[] = []
-    await walkDir(query.rootDir, absRoot, files)
-    for (const file of files.sort()) {
+    let files: readonly string[] = []
+    try {
+      files = enumerateFilesRel(absRoot)
+    } catch {
+      files = []
+    }
+    for (const rel of files) {
+      const file = relRoot === "." ? rel : `${relRoot}/${rel}`
       try {
         const content = await readFile(join(query.rootDir, file), "utf8")
         if (content.toLowerCase().includes(term) || file.toLowerCase().includes(term)) {

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/lib/verification.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/lib/verification.ts
@@ -1,5 +1,6 @@
-import { readFile, readdir, stat } from "node:fs/promises"
+import { readFile, stat } from "node:fs/promises"
 import { dirname, join, normalize } from "node:path"
+import { enumerateFilesRel } from "./glob_walk.ts"
 import type { GraphData } from "./model.ts"
 import type { ResolvedConfig } from "./config.ts"
 
@@ -51,45 +52,42 @@ async function independentScan(root: string, config: ResolvedConfig): Promise<{
   const links: IndependentLink[] = []
   let checkedFiles = 0
 
-  async function walk(dir: string): Promise<void> {
-    let entries
+  async function scanIndexedPath(indexedPath: string): Promise<void> {
+    const dir = join(root, indexedPath)
+    let files: readonly string[] = []
     try {
-      entries = await readdir(dir, { withFileTypes: true })
+      files = enumerateFilesRel(dir)
     } catch {
       return
     }
-    for (const entry of entries) {
-      const full = join(dir, entry.name)
-      const rel = full.slice(root.length + 1).replace(/\\/g, "/")
-      if (entry.isDirectory()) {
-        await walk(full)
-      } else if (entry.isFile() && rel.endsWith(".md")) {
-        checkedFiles += 1
-        let content: string
+    for (const relFile of files) {
+      if (!relFile.endsWith(".md")) continue
+      const rel = indexedPath === "." ? relFile : `${indexedPath}/${relFile}`
+      checkedFiles += 1
+      let content: string
+      try {
+        content = await readFile(join(root, rel), "utf8")
+      } catch {
+        continue
+      }
+      // Different regex pattern than Graph's parser for independence
+      for (const m of content.matchAll(/\[[^\]]*\]\(([^)\s]+)\)/g)) {
+        const target = m[1]
+        if (target === undefined) continue
+        if (/^[a-z]+:/i.test(target) || target.startsWith("#")) continue
+        const targetPath = target.split("#")[0] ?? ""
+        const sourceDir = dirname(rel)
+        const resolvedTarget = normalize(sourceDir === "." ? targetPath : join(sourceDir, targetPath))
+          .replace(/\\/g, "/")
+        let resolved = false
         try {
-          content = await readFile(full, "utf8")
+          const s = await stat(join(root, resolvedTarget))
+          resolved = s.isFile()
         } catch {
-          continue
+          resolved = false
         }
-        // Different regex pattern than Graph's parser for independence
-        for (const m of content.matchAll(/\[[^\]]*\]\(([^)\s]+)\)/g)) {
-          const target = m[1]
-          if (target === undefined) continue
-          if (/^[a-z]+:/i.test(target) || target.startsWith("#")) continue
-          const targetPath = target.split("#")[0] ?? ""
-          const sourceDir = dirname(rel)
-          const resolvedTarget = normalize(sourceDir === "." ? targetPath : join(sourceDir, targetPath))
-            .replace(/\\/g, "/")
-          let resolved = false
-          try {
-            const s = await stat(join(root, resolvedTarget))
-            resolved = s.isFile()
-          } catch {
-            resolved = false
-          }
-          const line = content.slice(0, m.index ?? 0).split("\n").length
-          links.push({ source_path: rel, target, line, resolved })
-        }
+        const line = content.slice(0, m.index ?? 0).split("\n").length
+        links.push({ source_path: rel, target, line, resolved })
       }
     }
   }
@@ -97,7 +95,7 @@ async function independentScan(root: string, config: ResolvedConfig): Promise<{
   for (const indexedPath of config.indexed_paths) {
     try {
       const s = await stat(join(root, indexedPath))
-      if (s.isDirectory()) await walk(join(root, indexedPath))
+      if (s.isDirectory()) await scanIndexedPath(indexedPath)
     } catch {
       // path doesn't exist, skip
     }

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/tests/enumeration_contract.test.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/tests/enumeration_contract.test.ts
@@ -38,57 +38,57 @@ afterEach(async () => {
 describe("recursive enumeration contract: input collection", () => {
   it("collects the exact file set with forward-slash repo-relative paths", async () => {
     const root = await tmpRoot("ag-enum-input-")
-    await write(root, "docs/specs/a.md")
-    await write(root, "docs/specs/sub/b.md")
-    await write(root, "docs/specs/sub/deep/c.yaml")
-    await write(root, "docs/specs/notes.yml")
+    await write(root, "tree/a.md")
+    await write(root, "tree/sub/b.md")
+    await write(root, "tree/sub/deep/c.yaml")
+    await write(root, "tree/notes.yml")
     await write(root, "other/o.md")
     const base = await resolveBuildConfig(root)
-    const config = { ...base, indexed_paths: ["docs/specs", "other"] }
+    const config = { ...base, indexed_paths: ["tree", "other"] }
 
     const inputs = await collectInputs(root, config)
 
     expect(inputs.map((f) => f.path)).toEqual([
-      "docs/specs/a.md",
-      "docs/specs/notes.yml",
-      "docs/specs/sub/b.md",
-      "docs/specs/sub/deep/c.yaml",
       "other/o.md",
+      "tree/a.md",
+      "tree/notes.yml",
+      "tree/sub/b.md",
+      "tree/sub/deep/c.yaml",
     ])
   })
 
   it("excludes dependency and cache directories and temporary files", async () => {
     const root = await tmpRoot("ag-enum-excl-")
-    await write(root, "docs/specs/keep.md")
-    await write(root, "docs/specs/node_modules/deep/nm.md")
-    await write(root, "docs/specs/.git/g.md")
-    await write(root, "docs/specs/.cache/c.md")
-    await write(root, "docs/specs/scratch.tmp")
+    await write(root, "tree/keep.md")
+    await write(root, "tree/node_modules/deep/nm.md")
+    await write(root, "tree/.git/g.md")
+    await write(root, "tree/.cache/c.md")
+    await write(root, "tree/scratch.tmp")
     const base = await resolveBuildConfig(root)
-    const config = { ...base, indexed_paths: ["docs/specs"] }
+    const config = { ...base, indexed_paths: ["tree"] }
 
     const inputs = await collectInputs(root, config)
 
-    expect(inputs.map((f) => f.path)).toEqual(["docs/specs/keep.md"])
+    expect(inputs.map((f) => f.path)).toEqual(["tree/keep.md"])
   })
 
   it("treats a missing indexed path as empty without failing the run", async () => {
     const root = await tmpRoot("ag-enum-missing-")
-    await write(root, "docs/specs/keep.md")
+    await write(root, "tree/keep.md")
     const base = await resolveBuildConfig(root)
-    const config = { ...base, indexed_paths: ["docs/specs", "does/not/exist"] }
+    const config = { ...base, indexed_paths: ["tree", "does/not/exist"] }
 
     const inputs = await collectInputs(root, config)
 
-    expect(inputs.map((f) => f.path)).toEqual(["docs/specs/keep.md"])
+    expect(inputs.map((f) => f.path)).toEqual(["tree/keep.md"])
   })
 
   it("is deterministic: identical inputs produce identical paths and digest", async () => {
     const root = await tmpRoot("ag-enum-det-")
-    await write(root, "docs/specs/a.md", "alpha\n")
-    await write(root, "docs/specs/sub/b.yaml", "beta: 1\n")
+    await write(root, "tree/a.md", "alpha\n")
+    await write(root, "tree/sub/b.yaml", "beta: 1\n")
     const base = await resolveBuildConfig(root)
-    const config = { ...base, indexed_paths: ["docs/specs"] }
+    const config = { ...base, indexed_paths: ["tree"] }
 
     const first = await collectInputs(root, config)
     const second = await collectInputs(root, config)
@@ -99,27 +99,27 @@ describe("recursive enumeration contract: input collection", () => {
 
   it("does not descend into link directories and does not report link files", async () => {
     const root = await tmpRoot("ag-enum-links-")
-    await write(root, "docs/specs/real/inner.md")
-    await write(root, "docs/specs/plain.md")
+    await write(root, "tree/real/inner.md")
+    await write(root, "tree/plain.md")
     // Junction creation works without elevated privileges on Windows.
-    await symlink(join(root, "docs/specs/real"), join(root, "docs/specs/jdir"), "junction")
+    await symlink(join(root, "tree/real"), join(root, "tree/jdir"), "junction")
     let fileLinkCreated = true
     try {
-      await symlink(join(root, "docs/specs/plain.md"), join(root, "docs/specs/slink.md"), "file")
+      await symlink(join(root, "tree/plain.md"), join(root, "tree/slink.md"), "file")
     } catch {
       fileLinkCreated = false
     }
     const base = await resolveBuildConfig(root)
-    const config = { ...base, indexed_paths: ["docs/specs"] }
+    const config = { ...base, indexed_paths: ["tree"] }
 
     const inputs = await collectInputs(root, config)
     const paths = inputs.map((f) => f.path)
 
-    expect(paths).toContain("docs/specs/plain.md")
-    expect(paths).toContain("docs/specs/real/inner.md")
-    expect(paths.some((p) => p.startsWith("docs/specs/jdir/"))).toBe(false)
+    expect(paths).toContain("tree/plain.md")
+    expect(paths).toContain("tree/real/inner.md")
+    expect(paths.some((p) => p.startsWith("tree/jdir/"))).toBe(false)
     if (fileLinkCreated) {
-      expect(paths).not.toContain("docs/specs/slink.md")
+      expect(paths).not.toContain("tree/slink.md")
     }
   })
 })
@@ -127,22 +127,22 @@ describe("recursive enumeration contract: input collection", () => {
 describe("recursive enumeration contract: discover query", () => {
   it("finds matches under the query roots with sorted, deduplicated output", async () => {
     const root = await tmpRoot("ag-enum-disc-")
-    await write(root, "docs/specs/alpha-term.md", "contains zebra\n")
-    await write(root, "docs/specs/sub/zebra.md", "plain\n")
-    await write(root, "docs/specs/sub/deep/other.md", "zebra inside\n")
+    await write(root, "tree/alpha-term.md", "contains zebra\n")
+    await write(root, "tree/sub/zebra.md", "plain\n")
+    await write(root, "tree/sub/deep/other.md", "zebra inside\n")
     await write(root, "other/no-term.md")
 
     const result = await queryGraph(emptyGraph(), {
       kind: "discover",
       term: "zebra",
-      roots: ["docs/specs", "missing-root"],
+      roots: ["tree", "missing-root"],
       rootDir: root,
     })
 
     expect(result.discovered).toEqual([
-      "docs/specs/alpha-term.md",
-      "docs/specs/sub/deep/other.md",
-      "docs/specs/sub/zebra.md",
+      "tree/alpha-term.md",
+      "tree/sub/deep/other.md",
+      "tree/sub/zebra.md",
     ])
   })
 })
@@ -162,8 +162,8 @@ describe("recursive enumeration contract: verification scan", () => {
     // Independent .md count as the oracle: non-markdown inputs (extra.yaml)
     // must not inflate the verification file count.
     const mdCount = ["docs/requirements", "docs/decisions", "docs/designs"]
-      .flatMap((p) => readdirSync(join(root, p), { recursive: true }))
-      .filter((f) => String(f).endsWith(".md")).length
+      .flatMap((p) => readdirSync(join(root, p), { recursive: true }) as string[])
+      .filter((f) => f.endsWith(".md")).length
     expect(report.summary.checked_files).toBe(mdCount)
     expect(report.summary.checked_files).toBeGreaterThan(0)
   })
@@ -175,5 +175,5 @@ function emptyGraph() {
     nodes: [],
     edges: [],
     provenance: [],
-  } as Parameters<typeof queryGraph>[0]
+  } as unknown as Parameters<typeof queryGraph>[0]
 }

--- a/src/opencode/skills/agentdev-artifact-graph/scripts/tests/enumeration_contract.test.ts
+++ b/src/opencode/skills/agentdev-artifact-graph/scripts/tests/enumeration_contract.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
+import { readdirSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { collectInputs, computeInputDigest } from "../lib/input.ts"
+import { queryGraph } from "../lib/query.ts"
+import { verifyGraph } from "../lib/verification.ts"
+import { buildGraph, loadGraph, resolveBuildConfig } from "../lib/graph.ts"
+import { createFixture } from "./fixture.ts"
+
+// Enumeration contract regression (standard API migration).
+//
+// Fixes the acceptance behavior of the recursive file enumeration used by
+// input collection, discover queries, and the verification scan so that the
+// migration to the standard glob API keeps: the enumerated file set,
+// exclusion of dependency/cache directories, ENOENT (missing indexed path)
+// handling, forward-slash path normalization, determinism, and the
+// non-descent of link directories (junctions/symlinks).
+
+const roots: string[] = []
+
+async function tmpRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix))
+  roots.push(root)
+  return root
+}
+
+async function write(root: string, rel: string, content = "content\n"): Promise<void> {
+  await mkdir(join(root, ...rel.split("/").slice(0, -1)), { recursive: true })
+  await writeFile(join(root, ...rel.split("/")), content, "utf8")
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe("recursive enumeration contract: input collection", () => {
+  it("collects the exact file set with forward-slash repo-relative paths", async () => {
+    const root = await tmpRoot("ag-enum-input-")
+    await write(root, "docs/specs/a.md")
+    await write(root, "docs/specs/sub/b.md")
+    await write(root, "docs/specs/sub/deep/c.yaml")
+    await write(root, "docs/specs/notes.yml")
+    await write(root, "other/o.md")
+    const base = await resolveBuildConfig(root)
+    const config = { ...base, indexed_paths: ["docs/specs", "other"] }
+
+    const inputs = await collectInputs(root, config)
+
+    expect(inputs.map((f) => f.path)).toEqual([
+      "docs/specs/a.md",
+      "docs/specs/notes.yml",
+      "docs/specs/sub/b.md",
+      "docs/specs/sub/deep/c.yaml",
+      "other/o.md",
+    ])
+  })
+
+  it("excludes dependency and cache directories and temporary files", async () => {
+    const root = await tmpRoot("ag-enum-excl-")
+    await write(root, "docs/specs/keep.md")
+    await write(root, "docs/specs/node_modules/deep/nm.md")
+    await write(root, "docs/specs/.git/g.md")
+    await write(root, "docs/specs/.cache/c.md")
+    await write(root, "docs/specs/scratch.tmp")
+    const base = await resolveBuildConfig(root)
+    const config = { ...base, indexed_paths: ["docs/specs"] }
+
+    const inputs = await collectInputs(root, config)
+
+    expect(inputs.map((f) => f.path)).toEqual(["docs/specs/keep.md"])
+  })
+
+  it("treats a missing indexed path as empty without failing the run", async () => {
+    const root = await tmpRoot("ag-enum-missing-")
+    await write(root, "docs/specs/keep.md")
+    const base = await resolveBuildConfig(root)
+    const config = { ...base, indexed_paths: ["docs/specs", "does/not/exist"] }
+
+    const inputs = await collectInputs(root, config)
+
+    expect(inputs.map((f) => f.path)).toEqual(["docs/specs/keep.md"])
+  })
+
+  it("is deterministic: identical inputs produce identical paths and digest", async () => {
+    const root = await tmpRoot("ag-enum-det-")
+    await write(root, "docs/specs/a.md", "alpha\n")
+    await write(root, "docs/specs/sub/b.yaml", "beta: 1\n")
+    const base = await resolveBuildConfig(root)
+    const config = { ...base, indexed_paths: ["docs/specs"] }
+
+    const first = await collectInputs(root, config)
+    const second = await collectInputs(root, config)
+
+    expect(second).toEqual(first)
+    expect(computeInputDigest(second)).toBe(computeInputDigest(first))
+  })
+
+  it("does not descend into link directories and does not report link files", async () => {
+    const root = await tmpRoot("ag-enum-links-")
+    await write(root, "docs/specs/real/inner.md")
+    await write(root, "docs/specs/plain.md")
+    // Junction creation works without elevated privileges on Windows.
+    await symlink(join(root, "docs/specs/real"), join(root, "docs/specs/jdir"), "junction")
+    let fileLinkCreated = true
+    try {
+      await symlink(join(root, "docs/specs/plain.md"), join(root, "docs/specs/slink.md"), "file")
+    } catch {
+      fileLinkCreated = false
+    }
+    const base = await resolveBuildConfig(root)
+    const config = { ...base, indexed_paths: ["docs/specs"] }
+
+    const inputs = await collectInputs(root, config)
+    const paths = inputs.map((f) => f.path)
+
+    expect(paths).toContain("docs/specs/plain.md")
+    expect(paths).toContain("docs/specs/real/inner.md")
+    expect(paths.some((p) => p.startsWith("docs/specs/jdir/"))).toBe(false)
+    if (fileLinkCreated) {
+      expect(paths).not.toContain("docs/specs/slink.md")
+    }
+  })
+})
+
+describe("recursive enumeration contract: discover query", () => {
+  it("finds matches under the query roots with sorted, deduplicated output", async () => {
+    const root = await tmpRoot("ag-enum-disc-")
+    await write(root, "docs/specs/alpha-term.md", "contains zebra\n")
+    await write(root, "docs/specs/sub/zebra.md", "plain\n")
+    await write(root, "docs/specs/sub/deep/other.md", "zebra inside\n")
+    await write(root, "other/no-term.md")
+
+    const result = await queryGraph(emptyGraph(), {
+      kind: "discover",
+      term: "zebra",
+      roots: ["docs/specs", "missing-root"],
+      rootDir: root,
+    })
+
+    expect(result.discovered).toEqual([
+      "docs/specs/alpha-term.md",
+      "docs/specs/sub/deep/other.md",
+      "docs/specs/sub/zebra.md",
+    ])
+  })
+})
+
+describe("recursive enumeration contract: verification scan", () => {
+  it("counts only markdown files under the indexed paths", async () => {
+    const root = await tmpRoot("ag-enum-verify-")
+    await createFixture(root)
+    // Non-markdown input files must not inflate the verification file count.
+    await write(root, "docs/requirements/extra.yaml", "extra: 1\n")
+    await buildGraph({ root, output: join(root, ".agentdev", "graph") })
+    const graph = await loadGraph(join(root, ".agentdev", "graph"))
+    const config = await resolveBuildConfig(root)
+
+    const report = await verifyGraph(root, graph, config)
+
+    // Independent .md count as the oracle: non-markdown inputs (extra.yaml)
+    // must not inflate the verification file count.
+    const mdCount = ["docs/requirements", "docs/decisions", "docs/designs"]
+      .flatMap((p) => readdirSync(join(root, p), { recursive: true }))
+      .filter((f) => String(f).endsWith(".md")).length
+    expect(report.summary.checked_files).toBe(mdCount)
+    expect(report.summary.checked_files).toBeGreaterThan(0)
+  })
+})
+
+function emptyGraph() {
+  return {
+    meta: { generated_at: "", config_digest: "", schema: "", tool: { name: "", version: "" } },
+    nodes: [],
+    edges: [],
+    provenance: [],
+  } as Parameters<typeof queryGraph>[0]
+}


### PR DESCRIPTION
## 概要

Issue #2353（親 Epic #2351、REQ-044、DEC-019）。OU-002 として、repo-local 検査器群と agentdev-artifact-graph scripts の再帰ファイル探索独自実装（listFilesRecursive、listMarkdownRecursive、walkMarkdown、walk、walkDir 相当）を `node:fs` の `glob` / `globSync` へ移行する。列挙結果の決定性、隠しディレクトリの探索範囲、symlink/junction の扱い、存在しないディレクトリの失敗時動作、パス正規化の既存外部契約を維持する（checker-execution-contracts Design「再帰ファイル探索と CLI 引数解析の標準API移行」節、agentdev-artifact-graph Design「スクリプト実装の標準API移行」節）。

Closes #2353

## 実装内容

### 共通ヘルパー（新規 2 ファイル）

- `.opencode/skills/repo-agentdev-integrity/scripts/lib/glob_walk.ts` — `globWalkRel(rootDir, opts)`。`fs.globSync("**/*", { cwd })` を基調とし、拡張子フィルタ・ディレクトリ名スキップ・lstat isFile フィルタ（旧 `Dirent.isFile()` 相当）・祖先リンク検査（symlink/junction ディレクトリ非下降の維持）を適用し、forward slash 正規化済み相対パスの sort 順で返す。ENOENT は空扱い、それ以外の走査エラーは握り潰さず伝播
- `src/opencode/skills/agentdev-artifact-graph/scripts/lib/glob_walk.ts` — `enumerateFilesRel(rootDir)`。同契約の distributed 版（isExcludedPath/isInputFile の適用は呼び出し側）

### repo-local 検査器群（8 ファイル）

| ファイル | 移行対象 | 移行後の形 |
|---|---|---|
| check_extensions.ts | listFilesRecursive、listYamlFilesRecursive | globWalkRel（filesOnly、拡張子フィルタ）への薄ラッパー |
| check_extensions.ts | listMarkdownFiles | 両呼び出し点が `recursive=false`（実質単一ディレクトリ列挙）のため未使用再帰分岐を削除。単一ディレクトリ直下の列挙は Design 上の移行対象外のため readdirSync のまま |
| check_workflow_preventive.ts | listFilesRecursive | globWalkRel（extensions パラメータは呼び出し側フィルタとして維持） |
| check_executor_notation.ts | listMarkdownRecursive | globWalkRel（skipDirNames: node_modules / .git を維持） |
| check_delegation_contract_residual.ts | listMarkdownRecursive | globWalkRel |
| check_retired_artifact_residual.ts | listMarkdownRecursive | globWalkRel |
| check_integrity.ts | walkMarkdown、collectMarkdownTree、walkAllFiles | globWalkRel（acc ベース署名は維持、呼び出し点無変更） |
| lint_skills.ts | references 収集の IIFE walk | `collectReferenceMarkdownFiles` として抽出し globWalkRel へ |

補足: lint_skills.ts の `main()` が import 即実行だったため `import.meta.main` ガードを追加（check_test_impact.ts と同じ規約。テストからの直接 import を可能にする）。

### check_test_impact.ts（テストファイル発見）

- 旧ミニ glob 実装（`globMatch`、正規表現変換）を廃止し、`fs.globSync(testGlob, { cwd: root })` へ統合（二重解析経路の解消）
- 旧解釈の「`**/` 先頭パターンは `/` を含む相対パスのみマッチ（リポジトリルート直下ファイルは対象外）」を明示的に維持（Design の「標準 API が受理できる形式を新規の公開 CLI 仕様として追加しない」への準拠。移行前後で対象ファイル集合が同一）
- `node:fs glob` のワイルドカードはドット始まりディレクトリを列挙できないため、リポジトリルート直下の隠しディレクトリ（`.opencode`、`.agentdev`）は「トップレベル単一階層 readdir で発見 → その内側を cwd 直指定の glob で列挙」の補助パスで網羅（`.opencode` 配下のテストファイル群を含む全 455 件が移行前と同一）

### agentdev-artifact-graph scripts/lib（3 ファイル）

| ファイル | 移行後 |
|---|---|
| input.ts | walk を enumerateFilesRel ベースへ。indexed_paths の isExcludedPath 除外、isInputFile フィルタ、ENOENT 空扱い（それ以外は伝播）、collectInputs の Set+sort による決定性を維持 |
| query.ts | walkDir を廃止し enumerateFilesRel へ。discover の roots 存在チェック・sort 済み出力を維持 |
| verification.ts | 独立スキャンの walk を enumerateFilesRel ベースへ。`.md` のみカウント、indexed_paths 存在チェックを維持 |

scripts/README.md の lib 構成図に glob_walk.ts を追記。

## 比較表（移行前後の回帰データ）

### コミット済み契約テスト（TS-003 固定データ）

- `walk_enumeration_contract.test.ts`（repo-local、11 test）: 対象ファイル集合（拡張子フィルタ、単一ディレクトリと再帰の違い）、node_modules/.git スキップの有無（実装ごとの差を含む）、ルート直下 `.git`/`.opencode` 等の隠しディレクトリ包含、欠落ディレクトリは全実装で `[]`（例外送出なし）、junction/symlink ディレクトリ非下降・リンクファイル非報告、同一入力から同一順序（決定性）
- `enumeration_contract.test.ts`（artifact-graph、7 test）: 入力収集の対象ファイル集合と forward slash 正規化、node_modules/.git/.cache/.tmp 除外、欠落 indexed path の空扱い、パスと digest の決定性、リンク非下降、discover の sorted/dedup 出力、verification の .md のみカウント

いずれも移行前実装で green を確認した後、移行後も green（変更なし）。

### 実リポジトリ出力の before/after（timestamp 行を除き完全一致）

| 対象 | 結果 |
|---|---|
| check_extensions --json | IDENTICAL（exit 0） |
| check_workflow_preventive --json | IDENTICAL（exit 0） |
| check_executor_notation --json | IDENTICAL（exit 0） |
| check_delegation_contract_residual --json | IDENTICAL（scanned_files 500、exit 0） |
| check_retired_artifact_residual --json | IDENTICAL（exit 0） |
| check_test_impact --base-ref HEAD --json | IDENTICAL（tests_scanned 455、exit 0。旧実装スナップショットとの同一ツリー比較） |
| lint_skills --json | IDENTICAL（673 ok / 1 ng〔移行前から存在する unmanaged NG 1 件〕、exit 1） |
| check_integrity --json | IDENTICAL（4,317 行一致、ng=14 は移行前と同一、exit 1） |
| build_graph + query_graph discover | IDENTICAL（exit 0） |
| verify_graph | IDENTICAL（checked_files=481、checked_links=969、differences=33） |
| graph 5 ファイル | edges.jsonl / diagnostics.json はバイト同一。nodes.jsonl / provenance.jsonl は本 PR の新規 4 ファイル（テスト 2、ヘルパー 2）のみ差分（喪失 0。manifest.json は generated_at 含むため常に差異） |

決定性: `discoverTestFiles` を 10 連続実行し同一結果を確認。

## 検証

### TS-004（node:fs glob の Bun 実行環境での可用性）

- `bun 1.3.10`（Windows）で `typeof fs.globSync === "function"` を確認、最小列挙を実行済み。利用可能のため blocked ではなく実装完了
- 実測した制約（設計に反映済み）:
  - `withFileTypes` オプション非対応（エラー）。promise 形式 `glob()` は callback 必須
  - ワイルドカードはドット始まりパス要素を列挙不可。ただし cwd に直接指定したディレクトリ（例: `.agentdev/extensions/skills`）配下は列挙可 → 走査ルート直指定 + ルート直下隠しディレクトリの補助パスで網羅
  - junction / symlink ディレクトリを下降する（旧 readdir 実装は非下降）→ 祖先 lstat 検査でリンク経由パスを除外し旧挙動を厳密維持
  - 欠落 cwd は ENOENT throw → キャッチして空扱い（旧契約維持）
  - `a/**/b` のゼロコンポーネントマッチ、`**/*.{yaml,yml}` ブレースは利用可

### TS-001（残存スキャン）

- 対象スコープから再帰列挙独自実装が消滅。各 walker は globWalkRel / enumerateFilesRel へ委譲する薄ラッパー（関数名は呼び出し点互換のため維持、再帰呼び出しは残っていない）
- check_test_impact のミニ glob 実装を廃止（同一入力に対する二重解析経路なし）
- 残存する `readdirSync` はすべて: (a) 単一ディレクトリ直下の列挙、(b) `Dirent`/`stat` による属性判定（いずれも Design 上の移行対象外）、(c) `check_integrity.ts` の `readdirSync(dir, { recursive: true })`（標準API利用のため対象外）
- 意図的な移行対象外（根拠: 本 Issue の Execution Contract「変更対象成果物」に含まれない、および artifact-graph Design の移行契約が lib 3 ファイルのみ列挙）:
  - `lib/distribution-boundary-fs.ts` listArtifactsRec、`lib/distribution-boundary-rules.ts` listPublicMarkdownFiles（配布境界 gate 自身の列挙）
  - `trusted-distribution-gate/archive-installed-verifier.ts`、`trusted-distribution-gate/archive-zip.ts`（trust 検証の列挙）
  - `generate_indexes.ts` countDesignFiles
  - `effectiveness/independent_search.ts` walkFiles（Graph を使わない独立探索として意図的に素の fs 実装を保持する評価 harness）

### テストスイート

- repo-local（`bun test ./.opencode/skills/repo-agentdev-integrity/scripts/`）: **2100 pass / 1 fail**。1 fail は移行前ベースラインと同一の既知 IR-055 delta テスト（Wave 1 merge 起因、intake item 2026-08-20-project-extensions-readme-ir055-repo-refs.md で既に回収済み。本 PR では不対応）
- artifact-graph（`bun test`）: **176 pass / 0 fail**（既存 169 + 本 PR 7）
- 型チェック: artifact-graph `tsc --noEmit` exit 0、repo-local `typecheck`（tsconfig.distribution-boundary.json）exit 0
- 配布境界最終 gate: `check_distribution_boundary.ts --profile source --json` **ok=true / exit 0**（failures=0）

### 経路G（adversarial-review）について

実施せず（スキップ根拠を記録）: 本移行は Design 契約（checker-execution-contracts「再帰ファイル探索と CLI 引数解析の標準API移行」節、artifact-graph「スクリプト実装の標準API移行」節）が移行対象・契約維持事項・blocked 条件を具体的に定めており、実装方針は契約から機械的に導出可能であった。実行時に判明した非自明点（Bun globSync のドット要素列挙不能、ジャンクション下降、エラー握り潰しリスク）はすべて Design の契約維持要求（隠しディレクトリ網羅、リンク探索範囲維持、ENOENT 扱い）に照らして一意に解決し、それぞれ下記の Design確定候補として記録した。未解決の本質的争点やユーザー判断事項は残っていない。

## Findings / Capture候補

1. **旧実装の静かな部分走査リスク（learning capture 候補）**: 移行前の walk 実装群はディレクトリ単位のエラーを黙ってスキップする構造だった。本検証中、Windows のディレクトリロック（AV 等が起因と推定）時に走査結果が一過性に減少する事象（tests_scanned 455→285、checked_files 481→473、scanned_files 500→484）を観測した。穏やかな状態では旧実装・新実装とも完全一致・決定的（10 連続実行で同一）。移行後は ENOENT 以外の走査エラーを伝播させ、静かな部分レポートを構造的に排除したが、Bun の globSync が内部で一部エラーを握り潰す可能性は残る。列挙件数を期待件数と突合する既存規約（パターンマッチ・網羅検査設計の標準規約「二重確認」）の適用を各 checker で検討する価値がある
2. **スコープ外残存再帰実装 6 箇所**（TS-001 の意図的な移行対象外リスト）: Execution Contract の変更対象成果物外であるため本 PR では未移行。後続 Issue 化の候補（distribution-boundary gate 自身の列挙、trusted-distribution-gate、generate_indexes、effectiveness harness）
3. **lint_skills.ts の main() 無ガード**: import 即 CLI 実行・`process.exit` する構造だった（他の checker は `import.meta.main` ガードあり）。本 PR でガードを追加
4. **check_test_impact の走査除外リストと現行配置の乖離**: SCAN_EXCLUDE_DIRS は `node_modules/` をルート直下のみ前提とする先頭一致のため、`src/opencode/skills/*/scripts/node_modules` 配下の依存パッケージのテストファイル（zod 等、約 160 件）が tests_scanned に含まれる（移行前から同様。本 PR では契約維持のためそのまま）

## Design確定候補

1. **ドット名ディレクトリ・ドットファイルの列挙範囲の明文化**: `node:fs glob`（Bun 1.3.10 実装）のワイルドカードはドット始まりパス要素を列挙できない。本実装は「走査ルート直下のドット名ディレクトリは単一階層 readdir + cwd 直指定 glob で網羅、それより深い位置のドット名ディレクトリ・ドットファイルは列挙不能」という上限を持つ。本リポジトリの走査対象ツリーに該当は存在しない。Design「`.agentdev`、`.opencode` 等の隠しディレクトリを明示的な探索対象から除外しない」の実装可能な解釈として「明示的な走査ルート（ドット名ルートの直指定を含む）とルート直下の隠しディレクトリの網羅」を明文化する提案
2. **列挙エラー伝播方針の明文化**: ENOENT は空、それ以外の走査エラーは伝播（旧 repo-local 実装の挙動に一致。部分走査の黙り込み排除）を Design に明記する提案
3. **列挙順の契約化**: 「正規化後パスの辞書順 sort」を列挙契約として明記する提案（NTFS の readdir 順は大文字小文字を区別しないたずれにより辞書順と異なり得る。本ケースでは実出力への影響を確認済み: 全 checker 出力が移行前と完全一致）
