### PR TITLE
docs-check 新規機械検査クラスの追加（REQ-010-064〜068、Issue #2372）

### DIFF
--- a/.opencode/skills/repo-agentdev-integrity/SKILL.md
+++ b/.opencode/skills/repo-agentdev-integrity/SKILL.md
@@ -72,6 +72,9 @@ agent-dev-flow リポジトリ（self-hosting repo）の artifact 整合性検�
 | REQ verification basis | `check_integrity.ts` | REQ 要件行の検証基準が 規範語ではなく必達要件判定であること（REQ-0115-044） |
 | Runtime reference | `check_integrity.ts` | 配布物（src/opencode/commands/agentdev、src/opencode/skills/agentdev-*/**/*.md）内の導入先未解決参照検出。baseline 既知と新規区別、段階導入（IR-055, REQ-0108-263/264） |
 | Distribution untracked skill | `check_integrity.ts` | 配布物が `.opencode/skills/` 配下にのみ存在するスキルを参照した場合の src 昇格漏れ検出（IR-058, REQ-0159-003） |
+| Guardrail number invariant | `check_integrity.ts` | 公開 command のガードレール番号（Gxx）不変量: 開始番号（G01 起点）・欠番・重複・未定義本文参照（IR-063, REQ-010-064, Issue #2372）。既知違反は NG baseline（delta-aware） |
+| Unresolved placeholder | `check_integrity.ts` | 実行時配布対象の未解決プレースホルダー: TODO 系マーカー（strict）と ID プレースホルダー裸出力（heuristic）。許容条件: テンプレート、code block、code span、括弧内、引用「」内列挙（IR-064, REQ-010-065, Issue #2372） |
+| Obsolete vocabulary & legacy path | `check_integrity.ts` | 廃止語彙（旧 ADR 表記等）・旧パス・削除済み名称の現行概念としての使用検出（IR-065/IR-066, REQ-010-066/067, Issue #2372）。許容条件: `v2:` プレフィックス、行レベル履歴マーカー、superseded Decision、否定文脈、existence_probe、exemption_files（`data/obsolete-vocabulary-map.yaml`） |
 | Skill rename 対称性 | `check_skill_rename_symmetry.ts` | 配布 skill `agentdev-*` と Design `docs/designs/skills/{X}.md` の物理 path 一致、SKILL.md frontmatter `name` ↔ 親 dir、Design title token ↔ filename stem、Artifact Graph skill node ↔ skill dir の整合（REQ-026）。`status: superseded` Design の skill dir 欠落は許容 |
 
 ### 補助検査スクリプト（categoryToCheckPattern 対象外）

--- a/.opencode/skills/repo-agentdev-integrity/baselines/ng-baseline.json
+++ b/.opencode/skills/repo-agentdev-integrity/baselines/ng-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "rule_id": "NG-BASELINE",
-  "generated_at": "2026-08-15",
+  "generated_at": "2026-08-22",
   "entries": [
     {
       "category": "ADR",
@@ -236,6 +236,1266 @@
       "count": 1,
       "provenance": "proposed-decision-citation",
       "reason": "proposed-decision-citation: proposed Decision DEC-008 を根拠として引用する意図的な記述。Decision の accepted 昇格または SPEC 再構成（OU-009）で解消するまでの承認（Issue #2136 NG21 外 warning 分類）"
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/backlog-review.md",
+      "evidence": "gap:G03",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/backlog-review.md",
+      "evidence": "gap:G05",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/backlog-review.md",
+      "evidence": "gap:G07",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "start-number:G02",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G03",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G04",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G06",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G07",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G08",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G09",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G10",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G11",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G12",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G13",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G14",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G15",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G17",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G18",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G19",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G20",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G21",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G22",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G23",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G24",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G25",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G26",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G27",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G28",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G29",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G30",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G31",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-auto.md",
+      "evidence": "gap:G32",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G02",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G03",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G05",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G06",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G07",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G09",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G10",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G11",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G13",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G14",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G15",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G16",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G18",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G19",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G20",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G22",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G23",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G25",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-close.md",
+      "evidence": "gap:G26",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-open.md",
+      "evidence": "start-number:G23",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-open.md",
+      "evidence": "gap:G24",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "start-number:G02",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G03",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G05",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G06",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G07",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G08",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G09",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G10",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G11",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G12",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G13",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G14",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G16",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G17",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G18",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G19",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G20",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G21",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G22",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G23",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G25",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G26",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G27",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G28",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G29",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G31",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-run.md",
+      "evidence": "gap:G32",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/case-update.md",
+      "evidence": "start-number:G08",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/design-save.md",
+      "evidence": "start-number:G02",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/design-save.md",
+      "evidence": "gap:G03",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/design-save.md",
+      "evidence": "gap:G04",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/design-save.md",
+      "evidence": "gap:G05",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/design-save.md",
+      "evidence": "gap:G07",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/design-save.md",
+      "evidence": "gap:G08",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/design-save.md",
+      "evidence": "gap:G09",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/design-save.md",
+      "evidence": "gap:G10",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/design-save.md",
+      "evidence": "gap:G11",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/inspect-promote.md",
+      "evidence": "gap:G03",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/inspect-promote.md",
+      "evidence": "gap:G04",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/inspect-promote.md",
+      "evidence": "gap:G05",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-capture.md",
+      "evidence": "gap:G02",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-capture.md",
+      "evidence": "gap:G04",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-capture.md",
+      "evidence": "gap:G05",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-capture.md",
+      "evidence": "gap:G06",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-capture.md",
+      "evidence": "gap:G07",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-capture.md",
+      "evidence": "gap:G08",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-capture.md",
+      "evidence": "gap:G09",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-capture.md",
+      "evidence": "gap:G10",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-capture.md",
+      "evidence": "gap:G11",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-from-github.md",
+      "evidence": "gap:G02",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-from-github.md",
+      "evidence": "gap:G03",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-from-github.md",
+      "evidence": "gap:G05",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-from-github.md",
+      "evidence": "gap:G06",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-from-github.md",
+      "evidence": "gap:G07",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-from-github.md",
+      "evidence": "gap:G08",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-from-github.md",
+      "evidence": "gap:G10",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-from-github.md",
+      "evidence": "gap:G11",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-promote.md",
+      "evidence": "gap:G02",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-promote.md",
+      "evidence": "gap:G03",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-promote.md",
+      "evidence": "gap:G04",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-promote.md",
+      "evidence": "gap:G05",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-promote.md",
+      "evidence": "gap:G07",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-promote.md",
+      "evidence": "gap:G09",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-promote.md",
+      "evidence": "gap:G10",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-promote.md",
+      "evidence": "gap:G11",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-promote.md",
+      "evidence": "gap:G13",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-promote.md",
+      "evidence": "gap:G14",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-promote.md",
+      "evidence": "gap:G15",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/intake-promote.md",
+      "evidence": "gap:G17",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/learning-promote.md",
+      "evidence": "gap:G02",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/learning-promote.md",
+      "evidence": "gap:G03",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/learning-promote.md",
+      "evidence": "gap:G04",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/learning-promote.md",
+      "evidence": "gap:G05",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/learning-promote.md",
+      "evidence": "gap:G08",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-define.md",
+      "evidence": "start-number:G03",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-define.md",
+      "evidence": "gap:G05",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-define.md",
+      "evidence": "gap:G06",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-define.md",
+      "evidence": "gap:G07",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-save.md",
+      "evidence": "start-number:G02",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-save.md",
+      "evidence": "gap:G03",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-save.md",
+      "evidence": "gap:G04",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-save.md",
+      "evidence": "gap:G05",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-save.md",
+      "evidence": "gap:G06",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-save.md",
+      "evidence": "gap:G07",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-save.md",
+      "evidence": "gap:G08",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-save.md",
+      "evidence": "gap:G09",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
+    },
+    {
+      "category": "GuardrailNumber",
+      "check": "guardrail-number-invariant",
+      "file": "src/opencode/commands/agentdev/req-save.md",
+      "evidence": "gap:G10",
+      "count": 1,
+      "provenance": "issue-2372-ir063-initial-baseline",
+      "reason": "REQ-010-064 (IR-063) detection rollout: pre-existing violations recorded in Wave 1 audit F-009 / Wave 2 NORMALIZATION-REQ-046 section 4 (14 commands with non-G01 start or gaps; renumbering intentionally not executed while B-01 remains blocked). Resolution follows B-01 Design decision."
     },
     {
       "category": "IndexGenerationConsistency",
@@ -1487,6 +2747,204 @@
       "count": 1,
       "provenance": "legacy",
       "reason": "Pre-existing baseline before provenance tracking (REQ-0161-005, Issue #1780)"
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": ".agentdev/extensions/skills/agentdev-backlog-integration.yaml",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": ".agentdev/extensions/skills/agentdev-quality-gates.yaml",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": ".agentdev/extensions/skills/agentdev-req-analysis.yaml",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-architecture-advisory/SKILL.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 3,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-artifact-validation/SKILL.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-case-run-execution-adapter/references/adversarial-review-integration.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 4,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-doc-diagnostics/SKILL.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-categories.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 2,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-doc-diagnostics/references/diagnostic-routing.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-doc-writing/SKILL.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 3,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-doc-writing/references/document-boundaries.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 2,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-doc-writing/references/mechanical-replacement-rules.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-doc-writing/references/rewrite-patterns.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-inspect-skills/references/semantic-diagnostic-perspectives.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-learning-pipeline/references/disposition-and-artifact-schema.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-quality-gates/references/qg-2-acceptance-criteria-coverage.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-req-analysis/references/investigation-scope-refinement.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 4,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-req-analysis/references/wall-methodology.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/agentdev-req-file-manager/references/numbering-and-validation.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
+    },
+    {
+      "category": "ObsoleteVocabulary",
+      "check": "obsolete-vocabulary-current-use",
+      "file": "src/opencode/skills/japanese-tech-writing/SKILL.md",
+      "evidence": "req-adr-kind-enumeration:REQ/ADR/",
+      "count": 1,
+      "provenance": "issue-2372-ir065-initial-baseline",
+      "reason": "REQ-010-066 (IR-065) detection rollout: pre-existing legacy ADR kind enumeration (REQ/ADR/) residue outside Wave 2 normalization scope (audit viewpoint V1 did not enumerate kind lists). Bulk normalization to REQ/Decision/Design is an intake decision."
     },
     {
       "category": "RuntimeReference",
@@ -2990,6 +4448,87 @@
       "count": 1,
       "provenance": "v3-migration",
       "reason": "Stage 5 v2→v3 migration structural consequence (ADR-001 naming, v2: prefix range parsing, README table mismatch)"
+    },
+    {
+      "category": "UnresolvedPlaceholder",
+      "check": "unresolved-placeholder",
+      "file": "src/opencode/skills/agentdev-adversarial-review/SKILL.md",
+      "evidence": "id-placeholder:REQ-{NNNN}",
+      "count": 11,
+      "provenance": "issue-2372-ir064-initial-baseline",
+      "reason": "REQ-010-065 (IR-064) detection rollout: pre-existing bare ID placeholders used consistently as delegation-notation style. Style normalization (backticks or concrete IDs) is a Design candidate recorded in PR #2372; approve or remediate via intake."
+    },
+    {
+      "category": "UnresolvedPlaceholder",
+      "check": "unresolved-placeholder",
+      "file": "src/opencode/skills/agentdev-backlog-integration/SKILL.md",
+      "evidence": "id-placeholder:REQ-{NNNN}",
+      "count": 11,
+      "provenance": "issue-2372-ir064-initial-baseline",
+      "reason": "REQ-010-065 (IR-064) detection rollout: pre-existing bare ID placeholders used consistently as delegation-notation style. Style normalization (backticks or concrete IDs) is a Design candidate recorded in PR #2372; approve or remediate via intake."
+    },
+    {
+      "category": "UnresolvedPlaceholder",
+      "check": "unresolved-placeholder",
+      "file": "src/opencode/skills/agentdev-case-run-execution-adapter/SKILL.md",
+      "evidence": "id-placeholder:REQ-{NNNN}",
+      "count": 11,
+      "provenance": "issue-2372-ir064-initial-baseline",
+      "reason": "REQ-010-065 (IR-064) detection rollout: pre-existing bare ID placeholders used consistently as delegation-notation style. Style normalization (backticks or concrete IDs) is a Design candidate recorded in PR #2372; approve or remediate via intake."
+    },
+    {
+      "category": "UnresolvedPlaceholder",
+      "check": "unresolved-placeholder",
+      "file": "src/opencode/skills/agentdev-inspect-skills/SKILL.md",
+      "evidence": "id-placeholder:IR-{NNN}",
+      "count": 2,
+      "provenance": "issue-2372-ir064-initial-baseline",
+      "reason": "REQ-010-065 (IR-064) detection rollout: pre-existing bare ID placeholders used consistently as delegation-notation style. Style normalization (backticks or concrete IDs) is a Design candidate recorded in PR #2372; approve or remediate via intake."
+    },
+    {
+      "category": "UnresolvedPlaceholder",
+      "check": "unresolved-placeholder",
+      "file": "src/opencode/skills/agentdev-intake-pipeline/SKILL.md",
+      "evidence": "id-placeholder:REQ-{NNNN}",
+      "count": 4,
+      "provenance": "issue-2372-ir064-initial-baseline",
+      "reason": "REQ-010-065 (IR-064) detection rollout: pre-existing bare ID placeholders used consistently as delegation-notation style. Style normalization (backticks or concrete IDs) is a Design candidate recorded in PR #2372; approve or remediate via intake."
+    },
+    {
+      "category": "UnresolvedPlaceholder",
+      "check": "unresolved-placeholder",
+      "file": "src/opencode/skills/agentdev-req-analysis/references/pass-criteria-writing-guide.md",
+      "evidence": "id-placeholder:REQ-{NNNN}",
+      "count": 5,
+      "provenance": "issue-2372-ir064-initial-baseline",
+      "reason": "REQ-010-065 (IR-064) detection rollout: pre-existing bare ID placeholders used consistently as delegation-notation style. Style normalization (backticks or concrete IDs) is a Design candidate recorded in PR #2372; approve or remediate via intake."
+    },
+    {
+      "category": "UnresolvedPlaceholder",
+      "check": "unresolved-placeholder",
+      "file": "src/opencode/skills/agentdev-req-analysis/references/test-strategy-numeric-threshold-guide.md",
+      "evidence": "id-placeholder:TS-{NNN}",
+      "count": 2,
+      "provenance": "issue-2372-ir064-initial-baseline",
+      "reason": "REQ-010-065 (IR-064) detection rollout: pre-existing bare ID placeholders used consistently as delegation-notation style. Style normalization (backticks or concrete IDs) is a Design candidate recorded in PR #2372; approve or remediate via intake."
+    },
+    {
+      "category": "UnresolvedPlaceholder",
+      "check": "unresolved-placeholder",
+      "file": "src/opencode/skills/agentdev-workflow-case-close/SKILL.md",
+      "evidence": "id-placeholder:IR-{NNN}",
+      "count": 1,
+      "provenance": "issue-2372-ir064-initial-baseline",
+      "reason": "REQ-010-065 (IR-064) detection rollout: pre-existing bare ID placeholders used consistently as delegation-notation style. Style normalization (backticks or concrete IDs) is a Design candidate recorded in PR #2372; approve or remediate via intake."
+    },
+    {
+      "category": "UnresolvedPlaceholder",
+      "check": "unresolved-placeholder",
+      "file": "src/opencode/skills/agentdev-workflow-case-run/SKILL.md",
+      "evidence": "id-placeholder:DEC-{N}",
+      "count": 1,
+      "provenance": "issue-2372-ir064-initial-baseline",
+      "reason": "REQ-010-065 (IR-064) detection rollout: pre-existing bare ID placeholders used consistently as delegation-notation style. Style normalization (backticks or concrete IDs) is a Design candidate recorded in PR #2372; approve or remediate via intake."
     }
   ]
 }

