### PR TITLE
feat(agentdev): トレーサビリティ能力のワークフロー統合への切替（Issue #2361）

### DIFF
--- a/.agentdev/extensions/skills/agentdev-adversarial-review.yaml
+++ b/.agentdev/extensions/skills/agentdev-adversarial-review.yaml
@@ -3,16 +3,13 @@ kind: capability-skill-extension
 id: agentdev-adversarial-review
 
 context:
-  - id: artifact-graph-spec
-    when: Artifact Graphを論点候補の探索に使用するとき
+  - id: design-index
+    when: レビュー対象候補と evidence を README 索引、正規成果物の直接読取、rg 等の独立探索手段で探索するとき
     paths:
-      - "docs/designs/skills/agentdev-artifact-graph.md"
-    purpose: 派生索引の利用上の防護と障害耐性の確認
+      - "docs/designs/README.md"
+    purpose: Design 一覧と入口表を起点としたレビュー対象候補の探索
 
-rules:
-  - id: artifact-graph-deliberation-candidates
-    when: 複数規範関係、循環、集中ノード、孤立候補、複数経路から審議論点の候補を探索するとき。利用不能時は従来の探索手段で続行する
-    skill: agentdev-artifact-graph
+rules: []
 
 checks: []
 

--- a/.agentdev/extensions/skills/agentdev-workflow-case-close.yaml
+++ b/.agentdev/extensions/skills/agentdev-workflow-case-close.yaml
@@ -30,9 +30,9 @@ context:
     purpose: "docs/designs/integrity/integrity-rule-catalog.md 経由で関連 IR を確認してよい"
 
 rules:
-  - id: artifact-graph-closure-observation
-    when: 鮮度、未解決参照、存在しないノードへの関係、根拠欠落、関係閉包の候補を観測するとき。利用不能時は従来の検査手段で続行する
-    skill: agentdev-artifact-graph
+  - id: traceability-qg4-independent-recheck
+    when: QG-4 で対象要件の実装対応・検証対応の完全性を独立して再検査するとき。利用不能時は既存の品質ゲート、targeted docs guard、rg 等の従来の検査手段で続行する
+    skill: agentdev-traceability
 
 checks:
   - id: autogen-index-regeneration-diff

--- a/.agentdev/extensions/skills/agentdev-workflow-case-open.yaml
+++ b/.agentdev/extensions/skills/agentdev-workflow-case-open.yaml
@@ -23,10 +23,7 @@ context:
       - "docs/designs/commands/case-open.md"
     purpose: 統合先と実証CaseのIssue構成セクションの実行詳細確認
 
-rules:
-  - id: artifact-graph-impact-candidates
-    when: 起点成果物から変更影響、廃止参照、未解決参照の候補を探索するとき。利用不能時は従来の探索手段で続行する
-    skill: agentdev-artifact-graph
+rules: []
 
 checks: []
 

--- a/.agentdev/extensions/skills/agentdev-workflow-case-run.yaml
+++ b/.agentdev/extensions/skills/agentdev-workflow-case-run.yaml
@@ -14,9 +14,9 @@ context:
     purpose: "case-run 3フェーズ構成と自律修正ループ契約の確認"
 
 rules:
-  - id: artifact-graph-implementation-context
-    when: 実装対象に関係するREQ、Design、整合性ルール、周辺成果物の候補を探索するとき。利用不能時は従来の探索手段で続行する
-    skill: agentdev-artifact-graph
+  - id: traceability-check-before-pr
+    when: 対象要件の対応関係確認と PR 作成前の対応宣言整合性検査（check）を実施するとき。利用不能時は README 索引、正規成果物の直接読取、rg 等の独立探索手段で続行する
+    skill: agentdev-traceability
 
 checks: []
 

--- a/.agentdev/extensions/skills/agentdev-workflow-design-save.yaml
+++ b/.agentdev/extensions/skills/agentdev-workflow-design-save.yaml
@@ -18,10 +18,7 @@ context:
   - id: discovery-3
     purpose: "docs/designs/foundations/document-model.md で Design ドメイン分類規則を確認してよい"
 
-rules:
-  - id: artifact-graph-candidate-discovery
-    when: 対応REQ、同じ正規所有対象のDesign、関連command・skill・整合性ルールの候補を探索するとき。利用不能時は従来の探索手段で続行する
-    skill: agentdev-artifact-graph
+rules: []
 
 checks: []
 

--- a/.agentdev/extensions/skills/agentdev-workflow-req-define.yaml
+++ b/.agentdev/extensions/skills/agentdev-workflow-req-define.yaml
@@ -46,9 +46,9 @@ context:
     purpose: docs/designs/README.md 経由で Design 一覧と status を参照してよい
 
 rules:
-  - id: artifact-graph-candidate-discovery
-    when: 既存REQ、関連ADR・Design、構造的所有者重複の候補を探索するとき。利用不能時は従来の探索手段で続行する
-    skill: agentdev-artifact-graph
+  - id: traceability-impact-confirmation
+    when: 既存の明示的な対応関係と変更影響候補の確認に coverage、impact を利用するとき。利用不能時は README 索引、正規成果物の直接読取、rg 等の独立探索手段で続行する
+    skill: agentdev-traceability
 
 checks: []
 