--- a/.opencode/skills/repo-agentdev-integrity/data/obsolete-vocabulary-map.yaml
+++ b/.opencode/skills/repo-agentdev-integrity/data/obsolete-vocabulary-map.yaml
@@ -1,0 +1,126 @@
+# obsolete-vocabulary-map.yaml
+# REQ-010-066 / REQ-010-067 検出語彙の許容条件対照表（IR-065 / IR-066、Issue #2372）
+#
+# 検出シグナル（正規表現）は check_integrity.ts が所有する
+# （REQ-010 適用対象外宣言: 検出シグナルの正規表現、許容条件の判定実装は
+# integrity 関連 Design と checker 実装が所有）。本 yaml は語彙 ID ごとの
+# 運用データ（existence_probe、exemption_files）を宣言する。
+#
+# スキーマ:
+#   scope.include[]            : 走査対象ディレクトリ / ファイル（リポジトリルート相対）
+#   scope.exclude[]            : 走査除外パス接頭辞
+#   exemption_files[]          : {path, reason} 履歴説明として語彙の言及が正当なファイル
+#   negation_context_terms[]   : 行内に含まれる場合に語彙出現を「現行概念としての使用」と
+#                                しない否定文脈語
+#   vocabulary[]               : {id, rule, existence_probe} 検出語彙エントリ
+#     id                       : 語彙 ID（check_integrity.ts の語彙定義と対応）
+#     rule                     : 所有 IR（IR-065=廃止語彙 / IR-066=旧パス・削除済み名称）
+#     existence_probe          : 実在時に検出を skip するパス。probe 先が実在する場合、
+#                                当該語彙は現行機能として存在するため検出対象外とする
+#
+# Wave 1 監査（AUDIT-REQ-045-CONSISTENCY）観点V1/V2/V3/V4/V9、Wave 2 正規化
+# （NORMALIZATION-REQ-046）の再発防止として整備する。
+
+version: 1
+rule_ids:
+  - IR-065
+  - IR-066
+
+scope:
+  include:
+    - docs/designs
+    - docs/requirements
+    - docs/decisions
+    - docs/guides
+    - src/opencode
+    - .opencode/commands
+    - .agentdev/extensions
+  exclude:
+    - docs/requirements/retired/
+    - docs/decisions/retired/
+    - docs/reports/
+    - .opencode/skills/repo-agentdev-integrity/scripts/
+    - .opencode/skills/repo-agentdev-integrity/references/
+    - .opencode/skills/repo-agentdev-integrity/data/
+    - .opencode/skills/repo-agentdev-integrity/baselines/
+    - .opencode/skills/repo-agentdev-integrity/SKILL.md
+    - src/opencode/commands/agentdev/templates/
+
+# 履歴説明として語彙の言及が正当なファイル（検出基盤・正規契約上の言及）。
+# IR-057「例外登録（現行Decisionの履歴記載）」と同根の運用。
+exemption_files:
+  - path: docs/decisions/DEC-009.md
+    reason: "ADR→Decision 移行（1対1移行）の経緯を記載する正規 Decision。ADR-001..008 の旧識別子を移行説明として保持する"
+  - path: docs/decisions/DEC-007.md
+    reason: "superseded Decision（Artifact Graph 標準化と配布スキル昇格）。履歴文書として旧語彙を保持する"
+  - path: docs/decisions/DEC-017.md
+    reason: "Artifact Graph 廃止と最小トレーサビリティモデル採用の Decision。廃止経緯の正規記録"
+  - path: docs/decisions/DEC-019.md
+    reason: "一般処理の標準API委譲の Decision。旧スキルの依存実装（agentdev-artifact-graph）を参照例として記載する"
+  - path: docs/decisions/README.md
+    reason: "Decision 索引。superseded Decision のタイトル引用を含む"
+  - path: docs/designs/README.md
+    reason: "Design 索引・Report 分離規則。旧監査種別（DOC-MAP 監査）の言及が残る履歴文脈（解消要否は別途 intake 判断）"
+
+# 否定文脈許容: 行内にこれらの語がある場合の語彙出現は「現行概念としての使用」としない
+# （廃止機能を「使わないこと」を定める現行契約の記述は検出対象外）。
+negation_context_terms:
+  - 廃止
+  - 含めない
+  - とせず
+  - しないこと
+  - 生成しない
+  - 前提としない
+  - 対象外
+  - 撤去
+  - residual
+
+# 検出語彙エントリ（正規表現は check_integrity.ts の IR065_/IR066_ 定数が所有）
+vocabulary:
+  # --- IR-065（REQ-010-066）: 廃止語彙（種別・呼称・概念語） ---
+  - id: bare-adr-identifier
+    rule: IR-065
+    existence_probe: docs/adr
+  - id: docs-adr-path
+    rule: IR-065
+    existence_probe: docs/adr
+  - id: adr-kind-annotation
+    rule: IR-065
+    existence_probe: docs/adr
+  - id: req-adr-kind-enumeration
+    rule: IR-065
+    existence_probe: docs/adr
+  - id: artifact-graph-name
+    rule: IR-065
+    existence_probe: src/opencode/skills/agentdev-artifact-graph
+  - id: doc-map-name
+    rule: IR-065
+    existence_probe: docs/DOC-MAP.md
+  # --- IR-066（REQ-010-067）: 旧パス・削除済み名称 ---
+  - id: docs-specs-path
+    rule: IR-066
+    existence_probe: docs/specs
+  - id: agentdev-graph-path
+    rule: IR-066
+    existence_probe: .agentdev/graph
+  - id: agentdev-artifact-graph-skill
+    rule: IR-066
+    existence_probe: src/opencode/skills/agentdev-artifact-graph
+  - id: check-graph-script
+    rule: IR-066
+    existence_probe: src/opencode/skills/agentdev-artifact-graph
+  - id: agentdev-spec-compliance-skill
+    rule: IR-066
+    existence_probe: src/opencode/skills/agentdev-spec-compliance
+  - id: agentdev-adr-guidelines-skill
+    rule: IR-066
+    existence_probe: src/opencode/skills/agentdev-adr-guidelines
+  - id: agentdev-adr-file-manager-skill
+    rule: IR-066
+    existence_probe: src/opencode/skills/agentdev-adr-file-manager
+  - id: agentdev-doc-map-skill
+    rule: IR-066
+    existence_probe: src/opencode/skills/agentdev-doc-map
+  - id: agentdev-workflow-reporting-skill
+    rule: IR-066
+    existence_probe: src/opencode/skills/agentdev-workflow-reporting