--- a/.opencode/skills/repo-agentdev-integrity/scripts/tests/traceability_workflow_integration.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/tests/traceability_workflow_integration.test.ts
@@ -1,0 +1,250 @@
+// ADF-COVERS(verification): REQ-021-011, REQ-021-012, REQ-021-013, REQ-021-014, REQ-021-015, REQ-021-016, REQ-021-017, REQ-021-018, REQ-021-019, REQ-021-020, REQ-021-021, REQ-021-022
+//
+// トレーサビリティのワークフロー統合（OU-003、Issue #2361）の切替検証。
+// 対象 Design・Workflow Skill 本文・extension の旧 agentdev-artifact-graph 参照の残存なし、
+// 診断・レビュー系工程の agentdev-traceability 一般探索利用の禁止、
+// REQ-021-011〜022 の割り当て文言の存在を検証する。
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..", "..");
+
+function read(rel: string): string {
+  return readFileSync(join(REPO_ROOT, rel), "utf-8");
+}
+
+/** Issue #2361 の対象範囲（Design 10件 + req-save Design + Workflow Skill 10件 + extension 6件） */
+const SWITCH_TARGET_FILES: readonly string[] = [
+  "docs/designs/commands/req-define.md",
+  "docs/designs/commands/design-save.md",
+  "docs/designs/commands/case-open.md",
+  "docs/designs/commands/case-run.md",
+  "docs/designs/commands/case-close.md",
+  "docs/designs/commands/inspect-docs.md",
+  "docs/designs/commands/inspect-skills.md",
+  "docs/designs/commands/backlog-review.md",
+  "docs/designs/commands/req-save.md",
+  "docs/designs/skills/agentdev-doc-diagnostics.md",
+  "docs/designs/skills/agentdev-adversarial-review.md",
+  "src/opencode/skills/agentdev-workflow-req-define/SKILL.md",
+  "src/opencode/skills/agentdev-workflow-design-save/SKILL.md",
+  "src/opencode/skills/agentdev-workflow-case-open/SKILL.md",
+  "src/opencode/skills/agentdev-workflow-case-run/SKILL.md",
+  "src/opencode/skills/agentdev-workflow-case-close/SKILL.md",
+  "src/opencode/skills/agentdev-workflow-inspect-docs/SKILL.md",
+  "src/opencode/skills/agentdev-workflow-inspect-skills/SKILL.md",
+  "src/opencode/skills/agentdev-workflow-backlog-review/SKILL.md",
+  "src/opencode/skills/agentdev-adversarial-review/SKILL.md",
+  "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
+  ".agentdev/extensions/skills/agentdev-workflow-req-define.yaml",
+  ".agentdev/extensions/skills/agentdev-workflow-design-save.yaml",
+  ".agentdev/extensions/skills/agentdev-workflow-case-open.yaml",
+  ".agentdev/extensions/skills/agentdev-workflow-case-run.yaml",
+  ".agentdev/extensions/skills/agentdev-workflow-case-close.yaml",
+  ".agentdev/extensions/skills/agentdev-adversarial-review.yaml",
+];
+
+/** REQ-021-021 の対象（診断・レビュー系5工程: Design と Workflow Skill 本文） */
+const DIAGNOSTIC_REVIEW_FILES: readonly string[] = [
+  "docs/designs/commands/inspect-docs.md",
+  "docs/designs/commands/inspect-skills.md",
+  "docs/designs/commands/backlog-review.md",
+  "docs/designs/skills/agentdev-doc-diagnostics.md",
+  "docs/designs/skills/agentdev-adversarial-review.md",
+  "src/opencode/skills/agentdev-workflow-inspect-docs/SKILL.md",
+  "src/opencode/skills/agentdev-workflow-inspect-skills/SKILL.md",
+  "src/opencode/skills/agentdev-workflow-backlog-review/SKILL.md",
+  "src/opencode/skills/agentdev-adversarial-review/SKILL.md",
+];
+
+const LEGACY_PATTERNS: readonly RegExp[] = [
+  /agentdev-artifact-graph/,
+  /Artifact Graph/,
+  /\.agentdev\/graph/,
+];
+
+describe("トレーサビリティのワークフロー統合: 旧参照の残存なし", () => {
+  it.each(SWITCH_TARGET_FILES)("対象ファイルに旧参照が残存しない: %s", (rel) => {
+    const content = read(rel);
+    for (const pattern of LEGACY_PATTERNS) {
+      expect(pattern.test(content)).toBe(false);
+    }
+  });
+});
+
+describe("REQ-021-021: 診断・レビュー系工程の agentdev-traceability 一般探索利用の禁止", () => {
+  it.each(DIAGNOSTIC_REVIEW_FILES)("agentdev-traceability の言及が否定文のみ: %s", (rel) => {
+    const lines = read(rel).split(/\r?\n/);
+    for (const line of lines) {
+      if (line.includes("agentdev-traceability")) {
+        expect(line.includes("利用しない")).toBe(true);
+      }
+    }
+  });
+
+  it.each(DIAGNOSTIC_REVIEW_FILES.slice(0, 5))("独立探索手段への切替が記述されている: %s", (rel) => {
+    expect(read(rel).includes("独立探索手段")).toBe(true);
+  });
+});
+
+describe("REQ-021-011〜022 の割り当て文言の存在", () => {
+  const phraseChecks: ReadonlyArray<{ req: string; file: string; phrases: readonly string[] }> = [
+    {
+      req: "REQ-021-011",
+      file: "docs/designs/commands/req-define.md",
+      phrases: [
+        "impact を変更影響候補の確認に利用できる",
+        "impact の空結果を「影響なし」の根拠としない",
+        "推測して正規情報として保存しない",
+        "対象範囲を確定しない",
+      ],
+    },
+    {
+      req: "REQ-021-012",
+      file: "docs/designs/commands/req-save.md",
+      phrases: [
+        "対応宣言を作成する責務を持たない",
+        "失敗させない",
+      ],
+    },
+    {
+      req: "REQ-021-013",
+      file: "docs/designs/commands/design-save.md",
+      phrases: [
+        "明示的に確定している場合",
+        "再推論して正規の対応関係を生成しない",
+        "Design action が存在しない要件の処理を妨げない",
+      ],
+    },
+    {
+      req: "REQ-021-014",
+      file: "docs/designs/commands/case-open.md",
+      phrases: [
+        "対象要件と実行契約を Issue へ引き継ぐ",
+        "対象範囲を再決定しない",
+      ],
+    },
+    {
+      req: "REQ-021-015",
+      file: "docs/designs/commands/case-run.md",
+      phrases: [
+        "そのファイルを要件へ自動的に対応付けない",
+        "対応宣言として正規成果物へ明示する",
+      ],
+    },
+    {
+      req: "REQ-021-016",
+      file: "docs/designs/commands/case-run.md",
+      phrases: [
+        "PR 作成前に対象要件について check を実行し",
+        "修正して再検証する",
+      ],
+    },
+    {
+      req: "REQ-021-017",
+      file: "docs/designs/commands/case-run.md",
+      phrases: [
+        "blocked として必要な判断事項を報告する",
+      ],
+    },
+    {
+      req: "REQ-021-018",
+      file: "docs/designs/commands/case-close.md",
+      phrases: [
+        "独立して再検査する",
+        "マージせず停止する",
+        "修正対象として差し戻せる",
+      ],
+    },
+    {
+      req: "REQ-021-019",
+      file: "docs/designs/commands/case-run.md",
+      phrases: [
+        "恒常的な対応関係",
+        "実行結果は Issue, PR, QG 側で扱う",
+      ],
+    },
+    {
+      req: "REQ-021-019",
+      file: "docs/designs/commands/case-close.md",
+      phrases: [
+        "分離して扱う",
+      ],
+    },
+    {
+      req: "REQ-021-020",
+      file: "docs/designs/commands/design-save.md",
+      phrases: [
+        "同じ対応宣言を重複生成しない",
+      ],
+    },
+    {
+      req: "REQ-021-020",
+      file: "docs/designs/commands/case-run.md",
+      phrases: [
+        "同じ対応宣言を重複生成しない",
+      ],
+    },
+    {
+      req: "REQ-021-022",
+      file: "docs/designs/commands/req-define.md",
+      phrases: ["トレーサビリティ機能側の異常を区別する"],
+    },
+    {
+      req: "REQ-021-022",
+      file: "docs/designs/commands/case-run.md",
+      phrases: ["トレーサビリティ機能側の異常を区別する"],
+    },
+    {
+      req: "REQ-021-022",
+      file: "docs/designs/commands/case-close.md",
+      phrases: ["トレーサビリティ機能側の異常を区別する"],
+    },
+  ];
+
+  it.each(phraseChecks)("%s: %s", ({ file, phrases }) => {
+    const content = read(file);
+    for (const phrase of phrases) {
+      expect(content.includes(phrase)).toBe(true);
+    }
+  });
+});
+
+describe("Workflow Skill 本文・extension の切替", () => {
+  it.each([
+    "src/opencode/skills/agentdev-workflow-req-define/SKILL.md",
+    "src/opencode/skills/agentdev-workflow-design-save/SKILL.md",
+    "src/opencode/skills/agentdev-workflow-case-open/SKILL.md",
+    "src/opencode/skills/agentdev-workflow-case-run/SKILL.md",
+    "src/opencode/skills/agentdev-workflow-case-close/SKILL.md",
+  ])("5工程 Workflow Skill がトレーサビリティ能力の利用節を持つ: %s", (rel) => {
+    expect(read(rel).includes("## トレーサビリティ能力の利用")).toBe(true);
+  });
+
+  it.each([
+    "src/opencode/skills/agentdev-workflow-inspect-docs/SKILL.md",
+    "src/opencode/skills/agentdev-workflow-inspect-skills/SKILL.md",
+    "src/opencode/skills/agentdev-workflow-backlog-review/SKILL.md",
+    "src/opencode/skills/agentdev-adversarial-review/SKILL.md",
+  ])("診断・レビュー系 Workflow Skill が独立探索手段の節を持つ: %s", (rel) => {
+    expect(read(rel).includes("## 候補探索（独立探索手段）")).toBe(true);
+  });
+
+  it.each([
+    ".agentdev/extensions/skills/agentdev-workflow-req-define.yaml",
+    ".agentdev/extensions/skills/agentdev-workflow-case-run.yaml",
+    ".agentdev/extensions/skills/agentdev-workflow-case-close.yaml",
+  ])("traceability を利用する工程の extension rule が agentdev-traceability を指す: %s", (rel) => {
+    expect(read(rel).includes("skill: agentdev-traceability")).toBe(true);
+  });
+
+  it.each([
+    ".agentdev/extensions/skills/agentdev-workflow-design-save.yaml",
+    ".agentdev/extensions/skills/agentdev-workflow-case-open.yaml",
+    ".agentdev/extensions/skills/agentdev-adversarial-review.yaml",
+  ])("traceability を利用しない工程の extension が rules を持たない: %s", (rel) => {
+    expect(read(rel).includes("rules: []")).toBe(true);
+  });
+});

--- a/docs/designs/commands/backlog-review.md
+++ b/docs/designs/commands/backlog-review.md
@@ -2,8 +2,10 @@
 title: backlog-review Design
 status: accepted
 created: 2026-06-21
-updated: 2026-08-15
+updated: 2026-08-21
 ---
+
+<!-- ADF-COVERS(implementation): REQ-021-021 -->
 
 # backlog-review Design
 
@@ -61,16 +63,14 @@ updated: 2026-08-15
 - Workflow Skill の単独起動防止（soft guard）は Workflow Skill description の DO NOT USE FOR トリガーにより実効する（command 定義本文に soft guard 宣言節を持たない構成である）。
 - Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
-## Artifact Graph 利用
+## 候補探索（独立探索手段）
 
-backlog-review は入力成果物に含まれる REQ, Decision, Design, canonical owner 等の明示情報を起点として既存正規成果物との関係候補を Artifact Graph 経由で取得できる。
-候補には統合, 分割, depends_on 解決の補助 evidence を含む。
+backlog-review は、入力成果物に含まれる REQ, Decision, Design, canonical owner 等の明示情報を起点として、README 索引、正規成果物の直接読取、`rg` 等の独立探索手段で既存正規成果物との関係候補を探索する（REQ-021-021）。
+agentdev-traceability の coverage, impact, check を一般文書探索、構造診断、依存関係探索の用途に利用しない。
 
-Graph は候補提供者であり、統合, 分割, depends_on, 意味的重複の最終判断は正規成果物本文と独立探索手段での確認後に下す。
-promoted artifact 自体を Graph の正規 node とすることは必須でない。
-共通利用原則の防護事項は `agentdev-artifact-graph` Design「ワークフロー利用」を参照。
-
-Graph 不在、stale、consumer 環境に対応 node type または relation type が存在しない場合は、従来の探索経路で継続し、workflow を停止しない（fail-open）。
+- 候補には統合, 分割, depends_on 解決の補助 evidence を含める
+- 統合, 分割, depends_on, 意味的重複の最終判断は正規成果物本文と独立探索手段での確認後に下す
+- promoted artifact 自体を特定の探索機構の正規 node とすることは必須でない
 
 ## 参照する横断 Design
 

--- a/docs/designs/commands/case-close.md
+++ b/docs/designs/commands/case-close.md
@@ -2,8 +2,10 @@
 title: case-close Design
 status: accepted
 created: 2026-06-21
-updated: 2026-08-19
+updated: 2026-08-21
 ---
+
+<!-- ADF-COVERS(implementation): REQ-021-018, REQ-021-019, REQ-021-022 -->
 
 # case-close Design
 
@@ -144,15 +146,16 @@ Epic Issue 本文の `## 完了条件` セクションを読み込み、全完�
 - Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
 - Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
-## Artifact Graph 利用
+## トレーサビリティ能力の利用（QG-4 独立再検査）
 
-case-close は Artifact Graph を変更後の関係整合性検証に利用する。
-確認対象は Graph の生成と鮮度, Graph integrity, unresolved relation, dangling relation, provenance defect, Graph と独立確認結果との差異である。
-Graph defect と canonical defect を区別する。
+case-close は QG-4 の一部として、対象要件の実装対応と検証対応の完全性を `agentdev-traceability` の check で正規成果物から独立して再検査する（REQ-021-018）。
+case-run 側の事前検査とは独立に実施する。検証手段との対応関係と「今回その検証を実行して合格したか」という実行結果（Issue, PR, QG の記録）を分離して扱う（REQ-021-019）。
 