--- a/.opencode/skills/repo-agentdev-integrity/references/vocabulary-registry.md
+++ b/.opencode/skills/repo-agentdev-integrity/references/vocabulary-registry.md
@@ -314,6 +314,28 @@ exemption: code block 内部、template placeholder（`{xxx}`）、`vocabulary-r
 
 段階導入（REQ-0108-264）: baseline 既知違反は `info`（報告のみ、fail なし）。新規違反は strict→`ng`、heuristic→`warning`（delta guard / impact guard で fail）。baseline ファイル（`.opencode/skills/repo-agentdev-integrity/baselines/ir-055-baseline.json`）は `--update-ir055-baseline` で再生成する。baseline 0 到達後に full audit を fail gate 化する。
 
+## IR-065/IR-066 廃止語彙・旧パス検出対照（REQ-010-066/067）
+
+IR-065（廃止語彙の現行使用検出）と IR-066（旧パス・削除済み名称検出）の検出語彙対照（Issue #2372）。検出シグナル（正規表現）は `check_integrity.ts` が、許容条件の運用データ（existence_probe、exemption_files、否定文脈語）は `data/obsolete-vocabulary-map.yaml` が所有する。詳細は [rules/IR-065-obsolete-vocabulary-current-use.md](../../../docs/designs/integrity/rules/IR-065-obsolete-vocabulary-current-use.md) と [rules/IR-066-legacy-path-removed-name.md](../../../docs/designs/integrity/rules/IR-066-legacy-path-removed-name.md) 参照。
+
+| 旧語彙 | 現行語彙 | IR | 備考 |
+|--------|----------|----|------|
+| bare `ADR-NNN` | `DEC-NNN` / `v2:ADR-NNNN`（歴史識別子） | IR-065 | v2: プレフィックス付きは許容 |
+| `docs/adr/` | `docs/decisions/` | IR-065 | DEC-009 移行済み |
+| `（ADR）` 注記 | （Design 名）等の正規根拠参照、または注記削除 | IR-065 | strict。Wave 2 #2371 で解消済み |
+| `REQ/ADR/` 種別列挙 | `REQ/Decision/` | IR-065 | 既知 34 件は NG baseline 管理 |
+| `Artifact Graph` | 最小トレーサビリティモデル（TIM） | IR-065 | DEC-017 で廃止 |
+| `DOC-MAP` | `docs/designs/README.md` 索引 | IR-065 | REQ-013 廃止済み |
+| `docs/specs/` | `docs/designs/` | IR-066 | ドメイン分割移行済み |
+| `.agentdev/graph/` | 正規成果物の直接走査 | IR-066 | DEC-017 で廃止 |
+| `agentdev-artifact-graph` | `agentdev-traceability` | IR-066 | DEC-017 決定3 |
+| `check_graph` | `agentdev-traceability` の check | IR-066 | 削除済みスクリプト |
+| `agentdev-spec-compliance` | QG-3（`agentdev-quality-gates`） | IR-066 | Wave 2 C-03 で置換済み |
+| `agentdev-adr-guidelines` | `agentdev-decision-guidelines` | IR-066 | DEC-009 決定14 |
+| `agentdev-adr-file-manager` | `agentdev-decision-file-manager` | IR-066 | DEC-009 決定14 |
+| `agentdev-doc-map` | （後継なし、Design 索引へ移行） | IR-066 | REQ-013 廃止済み |
+| `agentdev-workflow-reporting` | （完了報告は各工程の完了報告 template） | IR-066 | 廃止済み skill |
+
 ## メンテナンス
 
 - 新規語彙の追加・旧語彙の変更は docs-check（/repo/docs-check）の検出パターンと同期すること

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.test.ts
@@ -3170,3 +3170,565 @@ describe("WP-3 execution profiles (Issue #1928)", () => {
     expect(installedNg.length).toBe(0);
   });
 });
+
+// ─── IR-063 guardrail-number-invariant (REQ-010-064, Issue #2372) ────────────
+// Fixture kinds per REQ-010-068: 正常例 (ok-cmd), 違反例 (violation-cmd),
+// 境界例 (boundary-cmd: single G01, defined reference), 許容例 (no-guardrail-cmd:
+// Gxx 未使用 command は対象外), 再現例 (f009-cmd: Wave 1 F-009 の req-define 形式).
+
+const IR063_ROOT = join(TEMP_ROOT, "ir063");
+
+function buildIr063Fixture(root: string): void {
+  const reqDir = join(root, "docs", "requirements");
+  mkdirp(reqDir);
+  writeFileSync(
+    join(reqDir, "README.md"),
+    "# Requirements\n\n| ID | Title |\n|----|-------|\n| REQ-9301 | IR-063 fixture |\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(reqDir, "REQ-9301.md"),
+    "---\nid: REQ-9301\ntitle: IR-063 fixture\ncreated: 2025-01-01\nupdated: 2025-01-01\n---\n\nBody.\n",
+    "utf-8",
+  );
+  mkdirp(join(root, "docs", "designs"));
+  writeFileSync(join(root, "docs", "designs", "README.md"), "# Design\n", "utf-8");
+
+  const cmdDir = join(root, "src", "opencode", "commands", "agentdev");
+  mkdirp(cmdDir);
+
+  writeFileSync(
+    join(cmdDir, "README.md"),
+    "# Commands\n\n| Command |\n|---------|\n| `agentdev/ok-cmd` |\n",
+    "utf-8",
+  );
+
+  // 正常例: G01 連番 + 定義済み参照
+  writeFileSync(
+    join(cmdDir, "ok-cmd.md"),
+    [
+      "---",
+      "description: ok command",
+      "agent: test-agent",
+      "---",
+      "",
+      "## ガードレール",
+      "",
+      "- G01: 編集スコープは限定する",
+      "- G02: 破壊的操作は行わない",
+      "- G03: レポートのみ出力する",
+      "",
+      "手順は G02 に従う。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 違反例: 非 G01 開始 + 重複 + 未定義参照
+  writeFileSync(
+    join(cmdDir, "violation-cmd.md"),
+    [
+      "---",
+      "description: violation command",
+      "agent: test-agent",
+      "---",
+      "",
+      "## ガードレール",
+      "",
+      "- G01: first guardrail",
+      "- G01: duplicate definition of G01",
+      "- G03: skips G02",
+      "",
+      "本文は G09 を参照する（未定義）。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 境界例: 最小構成（G01 単体）+ 定義行の直前参照
+  writeFileSync(
+    join(cmdDir, "boundary-cmd.md"),
+    [
+      "---",
+      "description: boundary command",
+      "agent: test-agent",
+      "---",
+      "",
+      "## ガードレール",
+      "",
+      "- G01: only guardrail",
+      "",
+      "G01 を適用する。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 許容例: Gxx を使用しない command（検査対象外）
+  writeFileSync(
+    join(cmdDir, "no-guardrail-cmd.md"),
+    [
+      "---",
+      "description: no guardrail command",
+      "agent: test-agent",
+      "---",
+      "",
+      "本文にガードレール番号を持たない。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 再現例: Wave 1 監査 F-009 の req-define.md 形式（G03/G04/G08 = 非 G01 開始 + 欠番）
+  writeFileSync(
+    join(cmdDir, "f009-cmd.md"),
+    [
+      "---",
+      "description: F-009 reproduction",
+      "agent: test-agent",
+      "---",
+      "",
+      "## ガードレール",
+      "",
+      "- G03: 編集スコープは限定する",
+      "- G04: 入力ファイルは参照専用とする",
+      "- G08: git コマンドは実行しない",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  copyScripts(root);
+}
+
+describe("IR-063 guardrail-number-invariant (REQ-010-064, Issue #2372)", () => {
+  beforeAll(() => {
+    mkdirp(IR063_ROOT);
+    buildIr063Fixture(IR063_ROOT);
+  });
+
+  it("passes a sequential G01-start command with resolved references (正常例)", () => {
+    const r = runScript(IR063_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const violations = parsed.results.filter(
+      (res: { category: string; level: string; file?: string }) =>
+        res.category === "GuardrailNumber" &&
+        res.level !== "ok" &&
+        (res.file ?? "").includes("ok-cmd.md"),
+    );
+    expect(violations.length).toBe(0);
+  });
+
+  it("detects start-number, duplicate, and undefined-reference violations (違反例)", () => {
+    const r = runScript(IR063_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const byEvidence = parsed.results
+      .filter(
+        (res: { category: string; level: string; file?: string }) =>
+          res.category === "GuardrailNumber" &&
+          res.level === "ng" &&
+          (res.file ?? "").includes("violation-cmd.md"),
+      )
+      .map((res: { evidence?: string }) => res.evidence ?? "");
+    expect(byEvidence).toContain("duplicate:G01");
+    expect(byEvidence).toContain("gap:G02");
+    expect(byEvidence).toContain("undefined-reference:G09");
+  });
+
+  it("accepts a single-G01 minimal command and does not flag Gxx-free commands (境界例・許容例)", () => {
+    const r = runScript(IR063_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const violations = parsed.results.filter(
+      (res: { category: string; level: string; file?: string }) =>
+        res.category === "GuardrailNumber" &&
+        res.level === "ng" &&
+        ((res.file ?? "").includes("boundary-cmd.md") ||
+          (res.file ?? "").includes("no-guardrail-cmd.md")),
+    );
+    expect(violations.length).toBe(0);
+  });
+
+  it("reproduces Wave 1 F-009 (non-G01 start and gaps, 再現例)", () => {
+    const r = runScript(IR063_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const byEvidence = parsed.results
+      .filter(
+        (res: { category: string; level: string; file?: string }) =>
+          res.category === "GuardrailNumber" &&
+          res.level === "ng" &&
+          (res.file ?? "").includes("f009-cmd.md"),
+      )
+      .map((res: { evidence?: string }) => res.evidence ?? "");
+    expect(byEvidence).toContain("start-number:G03");
+    expect(byEvidence).toContain("gap:G05");
+    expect(byEvidence).toContain("gap:G07");
+  });
+});
+
+// ─── IR-064 unresolved-placeholder (REQ-010-065, Issue #2372) ────────────────
+// Fixture kinds: 正常例 (ok-skill), 違反例 (violation-skill), 境界例 (boundary
+// lines in ok file), 許容例 (template file), 再現例 (Wave 1 audit viewpoint V5
+// pattern: bare TODO-family marker and bare ID placeholder).
+
+const IR064_ROOT = join(TEMP_ROOT, "ir064");
+
+function buildIr064Fixture(root: string): void {
+  const reqDir = join(root, "docs", "requirements");
+  mkdirp(reqDir);
+  writeFileSync(
+    join(reqDir, "README.md"),
+    "# Requirements\n\n| ID | Title |\n|----|-------|\n| REQ-9302 | IR-064 fixture |\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(reqDir, "REQ-9302.md"),
+    "---\nid: REQ-9302\ntitle: IR-064 fixture\ncreated: 2025-01-01\nupdated: 2025-01-01\n---\n\nBody.\n",
+    "utf-8",
+  );
+  mkdirp(join(root, "docs", "designs"));
+  writeFileSync(join(root, "docs", "designs", "README.md"), "# Design\n", "utf-8");
+
+  const cmdDir = join(root, "src", "opencode", "commands", "agentdev");
+  mkdirp(cmdDir);
+  writeFileSync(
+    join(cmdDir, "README.md"),
+    "# Commands\n\n| Command |\n|---------|\n| `agentdev/placeholder-cmd` |\n",
+    "utf-8",
+  );
+
+  // 正常例 + 境界例: code span 内・括弧内・「」引用列挙・code block 内は許容
+  writeFileSync(
+    join(cmdDir, "placeholder-cmd.md"),
+    [
+      "---",
+      "description: placeholder boundary command",
+      "agent: test-agent",
+      "---",
+      "",
+      "`REQ-{NNNN}` は code span 内の様式例示である。",
+      "",
+      "本コマンドは workflow 実装本体を委譲する（DEC-{N}、REQ-{NNNN}-{NNN})。",
+      "",
+      "検知キーワード:「TODO」「FIXME」等の列挙は引用例示である。",
+      "",
+      "```",
+      "REQ-{NNNN} inside fenced code block",
+      "TODO inside fenced code block",
+      "```",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const skillDir = join(root, "src", "opencode", "skills", "agentdev-fixture-skill");
+  mkdirp(skillDir);
+
+  // 違反例 + 再現例: bare TODO マーカー（strict）と裸 ID プレースホルダー（heuristic）
+  writeFileSync(
+    join(skillDir, "SKILL.md"),
+    [
+      "---",
+      "name: agentdev-fixture-skill",
+      "description: fixture skill",
+      "---",
+      "",
+      "# agentdev-fixture-skill",
+      "",
+      "REQ-{NNNN} で定義される対象について、TODO を残さない。",
+      "",
+      "FIXME: 未解決の残置マーカー。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 許容例: command templates/ 配下と _template.md はテンプレート領域
+  const tplDir = join(cmdDir, "templates", "fixture");
+  mkdirp(tplDir);
+  writeFileSync(
+    join(tplDir, "standard.md"),
+    "REQ-{NNNN} と TODO はテンプレート内では許容される。\n",
+    "utf-8",
+  );
+  const skillTplDir = join(root, "src", "opencode", "skills", "agentdev-fixture-skill", "templates");
+  mkdirp(skillTplDir);
+  writeFileSync(
+    join(skillTplDir, "doc.md"),
+    "id: REQ-{NNNN}\n\nREQ-{NNNN} テンプレート。\n",
+    "utf-8",
+  );
+
+  copyScripts(root);
+}
+
+describe("IR-064 unresolved-placeholder (REQ-010-065, Issue #2372)", () => {
+  beforeAll(() => {
+    mkdirp(IR064_ROOT);
+    buildIr064Fixture(IR064_ROOT);
+  });
+
+  it("does not flag code span, parentheses, quote-enumeration, or fenced blocks (正常例・境界例)", () => {
+    const r = runScript(IR064_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const violations = parsed.results.filter(
+      (res: { category: string; file?: string }) =>
+        res.category === "UnresolvedPlaceholder" &&
+        (res.file ?? "").includes("placeholder-cmd.md"),
+    );
+    expect(violations.length).toBe(0);
+  });
+
+  it("detects bare TODO-family marker as strict and bare ID placeholder as heuristic (違反例)", () => {
+    const r = runScript(IR064_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const levels = parsed.results
+      .filter(
+        (res: { category: string; file?: string }) =>
+          res.category === "UnresolvedPlaceholder" &&
+          (res.file ?? "").includes("agentdev-fixture-skill"),
+      )
+      .map((res: { level: string; evidence?: string }) => `${res.level}:${res.evidence}`);
+    expect(levels).toContain("ng:todo-marker:FIXME");
+    expect(levels).toContain("warning:id-placeholder:REQ-{NNNN}");
+  });
+
+  it("exempts command templates/ and skill templates/ directories (許容例)", () => {
+    const r = runScript(IR064_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const violations = parsed.results.filter(
+      (res: { category: string; file?: string }) =>
+        res.category === "UnresolvedPlaceholder" &&
+        ((res.file ?? "").includes("/templates/") ||
+          (res.file ?? "").includes("\\templates\\")),
+    );
+    expect(violations.length).toBe(0);
+  });
+
+  it("does not treat non-ID brace tokens like UTF-{N} as placeholders (再現例の誤検出防止)", () => {
+    const r = runScript(IR064_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const utf = parsed.results.filter(
+      (res: { category: string; evidence?: string }) =>
+        res.category === "UnresolvedPlaceholder" &&
+        (res.evidence ?? "").includes("UTF"),
+    );
+    expect(utf.length).toBe(0);
+  });
+});
+
+// ─── IR-065/IR-066 obsolete-vocabulary & legacy-path (REQ-010-066/067, Issue #2372) ──
+// Fixture kinds: 正常例 (current vocabulary only), 違反例 (（ADR）注記・bare ADR
+// ・docs/specs/・廃止スキル名), 境界例 (v2:ADR-0123 は REQ-010-066 文言どおり許容),
+// 許容例 (superseded Decision・行履歴マーカー・否定文脈・existence_probe),
+// 再現例 (Wave 2 F-001 （ADR）注記・F-003 agentdev-spec-compliance 参照).
+
+const IR065_ROOT = join(TEMP_ROOT, "ir065");
+
+function buildIr065Fixture(root: string): void {
+  const reqDir = join(root, "docs", "requirements");
+  mkdirp(reqDir);
+  writeFileSync(
+    join(reqDir, "README.md"),
+    "# Requirements\n\n| ID | Title |\n|----|-------|\n| REQ-9303 | IR-065 fixture |\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(reqDir, "REQ-9303.md"),
+    "---\nid: REQ-9303\ntitle: IR-065 fixture\ncreated: 2025-01-01\nupdated: 2025-01-01\n---\n\nBody.\n",
+    "utf-8",
+  );
+  mkdirp(join(root, "docs", "designs"));
+  writeFileSync(join(root, "docs", "designs", "README.md"), "# Design\n", "utf-8");
+
+  // 正常例 + 境界例: 現行語彙（REQ/Decision/Design）と v2: プレフィックス付き歴史識別子
+  const designDir = join(root, "docs", "designs", "skills");
+  mkdirp(designDir);
+  writeFileSync(
+    join(designDir, "current-design.md"),
+    [
+      "# Current design",
+      "",
+      "REQ/Decision/Design/guides の現行種別列挙である。",
+      "",
+      "許容された歴史的識別子（v2:ADR-0123 等）は誤検出しない。",
+      "",
+      "`ADR-0099` は code span 内の様式例示である。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 許容例: superseded Decision はファイル単位で履歴文書
+  const decDir = join(root, "docs", "decisions");
+  mkdirp(decDir);
+  writeFileSync(
+    join(decDir, "DEC-9901.md"),
+    [
+      "---",
+      "id: DEC-9901",
+      "title: superseded decision",
+      "status: superseded",
+      "---",
+      "",
+      "# DEC-9901",
+      "",
+      "旧 Artifact Graph 標準化の決定。agentdev-artifact-graph への言及を履歴として保持する。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 違反例 + 再現例（F-001/F-003 相当）
+  const cmdDir = join(root, "src", "opencode", "commands", "agentdev");
+  mkdirp(cmdDir);
+  writeFileSync(
+    join(cmdDir, "README.md"),
+    "# Commands\n\n| Command |\n|---------|\n| `agentdev/vocab-cmd` |\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(cmdDir, "vocab-cmd.md"),
+    [
+      "---",
+      "description: vocabulary violation command",
+      "agent: test-agent",
+      "---",
+      "",
+      "project extension を読み込む（ADR）。",
+      "",
+      "設計判断の記録は ADR-0099 を参照する。",
+      "",
+      "仕様文書は docs/specs/foundations/system.md にある。",
+      "",
+      "乖離報告は agentdev-spec-compliance から抽出する。",
+      "",
+      "判断記録は docs/adr/ 配下のファイルを参照する。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 許容例: 行履歴マーカー・否定文脈
+  writeFileSync(
+    join(designDir, "history-design.md"),
+    [
+      "# History and negation design",
+      "",
+      "旧 ADR-0099 の記述は履歴マーカー付きのため許容される。",
+      "",
+      "`.agentdev/graph/` のような派生索引を標準動作に含めない（廃止）。",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // 境界例: existence_probe — agentdev-artifact-graph が実在すれば語彙検出を skip
+  const probeSkillDir = join(root, "src", "opencode", "skills", "agentdev-artifact-graph");
+  mkdirp(probeSkillDir);
+  writeFileSync(
+    join(probeSkillDir, "SKILL.md"),
+    "---\nname: agentdev-artifact-graph\ndescription: probe skill\n---\n# agentdev-artifact-graph\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(designDir, "probe-design.md"),
+    "# Probe design\n\nagentdev-artifact-graph が実在するため検出を skip する（existence_probe）。\n",
+    "utf-8",
+  );
+
+  // IR-065/066 は data/obsolete-vocabulary-map.yaml を読むため fixture へコピー
+  const dataDir = join(
+    root,
+    ".opencode",
+    "skills",
+    "repo-agentdev-integrity",
+    "data",
+  );
+  mkdirp(dataDir);
+  writeFileSync(
+    join(dataDir, "obsolete-vocabulary-map.yaml"),
+    readFileSync(
+      join(SCRIPT_DIR, "..", "data", "obsolete-vocabulary-map.yaml"),
+      "utf-8",
+    ),
+    "utf-8",
+  );
+
+  copyScripts(root);
+}
+
+describe("IR-065/IR-066 obsolete-vocabulary & legacy-path (REQ-010-066/067, Issue #2372)", () => {
+  beforeAll(() => {
+    mkdirp(IR065_ROOT);
+    buildIr065Fixture(IR065_ROOT);
+  });
+
+  it("passes current vocabulary and v2:-prefixed historical identifiers (正常例・境界例)", () => {
+    const r = runScript(IR065_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const violations = parsed.results.filter(
+      (res: { category: string; file?: string }) =>
+        (res.category === "ObsoleteVocabulary" || res.category === "LegacyPathName") &&
+        (res.file ?? "").includes("current-design.md"),
+    );
+    expect(violations.length).toBe(0);
+  });
+
+  it("detects (ADR) annotation as strict and legacy identifiers as heuristic (違反例)", () => {
+    const r = runScript(IR065_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const found = parsed.results
+      .filter(
+        (res: { category: string; file?: string }) =>
+          (res.category === "ObsoleteVocabulary" || res.category === "LegacyPathName") &&
+          (res.file ?? "").includes("vocab-cmd.md"),
+      )
+      .map((res: { level: string; evidence?: string }) => `${res.level}:${res.evidence}`);
+    expect(found).toContain("ng:adr-kind-annotation:（ADR）");
+    expect(found).toContain("warning:bare-adr-identifier:ADR-0099");
+    expect(found).toContain("warning:docs-adr-path:docs/adr/");
+    expect(found).toContain("warning:docs-specs-path:docs/specs/");
+    expect(found).toContain("warning:agentdev-spec-compliance-skill:agentdev-spec-compliance");
+  });
+
+  it("exempts superseded decisions, line history markers, and negation contexts (許容例)", () => {
+    const r = runScript(IR065_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const violations = parsed.results.filter(
+      (res: { category: string; file?: string }) =>
+        (res.category === "ObsoleteVocabulary" || res.category === "LegacyPathName") &&
+        ((res.file ?? "").includes("DEC-9901.md") ||
+          (res.file ?? "").includes("history-design.md")),
+    );
+    expect(violations.length).toBe(0);
+  });
+
+  it("skips vocabulary whose existence_probe target exists (境界例: existence_probe)", () => {
+    const r = runScript(IR065_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const violations = parsed.results.filter(
+      (res: { category: string; file?: string }) =>
+        (res.category === "ObsoleteVocabulary" || res.category === "LegacyPathName") &&
+        (res.file ?? "").includes("probe-design.md"),
+    );
+    expect(violations.length).toBe(0);
+  });
+
+  it("reproduces Wave 2 F-001 ((ADR) annotation) and F-003 (agentdev-spec-compliance) residue (再現例)", () => {
+    const r = runScript(IR065_ROOT, ["--json"]);
+    const parsed = JSON.parse(r.stdout);
+    const adrAnnotation = parsed.results.filter(
+      (res: { category: string; evidence?: string; level: string }) =>
+        res.category === "ObsoleteVocabulary" &&
+        res.level === "ng" &&
+        res.evidence === "adr-kind-annotation:（ADR）",
+    );
+    expect(adrAnnotation.length).toBeGreaterThanOrEqual(1);
+    const specCompliance = parsed.results.filter(
+      (res: { category: string; evidence?: string }) =>
+        res.category === "LegacyPathName" &&
+        res.evidence === "agentdev-spec-compliance-skill:agentdev-spec-compliance",
+    );
+    expect(specCompliance.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts
@@ -4908,6 +4908,9 @@ function checkSkillCategoryGap(
     ["Runtime reference", ["RuntimeUnresolvedReference"]],
     ["Distribution untracked skill", ["DistributionUntrackedSkillReference"]],
     ["Skill rename 対称性", ["SkillRenameSymmetry"]],
+    ["Guardrail number invariant", ["GuardrailNumberInvariant"]],
+    ["Unresolved placeholder", ["UnresolvedPlaceholder"]],
+    ["Obsolete vocabulary & legacy path", ["ObsoleteVocabulary"]],
   ]);
 
   let foundGap = false;
@@ -8862,6 +8865,597 @@ function checkSkillSeeAlsoReference(skillsDir: string, root: string): CheckResul
   return results;
 }
 
+// ─── IR-063 / IR-064 / IR-065 / IR-066 (Issue #2372, REQ-010-064..067) ──────
+// Wave 1 監査（AUDIT-REQ-045-CONSISTENCY）と Wave 2 正規化
+// （NORMALIZATION-REQ-046）後の状態を機械検査で固定する新規検査クラス群。
+// 検出シグナル・許容条件の詳細は docs/designs/integrity/rules/IR-063..066 が所有する。
+
+// IR-063 (REQ-010-064): 公開 command のガードレール番号 (Gxx) 不変条件。
+// 定義行様式は `- Gxx: ...`（Wave 1 監査観点V6 と同一抽出パターン）。
+const GUARDRAIL_DEF_LINE_RE = /^[-*]\s+(?:\*\*)?`?G(\d{2})`?(?:\*\*)?\s*[:：]/;
+const GUARDRAIL_REF_RE = /\bG(\d{2})\b/g;
+
+function collectPublicCommandMarkdown(root: string): string[] {
+  const cmdDir = path.join(root, "src", "opencode", "commands", "agentdev");
+  if (!fs.existsSync(cmdDir)) return [];
+  // 直下の .md のみ（templates/ サブディレクトリと README.md は対象外）
+  return listFiles(cmdDir)
+    .filter((f) => f !== "README.md")
+    .map((f) => path.join(cmdDir, f));
+}
+
+function guardrailNg(
+  relPath: string,
+  line: number,
+  message: string,
+  evidence: string,
+  expected: string,
+): CheckResult {
+  return ng("GuardrailNumber", "guardrail-number-invariant", message, relPath, line, {
+    evidence,
+    expected,
+    route: "intake",
+    finding_category: "document-drift",
+    finding_level: "strict",
+  });
+}
+
+function checkGuardrailNumberInvariant(root: string): CheckResult[] {
+  const results: CheckResult[] = [];
+  const files = collectPublicCommandMarkdown(root);
+  let violationCount = 0;
+  for (const fullPath of files) {
+    const relPath = resolveRelative(fullPath, root);
+    const content = readText(fullPath);
+    if (!content) continue;
+    const lines = content.split("\n");
+
+    // 定義抽出（出現順。重複検出のため同一番号の行リストを保持）
+    const defLineIdx = new Map<string, number[]>();
+    const defOrder: string[] = [];
+    lines.forEach((line, idx) => {
+      const m = line.match(GUARDRAIL_DEF_LINE_RE);
+      if (!m) return;
+      const num = m[1];
+      if (!defLineIdx.has(num)) defOrder.push(num);
+      const arr = defLineIdx.get(num) ?? [];
+      arr.push(idx);
+      defLineIdx.set(num, arr);
+    });
+    // Gxx 定義を持たない command は検査対象外（ガードレール定義は必須でない）
+    if (defOrder.length === 0) continue;
+
+    // 1. 開始番号（G01 起点）
+    const first = defOrder[0];
+    if (first !== "01") {
+      violationCount++;
+      results.push(
+        guardrailNg(
+          relPath,
+          (defLineIdx.get(first)?.[0] ?? 0) + 1,
+          `Guardrail numbers must start at G01: first defined guardrail is G${first} (REQ-010-064, IR-063)`,
+          `start-number:G${first}`,
+          "first guardrail definition is G01",
+        ),
+      );
+    }
+
+    // 2. 欠番（定義番号は連番であること）
+    const nums = defOrder.map((n) => parseInt(n, 10));
+    for (let i = 1; i < nums.length; i++) {
+      if (nums[i] === nums[i - 1] + 1) continue;
+      const prev = String(nums[i - 1]).padStart(2, "0");
+      const next = String(nums[i]).padStart(2, "0");
+      for (let g = nums[i - 1] + 1; g < nums[i]; g++) {
+        const gStr = String(g).padStart(2, "0");
+        violationCount++;
+        results.push(
+          guardrailNg(
+            relPath,
+            (defLineIdx.get(next)?.[0] ?? 0) + 1,
+            `Guardrail number gap detected: G${gStr} is missing between G${prev} and G${next} (REQ-010-064, IR-063)`,
+            `gap:G${gStr}`,
+            `guardrail numbers are sequential (G${prev} directly followed by G${next} leaves G${gStr} unused)`,
+          ),
+        );
+      }
+    }
+
+    // 3. 重複（同一番号の定義は 1 回のみ）
+    for (const [num, idxs] of defLineIdx) {
+      if (idxs.length <= 1) continue;
+      violationCount++;
+      results.push(
+        guardrailNg(
+          relPath,
+          idxs[1] + 1,
+          `Duplicate guardrail number definition: G${num} is defined ${idxs.length} times (REQ-010-064, IR-063)`,
+          `duplicate:G${num}`,
+          `G${num} is defined exactly once`,
+        ),
+      );
+    }
+
+    // 4. 未定義参照（本文中の Gxx は同一ファイルの定義へ解決されること）
+    lines.forEach((line, idx) => {
+      if (GUARDRAIL_DEF_LINE_RE.test(line)) return;
+      GUARDRAIL_REF_RE.lastIndex = 0;
+      let m2: RegExpExecArray | null;
+      const reported = new Set<string>();
+      while ((m2 = GUARDRAIL_REF_RE.exec(line)) !== null) {
+        if (defLineIdx.has(m2[1])) continue;
+        if (reported.has(m2[1])) continue;
+        reported.add(m2[1]);
+        violationCount++;
+        results.push(
+          guardrailNg(
+            relPath,
+            idx + 1,
+            `Body references undefined guardrail number G${m2[1]}: no matching definition in this command (REQ-010-064, IR-063)`,
+            `undefined-reference:G${m2[1]}`,
+            `G${m2[1]} is defined in the same command file`,
+          ),
+        );
+      }
+    });
+  }
+  if (violationCount === 0) {
+    results.push(
+      ok(
+        "GuardrailNumber",
+        "guardrail-number-invariant",
+        `IR-063 guardrail-number-invariant: ${files.length} public commands scanned, 0 violations (REQ-010-064)`,
+      ),
+    );
+  }
+  return results;
+}
+
+// IR-064 (REQ-010-065): 実行時配布対象に残る未解決プレースホルダー。
+// ID プレフィックスは文書 ID 系接頭辞に限定する（Wave 1 監査観点V5 と同じ限定列挙。
+// UTF-{N} 等の文字コード様式表記を誤検出しない）。
+const IR064_TODO_MARKER_RE = /\b(TODO|FIXME|XXX|HACK)\b/g;
+const IR064_ID_PLACEHOLDER_RE =
+  /\b(?:REQ|DEC|ADR|AG|QG|IR|RU|TS|OU|AC|CR|EC|SC|ACT|DD|DESIGN|RD|SPEC|WS|GMT)-\{[^}]*\}/g;
+
+function isIr064TemplatePath(relPath: string): boolean {
+  return (
+    relPath.startsWith("src/opencode/commands/agentdev/templates/") ||
+    /^src\/opencode\/skills\/[^/]+\/templates\//.test(relPath) ||
+    /(^|\/)_template\.md$/.test(relPath)
+  );
+}
+
+// マッチ位置が括弧（ASCII / 全角）の内側か（委譲注記様式（DEC-{N}、REQ-{NNNN}-{NNN}）の許容判定）。
+function isIr064InsideParentheses(line: string, matchIndex: number): boolean {
+  let depth = 0;
+  for (let i = 0; i < matchIndex && i < line.length; i++) {
+    const c = line[i];
+    if (c === "(" || c === "（") depth++;
+    else if (c === ")" || c === "）") depth = Math.max(0, depth - 1);
+  }
+  return depth > 0;
+}
+
+// マッチ位置が全角引用「」の内側か（検出キーワードの列挙例示の許容判定）。
+function isIr064InsideQuoteBracket(line: string, matchIndex: number): boolean {
+  let inQuote = false;
+  for (let i = 0; i < matchIndex && i < line.length; i++) {
+    if (line[i] === "「") inQuote = true;
+    else if (line[i] === "」") inQuote = false;
+  }
+  return inQuote;
+}
+
+function collectDistributionMarkdown(root: string): string[] {
+  const targets: string[] = [];
+  const commandDir = path.join(root, "src", "opencode", "commands", "agentdev");
+  if (fs.existsSync(commandDir)) {
+    targets.push(
+      ...globWalkRel(commandDir, { extensions: [".md"] }).map((rel) =>
+        path.join(commandDir, ...rel.split("/")),
+      ),
+    );
+  }
+  const skillRoot = path.join(root, "src", "opencode", "skills");
+  if (fs.existsSync(skillRoot)) {
+    for (const dir of listDirs(skillRoot)) {
+      if (!dir.startsWith("agentdev-")) continue;
+      const skillDir = path.join(skillRoot, dir);
+      targets.push(
+        ...globWalkRel(skillDir, { extensions: [".md"] }).map((rel) =>
+          path.join(skillDir, ...rel.split("/")),
+        ),
+      );
+    }
+  }
+  return targets;
+}
+
+function checkUnresolvedPlaceholder(root: string): CheckResult[] {
+  const results: CheckResult[] = [];
+  const files = collectDistributionMarkdown(root);
+  let todoCount = 0;
+  let placeholderCount = 0;
+  for (const fullPath of files) {
+    const relPath = resolveRelative(fullPath, root);
+    const content = readText(fullPath);
+    if (!content) continue;
+    const isTemplate = isIr064TemplatePath(relPath);
+    const lines = content.split("\n");
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (isIr057InCodeBlock(lines, i)) continue;
+
+      // (a) 未解決 TODO 系マーカー（引用「」内の語彙列挙、code span 内は許容）
+      IR064_TODO_MARKER_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = IR064_TODO_MARKER_RE.exec(line)) !== null) {
+        if (isInsideCodeSpan(line, m.index)) continue;
+        if (isIr064InsideQuoteBracket(line, m.index)) continue;
+        if (isTemplate) continue;
+        todoCount++;
+        results.push(
+          ng(
+            "UnresolvedPlaceholder",
+            "unresolved-placeholder",
+            `Unresolved TODO-family marker '${m[1]}' remains in distribution target (REQ-010-065, IR-064)`,
+            relPath,
+            i + 1,
+            {
+              evidence: `todo-marker:${m[1]}`,
+              expected: "resolve the marker or move the note to a non-distribution document",
+              route: "intake",
+              finding_category: "document-drift",
+              finding_level: "strict",
+            },
+          ),
+        );
+      }
+
+      // (b) ID 系プレースホルダーの裸出力（様式例示の場所: code span・括弧内・
+      // テンプレートは許容。それ以外の本文裸出力は heuristic）
+      IR064_ID_PLACEHOLDER_RE.lastIndex = 0;
+      let m2: RegExpExecArray | null;
+      const reported = new Set<string>();
+      while ((m2 = IR064_ID_PLACEHOLDER_RE.exec(line)) !== null) {
+        if (isInsideCodeSpan(line, m2.index)) continue;
+        if (isIr064InsideParentheses(line, m2.index)) continue;
+        if (isTemplate) continue;
+        if (reported.has(m2[0])) continue;
+        reported.add(m2[0]);
+        placeholderCount++;
+        results.push(
+          warn(
+            "UnresolvedPlaceholder",
+            "unresolved-placeholder",
+            `ID placeholder '${m2[0]}' appears bare in body text (not in code span, parentheses, or template) (REQ-010-065, IR-064)`,
+            relPath,
+            i + 1,
+            {
+              evidence: `id-placeholder:${m2[0]}`,
+              expected:
+                "wrap the placeholder in backticks or parenthesized delegation-notation, or resolve it to a concrete value",
+              route: "intake",
+              finding_category: "document-drift",
+              finding_level: "heuristic",
+            },
+          ),
+        );
+      }
+    }
+  }
+  if (todoCount === 0 && placeholderCount === 0) {
+    results.push(
+      ok(
+        "UnresolvedPlaceholder",
+        "unresolved-placeholder",
+        `IR-064 unresolved-placeholder: ${files.length} distribution files scanned, 0 violations (REQ-010-065)`,
+      ),
+    );
+  }
+  return results;
+}
+
+// IR-065 (REQ-010-066) / IR-066 (REQ-010-067): 廃止語彙・旧パス・削除済み名称。
+// 許容条件の運用データ（existence_probe、exemption_files、否定文脈語）は
+// data/obsolete-vocabulary-map.yaml が宣言する。
+interface ObsoleteVocabEntry {
+  id: string;
+  rule: string;
+  probe: string;
+}
+
+interface ObsoleteVocabMap {
+  scopeInclude: string[];
+  scopeExclude: string[];
+  exemptionFiles: Map<string, string>;
+  negationTerms: string[];
+  vocab: ObsoleteVocabEntry[];
+}
+
+function unquoteYamlScalar(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function loadObsoleteVocabularyMap(root: string): ObsoleteVocabMap | null {
+  const mapPath = path.join(
+    root,
+    ".opencode",
+    "skills",
+    "repo-agentdev-integrity",
+    "data",
+    "obsolete-vocabulary-map.yaml",
+  );
+  const content = readText(mapPath);
+  if (!content) return null;
+  const map: ObsoleteVocabMap = {
+    scopeInclude: [],
+    scopeExclude: [],
+    exemptionFiles: new Map<string, string>(),
+    negationTerms: [],
+    vocab: [],
+  };
+  let section: "scope" | "exemption" | "negation" | "vocab" | null = null;
+  let subsection: "include" | "exclude" | null = null;
+  let currentExemption: { path?: string; reason?: string } | null = null;
+  let currentVocab: Partial<ObsoleteVocabEntry> | null = null;
+  for (const raw of content.split("\n")) {
+    const line = raw.replace(/\r$/, "");
+    if (/^#/.test(line) || line.trim() === "") continue;
+    if (/^scope:/.test(line)) {
+      section = "scope";
+      subsection = null;
+      continue;
+    }
+    if (/^exemption_files:/.test(line)) {
+      section = "exemption";
+      currentExemption = null;
+      continue;
+    }
+    if (/^negation_context_terms:/.test(line)) {
+      section = "negation";
+      continue;
+    }
+    if (/^vocabulary:/.test(line)) {
+      section = "vocab";
+      currentVocab = null;
+      continue;
+    }
+    if (section === "scope") {
+      const sub = line.match(/^\s{2}(include|exclude):/);
+      if (sub) {
+        subsection = sub[1] as "include" | "exclude";
+        continue;
+      }
+      const item = line.match(/^\s{4}-\s+(.+)$/);
+      if (item && subsection === "include") {
+        map.scopeInclude.push(unquoteYamlScalar(item[1]));
+      } else if (item && subsection === "exclude") {
+        map.scopeExclude.push(unquoteYamlScalar(item[1]));
+      }
+      continue;
+    }
+    if (section === "exemption") {
+      const pathMatch = line.match(/^\s{2}-\s+path:\s*(.+)$/);
+      if (pathMatch) {
+        currentExemption = { path: unquoteYamlScalar(pathMatch[1]) };
+        continue;
+      }
+      const reasonMatch = line.match(/^\s{4}reason:\s*(.+)$/);
+      if (reasonMatch && currentExemption) {
+        currentExemption.reason = unquoteYamlScalar(reasonMatch[1]);
+        if (currentExemption.path) {
+          map.exemptionFiles.set(currentExemption.path, currentExemption.reason ?? "");
+        }
+        continue;
+      }
+      continue;
+    }
+    if (section === "negation") {
+      const item = line.match(/^\s{2}-\s+(.+)$/);
+      if (item) map.negationTerms.push(unquoteYamlScalar(item[1]));
+      continue;
+    }
+    if (section === "vocab") {
+      const idMatch = line.match(/^\s{2}-\s+id:\s*(.+)$/);
+      if (idMatch) {
+        if (currentVocab && currentVocab.id) {
+          map.vocab.push({
+            id: currentVocab.id,
+            rule: currentVocab.rule ?? "",
+            probe: currentVocab.probe ?? "",
+          });
+        }
+        currentVocab = { id: unquoteYamlScalar(idMatch[1]) };
+        continue;
+      }
+      const ruleMatch = line.match(/^\s{4}rule:\s*(.+)$/);
+      if (ruleMatch && currentVocab) {
+        currentVocab.rule = unquoteYamlScalar(ruleMatch[1]);
+        continue;
+      }
+      const probeMatch = line.match(/^\s{4}existence_probe:\s*(.+)$/);
+      if (probeMatch && currentVocab) {
+        currentVocab.probe = unquoteYamlScalar(probeMatch[1]);
+        continue;
+      }
+    }
+  }
+  if (currentVocab && currentVocab.id) {
+    map.vocab.push({
+      id: currentVocab.id,
+      rule: currentVocab.rule ?? "",
+      probe: currentVocab.probe ?? "",
+    });
+  }
+  return map;
+}
+
+const IR065_VOCAB_PATTERNS: ReadonlyArray<{ id: string; pattern: RegExp }> = [
+  // bare ADR-NNN（v2: プレフィックス付きは許容済み識別子のため除外）
+  { id: "bare-adr-identifier", pattern: /(?<!v2:)(?<![\w-])ADR-\d{3,4}(?!\d)/g },
+  { id: "docs-adr-path", pattern: /docs\/adr\//g },
+  // Wave 2 (#2371) で解消済みの孤立注記。再発は即 fail（strict）
+  { id: "adr-kind-annotation", pattern: /（ADR）/g },
+  { id: "req-adr-kind-enumeration", pattern: /REQ\/ADR\//g },
+  { id: "artifact-graph-name", pattern: /\bArtifact Graph\b/g },
+  { id: "doc-map-name", pattern: /\bDOC-MAP\b/g },
+];
+
+const IR066_VOCAB_PATTERNS: ReadonlyArray<{ id: string; pattern: RegExp }> = [
+  { id: "docs-specs-path", pattern: /docs\/specs\//g },
+  { id: "agentdev-graph-path", pattern: /\.agentdev\/graph/g },
+  { id: "agentdev-artifact-graph-skill", pattern: /agentdev-artifact-graph/g },
+  { id: "check-graph-script", pattern: /\bcheck_graph\b/g },
+  { id: "agentdev-spec-compliance-skill", pattern: /agentdev-spec-compliance/g },
+  { id: "agentdev-adr-guidelines-skill", pattern: /agentdev-adr-guidelines/g },
+  { id: "agentdev-adr-file-manager-skill", pattern: /agentdev-adr-file-manager/g },
+  { id: "agentdev-doc-map-skill", pattern: /agentdev-doc-map/g },
+  { id: "agentdev-workflow-reporting-skill", pattern: /agentdev-workflow-reporting/g },
+];
+
+function isSupersededDecision(relPath: string, content: string): boolean {
+  if (!/^docs\/decisions\/[^/]+\.md$/.test(relPath)) return false;
+  const statusMatch = content.match(/^status:\s*(\S+)/m);
+  return statusMatch !== null && statusMatch[1] === "superseded";
+}
+
+// 「## 廃止済み要件」等の retired 系見出し配下の行か（retired/ ディレクトリと
+// 同種の履歴領域。docs/requirements/README.md の廃止済み REQ タイトル表を含む）。
+function isIr065UnderRetiredHeading(lines: string[], lineIdx: number): boolean {
+  let underRetired = false;
+  for (let i = 0; i <= lineIdx && i < lines.length; i++) {
+    const headingMatch = lines[i].match(/^#{1,6}\s+(.+)$/);
+    if (headingMatch) {
+      underRetired =
+        /\b(retired|historical)\b|履歴|過去経緯|廃止済み|廃止|retired-no-successor|historical-only/i.test(
+          headingMatch[1],
+        );
+    }
+  }
+  return underRetired;
+}
+
+function checkObsoleteVocabulary(root: string): CheckResult[] {
+  const results: CheckResult[] = [];
+  const map = loadObsoleteVocabularyMap(root);
+  if (!map) {
+    results.push(
+      info(
+        "ObsoleteVocabulary",
+        "obsolete-vocabulary-map-load",
+        "obsolete-vocabulary-map.yaml not found; IR-065/IR-066 skipped",
+      ),
+    );
+    return results;
+  }
+
+  // existence_probe: probe 先が実在する語彙は現行機能として存在するため検出対象外
+  const activeVocab = new Map<string, { rule: string }>();
+  for (const v of map.vocab) {
+    if (v.probe && fs.existsSync(path.join(root, ...v.probe.split("/")))) continue;
+    activeVocab.set(v.id, { rule: v.rule });
+  }
+
+  // 走査対象収集（scope.include 配下、scope.exclude 接頭辞除外、.md/.yaml/.yml）
+  const targetFiles: string[] = [];
+  for (const inc of map.scopeInclude) {
+    const abs = path.join(root, ...inc.split("/"));
+    if (!fs.existsSync(abs)) continue;
+    if (fs.statSync(abs).isDirectory()) {
+      const acc: string[] = [];
+      walkAllFiles(abs, acc);
+      targetFiles.push(...acc);
+    } else {
+      targetFiles.push(abs);
+    }
+  }
+  const scoped = targetFiles.filter((f) => {
+    const rel = resolveRelative(f, root);
+    if (map.scopeExclude.some((p) => rel.startsWith(p))) return false;
+    return /\.(md|yaml|yml)$/.test(f);
+  });
+
+  const allPatterns: ReadonlyArray<{ id: string; pattern: RegExp; rule: string }> = [
+    ...IR065_VOCAB_PATTERNS.map((p) => ({ ...p, rule: "IR-065" })),
+    ...IR066_VOCAB_PATTERNS.map((p) => ({ ...p, rule: "IR-066" })),
+  ];
+
+  let violationCount = 0;
+  for (const fullPath of scoped) {
+    const relPath = resolveRelative(fullPath, root);
+    // exemption_files（履歴説明として正当なファイル）
+    if (map.exemptionFiles.has(relPath)) continue;
+    const content = readText(fullPath);
+    if (!content) continue;
+    // superseded Decision は履歴文書としてファイル単位許容
+    if (isSupersededDecision(relPath, content)) continue;
+    const lines = content.split("\n");
+
+    for (const { id, pattern, rule } of allPatterns) {
+      if (!activeVocab.has(id)) continue;
+      const category = rule === "IR-065" ? "ObsoleteVocabulary" : "LegacyPathName";
+      const check = rule === "IR-065" ? "obsolete-vocabulary-current-use" : "legacy-path-removed-name";
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        pattern.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        const reported = new Set<string>();
+        while ((m = pattern.exec(line)) !== null) {
+          if (isIr057InCodeBlock(lines, i)) break;
+          if (isInsideCodeSpan(line, m.index)) continue;
+          // retired 系見出し配下（廃止済み要件表等）は履歴領域として許容
+          if (isIr065UnderRetiredHeading(lines, i)) continue;
+          // 行レベル履歴マーカー（旧/移行/廃止/履歴/経緯 等）は許容
+          if (hasLineLevelHistoryMarker(line)) continue;
+          // 否定文脈（廃止機能を「使わないこと」を定める現行契約の記述）は許容
+          if (map.negationTerms.some((t) => line.includes(t))) continue;
+          if (reported.has(m[0])) continue;
+          reported.add(m[0]);
+          violationCount++;
+          const strict = id === "adr-kind-annotation";
+          const ctor = strict ? ng : warn;
+          results.push(
+            ctor(
+              category,
+              check,
+              `Obsolete ${rule === "IR-065" ? "vocabulary" : "path/removed name"} '${m[0]}' (${id}) used as current concept (REQ-010-${rule === "IR-065" ? "066" : "067"}, ${rule})`,
+              relPath,
+              i + 1,
+              {
+                evidence: `${id}:${m[0]}`,
+                expected: "replace with the current vocabulary or mark the mention as historical",
+                route: "intake",
+                finding_category: "obsolete-structure",
+                finding_level: strict ? "strict" : "heuristic",
+              },
+            ),
+          );
+        }
+      }
+    }
+  }
+  if (violationCount === 0) {
+    results.push(
+      ok(
+        "ObsoleteVocabulary",
+        "obsolete-vocabulary-current-use",
+        `IR-065/IR-066 obsolete vocabulary & legacy path: ${scoped.length} files scanned, 0 violations (REQ-010-066/067)`,
+      ),
+    );
+  }
+  return results;
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   let options;
@@ -9036,6 +9630,9 @@ async function main(): Promise<void> {
     ...checkRuntimeUnresolvedReference(root), // IR-055 (v2:REQ-0108-263/264)
     ...checkObsoleteSpecPath(root), // IR-057 (v2:REQ-0158-002)
     ...checkIndexGenerationConsistency(root), // IR-061 (SC-002 Phase C, 索引類自動生成整合性)
+    ...checkGuardrailNumberInvariant(root), // IR-063 (REQ-010-064, Issue #2372)
+    ...checkUnresolvedPlaceholder(root), // IR-064 (REQ-010-065, Issue #2372)
+    ...checkObsoleteVocabulary(root), // IR-065/IR-066 (REQ-010-066/067, Issue #2372)
   ];
 
   // WP-3 (Issue #1928): profile-gated projection checks. §7.3 source skips

--- a/docs/designs/integrity/integrity-rule-catalog.md
+++ b/docs/designs/integrity/integrity-rule-catalog.md
@@ -162,6 +162,10 @@ IR エントリ一覧（IR-046 以降）は `generate_indexes.ts` が自動生�
 - [IR-060: forbidden Japanese word detection](rules/IR-060-forbidden-japanese-word-detection.md)
 - [IR-061: 索引類自動生成整合性](rules/IR-061-index-generation-consistency.md)
 - [IR-062: skill/command パス参照実在](rules/IR-062-reference-path-existence.md)
+- [IR-063: guardrail-number-invariant](rules/IR-063-guardrail-number-invariant.md)
+- [IR-064: unresolved-placeholder](rules/IR-064-unresolved-placeholder.md)
+- [IR-065: obsolete-vocabulary-current-use](rules/IR-065-obsolete-vocabulary-current-use.md)
+- [IR-066: legacy-path-removed-name](rules/IR-066-legacy-path-removed-name.md)
 <!-- AUTOGEN:END -->
 
 ### 新規 IR 候補（candidate state、新規 IR 登録 gate 前）

--- a/docs/designs/integrity/rule-ownership.md
+++ b/docs/designs/integrity/rule-ownership.md
@@ -64,6 +64,9 @@ req-impact-map.md の配置移動は未確定事項とし、参照方向、利�
 | 36 | project-extensions-integrity（extensions 機構整合性検査） | REQ-002 (001-003) | integrity-rule-catalog.md (IR-056) | project extensions 機構（Design `../foundations/project-extensions.md`）の整合性検査。extension schema（5セクション構造）、kind/配置/id 対応、context.paths 実在、project-local skill 存在、旧 doc-inputs 残存検出、上書き意図検出、配布コード直接参照残存を検査。regression_test は `check_extensions.test.ts` が統合テストとして存在、正常系 ok=true 確認済み（Issue #1406 移行完了時）。旧機構から extensions 移行で再実装 |
 | 37 | IR 存在条件モデル（DEC-013 適用） | REQ-028 (008, 009, 010, 012; retired、恒常行は DEC-013 が移管受入れ), REQ-036 (022) | integrity-contracts.md | DEC-013 AG-008/009 適用後の IR モデルを所有。`lifecycle_state`、`enforcement_mode`、`baseline_status` を現行 IR 属性から削除し、「現存 IR = 現行 = executable detector」へ統一。8項目存在条件、finding-baseline 分類（finding 側）、新規 IR 登録 gate (a)/(b)、一時移行検査 registry を正規所有する。catalog（[integrity-rule-catalog.md](integrity-rule-catalog.md)）は schema 定義のみ重複所有し、判定規則は本ドメインへ委譲する |
 | 38 | skill 記述基準（層1〜2）機械検査（AG-005 規則群） | REQ-002, REQ-027 | agentdev-skill-authoring.md, command-file-format.md, integrity-rule-catalog.md（AG-005 規則群） | `lint_skills.ts` が検出する層1〜2記述基準検査（hard 6規則 + warn 1規則、RU-0018 / PR #2184）。検出規則の登録は integrity-rule-catalog「AG-005 規則群」節、正典は skill authoring Design と command-file-format Design。既知違反は `baselines/lint-skills-baseline.json` で管理 |
+| 39 | guardrail-number-invariant（ガードレール番号不変量検査） | REQ-010 (064, 068) | integrity-rule-catalog.md (IR-063) | 公開 command の Gxx 開始番号（G01 起点）・欠番・重複・未定義本文参照の検出（Issue #2372）。既知違反 14 command 分は NG baseline で管理し、B-01（採番規則 Design 確定）解消後に是正 |
+| 40 | unresolved-placeholder（未解決プレースホルダー検査） | REQ-010 (065, 068) | integrity-rule-catalog.md (IR-064) | 実行時配布対象の TODO 系マーカー（strict）と ID プレースホルダー裸出力（heuristic）。テンプレート・code span・括弧内等の許容条件付き（Issue #2372）。既知違反は NG baseline で管理 |
+| 41 | obsolete-vocabulary / legacy-path（廃止語彙・旧パス・削除済み名称検査） | REQ-010 (066, 067, 068) | integrity-rule-catalog.md (IR-065/IR-066) | 旧 ADR 表記等の廃止語彙と旧パス・削除済み名称の現行使用検出（Issue #2372）。許容条件の運用データは `data/obsolete-vocabulary-map.yaml`、検出シグナルは checker 実装が所有。v2: プレフィックス・履歴文脈・existence_probe 許容付き |
 
 ## IR 別関連マッピング（自動生成）
 
@@ -132,6 +135,10 @@ IR-* ファイル（`rules/IR-NNN-*.md`）の frontmatter / Field/Value 表か�
 | IR-060 | forbidden Japanese word detection | v2:REQ-0140（v2:REQ-0140-033, v2:REQ-0140-035, v2:REQ-0140-036）, REQ-010（文意判断は docs-check 対象外、本ルールは完全一致検出に限定） | ../responsibilities/document-type-responsibilities.md（不自然表現検出分類 P0〜P4）, ../../../src/opencode/skills/agentdev-doc-writing/references/japanese-replacement-dictionary.md（forbidden 語リスト正）, integrity-rule-catalog.md |
 | IR-061 | 索引類自動生成整合性 | - | - |
 | IR-062 | skill/command パス参照実在 | REQ-010 | integrity-contracts.md, agentdev-skill-authoring.md, agentdev-command-authoring.md |
+| IR-063 | guardrail-number-invariant | REQ-010-064, REQ-010-068 | ../integrity-rule-catalog.md, ../../authoring/command-file-format.md |
+| IR-064 | unresolved-placeholder | REQ-010-065, REQ-010-068 | ../integrity-rule-catalog.md |
+| IR-065 | obsolete-vocabulary-current-use | REQ-010-066, REQ-010-068 | ../integrity-rule-catalog.md, data/obsolete-vocabulary-map.yaml |
+| IR-066 | legacy-path-removed-name | REQ-010-067, REQ-010-068 | ../integrity-rule-catalog.md, data/obsolete-vocabulary-map.yaml |
 <!-- AUTOGEN:END -->
 
 > **IR-019, IR-022, IR-026, IR-036 について（2026-08-11 移管）**: 4件の意味判断系 IR は docs-check 機械検出層から除外し、inspect/diagnostics 層（`/agentdev/inspect-docs`、`/agentdev/inspect-skills`、`agentdev-doc-writing` skill）へ移管した（retired REQ-028-007、DEC-006、Phase 3 §5.2）。

--- a/docs/designs/integrity/rules/IR-063-guardrail-number-invariant.md
+++ b/docs/designs/integrity/rules/IR-063-guardrail-number-invariant.md
@@ -1,0 +1,59 @@
+---
+title: "IR-063: guardrail-number-invariant"
+status: accepted
+created: 2026-08-22
+updated: 2026-08-22
+---
+
+# IR-063: guardrail-number-invariant
+
+| Field | Value |
+|-------|-------|
+| rule_id | IR-063 |
+| description | 公開 command（`src/opencode/commands/agentdev/*.md` 直下、templates/ と README.md は対象外）のガードレール番号（Gxx）について、開始番号（G01 起点）、欠番なし（連番）、重複なし、本文参照の全定義への解決を検証する（REQ-010-064） |
+| severity | strict |
+| category | document-drift |
+| detection_method | `check_integrity.ts` による定義行抽出（`^[-*]\s+(?:\*\*)?`?G(\d{2})`?(?:\*\*)?\s*[:：]`、Wave 1 監査 AUDIT-REQ-045-CONSISTENCY 観点V6 と同一パターン）と本文参照抽出（定義行以外の `\bG\d{2}\b`）の突合。開始番号違反（evidence `start-number:Gxx`）、欠番（`gap:Gxx`）、重複（`duplicate:Gxx`）、未定義参照（`undefined-reference:Gxx`）を検出する |
+| affected_artifacts | [src/opencode/commands/agentdev/*.md] |
+| related_req | [REQ-010-064, REQ-010-068] |
+| related_design | [../integrity-rule-catalog.md, ../../authoring/command-file-format.md] |
+| gate_level | full-audit |
+| false_positive_risk | 低。Gxx 定義を持たない command は検査対象外（ガードレール定義は必須でない）。定義抽出パターンが様式変更に追随しない場合、未定義参照検出として顕在化する（過検出方向、REQ-010 の false positive 許容・false negative 減少方針に合致） |
+| regression_test | `check_integrity.test.ts` describe "IR-063 guardrail-number-invariant"。正常例・違反例・境界例・許容例・再現例（Wave 1 F-009 の req-define 形式）の 5 種 fixture |
+| finding_route | intake |
+| triage_action | 新規検出時は是正（G01 開始・連番への再採番）または baseline 承認。既知違反 14 command 分（140 検出）は NG baseline（provenance `issue-2372-ir063-initial-baseline`）で管理し、B-01（Gxx 採番規則の Design 確定、AUDIT-REQ-045 blocked）解消後に是正する |
+| last_verified | 2026-08-22 |
+
+## 検査項目
+
+| # | 検査項目 | 失敗時 |
+|---|----------|--------|
+| 1 | ガードレール番号の定義は G01 から開始すること | strict fail |
+| 2 | 定義番号は欠番なく連番であること | strict fail |
+| 3 | 同一番号の定義は 1 回のみであること | strict fail |
+| 4 | 本文中の Gxx 参照は同一ファイル内の定義へ解決されること | strict fail |
+
+## 対象範囲と B-01/B-02 との関係
+
+検査対象は `src/opencode/commands/agentdev/*.md` 直下（公開 command）。repo-local command（`.opencode/commands/repo/`）とスキル側の Gxx 定義・参照は対象外である。これは Wave 1 監査の blocked B-02（Gxx・工程ラベル参照の修飾形式と、スキル・repo-local 側の G 番号定義の可否）が未確定であるためであり、本ルールは B-02 の判断を代行しない。
+
+REQ-010-064 が「開始番号（G01 起点）、欠番、重複、および定義されていないガードレール番号への本文参照を検出すること」を要件行として正規契約化したことに基づき、当該検出意味論を本ルールの canonical な契約とする（Wave 2 NORMALIZATION-REQ-046 は B-01 blocked のため再採番を実施していない。既知違反の是正は B-01 の Design 確定後に行う）。
+
+## exemption（検出対象外）
+
+| 対象 | 理由 |
+|------|------|
+| `templates/` サブディレクトリ | テンプレートの番号は様式例示 |
+| `README.md` | command 定義ではない |
+| Gxx 定義を持たない command | ガードレール定義は必須でない |
+
+## baseline 運用
+
+導入時点（Issue #2372、2026-08-22）の既知違反は 14 command 分（start-number 5 件、gap 135 件。Wave 2 記録「非 G01 開始または欠番: 14 ファイル」と一致）。NG baseline additions manifest（provenance `issue-2372-ir063-initial-baseline`）で登録し、baseline-known は info 降格、新規違反のみ strict fail とする（delta 運用）。
+
+## See Also
+
+- [integrity-rule-catalog.md](../integrity-rule-catalog.md)
+- [rule-ownership.md](../rule-ownership.md)
+- `docs/reports/integrity/audits/req-045-consistency-audit-20260822.md`（F-009、B-01）
+- `docs/reports/integrity/normalizations/req-046-normalization-20260822.md`（§4）

--- a/docs/designs/integrity/rules/IR-064-unresolved-placeholder.md
+++ b/docs/designs/integrity/rules/IR-064-unresolved-placeholder.md
@@ -1,0 +1,52 @@
+---
+title: "IR-064: unresolved-placeholder"
+status: accepted
+created: 2026-08-22
+updated: 2026-08-22
+---
+
+# IR-064: unresolved-placeholder
+
+| Field | Value |
+|-------|-------|
+| rule_id | IR-064 |
+| description | 実行時配布対象（`src/opencode/commands/agentdev/**/*.md`、`src/opencode/skills/agentdev-*/**/*.md`）に残る未解決プレースホルダーを検出する。(a) TODO/FIXME/XXX/HACK の bare トークン（strict）、(b) ID 系プレースホルダー（`REQ-{NNNN}`、`DEC-{N}` 等）の本文裸出力（heuristic）。正規テンプレート内の意図的なプレースホルダーは対象種別と許容条件に従い誤検出しない（REQ-010-065） |
+| severity | strict（TODO 系）/ heuristic（ID プレースホルダー裸出力） |
+| category | document-drift |
+| detection_method | `check_integrity.ts` による行単位走査。TODO 系は `\b(TODO\|FIXME\|XXX\|HACK)\b`、ID 系は `\b(?:REQ\|DEC\|ADR\|AG\|QG\|IR\|RU\|TS\|OU\|AC\|CR\|EC\|SC\|ACT\|DD\|DESIGN\|RD\|SPEC\|WS\|GMT)-\{[^}]*\}`（文書 ID 系接頭辞の限定列挙。Wave 1 監査観点V5 と同じ限定方針） |
+| affected_artifacts | [src/opencode/commands/agentdev/**/*.md, src/opencode/skills/agentdev-*/**/*.md] |
+| related_req | [REQ-010-065, REQ-010-068] |
+| related_design | [../integrity-rule-catalog.md] |
+| gate_level | full-audit |
+| false_positive_risk | 低〜中。許容条件（下表）で様式例示を除外する。ID 接頭辞の限定列挙により `UTF-{N}` 等の非 ID 様式（文字コード表記）は検出しない。裸出力の様式確定（backtick 包囲の義務化等）は未確定のため heuristic とし、baseline で既知を管理する |
+| regression_test | `check_integrity.test.ts` describe "IR-064 unresolved-placeholder"。正常例・違反例・境界例・許容例・再現例（観点V5 パターン）の 5 種 fixture |
+| finding_route | intake |
+| triage_action | TODO 系の新規検出は即時是正（解決または非配布文書への移動）。ID プレースホルダー裸出力の新規検出は backtick・括弧への整形容式化または具体 ID 解決。既知 48 件は NG baseline（provenance `issue-2372-ir064-initial-baseline`）で管理 |
+| last_verified | 2026-08-22 |
+
+## 検査項目
+
+| # | 検査項目 | 失敗時 |
+|---|----------|--------|
+| 1 | TODO/FIXME/XXX/HACK の bare トークンが配布対象に残存しないこと（引用「」内列挙、code span/block 内は対象外） | strict fail |
+| 2 | ID 系プレースホルダーの本文裸出力がないこと（code span・括弧内・テンプレートは対象外） | heuristic fail |
+
+## exemption（許容条件）
+
+| 対象 | 理由 |
+|------|------|
+| `src/opencode/commands/agentdev/templates/`、`src/opencode/skills/*/templates/`、`_template.md` | 正規テンプレート内の意図的なプレースホルダー |
+| code block（``` 囲み）内 | 例示・パターン説明 |
+| code span（backtick 囲み）内 | 様式例示（`` `REQ-{NNNN}` `` 等） |
+| 括弧（ASCII/全角）内 | 委譲注記様式（`（DEC-{N}、REQ-{NNNN}-{NNN}）`） |
+| 全角引用「」内 | 検出キーワードの列挙例示（「TODO」「FIXME」等） |
+
+## baseline 運用
+
+導入時点（Issue #2372、2026-08-22）の既知違反は ID プレースホルダー裸出力 48 件（TODO 系は 0 件）。裸出力は委譲注記様式として一貫使用されているが、様式の正規契約（backtick 包囲等）が未確定のため heuristic とし、NG baseline additions manifest（provenance `issue-2372-ir064-initial-baseline`）で管理する。様式の正規化は Design 確定候補・intake 経由で判断する。
+
+## See Also
+
+- [integrity-rule-catalog.md](../integrity-rule-catalog.md)
+- [rule-ownership.md](../rule-ownership.md)
+- `docs/reports/integrity/audits/req-045-consistency-audit-20260822.md`（観点V5）

--- a/docs/designs/integrity/rules/IR-065-obsolete-vocabulary-current-use.md
+++ b/docs/designs/integrity/rules/IR-065-obsolete-vocabulary-current-use.md
@@ -1,0 +1,62 @@
+---
+title: "IR-065: obsolete-vocabulary-current-use"
+status: accepted
+created: 2026-08-22
+updated: 2026-08-22
+---
+
+# IR-065: obsolete-vocabulary-current-use
+
+| Field | Value |
+|-------|-------|
+| rule_id | IR-065 |
+| description | 現行概念として使用される廃止語彙（旧 ADR 表記等）を検出する。対象は bare `ADR-NNN` 識別子（v2: プレフィックスなし）、`docs/adr/` パス、`（ADR）` 種別注記、`REQ/ADR/` 種別列挙、`Artifact Graph` 呼称、`DOC-MAP` 呼称。許容された歴史的識別子（`v2:ADR-0123` 等）は誤検出しない（REQ-010-066） |
+| severity | heuristic（`（ADR）` 注記は strict） |
+| category | obsolete-structure |
+| detection_method | `check_integrity.ts` による行単位走査。検出パターンはスクリプト内 `IR065_VOCAB_PATTERNS` 定数、許容条件の運用データ（existence_probe、exemption_files、否定文脈語）は `data/obsolete-vocabulary-map.yaml` が宣言する |
+| affected_artifacts | [docs/designs/**, docs/requirements/*.md, docs/decisions/*.md, docs/guides/*.md, src/opencode/**, .opencode/commands/**, .agentdev/extensions/**]（詳細は yaml scope） |
+| related_req | [REQ-010-066, REQ-010-068] |
+| related_design | [../integrity-rule-catalog.md, data/obsolete-vocabulary-map.yaml] |
+| gate_level | full-audit |
+| false_positive_risk | 中。行レベル履歴マーカー（旧/移行/廃止/履歴 等、`hasLineLevelHistoryMarker`）、retired 系見出し配下、superseded Decision、否定文脈語、exemption_files、existence_probe で歴史文脈を許容する。`REQ/ADR/` 種別列挙は Wave 2 の正規化対象外領域に 34 件残存するため baseline で管理する |
+| regression_test | `check_integrity.test.ts` describe "IR-065/IR-066 obsolete-vocabulary & legacy-path"。正常例・違反例・境界例・許容例・再現例（Wave 2 F-001（ADR）注記）の 5 種 fixture |
+| finding_route | intake |
+| triage_action | `（ADR）` 注記の新規検出は即時是正（Wave 2 #2371 で解消済みの回帰）。他語彙の新規検出は現行語彙（Decision、`docs/decisions/` 等）への置換または履歴注記化。既知 34 件（`REQ/ADR/` 列挙）は NG baseline（provenance `issue-2372-ir065-initial-baseline`）で管理 |
+| last_verified | 2026-08-22 |
+
+## 検査項目
+
+| # | 検査項目 | 失敗時 |
+|---|----------|--------|
+| 1 | bare `ADR-NNN` 識別子が現行文書で種別参照として使用されないこと（`v2:` プレフィックス付きは許容） | heuristic fail |
+| 2 | `docs/adr/` パス参照が残存しないこと | heuristic fail |
+| 3 | `（ADR）` 種別注記が残存しないこと（Wave 2 #2371 で解消済み。再発防止） | strict fail |
+| 4 | `REQ/ADR/` 種別列挙が現行種別列挙として使用されないこと（現行は `REQ/Decision/`） | heuristic fail |
+| 5 | `Artifact Graph`、`DOC-MAP` 呼称が現行概念として使用されないこと | heuristic fail |
+
+## exemption（許容条件）
+
+許容条件の運用データは `data/obsolete-vocabulary-map.yaml` が宣言する（検出シグナルの正規表現は本ルールの checker 実装が所有）。
+
+| 対象 | 理由 |
+|------|------|
+| `v2:ADR-NNNN` プレフィックス付き識別子 | 許容された歴史的識別子（DEC-009 決定11、REQ-010-066 文言） |
+| 行レベル履歴マーカーを含む行（旧/移行/廃止/履歴/経緯/legacy/deprecated 等） | 歴史経緯の記述（IR-057 `hasLineLevelHistoryMarker` と同一規則） |
+| retired 系見出し（「## 廃止済み要件」等）配下 | retired/ ディレクトリと同種の履歴領域 |
+| `status: superseded` の Decision | 履歴文書 |
+| exemption_files（DEC-009、DEC-017、DEC-019、decisions/README.md、designs/README.md） | 移行経緯・索引の正規記録 |
+| 否定文脈語を含む行（廃止/含めない/とせず 等） | 廃止機能を「使わないこと」を定める現行契約の記述 |
+| existence_probe 先が実在する語彙 | 現行機能として存在するため検出対象外 |
+| code block / code span 内 | 例示・様式説明 |
+| `docs/requirements/retired/`、`docs/decisions/retired/`、`docs/reports/`、検出基盤配下（scripts/references/data/baselines、repo-agentdev-integrity/SKILL.md） | 履歴領域・検出基盤許容（IR-057 と同一） |
+
+## baseline 運用
+
+導入時点（Issue #2372、2026-08-22）の既知違反は `REQ/ADR/` 種別列挙 34 件（配布スキル本文・extensions）。Wave 1 監査の観点V1 は種別列挙を検出対象に含まず、Wave 2 の正規化対象外だった領域である。NG baseline additions manifest（provenance `issue-2372-ir065-initial-baseline`）で管理し、`REQ/Decision/` 列挙への一括正規化は intake 経由で判断する。
+
+## See Also
+
+- [IR-066-legacy-path-removed-name.md](IR-066-legacy-path-removed-name.md)
+- [integrity-rule-catalog.md](../integrity-rule-catalog.md)
+- [rule-ownership.md](../rule-ownership.md)
+- `docs/reports/integrity/normalizations/req-046-normalization-20260822.md`（C-01〜C-02）

--- a/docs/designs/integrity/rules/IR-066-legacy-path-removed-name.md
+++ b/docs/designs/integrity/rules/IR-066-legacy-path-removed-name.md
@@ -1,0 +1,53 @@
+---
+title: "IR-066: legacy-path-removed-name"
+status: accepted
+created: 2026-08-22
+updated: 2026-08-22
+---
+
+# IR-066: legacy-path-removed-name
+
+| Field | Value |
+|-------|-------|
+| rule_id | IR-066 |
+| description | 現行参照として残る旧パスおよび削除済み名称を検出する。対象は `docs/specs/` パス、`.agentdev/graph/` パス、`agentdev-artifact-graph`、`check_graph`、廃止スキル名（`agentdev-spec-compliance`、`agentdev-adr-guidelines`、`agentdev-adr-file-manager`、`agentdev-doc-map`、`agentdev-workflow-reporting`）（REQ-010-067） |
+| severity | heuristic |
+| category | obsolete-structure |
+| detection_method | `check_integrity.ts` による行単位走査。検出パターンはスクリプト内 `IR066_VOCAB_PATTERNS` 定数、許容条件の運用データは `data/obsolete-vocabulary-map.yaml` が宣言する。IR-065 と同一の走査・許容基盤を共有する |
+| affected_artifacts | [docs/designs/**, docs/requirements/*.md, docs/decisions/*.md, docs/guides/*.md, src/opencode/**, .opencode/commands/**, .agentdev/extensions/**]（詳細は yaml scope） |
+| related_req | [REQ-010-067, REQ-010-068] |
+| related_design | [../integrity-rule-catalog.md, data/obsolete-vocabulary-map.yaml] |
+| gate_level | full-audit |
+| false_positive_risk | 低〜中。IR-065 と同一の許容条件（履歴マーカー、superseded Decision、否定文脈、existence_probe、exemption_files）を適用する。廃止スキル名の検出は REQ-0108-262（検出パターン縮小）で除外された語彙のうち Wave 1 監査が fail 実在を確認した語彙に限定する |
+| regression_test | `check_integrity.test.ts` describe "IR-065/IR-066 obsolete-vocabulary & legacy-path"。正常例・違反例・境界例・許容例・再現例（Wave 2 F-003 agentdev-spec-compliance 参照）の 5 種 fixture |
+| finding_route | intake |
+| triage_action | 新規検出は現行参照（実在パス・現行スキル名）への置換または履歴注記化。導入時点の既知違反は 0 件（baseline 空） |
+| last_verified | 2026-08-22 |
+
+## 検査項目
+
+| # | 検査項目 | 失敗時 |
+|---|----------|--------|
+| 1 | `docs/specs/` 旧パス参照が現行文書に残存しないこと | heuristic fail |
+| 2 | `.agentdev/graph/` 旧パス参照が現行参照として残存しないこと（否定文脈は許容） | heuristic fail |
+| 3 | 削除済み機能名（`agentdev-artifact-graph`、`check_graph`）が現行参照として残存しないこと | heuristic fail |
+| 4 | 廃止スキル名（`agentdev-spec-compliance` 等 5 種）が現行の委譲先・参照先として使用されないこと | heuristic fail |
+
+## 廃止語彙と REQ-0108-262 との関係
+
+v2:REQ-0108-262（検出パターン縮小）は旧ハイフン区切りスキル名・snake_case コマンド名等を「現行 docs での誤使用リスクが解消されたため」検出対象から除外した。本ルールは Wave 1 監査（AUDIT-REQ-045-CONSISTENCY 観点V4/V9）が実際に fail の実在を確認した語彙（F-003〜F-007 の廃止スキル名、F-014 の旧パス系）に限定して検出を復活させる。REQ-010-067 が旧パス・削除済み名称の検出を要件行として正規契約化したことに基づく。
+
+## exemption（許容条件）
+
+IR-065 と同一（`data/obsolete-vocabulary-map.yaml` が宣言）。existence_probe により、語彙に対応する実体（例: `src/opencode/skills/agentdev-spec-compliance/`）が実在する場合は当該語彙の検出を skip する。
+
+## baseline 運用
+
+導入時点（Issue #2372、2026-08-22）の既知違反は 0 件。新規検出は即時に heuristic fail として報告する。
+
+## See Also
+
+- [IR-065-obsolete-vocabulary-current-use.md](IR-065-obsolete-vocabulary-current-use.md)
+- [integrity-rule-catalog.md](../integrity-rule-catalog.md)
+- [rule-ownership.md](../rule-ownership.md)
+- `docs/reports/integrity/audits/req-045-consistency-audit-20260822.md`（F-003〜F-007、F-014）

--- a/docs/designs/responsibilities/req-impact-map.md
+++ b/docs/designs/responsibilities/req-impact-map.md
@@ -64,6 +64,7 @@ updated: 2026-06-28
 | v2:REQ-0143 | Command 定義ファイルフォーマット標準化 | IR-049 | commands, command-file-format.md |
 | REQ-010 | docs-check/integrity 運用是正 | IR-016, IR-052 | integrity scripts, docs-check, Design |
 | REQ-010 | docs-check/integrity 検出設計改善 | IR-044, IR-050, IR-051, IR-052 | integrity-rule-catalog.md, integrity scripts |
+| REQ-010 | docs-check 新規機械検査クラス（Gxx 不変量、未解決プレースホルダー、廃止語彙、旧パス・削除済み名称） | IR-063, IR-064, IR-065, IR-066 | integrity-rule-catalog.md, integrity scripts, data/obsolete-vocabulary-map.yaml, NG baseline |
 | REQ-003 | 実行契約、委譲、プロセス設計 | IR-006, IR-032, IR-033 | commands, Design |
 | REQ-003 | 文書化規律、HITL境界 | IR-013, IR-019, IR-035 | docs, commands, skills, guides |
 | REQ-006 | RU群バッチ処理と複数 execution_unit 並列実行 | IR-006, IR-016 | commands |


### PR DESCRIPTION
Refs: #2372

## 実装概要

REQ-010-064〜068 に基づく docs-check 新規機械検査クラス 4 種を、新規フレームワークを作成せず既存 integrity 基盤（check_integrity.ts・data yaml・NG baseline・回帰テスト）へ統合した。

### 検査クラス別の実装内容

| 検査クラス | REQ | 実装 | severity | 検出シグナル（概要） |
|---|---|---|---|---|
| IR-063 guardrail-number-invariant | REQ-010-064 | checkGuardrailNumberInvariant | strict | 公開 command 直下 .md（templates/・README.md 除外）の定義行（Wave 1 監査観点V6 と同一パターン）と本文参照の突合。開始番号 G01 起点・欠番なし・重複なし・未定義参照なしの 4 不変量 |
| IR-064 unresolved-placeholder | REQ-010-065 | checkUnresolvedPlaceholder | strict（TODO 系）/ heuristic（ID 系裸出力） | 配布対象（src/opencode/commands/agentdev/** + src/opencode/skills/agentdev-*/**）。ID 接頭辞は Wave 1 観点V5 準拠の限定列挙（UTF-{N} 等の非 ID 様式は誤検出しない） |
| IR-065 obsolete-vocabulary-current-use | REQ-010-066 | checkObsoleteVocabulary（IR-066 と共通走査） | heuristic（（ADR）注記は strict） | bare ADR-NNN・docs/adr/・（ADR）注記・REQ/ADR/ 種別列挙・Artifact Graph・DOC-MAP。v2: プレフィックスは REQ-010-066 文言どおり許容 |
| IR-066 legacy-path-removed-name | REQ-010-067 | 同上 | heuristic | docs/specs/・.agentdev/graph/・agentdev-artifact-graph・check_graph・廃止スキル名 5 種（REQ-0108-262 縮小語彙のうち Wave 1 で fail 実在を確認した語彙に限定） |

### 許容条件（誤検出抑制、TS-007 対象）

- IR-064: テンプレート（command templates/・skill templates/・_template.md）、code block、code span、括弧内（委譲注記様式）、引用「」内列挙
- IR-065/066: 許容条件の運用データを data/obsolete-vocabulary-map.yaml（新設）へ宣言。v2: プレフィックス、行レベル履歴マーカー（IR-057 hasLineLevelHistoryMarker 流用）、retired 系見出し配下、superseded Decision、否定文脈語、existence_probe（語彙の実体が現行実在なら検出 skip）、exemption_files（DEC-009/017/019・Decision 索引等）、検出基盤配下
- 検出シグナルの正規表現は checker 実装が所有（REQ-010 適用対象外宣言どおり、Issue 対象外の委譲境界を維持）

### REQ-010-064 と B-01/B-02 の関係

REQ-010-064 が「開始番号（G01 起点）、欠番、重複、未定義参照の検出」を要件行として正規契約化したため、当該検出意味論を IR-063 の canonical な契約として実装した。B-01（採番規則の Design 確定）・B-02（スキル側 G 番号定義の可否）は本 PR で解決しておらず、既知違反 14 command 分（Wave 1 F-009・Wave 2 記録 §4 と同一）の再採番も実施していない。既知違反は NG baseline で管理し、B-01 解消後に是正する。repo-local command（.opencode/commands/repo/）とスキル側の Gxx は B-02 blocked を踏襲して検査対象外とした。

### 回帰テスト（REQ-010-068、TS-008 対象）

check_integrity.test.ts に describe 3 件・テスト 13 件を追加。各検査クラスが正常例・違反例・境界例・許容例・過去に発生した再現例（Wave 1 F-009 Gxx 欠番、F-001（ADR）注記、F-003 agentdev-spec-compliance、観点V5 プレースホルダ）の 5 種 fixture を含む（fixture 種別はテスト内コメントで対応付けを明示）。

### baseline 運用（既存の正常入力を新たに fail させない、TS-006 前提）

新規検査導入時点の既知違反 222 件を NG baseline additions manifest（provenance/reason 記録、v2:REQ-0161-005 の承認痕跡要件）で登録した:

| provenance | 件数 | 内容 |
|---|---|---|
| issue-2372-ir063-initial-baseline | 140 | Gxx 非 G01 開始・欠番（14 command、B-01 blocked の再採番未実施分） |
| issue-2372-ir064-initial-baseline | 48 | ID プレースホルダー裸出力（委譲注記様式として一貫使用中。TODO 系は 0 件） |
| issue-2372-ir065-initial-baseline | 34 | REQ/ADR/ 種別列挙（Wave 2 正規化対象外領域。観点V1 は種別列挙を検出対象外だった） |

結果: baseline-known は info 降格し、新規カテゴリの delta は 0。main の check_integrity 残存は Wave 2 後と同一の ng 8（F-017×5・F-020×3）+ warning 1（F-028×1、全て blocked/対象外報告済み）である。baseline 承認（HITL 確定）は Findings / Capture候補 の intake 項目として記録した。

## 検証結果

| 検査 | 結果 |
|---|---|
| bun test（repo-agentdev-integrity scripts 全 94 ファイル） | 2248 pass / 0 fail（既存 2235 + 新規 13。Wave 2 記録の 2235 から増分のみ） |
| check_integrity.ts --profile source | ng 8 / warning 1（Wave 2 後の main と同一。新規 4 検査カテゴリの新規違反 0、baseline-known 222 件は info） |
| check_changed_docs.ts --workflow case-run --base-ref origin/main | files checked 7、failures 0、warnings 0。design_readme_update_required=true は新規 IR ファイル追加（lifecycle=added）による保守的推奨フラグで、docs/designs/README.md の integrity 表は integrity/rules/ 集約行でカバー済み（既存 IR-057〜062 と同一運用） |
| check_command_format.ts --root . | OK |
| check_extensions.ts | failures 0 |
| check_distribution_boundary.ts --profile source | failures 0（src/opencode/** は本 PR で無変更） |
| check_templates.ts | worktree 環境 warning（REQ-018 の既知 skip 挙動、failure なし） |
| generate_indexes.ts 再実行 | catalog・rule-ownership AUTOGEN に IR-063〜066 反映、冪等 |
| tsc --noEmit -p tsconfig.distribution-boundary.json | exit 0 |
| bun test check_integrity.test.ts -t IR-063 / IR-064 / IR-065 | 4+4+5 pass |

備考: worktree 内で bun test を実行する際、gitignore 対象の node_modules が伝播しないため src/opencode/skills/agentdev-project-extensions/scripts で bun install が必要だった（git-worktree skill の構造的制約どおり。PR には影響なし）。

## テスト戦略結果（Issue 本文 TS 項目）

- TS-006（AG-006）: 合格。全新規検査クラスで違反例 fail・正常例 pass（回帰テストの違反例・正常例 fixture）。全 integrity 検査の合否は上表のとおり（新規 delta 0、残存は Wave 2 と同一の blocked 系）
- TS-007（AG-007）: 合格。許容 fixture（v2:ADR-0123、テンプレート内プレースホルダー、code span・括弧内、superseded Decision、履歴マーカー行、否定文脈、existence_probe）の誤検出 0。検査対象種別と除外条件は IR-063〜066 ルールファイルの exemption 表と obsolete-vocabulary-map.yaml に明示
- TS-008（AG-008）: 合格。全回帰テスト pass、5 種の例を欠く検査クラスは 0 件
- TS-QC-3: 合格。変更成果物は scripts・checker 実装（integrity 関連 Design の個別定義＝IR-063〜066 ルールファイルに従い実装・文書化）、docs/**.md（文書品質査読: Design は現在仕様の記述に限定、AUTOGEN 部は直接編集せず generate_indexes で生成）。Command 定義（src/opencode/commands/**）は変更なし

## Findings / Capture候補

### intake

1. NG baseline 171 エントリの承認（issue-2372-ir063/064/065-initial-baseline）: 新規 4 検査クラス導入に伴う既知違反 222 件を baseline 登録した（provenance/reason 付き）。承認（info 降格の継続）か是正（一括解消）かの判断を要する。Gxx 140 件は B-01 解消後の再採番案と紐づく
2. REQ/ADR/ 種別列挙 34 件の一括正規化要否: 配布スキル本文・extensions yaml の「REQ/ADR/Design」列挙を「REQ/Decision/Design」へ正規化するかは Wave 2 が対象外とした領域。IR-065 で検出可能になったため、intake 判断を促す
3. ID プレースホルダー裸出力の様式確定: 48 件の裸出力（SKILL.md 表の根拠列等）を backtick 包囲等へ整形する正規様式の確定。Design確定候補と連動
4. worktree の bun test 事前セットアップ手順化: worktree で bun test を実行する際、agentdev-project-extensions/scripts の bun install が必要。git-worktree skill の構造的制約節への追記候補

### learning

1. 検出語彙の existence_probe パターン: 廃止語彙検出に「probe 先が実在すれば検出 skip」を導入すると、検証 fixture が旧体系の実体を持つ場合（docs/adr を持つ valid fixture）に誤検出を抑止できる。valid fixture との共存を壊さない新規検査設計の一般化可能な知見
2. 検出導入時の既知違反は additions manifest で初期化する: 新規検査クラスの既知違反は full fail gate にせず manifest（provenance/reason 必須）で baseline 初期化すると、ワークフロー破壊なしに承認痕跡を残せる。IR-055（専用 baseline ファイル）と ng-baseline（manifest 方式）の使い分け

## Design確定候補

1. IR-063〜066 ルールファイル（docs/designs/integrity/rules/）: 検出シグナルの正規表現、許容条件（exemption 表、existence_probe、否定文脈語）、baseline 運用の各契約を 4 ファイルに記述した。確定判断は case-close（QG-4・Design 確定フロー）で実施
2. ID プレースホルダーの様式: backtick 包囲（`REQ-{NNNN}` 形式）を正規様式とするか、表の根拠列裸出力を許容様式に加えるか。IR-064 の heuristic 判定の正規化
3. baseline 運用: issue-2372-ir063/064/065-initial-baseline の 3 provenance の扱い（承認継続か是正計画か）。Gxx 140 件は B-01（採番規則 Design）の確定と連動
4. obsolete-vocabulary-map.yaml のスキーマ: existence_probe・exemption_files・negation_context_terms の宣言形式。将来の語彙追加時の運用規範

## docs-integrity

なし（check_integrity の新規 delta は 0。残存 ng 8 / warning 1 は Wave 2 から引き継ぎの blocked/対象外報告済み項目 F-017×5, F-020×3, F-028×1）