-Graph 自体の生成または問い合わせ失敗のみを理由に case-close を失敗させず、fail-open して従来の検証経路で継続する。
-正規成果物側の実不整合が確認された場合は既存の品質ゲート, 受け入れ条件に従って fail とする。
-共通利用原則の防護事項は `agentdev-artifact-graph` Design「ワークフロー利用」を参照。
+- 対象要件に実装対応または検証対応の欠落が残る場合はマージせず停止する
+- 不足する対応関係を自動追加または修正せず、検査失敗を case-run 側の修正対象として差し戻せる
+- 移行期間中（全現行要件の対応付け完了まで）は QG-4 の対応完全性検査を強制しない（有効化は別途判断）。移行期間中に検査を実行した場合は、結果を参考情報として報告できる
+- agentdev-traceability の不在、実行失敗、空結果、候補過多だけを理由に case-close を失敗させない（fail-open）。正規成果物そのものの異常とトレーサビリティ機能側の異常を区別する
+- 正規成果物側の実不整合が確認された場合は、既存の品質ゲート, 受け入れ条件に従って fail とする
 
 ## 参照する横断 Design
 

--- a/docs/designs/commands/case-open.md
+++ b/docs/designs/commands/case-open.md
@@ -2,8 +2,10 @@
 title: case-open Design
 status: accepted
 created: 2026-06-21
-updated: 2026-08-19
+updated: 2026-08-21
 ---
+
+<!-- ADF-COVERS(implementation): REQ-021-014 -->
 
 # case-open Design
 
@@ -203,17 +205,14 @@ child Issue テンプレートの「レビュー判断」セクションは親 E
 `review_dispositions` を持たない旧ドラフトを case-open は入力として拒否しない（DEC-003 準拠）。
 フィールド欠落時は「レビュー判断」セクションへ「該当なし」と記載する。
 
-## Artifact Graph 利用
+## トレーサビリティ能力の利用
 
-case-open は Issue の対象範囲, 完了条件, test strategy, 必須 skill, 検証事項を確定する前に Artifact Graph による変更影響候補を評価する。
-候補には REQ, Decision, Design, command, skill, extension, integrity rule, 関連 source_file を含められる。
-Graph 候補は正規成果物または独立した探索手段で確認した上で in scope, verification only, out of scope に分類する。
+case-open は、上流工程（req-define）で確定した対象要件と実行契約を Issue へ引き継ぐ（REQ-021-014）。
+Issue の対象範囲, 完了条件, test strategy, 必須 skill, 検証事項は、上流工程の引き継ぎ情報（draft-data、artifact_actions、operation_units）を基に確定する。
 
-必須品質能力の導出は `artifact-quality-control-routing` Design が定める artifact type から品質能力キーへの変換に従い、Graph の delegates_to, governs 関係から必須 skill を直接決定しない。
-Graph は変更成果物候補と関連規則候補の探索のみを担当する。
-共通利用原則の防護事項は `agentdev-artifact-graph` Design「ワークフロー利用」を参照。
-
-Graph 不在、stale、consumer 環境に対応 node type または relation type が存在しない場合は、従来の探索経路で継続し、workflow を停止しない（fail-open）。
+- req-define と重複して一般的な変更影響探索や依存関係探索を行い、対象範囲を再決定しない
+- 引き継ぎ情報に欠落があり変更影響候補の確認（REQ-017-010）が必要な場合は、req-define へ差し戻す
+- 必須品質能力の導出は `artifact-quality-control-routing` Design が定める artifact type から品質能力キーへの変換に従う
 
 ## 参照する横断 Design
 

--- a/docs/designs/commands/case-run.md
+++ b/docs/designs/commands/case-run.md
@@ -2,8 +2,10 @@
 title: case-run Design
 status: accepted
 created: 2026-06-21
-updated: 2026-08-19
+updated: 2026-08-21
 ---
+
+<!-- ADF-COVERS(implementation): REQ-021-015, REQ-021-016, REQ-021-017, REQ-021-019, REQ-021-020, REQ-021-022 -->
 
 # case-run Design
 
@@ -210,17 +212,18 @@ verification-only PR は case-close の targeted docs guard で files_checked �
 - case-close は files_checked 空を検出した場合、v2:REQ-0158-002 に基づき verification-only 判定ステップを経て PASS 処理する（false-clean 3層防御との相互作用は case-close Design 参照）
 - case-run 側は PR 作成までを責務とし、verification-only 判定自体は case-close が行う（単一書き手: case-close、REQ-011 完了条件チェックボックス専任責務）
 
-## Artifact Graph 利用
+## トレーサビリティ能力の利用
 
-case-run での Artifact Graph 利用は REQ-017-010 が定める境界内で補助用途に限定する。
-補助用途は Issue に記録された対象から予期しない依存または参照が見つかった場合の補助探索, acceptance criteria の検証根拠への到達, case-open 時点からの関係差異確認を含む。
+case-run の実行担当（委譲内サブエージェント）は、対象要件について `agentdev-traceability` の coverage で既存の対応関係を確認しながら、実際に要件を実現する成果物へ実装対応を、実際に要件を検証する恒常的な検証手段へ検証対応を、対応宣言として正規成果物へ明示する（REQ-021-015）。
+実行担当は PR 作成前に対象要件について check を実行し、実装対応、検証対応、対応宣言の整合性を検査する（REQ-021-016）。
+対応宣言の表記仕様は `agentdev-traceability` Design「対応宣言の表記」が正規所有する。
 
-Graph で発見した候補のうち Issue scope 内の内部実装影響は case-run が自律処理する。
-scope, 完了条件, REQ, Decision, Design, 必須品質統制の変更が必要な場合は blocked として case-update 連携とする。
-証拠源（Graph, rg, filesystem scan の別）にかかわらず case-run は既存 scope を超える変更を自律拡大しない。
-本制限は REQ-017-010 の境界を変更せず、Graph 利用時の適用を明確化する。
-
-Graph 不在、stale、consumer 環境に対応 node type または relation type が存在しない場合は、従来の探索経路で継続し、workflow を停止しない（fail-open）。
+- 単に変更されたファイルであることを理由に、そのファイルを要件へ自動的に対応付けない
+- check の不合格が承認済み対象範囲内で修正可能な場合は、修正して再検証する
+- 要件変更、対象範囲拡大、追加設計判断、外部依存解消が必要な場合は反復を停止し、blocked として必要な判断事項を報告する（REQ-021-017）。証拠源にかかわらず既存 scope を超える変更を自律拡大しない
+- 検証対応は「何が要件を検証するか」という検証手段との恒常的な対応関係であり、「今回その検証を実行して合格したか」という実行結果は Issue, PR, QG 側で扱う。特定時点の検証結果を対応宣言として保存しない（REQ-021-019）
+- 中断後の再実行では、正規成果物に保存済みの対応関係を再利用し、同じ対応宣言を重複生成しない（REQ-021-020）
+- agentdev-traceability の不在、実行失敗、空結果、候補過多だけを理由として workflow を停止しない（fail-open）。README 索引、正規成果物の直接読取、`rg` 等の独立探索手段で継続し、正規成果物そのものの異常とトレーサビリティ機能側の異常を区別する
 
 ## 参照する横断 Design
 

--- a/docs/designs/commands/design-save.md
+++ b/docs/designs/commands/design-save.md
@@ -2,8 +2,10 @@
 title: design-save Design
 status: accepted
 created: 2026-06-21
-updated: 2026-08-15
+updated: 2026-08-21
 ---
+
+<!-- ADF-COVERS(implementation): REQ-021-013, REQ-021-020 -->
 
 # design-save Design
 
@@ -220,13 +222,15 @@ target_area 見出し検索は `agentdev-design-file-manager/scripts/src/search-
 Design operation の旧別名（`spec-create` / `spec-update` / `spec-append`）と新別名（`design-create` / `design-update` / `design-append`）は受理しない（REQ-008-058）。
 旧別名が指定された場合は形式不正としてエラー中止し、req-define 差し戻しを推奨する。
 
-## Artifact Graph 利用
+## トレーサビリティ能力の利用
 
-design-save は対応 REQ、同一または関連 canonical owner を持つ Design、関連 command, skill, integrity rule の探索に Artifact Graph を利用できる。
-Graph は候補提供者であり、target_area, 正規配置先, Design 操作分類の最終判断は正規成果物本文と独立探索手段での確認後に下す。
-共通利用原則の防護事項は `agentdev-artifact-graph` Design「ワークフロー利用」を参照。
+design-save は、req-define で Design action と対象要件の対応が明示的に確定している場合、その情報を利用して Design 文書と要件の対応関係を対応宣言として保存できる（REQ-021-013）。
+対応宣言の表記仕様は `agentdev-traceability` Design「対応宣言の表記」が正規所有し、本 Design は表記仕様を再定義しない。
 
-Graph 不在、stale、consumer 環境に対応 node type または relation type が存在しない場合は、従来の探索経路で継続し、workflow を停止しない（fail-open）。
+- Design 本文の自由記述から対象要件を再推論して正規の対応関係を生成しない
+- Design 文書の対応付けは任意とし、Design action が存在しない要件の処理を妨げない
+- 対応 REQ、同一または関連 canonical owner を持つ Design、関連 command, skill, integrity rule の探索は、README 索引、正規成果物の直接読取、`rg` 等の独立探索手段で行う（agentdev-traceability を一般文書探索、依存関係探索へ利用しない）
+- 中断後の再実行では、正規成果物に保存済みの対応宣言を再利用し、同じ対応宣言を重複生成しない（REQ-021-020）
 
 ## 参照する横断 Design
 

--- a/docs/designs/commands/inspect-docs.md
+++ b/docs/designs/commands/inspect-docs.md
@@ -2,8 +2,10 @@
 title: inspect-docs Design
 status: accepted
 created: 2026-06-21
-updated: 2026-08-15
+updated: 2026-08-21
 ---
+
+<!-- ADF-COVERS(implementation): REQ-021-021 -->
 
 # inspect-docs Design
 
@@ -66,16 +68,14 @@ REQ structure review（SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）に加えて De
 - Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
 - Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
-## Artifact Graph 利用
+## 候補探索（独立探索手段）
 
-inspect-docs は Artifact Graph を構造診断候補の探索に利用する。
-候補には unresolved reference, superseded artifact への現行参照, dangling relation, provenance 欠落, orphan candidate, 不自然な relation path, structural duplicate candidate を含む。
+inspect-docs の構造診断候補の探索は、README 索引、正規成果物の直接読取、`rg` 等の独立探索手段で行う（REQ-021-021）。
+agentdev-traceability の coverage, impact, check を一般文書探索、構造診断、依存関係探索の用途に利用しない。
 
-Graph は候補提供者であり、決定的検査（参照実在, 委譲先 skill 実在, YAML 構文, 必須 field）は ADR-006 が定める通り docs-check, IR-056 が所有する。
-inspect-docs は REQ-036-006〜011 が定める意味診断を担当し、Graph 構造候補を未検証 evidence として意味診断の入力に利用する。
-構造診断と意味診断を区別し、SPLIT, MERGE, MOVE, DUPLICATE, RETIRE, DRIFT 等の意味判断を Graph の構造情報だけから確定しない。
-
-consumer 環境に対応 node type または relation type が存在しない場合は異常とせず従来の診断経路を継続する。
+- 候補には未解決参照、superseded 成果物への現行参照、参照先が取得できない記述、正規所有者のいない成果物、構造的重複候補を含める
+- 決定的検査（参照実在, 委譲先 skill 実在, YAML 構文, 必須 field）は docs-check, 整合性ルール群が所有する。inspect-docs は REQ-036-006〜011 が定める意味診断を担当し、探索で得た候補を未検証 evidence として意味診断の入力に利用する
+- 構造診断と意味診断を区別し、SPLIT, MERGE, MOVE, DUPLICATE, RETIRE, DRIFT 等の意味判断を候補の構造情報だけから確定しない
 
 ## 参照する横断 Design
 

--- a/docs/designs/commands/inspect-skills.md
+++ b/docs/designs/commands/inspect-skills.md
@@ -2,8 +2,10 @@
 title: inspect-skills Design
 status: accepted
 created: 2026-06-21
-updated: 2026-08-15
+updated: 2026-08-21
 ---
+
+<!-- ADF-COVERS(implementation): REQ-021-021 -->
 
 # inspect-skills Design
 
@@ -66,14 +68,14 @@ Command→Skill 参照妥当性と Skill 構造を、検査対象を直接修正
 - Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
 - Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
-## Artifact Graph 利用
+## 候補探索（独立探索手段）
 
-inspect-skills は self-hosting augmentation が利用可能な場合、Artifact Graph を用いて command と skill 関係, command と extension と skill 関係, 予期しない delegation, orphan skill candidate の候補を探索できる。
+inspect-skills の構造診断候補の探索は、README 索引、配布物定義（command, skill, extension）の直接読取、`rg` 等の独立探索手段で行う（REQ-021-021）。
+agentdev-traceability の coverage, impact, check を一般文書探索、構造診断、依存関係探索の用途に利用しない。
 
-Graph は候補提供者であり、委譲先 skill 実在の決定的検査は ADR-006 が定める通り docs-check, IR-056 が所有する。
-inspect-skills は REQ-036-012〜016 が定める意味診断を担当し、Graph 構造候補を未検証 evidence として意味診断の入力に利用する。
-
-consumer 環境に対応 node type または relation type が存在しない場合は異常とせず従来の診断経路を継続する。
+- 候補には command と skill 関係, command と extension と skill 関係, 予期しない delegation, orphan skill candidate を含める
+- 委譲先 skill 実在などの決定的検査は docs-check, 整合性ルール群が所有する。inspect-skills は REQ-036-012〜016 が定める意味診断を担当し、探索で得た候補を未検証 evidence として意味診断の入力に利用する
+- 構造診断と意味診断を区別する
 
 ## 参照する横断 Design
 

--- a/docs/designs/commands/req-define.md
+++ b/docs/designs/commands/req-define.md
@@ -2,8 +2,10 @@
 title: req-define Design
 status: accepted
 created: 2026-06-21
-updated: 2026-08-19
+updated: 2026-08-21
 ---
+
+<!-- ADF-COVERS(implementation): REQ-021-011, REQ-021-022 -->
 
 # req-define Design
 
@@ -450,13 +452,15 @@ auto_gate:
 - Workflow Skill の単独起動防止（soft guard）は、command 定義本文の soft guard 宣言節と Workflow Skill description の DO NOT USE FOR トリガーの二層により実効する。
 - Capability Skill は See Also 記載のとおり名レベルで参照し、その内部構造へ依存しない。
 
-## Artifact Graph 利用
+## トレーサビリティ能力の利用
 
-req-define は既存 REQ、関連 Decision と Design、canonical owner、構造的所有者重複、downstream 変更影響候補の探索に Artifact Graph を利用できる。
-Graph は候補提供者であり、CREATE, APPEND, UPDATE, SPLIT, MERGE, 意味的重複, canonical owner の最終判断は正規成果物本文と独立探索手段（`glob`, `grep`, `rg` 等）での確認後に下す。
-共通利用原則の防護事項は `agentdev-artifact-graph` Design「ワークフロー利用」を参照。
+req-define は、既存の明示的な対応関係（`agentdev-traceability` の coverage）と impact を変更影響候補の確認に利用できる（REQ-021-011）。
+問い合わせ結果は候補提供であり、CREATE, APPEND, UPDATE, SPLIT, MERGE, 意味的重複, canonical owner の最終判断は正規成果物本文と独立探索手段（README 索引、正規成果物の直接読取、`glob`, `grep`, `rg` 等）での確認後に下す。
 
-Graph 不在、stale、consumer 環境に対応 node type または relation type が存在しない場合は、従来の探索経路で継続し、workflow を停止しない（fail-open）。
+- トレーサビリティ情報だけで変更対象、正規所有者、対象範囲を確定しない
+- impact の空結果を「影響なし」の根拠としない
+- 将来作成される実装成果物または検証手段との対応関係を推測して正規情報として保存しない
+- agentdev-traceability の不在、実行失敗、空結果、候補過多だけを理由として workflow を停止しない（fail-open）。独立探索手段で継続し、正規成果物そのものの異常とトレーサビリティ機能側の異常を区別する
 
 ## 参照する横断 Design
 

--- a/docs/designs/commands/req-save.md
+++ b/docs/designs/commands/req-save.md
@@ -2,8 +2,10 @@
 title: req-save Design
 status: accepted
 created: 2026-06-21
-updated: 2026-08-15
+updated: 2026-08-21
 ---
+
+<!-- ADF-COVERS(implementation): REQ-021-012 -->
 
 # req-save Design
 
@@ -101,6 +103,7 @@ req-save は check_integrity.ts（全体監査）を使用しない（保存工�
 ## 対象外
 
 - REQ/Decision 対象 artifact_actions がない場合の Design ファイル作成、編集（G01、no-op 完了）
+- トレーサビリティ対応（実装対応、検証対応）の作成（REQ-021-012。req-save は正式な要件IDの保存を担当し、対応宣言を作成する責務を持たない。新規要件の保存時点で対応が存在しないことを理由に req-save を失敗させない）
 - `docs/requirements/**`、`docs/decisions/**`、`docs/README.md`、`.agentdev/drafts/**` 以外のファイル作成、編集（G02、G03）
 - ドラフトファイル不存在時の実行（G04、エラー中止）
 - REQ番号の空き番号再利用（G05、`agentdev-req-file-manager` 採番ルール遵守）

--- a/docs/designs/skills/agentdev-adversarial-review.md
+++ b/docs/designs/skills/agentdev-adversarial-review.md
@@ -2,8 +2,10 @@
 title: agentdev-adversarial-review Design
 status: accepted
 created: 2026-08-09
-updated: 2026-08-15
+updated: 2026-08-21
 ---
+
+<!-- ADF-COVERS(implementation): REQ-021-021 -->
 
 # agentdev-adversarial-review Design
 
@@ -250,16 +252,15 @@ Reviewer と Reviewee は双方とも、必要に応じて複数のサブエー�
 agentdev-adversarial-review 自身による対象ファイル変更、レビュー結果のファイル保存、commit、push、merge、Issue と PR の作成・更新・コメント、レビュー結果の自動適用、ユーザー承認代行を行わない。
 レビュー結果保存用の新しい正規成果物種別を導入しない。
 
-## Artifact Graph 利用
+## 候補探索（独立探索手段）
 
-agentdev-adversarial-review は Artifact Graph をレビュー対象候補, evidence の探索に利用する。
-論点候補には複数の規範的成果物から到達する対象, 複数経路, cycle, relation 集中ノード, isolated node, 複数 owner または governing relation を持つ候補を含む。
+agentdev-adversarial-review のレビュー対象候補と evidence の探索は、README 索引、正規成果物の直接読取、`rg` 等の独立探索手段で行う（REQ-021-021）。
+agentdev-traceability の coverage, impact, check を一般文書探索、構造診断、依存関係探索の用途に利用しない。
+論点候補には複数の規範的成果物から到達する対象、複数経路、循環、関係の集中する対象、孤立候補、複数 owner を持つ候補を含む。
 
-Graph から得た情報は未検証 evidence として扱い、Reviewer または Reviewee の対論, 正規成果物確認を経ずに finding を確定しない。
-Graph はレビュー結論の確定ではなく evidence 探索に利用する。
-共通利用原則の防護事項は `agentdev-artifact-graph` Design「ワークフロー利用」を参照。
-
-Graph 不在、stale、consumer 環境に対応 node type または relation type が存在しない場合は、従来のレビュー経路で継続し、review を停止しない（fail-open）。
+- 探索で得た情報は未検証 evidence として扱い、Reviewer または Reviewee の対論, 正規成果物確認を経ずに finding を確定しない
+- 探索は evidence の収集に利用するものであり、レビュー結論の確定根拠としない
+- 探索手段の障害だけを理由に審議を停止しない
 
 ## QG、通常レビュー、診断との責務分界
 - QG-1〜QG-4 を代替しない。

--- a/docs/designs/skills/agentdev-doc-diagnostics.md
+++ b/docs/designs/skills/agentdev-doc-diagnostics.md
@@ -2,8 +2,10 @@
 title: agentdev-doc-diagnostics Design
 status: draft
 created: 2026-07-22
-updated: 2026-08-19
+updated: 2026-08-21
 ---
+
+<!-- ADF-COVERS(implementation): REQ-021-021 -->
 
 # agentdev-doc-diagnostics Design
 
@@ -16,7 +18,7 @@ docs 横断の診断カテゴリ、共通証拠構造、共通 finding 出力契
 
 `inspect-docs` command の実行時に docs 横断診断の実行を担う診断判断 skill の責務、対象外、境界を定義する。
 REQ 固有診断（`agentdev-req-structure-diagnostics`）、文意品質（`agentdev-doc-writing`）との責務重複を防ぎ、docs 横断診断の正規所有者を一つに定める。
-探索・導線（索引からの到達性）は README 索引（`docs/designs/README.md` 等の入口表）とトレーサビリティ派生索引（`agentdev-artifact-graph`）が担い、本 skill の診断対象外とする。
+探索・導線（索引からの到達性）は README 索引（`docs/designs/README.md` 等の入口表）と独立探索手段（正規成果物の直接読取、`rg` 等）が担い、本 skill の診断対象外とする。
 名称は REQ-036-013 の diagnostics 許容例外境界に基づき `agentdev-doc-diagnostics` を維持する（CR-001）。
 
 ## 適用対象
@@ -39,7 +41,7 @@ REQ 固有診断（`agentdev-req-structure-diagnostics`）、文意品質（`age
 - Issue、PR 操作（case-* command の責務）
 - REQ 固有の SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT 診断（`agentdev-req-structure-diagnostics` の責務）
 - 文意品質診断（`agentdev-doc-writing` の責務）
-- 探索・導線（README 索引とトレーサビリティ派生索引 `agentdev-artifact-graph` の責務）
+- 探索・導線（README 索引と独立探索手段（正規成果物の直接読取、`rg` 等）の責務）
 
 ## 提供する判断・操作
 
@@ -67,13 +69,13 @@ inspect-docs の診断観点は正規の観点レジストリが所有する（R
 ## 現在の動作
 
 - inspect-docs command は診断の実行と finding 出力を担い、診断カテゴリ、証拠構造、出力契約、ルーティングは本 skill が一次所有する（REQ-039-004）
-- REQ 固有診断（SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）は `agentdev-req-structure-diagnostics`、文意品質は `agentdev-doc-writing` が残留する。探索・導線は README 索引とトレーサビリティ派生索引（`agentdev-artifact-graph`）が担う（廃止済み探索順スキルの後継構成）
+- REQ 固有診断（SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）は `agentdev-req-structure-diagnostics`、文意品質は `agentdev-doc-writing` が残留する。探索・導線は README 索引と独立探索手段（正規成果物の直接読取、`rg` 等）が担う（廃止済み探索順スキルの後継構成）
 - 本 skill は横断編成と結果統合のみを所有し、専門診断の再定義を行わない
 - 診断対象は読み取り専用とし、許可される副作用は `.agentdev/inspect/inbox/*.md` の生成と `.agentdev/inspect/` 配下の git 永続化（commit / push）のみ（REQ-002-140-151、inspect lifecycle 準拠）
 
 ## 境界
 
-`agentdev-doc-writing`（文意品質）、`agentdev-req-structure-diagnostics`（REQ 固有 SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）、README 索引、トレーサビリティ派生索引 `agentdev-artifact-graph`（探索・導線）との責務重複がないこと。
+`agentdev-doc-writing`（文意品質）、`agentdev-req-structure-diagnostics`（REQ 固有 SPLIT/MERGE/MOVE/DUPLICATE/RETIRE/DRIFT）、README 索引と独立探索手段（正規成果物の直接読取、`rg` 等、探索・導線）との責務重複がないこと。
 docs 横断診断は本 skill が正規の所有者となる（REQ-036-013 の diagnostics 許容例外境界、CR-001）。
 
 ## 対象外

--- a/src/opencode/skills/agentdev-adversarial-review/SKILL.md
+++ b/src/opencode/skills/agentdev-adversarial-review/SKILL.md
@@ -56,15 +56,15 @@ Reviewer と Reviewee の双方が自身の以前の主張を撤回、限定、�
 OpenAI/Codex adversarial-review 等の外部知見を観点、問い、failure mode、検証方法を構成する知識源として活用する。
 実行時の外部サービス・外部リポジトリへの必須依存にせず、必要な知見を ADF 側の配布可能なレビュー知識として保持する。
 
-## Artifact Graph 利用
+## 候補探索（独立探索手段）
 
-本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（diagnostics、および論点に応じた他の問い合わせ）を、レビュー対象候補と evidence の探索に利用できる。
-論点候補には複数の規範的成果物から到達する対象、複数経路、cycle、relation 集中ノード、isolated node、複数 owner または governing relation を持つ候補を含む。
-問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` Design（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
+本スキルのレビュー対象候補と evidence の探索は、README 索引、正規成果物の直接読取、`rg` 等の独立探索手段で行う。
+agentdev-traceability の coverage、impact、check を一般文書探索、構造診断、依存関係探索の用途に利用しない。
+論点候補には複数の規範的成果物から到達する対象、複数経路、循環、関係の集中する対象、孤立候補、複数 owner を持つ候補を含む。
 
-- Graph から得た情報は未検証 evidence として扱い、Reviewer または Reviewee の対論、正規成果物確認を経ずに finding を確定しない
-- 問い合わせ結果は候補提供であり、レビュー結論の確定根拠としない
-- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、正規成果物の直接読取、`rg`、ファイル探索などの従来の探索手段で審議を継続する（fail-open）。派生索引側の障害だけを理由に審議を停止しない
+- 探索で得た情報は未検証 evidence として扱い、Reviewer または Reviewee の対論、正規成果物確認を経ずに finding を確定しない
+- 探索は evidence の収集に利用するものであり、レビュー結論の確定根拠としない
+- 探索手段の障害だけを理由に審議を停止しない
 
 ## 振る舞いプロトコルと合意候補再検証
 
@@ -129,6 +129,5 @@ user-decision-required の位置づけ（case-run result enum の第5状態で�
 - **agentdev-quality-gates**: QG-1〜QG-4 品質ゲート基準
 - **agentdev-doc-diagnostics**: 証拠付き finding の診断
 - **agentdev-skill-authoring**: スキル設計とレビュー規約
-- **`agentdev-artifact-graph`**: トレーサビリティ派生索引への高位問い合わせ（ワークフロー利用の割り当ては同 Design が正規所有）
 - **Design `docs/designs/<skills/agentdev-adversarial-review>.md`**: 振る舞い契約の正典
 - **references/adversarial-review-protocol.md**: 審議プロトコルの詳細手続き

--- a/src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md
+++ b/src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md
@@ -69,9 +69,11 @@ harness execution mechanism は本 SKILL の規範対象外とし、`references/
 
 1. **Issue 読込**: 対象 Issue 本文、受け入れ基準を読み込む。実行 command が Issue を success criteria に分解する
 2. **context 再確認**: ADR/ REQ/ Design/ docs/ repository context を再確認し、実装が既存の決定事項に矛盾しないことを担保する。
-トレーサビリティ派生索引への高位問い合わせ（implementation）を実行対象と正規成果物の実現関係確認の候補探索に利用できる（`agentdev-artifact-graph` 経由）。
-問い合わせ結果は候補提供であり最終判断としない、新規の依存関係、実行構成、Wave 構成、実行順序の設計には使用しない、派生索引の不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は代替探索で継続する（fail-open）
+トレーサビリティ能力（`agentdev-traceability` の coverage）を、対象要件と正規成果物の既存の対応関係確認に利用できる。
+問い合わせ結果は候補提供であり最終判断としない、新規の依存関係、実行構成、Wave 構成、実行順序の設計には使用しない、機能の不在、実行失敗、空結果、候補過多の場合は README 索引、正規成果物の直接読取、`rg` 等の代替探索で継続する（fail-open）
 3. **実装、検証、PR 作成**: 実行 command に従い evidence-backed に実装を実行し、品質ゲートを通して PR 作成手続き（`agentdev-gh-cli`）で PR を作成する。
+実際に要件を実現する成果物へ実装対応を、実際に要件を検証する恒常的な検証手段へ検証対応を、対応宣言として正規成果物へ明示する（単に変更されたファイルであることを理由に、そのファイルを要件へ自動的に対応付けない）。
+PR 作成前に `agentdev-traceability` の check を実行し、対象要件の実装対応、検証対応、対応宣言の整合性を検査する。check の不合格が承認済み対象範囲内で修正可能な場合は修正して再検証し、要件変更、対象範囲拡大、追加設計判断、外部依存解消が必要な場合は blocked として判断事項を報告する。
 ハーネスの plan artifact 等の中間成果物は解釈せず、PR URL で最終結果を受領する。
 実装完了後、test strategy 項目の test-fix ループ（後述）を実行する
 4. **blocker 処理**: 回答可能な blocker（ADR/REQ/Design/docs/Issue本文で回答できるもの）は自律的に実行 command 内で再評価できる

--- a/src/opencode/skills/agentdev-workflow-backlog-review/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-backlog-review/SKILL.md
@@ -99,18 +99,15 @@ RU 実ファイル（STEP-7 の成果物）を承認証跡として扱い、証�
 - `agentdev-adversarial-review`: 経路E の review 呼出（共通契約の正規所有者は adversarial-review Design、REQ-{NNNN}）
 - `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング、構造化エラー形式）
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open。document-model Design の文書7分類モデルは extension 経由で参照）
-- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（統合、分割、depends_on の補助 evidence 探索。fail-open）
 
-## Artifact Graph 利用
+## 候補探索（独立探索手段）
 
-本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（related、impact、必要に応じて dependency）を利用できる。
-採用済み成果物に含まれる REQ、Decision、Design、canonical owner 等の明示情報を起点に、統合、分割、depends_on 依存解決（STEP-3）の補助 evidence 探索を行う。
-問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` Design（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
-問い合わせ目的を指定し、返された候補を用いて判断する。
+本スキルの既存正規成果物との関係候補の探索は、採用済み成果物に含まれる REQ、Decision、Design、canonical owner 等の明示情報を起点に、README 索引、正規成果物の直接読取、`rg` 等の独立探索手段で行う。
+agentdev-traceability の coverage、impact、check を一般文書探索、構造診断、依存関係探索の用途に利用しない。
+統合、分割、depends_on 依存解決（STEP-3）の補助 evidence 探索に利用する。
 
-- 問い合わせ結果は候補提供であり、統合、分割、depends_on、意味的重複の判断は正規成果物本文と `rg` 等の独立探索での確認後に下す
-- 派生索引の不在、生成失敗、空結果、候補過多だけを理由として「関係なし」「影響なし」と判断しない
-- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、README 索引、正規成果物の直接読取、`rg`、ファイル探索などの代替探索で workflow を継続する（fail-open）。正規成果物そのものの異常と派生索引側の異常を区別する
+- 探索結果は候補提供であり、統合、分割、depends_on、意味的重複の判断は正規成果物本文と `rg` 等の独立探索での確認後に下す
+- promoted artifact 自体を特定の探索機構の正規 node とすることは必須でない
 
 ## Workflow Extension 読込
 

--- a/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
@@ -101,17 +101,17 @@ gate 違反時は両ルートとも PR マージを停止する。
 - `agentdev-workflow-orchestration`: capture 境界（intake/learning 分離）
 - `agentdev-conventional-commits`: GitHub auto-close 回避ガイドライン
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
-- `agentdev-artifact-graph`: トレーサビリティ派生索引（変更後の整合性確認、verification feedback。fail-open）
+- `agentdev-traceability`: トレーサビリティ能力（check。QG-4 の対応完全性の独立再検査。fail-open）
 - integrity checker skill（リポジトリ固有・配布対象外）: check_changed_docs.ts（targeted docs guard）、check_extensions.ts（IR-{NNN}）
 
-## Artifact Graph 利用
+## トレーサビリティ能力の利用（QG-4 独立再検査）
 
-本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引を、変更後の整合性確認（必要に応じて）に利用できる。
-確認対象は変更後の派生索引の生成と鮮度、整合性、unresolved relation、dangling relation、provenance defect、独立確認結果との差異である（STEP-3 docs 検証）。
-問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` Design（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
+本スキルは QG-4 の一部として、対象要件の実装対応と検証対応の完全性を `agentdev-traceability` の check で正規成果物から独立して再検査できる（STEP-3 docs 検証）。
+case-run 側の事前検査とは独立に実施する。検証手段との対応関係と「今回その検証を実行して合格したか」という実行結果（Issue、PR、QG の記録）を分離して扱う。
 
-- Graph defect（派生索引側の抽出問題）と canonical defect（正規成果物側の実不整合）を区別する
-- 派生索引の不在、破損、生成失敗、問い合わせ失敗、候補過多のみを理由に本 workflow を失敗させない（fail-open）。代替検証経路（既存の品質ゲート、targeted docs guard、`rg` 等の独立探索）で継続する
+- 対象要件に実装対応または検証対応の欠落が残る場合はマージせず停止する。不足する対応関係を自動追加または修正せず、検査失敗を case-run 側の修正対象として差し戻す
+- 移行期間中（全現行要件の対応付け完了まで）は QG-4 の対応完全性検査を強制しない（有効化は別途判断）。移行期間中に検査を実行した場合は、結果を参考情報として報告できる
+- agentdev-traceability の不在、実行失敗、空結果、候補過多のみを理由に本 workflow を失敗させない（fail-open）。代替検証経路（既存の品質ゲート、targeted docs guard、`rg` 等の独立探索）で継続し、正規成果物そのものの異常とトレーサビリティ機能側の異常を区別する
 - 正規成果物側の実不整合が確認された場合は、既存の品質ゲート、受け入れ条件に従って fail とする
 
 ## Workflow Extension 読込

--- a/src/opencode/skills/agentdev-workflow-case-open/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-open/SKILL.md
@@ -88,19 +88,15 @@ case-open workflow は次の6 STEP で構成する。
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
 - `agentdev-adversarial-review`: 経路F review 呼出
 - `agentdev-learning-capture` / `agentdev-intake-pipeline`: deviation capture 委譲（STEP-4/5 で実観測時）
-- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（変更影響候補の評価。fail-open）
 
-## Artifact Graph 利用
+## トレーサビリティ能力の利用
 
-本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（impact、dependency）を利用できる。
-Issue の対象範囲、完了条件、test strategy の確定前に変更影響候補を評価し、候補を in scope、verification only、out of scope に分類する（STEP-2、STEP-3）。
-問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` Design（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
-問い合わせ目的を指定し、返された候補を用いて判断する。
+case-open は、上流工程（req-define）で確定した対象要件と実行契約を Issue へ引き継ぐ。
+Issue の対象範囲、完了条件、test strategy の確定（STEP-2、STEP-3）は、上流工程の引き継ぎ情報（draft-data、artifact_actions、operation_units）を基に行う。
 
-- 問い合わせ結果は候補提供であり、対象範囲の分類判断は正規成果物本文と `rg` 等の独立探索での確認後に下す
-- 必須品質統制の導出は artifact type から品質能力キーへの変換（品質統制 routing Design が定める）に従い、問い合わせで得た関係から必須 skill を直接決定しない
-- 派生索引の不在、生成失敗、空結果、候補過多だけを理由として「関係なし」「影響なし」と判断しない
-- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、README 索引、正規成果物の直接読取、`rg`、ファイル探索などの代替探索で workflow を継続する（fail-open）。正規成果物そのものの異常と派生索引側の異常を区別する
+- req-define と重複して一般的な変更影響探索や依存関係探索を行い、対象範囲を再決定しない
+- 引き継ぎ情報に欠落があり変更影響候補の確認が必要な場合は、req-define へ差し戻す
+- 必須品質統制の導出は artifact type から品質能力キーへの変換（品質統制 routing Design が定める）に従う
 
 ## Workflow Extension 読込
 

--- a/src/opencode/skills/agentdev-workflow-case-run/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-run/SKILL.md
@@ -126,19 +126,21 @@ Epic 全体（複数 Wave）の処理、Wave 境界（PR マージ）は case-cl
 - `agentdev-quality-gates`: QG-3 前置 staleness check
 - `agentdev-gh-cli`: Issue 本文読取等の I/O 手続き
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
-- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（実行対象と正規成果物の実現関係確認のみ。fail-open）
+- `agentdev-traceability`: トレーサビリティ能力（coverage、check。委譲内の対応関係確認と PR 作成前検査。fail-open）
 - integrity checker skill（リポジトリ固有・配布対象外）: check_changed_docs.ts（targeted docs guard）、check_extensions.ts（IR-{NNN}）、check_distribution_boundary.ts（配布依存境界）
 
-## Artifact Graph 利用
+## トレーサビリティ能力の利用
 
-本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせのうち implementation を、既に決定された実装対象（Issue 本文）と正規成果物の実現関係確認（STEP-S2 の関連Decision確認、委譲内 context 再確認）に利用できる。
-問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` Design（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
-問い合わせ目的を指定し、返された候補を用いて判断する。
+case-run の実行担当（委譲内サブエージェント）は、対象要件について `agentdev-traceability` の coverage で既存の対応関係を確認しながら、実装対応と検証対応を対応宣言として正規成果物へ明示する（STEP-S2 の関連Decision確認、委譲内 context 再確認）。
+実行担当は PR 作成前に check を実行し、対象要件の実装対応、検証対応、対応宣言の整合性を検査する。
+対応宣言の表記仕様は `agentdev-traceability` Design「対応宣言の表記」が正規所有し、本スキルは表記仕様を再定義しない。
 
-- トレーサビリティ問い合わせを利用して新規の依存関係、実行構成、Wave 構成、実行順序を設計しない。依存関係と実行構成の決定責務は上流工程（case-open の execution_unit 構成、Epic Wave モデル）が所有する
-- 問い合わせ結果は候補提供であり、実現関係の確認は正規成果物本文と `rg` 等の独立探索で行う。Issue scope、完了条件、REQ、Decision、Design、必須品質統制の変更が必要な候補は blocked として case-update 連携とし、scope の自律拡大は行わない
-- 派生索引の不在、生成失敗、空結果、候補過多だけを理由として「関係なし」「影響なし」と判断しない
-- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、README 索引、正規成果物の直接読取、`rg`、ファイル探索などの代替探索で workflow を継続する（fail-open）。正規成果物そのものの異常と派生索引側の異常を区別する
+- 単に変更されたファイルであることを理由に、そのファイルを要件へ自動的に対応付けない
+- check の不合格が承認済み対象範囲内で修正可能な場合は修正して再検証する。要件変更、対象範囲拡大、追加設計判断、外部依存解消が必要な場合は blocked として必要な判断事項を報告する
+- 検証対応は「何が要件を検証するか」という検証手段との恒常的な対応関係であり、「今回その検証を実行して合格したか」という実行結果は Issue、PR、QG 側で扱う
+- 中断後の再実行では、正規成果物に保存済みの対応関係を再利用し、同じ対応宣言を重複生成しない
+- トレーサビリティ能力を利用して新規の依存関係、実行構成、Wave 構成、実行順序を設計しない。依存関係と実行構成の決定責務は上流工程（case-open の execution_unit 構成、Epic Wave モデル）が所有する
+- agentdev-traceability の不在、実行失敗、空結果、候補過多だけを理由として workflow を停止しない（fail-open）。README 索引、正規成果物の直接読取、`rg` 等の独立探索手段で継続し、正規成果物そのものの異常とトレーサビリティ機能側の異常を区別する
 
 ## Workflow Extension 読込
 

--- a/src/opencode/skills/agentdev-workflow-design-save/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-design-save/SKILL.md
@@ -91,19 +91,17 @@ design-save workflow は次の11 STEP で構成する。
 - `agentdev-conventional-commits`: commit message 生成
 - `agentdev-git-worktree`: 並列実行安全ステージングプロシージャ（明示パスステージ、`git commit -- <paths>`）
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
-- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（対応 REQ、同一 canonical owner の Design、関連 command、skill、integrity rule の探索。fail-open）
 - integrity checker skill（AG-{NNN} detector、repo 固有）: check_changed_docs.ts（--workflow design-save）
 
-## Artifact Graph 利用
+## トレーサビリティ能力の利用
 
-本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（related）を利用できる。
-対応 REQ、同一 canonical owner の Design、関連 command、skill、integrity rule の探索（STEP-3 配置先解決、STEP-4 Design 分離基準の最終確認）を補助する。
-問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` Design（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
-問い合わせ目的を指定し、返された候補を用いて判断する。
+design-save は、req-define で Design action と対象要件の対応が明示的に確定している場合、その情報を利用して Design 文書と要件の対応関係を対応宣言として正規成果物へ保存できる。
+対応宣言の表記仕様は `agentdev-traceability` Design「対応宣言の表記」が正規所有し、本スキルは表記仕様を再定義しない。
 
-- 問い合わせ結果は候補提供であり、Design 正規配置先、target_area、canonical owner、Design 操作分類の判断は正規成果物本文と `rg` 等の独立探索での確認後に下す
-- 派生索引の不在、生成失敗、空結果、候補過多だけを理由として「関係なし」「影響なし」と判断しない
-- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、README 索引、正規成果物の直接読取、`rg`、ファイル探索などの代替探索で workflow を継続する（fail-open）。正規成果物そのものの異常と派生索引側の異常を区別する
+- Design 本文の自由記述から対象要件を再推論して正規の対応関係を生成しない
+- Design 文書の対応付けは任意とし、Design action が存在しない要件の処理を妨げない
+- 対応 REQ、同一 canonical owner の Design、関連 command、skill、integrity rule の探索（STEP-3 配置先解決、STEP-4 Design 分離基準の最終確認）は、README 索引、正規成果物の直接読取、`rg` 等の独立探索手段で行う（agentdev-traceability を一般文書探索、依存関係探索へ利用しない）
+- 中断後の再実行では、正規成果物に保存済みの対応宣言を再利用し、同じ対応宣言を重複生成しない
 
 ## Workflow Extension 読込
 

--- a/src/opencode/skills/agentdev-workflow-inspect-docs/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-docs/SKILL.md
@@ -82,17 +82,15 @@ STEP ラベルは工程順序の整理ラベルであり、**resume point では
 - `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング含む）
 - `agentdev-conventional-commits`: commit message 規約
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
-- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（diagnostics、構造診断候補の探索。fail-open）
 
-## Artifact Graph 利用
+## 候補探索（独立探索手段）
 
-本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（diagnostics）を構造診断候補の探索に利用できる。
-候補には unresolved reference、superseded artifact への現行参照、dangling relation、provenance 欠落、orphan candidate、不自然な relation path、structural duplicate candidate を含む（STEP-2 意味診断の入力）。
-問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` Design（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
+本スキルの構造診断候補の探索は、README 索引、正規成果物の直接読取、`rg` 等の独立探索手段で行う。
+agentdev-traceability の coverage、impact、check を一般文書探索、構造診断、依存関係探索の用途に利用しない。
+候補には未解決参照、superseded 成果物への現行参照、参照先が取得できない記述、正規所有者のいない成果物、構造的重複候補を含む（STEP-2 意味診断の入力）。
 
-- Graph は候補提供者であり、決定的検査（参照実在、委譲先 skill 実在、YAML 構文、必須 field）は docs-check、整合性ルール群が所有する。本スキルは Graph 構造候補を未検証 evidence として意味診断の入力に利用し、構造診断と意味診断を区別する
-- SPLIT、MERGE、MOVE、DUPLICATE、RETIRE、DRIFT 等の意味判断を問い合わせ結果の構造情報だけから確定しない
-- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、正規成果物の直接読取、`rg`、ファイル探索などの従来の診断経路で workflow を継続する（fail-open）。派生索引側の障害だけを理由に本 workflow を停止しない
+- 決定的検査（参照実在、委譲先 skill 実在、YAML 構文、必須 field）は docs-check、整合性ルール群が所有する。本スキルは探索で得た候補を未検証 evidence として意味診断の入力に利用し、構造診断と意味診断を区別する
+- SPLIT、MERGE、MOVE、DUPLICATE、RETIRE、DRIFT 等の意味判断を候補の構造情報だけから確定しない
 
 ## Workflow Extension 読込契約
 

--- a/src/opencode/skills/agentdev-workflow-inspect-skills/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-inspect-skills/SKILL.md
@@ -83,17 +83,14 @@ STEP ラベルは工程順序の整理ラベルであり、**resume point では
 - `agentdev-git-worktree`: ドメイン状態永続化プロシージャ（並列実行安全ステージング含む）
 - `agentdev-conventional-commits`: commit message 規約
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
-- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（diagnostics、構造診断候補の探索。fail-open）
 
-## Artifact Graph 利用
+## 候補探索（独立探索手段）
 
-本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（diagnostics）を構造診断候補の探索に利用できる。
-self-hosting augmentation が利用可能な場合、command と skill 関係、command と extension と skill 関係、予期しない delegation、orphan skill candidate の候補を探索できる（STEP-2 の入力）。
-問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` Design（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
+本スキルの構造診断候補の探索は、README 索引、配布物定義（command、skill、extension）の直接読取、`rg` 等の独立探索手段で行う。
+agentdev-traceability の coverage、impact、check を一般文書探索、構造診断、依存関係探索の用途に利用しない。
+候補には command と skill 関係、command と extension と skill 関係、予期しない delegation、orphan skill candidate を含む（STEP-2 の入力）。
 
-- Graph は候補提供者であり、委譲先 skill 実在などの決定的検査は docs-check、整合性ルール群が所有する。本スキルは Graph 構造候補を未検証 evidence として意味診断の入力に利用し、構造診断と意味診断を区別する
-- consumer 環境で対応 node type、relation type が存在しない場合は異常とせず、配布物定義の直接読取、`rg` などの従来の診断経路で継続する
-- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合も従来の診断経路で workflow を継続する（fail-open）。派生索引側の障害だけを理由に本 workflow を停止しない
+- 委譲先 skill 実在などの決定的検査は docs-check、整合性ルール群が所有する。本スキルは探索で得た候補を未検証 evidence として意味診断の入力に利用し、構造診断と意味診断を区別する
 
 ## Workflow Extension 読込契約
 

--- a/src/opencode/skills/agentdev-workflow-req-define/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-req-define/SKILL.md
@@ -93,18 +93,17 @@ req-define workflow は次の11 STEP で構成する。
 - `agentdev-workflow-lifecycle`: work_type・Scale 判定、前工程引き継ぎ判定
 - `agentdev-adversarial-review`: 経路A review 呼出
 - `agentdev-project-extensions`: project extension 読込（5セクション、fail-open）
-- `agentdev-artifact-graph`: トレーサビリティ派生索引への高位問い合わせ（既存 REQ、関連 Decision、関連 Design、影響候補の探索。fail-open）
+- `agentdev-traceability`: トレーサビリティ能力（coverage、impact。既存の明示的な対応関係と変更影響候補の確認。fail-open）
 
-## Artifact Graph 利用
+## トレーサビリティ能力の利用
 
-本スキルは `agentdev-artifact-graph` が提供するトレーサビリティ派生索引への高位問い合わせ（related、impact、必要に応じて dependency）を利用できる。
-既存 REQ、関連 Decision、関連 Design、canonical owner、変更影響候補の探索（STEP-3 既存REQ照合、STEP-4 要件展開）を補助する。
-問い合わせ目的とワークフローの割り当ては `agentdev-artifact-graph` Design（ワークフロー利用）が正規所有し、本スキルは TIM、派生索引、問い合わせ内部規則を独自に再定義しない。
-問い合わせ目的を指定し、返された候補を用いて判断する。
+本スキルは `agentdev-traceability` の coverage と impact を、既存の明示的な対応関係と変更影響候補の確認（STEP-3 既存REQ照合、STEP-4 要件展開）に利用できる。
+問い合わせ結果は候補提供であり、変更対象、正規所有者、対象範囲の確定に用いない。
 
-- 問い合わせ結果は候補提供であり、CREATE、APPEND、UPDATE、SPLIT、MERGE、意味的重複、canonical owner の判断は正規成果物本文と `rg` 等の独立探索での確認後に下す
-- 派生索引の不在、生成失敗、空結果、候補過多だけを理由として「関係なし」「影響なし」と判断しない
-- 派生索引が不在、破損、生成失敗、問い合わせ失敗、候補過多の場合は、README 索引、正規成果物の直接読取、`rg`、ファイル探索などの代替探索で workflow を継続する（fail-open）。正規成果物そのものの異常と派生索引側の異常を区別する
+- トレーサビリティ情報だけで変更対象、正規所有者、対象範囲を確定しない
+- impact の空結果を「影響なし」の根拠としない
+- 将来作成される実装成果物または検証手段との対応関係を推測して正規情報として保存しない
+- agentdev-traceability の不在、実行失敗、空結果、候補過多だけを理由として workflow を停止しない（fail-open）。README 索引、正規成果物の直接読取、`rg` 等の独立探索手段で継続し、正規成果物そのものの異常とトレーサビリティ機能側の異常を区別する
 
 ## Workflow Extension 読込
 


### PR DESCRIPTION
## 概要

Issue #2361（OU-003、Wave 3、Epic #2358 子Issue）の実装。
ADF ワークフロー各工程のトレーサビリティ能力利用を `agentdev-traceability`（coverage / impact / check）または独立探索手段（README 索引、正規成果物の直接読取、rg 等）へ切り替える（RU-0003、REQ-021-011〜022、DEC-017 決定4、DEC-019、CR-002）。

## 変更内容

### 要件 (1): 5 command Design のトレーサビリティ利用への切替

- `docs/designs/commands/req-define.md`: 「Artifact Graph 利用」節を「トレーサビリティ能力の利用」節へ切替。coverage と impact を変更影響候補の確認に利用、空結果を「影響なし」の根拠としない、確定・推測保存の禁止、fail-open（REQ-021-011、REQ-021-022）
- `docs/designs/commands/design-save.md`: 明示確定時のみ Design 対応（`ADF-COVERS(design)` 宣言）を保存、自由記述からの再推論禁止、Design action なし要件の処理を妨げない、探索は独立探索手段、重複宣言防止（REQ-021-013、REQ-021-020）
- `docs/designs/commands/case-open.md`: 上流工程で確定した対象要件と実行契約の引き継ぎ、重複探索と対象範囲再決定の禁止、欠落時は req-define へ差し戻し（REQ-021-014）
- `docs/designs/commands/case-run.md`: 実行担当による実装対応・検証対応の明示、PR 作成前の check、不合格時の修正 / blocked、検証手段と実行結果の分離、重複宣言防止、fail-open（REQ-021-015〜017、019、020、022）
- `docs/designs/commands/case-close.md`: QG-4 の一部として check による独立再検査、欠落時マージせず停止、自動修正禁止、差戻し、移行期間中の強制検査無効（有効化は別途判断）、fail-open（REQ-021-018、019、022）

### 要件 (2): 診断・レビュー系5 Design の独立探索手段への切替

`docs/designs/commands/inspect-docs.md`、`inspect-skills.md`、`backlog-review.md`、`docs/designs/skills/agentdev-doc-diagnostics.md`、`agentdev-adversarial-review.md` の「Artifact Graph」節を削除し、「候補探索（独立探索手段）」節へ置換（REQ-021-021）。
agentdev-traceability を一般文書探索・構造診断・依存関係探索へ利用する記述は残っていない。

### 要件 (3): Workflow Skill 本文10件・extension 6件の参照切替

- 5工程 Workflow Skill（`src/opencode/skills/agentdev-workflow-{req-define,design-save,case-open,case-run,case-close}/SKILL.md`）: 「Artifact Graph 利用」節をトレーサビリティ能力の利用（または上流引き継ぎ）へ切替。Capability Skill 参照リストの `agentdev-artifact-graph` 行を `agentdev-traceability` へ置換（design-save、case-open は削除）
- 診断・レビュー系4件（`agentdev-workflow-{inspect-docs,inspect-skills,backlog-review}/SKILL.md`、`agentdev-adversarial-review/SKILL.md`）: 候補探索（独立探索手段）節へ切替、参照行を削除
- `agentdev-case-run-execution-adapter/SKILL.md`: 委譲内 context 再確認の coverage 利用と、PR 作成前 check（不合格時の修正 / blocked）を責務に反映
- extension 6件（`.agentdev/extensions/skills/`）: req-define / case-run / case-close の rule を `agentdev-traceability` へ切替、design-save / case-open / adversarial-review の rule を削除（adversarial-review は context を Design 索引へ置換）

### 要件 (4): REQ-021-011〜022 への対応宣言の保存

- 実装対応（`ADF-COVERS(implementation)`）: 切替後の各 Design の frontmatter 直後に保存（req-define、design-save、case-open、case-run、case-close、req-save、inspect-docs、inspect-skills、backlog-review、agentdev-doc-diagnostics、agentdev-adversarial-review の11件）
- 検証対応（`ADF-COVERS(verification)`）: 新規テスト `.opencode/skills/repo-agentdev-integrity/scripts/tests/traceability_workflow_integration.test.ts` が全12要件行の検証を恒常的に担う（旧参照の残存なし、診断・レビュー系の一般探索利用禁止、割り当て文言の存在、extension の切替確認）

`docs/designs/commands/req-save.md` は Issue の変更対象成果物リスト外だが、REQ-021-012 の対応宣言の保存根拠として「対象外」節へ責務境界（対応宣言の非作成、存在しないことを理由に失敗させない）を2行追記した。

## 経路G（adversarial-review）の実施記録

最初の実装変更前に実装方針（切替方針・文言の統一ルール）を agentdev-adversarial-review で審議した。
主な合意: design-save は表記仕様の正規所有者として `agentdev-traceability` Design を仕様参照（能力利用ではない）、case-open は能力を利用しない工程として明記、起動コマンドの Design 転記はしない（traceability SKILL.md が正規所有）、Issue 番号依存の文言は Design に書かない、検証テストの期待値は要件の意味単位へ最小化。
unresolved なし。skip していない。

## 検証結果

| 項目 | 結果 |
|---|---|
| TS-003（RU-0003 全工程要件の網羅、REQ-012 との責務境界） | pass。RU-0003 要件1〜24 を REQ-021-011〜021 へ逐一対比し網羅を確認。REQ-012 との責務境界は REQ-021 目的節・対象外節に明示済み |
| TS-007（5 Design の切替確認） | pass。5 Design に Artifact Graph 記述なし、agentdev-traceability の言及は「利用しない」の否定文のみ、独立探索手段への切替記述あり（検証テストで恒常化） |
| TS-QC-01（Design 10件の doc-writing 査読） | pass。配布物 ID 汚染なし、em-dash / 中黒なし、文書種別責務・実行主体分類・一文一行の違反0件。targeted docs guard の Design frontmatter 検査も pass |
| TS-QC-02（変更 SKILL.md の skill-authoring 査読） | pass。frontmatter 無変更、節差し替えのみで構造維持、参照深度 1階層維持。check_extensions（IR-056）pass |
| traceability check（PR 作成前、REQ-021-016 の実証） | pass。`check.ts --req REQ-021-011,...,REQ-021-022` で6種検査すべて pass（missing-implementation / missing-verification 含む）、exit 0 |
| 検証テスト（新規） | 71 pass / 0 fail |
| targeted docs guard（--workflow case-run --base-ref origin/main） | pass（failures 0、warnings 0、files_checked 11件） |
| check_extensions.ts（IR-056） | pass（failures 0） |
| check_distribution_boundary.ts --profile source | pass（ok、findings 0） |
| bun test（全体） | 284 pass / 0 fail（31 files、scripts 依存の bun install 実施後） |
| bun test（repo-agentdev-integrity スイート） | 2241 pass / 1 fail。1 fail は base 既存失敗（後述） |

### base 既存失敗の区別記録

`check_integrity.test.ts`「IR-055 runtime-unresolved-reference 実修復回帰」の1 fail は自変更由来ではない。
`src/opencode/skills/agentdev-project-extensions/scripts/README.md` の repo-local / repo-agentdev-integrity 参照（commit f01b9cae、PR #2355、origin/main 由来）が `ir-055-baseline.json` に未登録のため delta として検出される。
本 PR の変更ファイルに同ファイルは含まれず、`git merge-base --is-ancestor f01b9cae origin/main` で base 由来であることを確認した。

## Findings / Capture候補

### intake

- `src/opencode/skills/agentdev-project-extensions/scripts/README.md`（commit f01b9cae 由来）の repo-local / repo-agentdev-integrity 参照が IR-055 baseline に未登録。check_integrity の delta guard が base 状態で失敗する。baseline 更新（`--update-ir055-baseline`）または当該 README の参照修正が必要

### learning

- worktree 環境では `src/opencode/skills/*/scripts/` 配下の node_modules（zod 等）が存在せず、`bun test` が unhandled error で中断する。該当 scripts ディレクトリで `bun install` を実行することで解決する（同期スクリプト不使用の制約とは独立した依存解決操作）

### docs-integrity

- なし（targeted docs guard pass、Design frontmatter 検査 pass）

## Design確定候補

- REQ-021-012 の保存先として req-save.md Design の「対象外」節へ責務境界を追記した（Issue の変更対象成果物リスト外への最小追記。対応宣言の保存根拠を担保するための判断）
- 移行期間の終了判定（全現行要件の対応付け完了の検出方法）と QG-4 強制検査の有効化条件は本 PR では「別途判断」として明記のみ行った。OU-004 での確定が必要
- check のワークフロー実行時の呼出形態（`--req` 限定の運用、コーパス全体との切り替え条件）は各 Workflow Skill の実行詳細として未確定。traceability Design の I/O 契約を維持したまま case-run / case-close の運用詳細を確定する余地がある

Refs: #2361
