### PR TITLE
fix(agentdev): command 定義・template・skill ガイダンスの仕様修正5件（Issue #2384）

### DIFF
--- a/src/opencode/commands/agentdev/templates/intake-promote/standard.md
+++ b/src/opencode/commands/agentdev/templates/intake-promote/standard.md
@@ -4,7 +4,9 @@
 対象: .agentdev/intake/promoted/（{N}件）
 結果:
  - 整形対象: {N}件
+ - 分類結果: 採用 {N}件/ 保留 {N}件/ 却下 {N}件
  - 採用済み成果物: {N}件
+ - 自律確定: {N}件（主要根拠とHITL不要理由: {grounds_list}）
 検証結果: ✅ OK
 git 永続化: commit: {hash}, push: {成功/失敗}
 次のコマンド:/agentdev/backlog-review

--- a/src/opencode/skills/agentdev-command-authoring/references/command-authoring-standards.md
+++ b/src/opencode/skills/agentdev-command-authoring/references/command-authoring-standards.md
@@ -511,16 +511,16 @@ capture_handoff:
 
 ### 定義
 
-```markdown
-### Step N: {検査名}（delegated_check）
+delegated_check は工程表（前出出力検証表）の行として記述する。
+公開 command の手順セクションの正規形は表形式であり、`### Step N` 見出しの逐次列挙は使用しない。
 
-- **委譲先**: skill `{skill-name}`, reference `{path}`
-- **入力**: {検査対象、参照基準、除外対象}
-- **副作用境界**: 検査対象を直接修正しない。許可操作は `read_files` / `inspect_content` / `return_evidence` 等。保存、Issue / PR 更新、commit、push、ユーザー確認は禁止
-- **返却形式**: `pass` / `warn` / `fail` / `partial`、要約、根拠、親判断事項、副作用なしの明示
-- **capture handoff**: intake / learning 候補は保存せず親へ返す
-- **制約**: 検証結果の最終判断は本コマンドが保持する
+```markdown
+| 工程 | 前提条件 | 出力契約 | 検証基準 |
+|---|---|---|---|
+| STEP-N {検査名}（delegated_check、委譲先: skill `{skill-name}`） | {検査対象、参照基準、除外対象の確定} | `pass` / `warn` / `fail` / `partial`、要約、根拠、親判断事項、intake / learning 候補（保存せず親へ返す） | 副作用なし（許可操作は `read_files` / `inspect_content` / `return_evidence` 等。保存、Issue / PR 更新、commit、push、ユーザー確認は委譲しない）。検証結果の最終判断は本コマンドが保持すること |
 ```
+
+委譲先の記述は skill 名と責務名までとし、他 skill の内部 reference path（`references/*.md`）は直接指定しない（「他 Skill 参照境界」参照）。
 
 ### 制約
 

--- a/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/SKILL.md
@@ -60,7 +60,7 @@ Epic Wave クローズは STEP-1 のルーティングで分岐し、E1〜E6 と
 | STEP-4 | PR マージ・コンフリクト解消 | docs 検証合格（配布依存境界 最終 gate 含む） | マージ済みPR（squash merge 先は当該 Case の統合先）、HEAD commit hash 記録、コンフリクト Level 1 解消 or case-auto エスカレーション | [references/pr-merge-and-conflict.md](references/pr-merge-and-conflict.md) |
 | STEP-5 | Post-merge・Issue クローズ | PR マージ完了 | CI 通過確認、Issue 本文更新、実証最終クローズ（最終評価結果導出・Issue 最終コメント正規記録）、Issue close | [references/cleanup-and-capture.md](references/cleanup-and-capture.md) |
 | STEP-6 | クリーンアップ・Capture 回収・永続化 | Issue クローズ完了 | worktree/branch 削除、親Epic 自動クローズ、実行前同期、Capture 回収、学び検知、実証最終クローズの正式化案内、`.agentdev/` 永続化、tmp/ 残存確認、完了報告 | [references/cleanup-and-capture.md](references/cleanup-and-capture.md) |
-| STEP-E1〜E6 | Epic Wave クローズ（E4-1 配布依存境界 最終 gate 含む） | Epic Issue 番号受領、ステータス追跡テーブル存在 | 現在 Wave の子Issue 一括マージ・クローズ（E4-1 gate 違反子Issue は `blocked` でマージ対象外）、Epic status table 更新、最終 Wave 判定 | [references/epic-wave-close.md](references/epic-wave-close.md) |
+| STEP-E1〜E6 | Epic Wave クローズ（E4-1 配布依存境界 最終 gate 含む） | Epic Issue 番号受領、ステータス追跡テーブル存在 | 現在 Wave の子Issue 一括マージ・クローズ（E4-1 gate 違反子Issue は `blocked` でマージ対象外）、Epic status table 更新、当該 Wave スコープの一時成果物残留確認（E6-1、残留時は完了扱いにしない）、最終 Wave 判定 | [references/epic-wave-close.md](references/epic-wave-close.md) |
 
 ### STEP 間の依存と分岐
 
@@ -83,6 +83,7 @@ gate 違反時は両ルートとも PR マージを停止する。
 
 - 正常終了: 単一 Issue ルートはクリーンアップ・Capture 回収・永続化 STEP の完了報告まで。Epic Wave ルートは最終 Wave 判定（Epic クローズ または 残 Wave 通知）まで
 - 一時ファイル残存: 単一 Issue ルートの正常終了の前提として、当該実行で `.agentdev/tmp/` に作成した一時ファイルが残存していないこと（STEP-6-6 で確認。cleanup 規定は `agentdev-gh-cli`）
+- 一時成果物残留（Epic Wave ルート）: Epic Wave クローズの正常終了の前提として、当該 Wave スコープの一時成果物（draft、RU、検出事項等のドメイン状態）残留と当該実行で `.agentdev/tmp/` に作成した一時ファイルの残存がないこと（E6-1 で確認。残留時は当該 Wave を完了扱いにしない）
 - 停止終了: 未達チェックボックス残存（構造化エラー）、QG-4 不合格、配布依存境界 最終 gate 違反、mergeable ポーリング上限超過、Level 1 rebase 失敗（case-auto エスカレーション）
 
 ## 主要 Capability Skill 連携

--- a/src/opencode/skills/agentdev-workflow-case-close/references/epic-wave-close.md
+++ b/src/opencode/skills/agentdev-workflow-case-close/references/epic-wave-close.md
@@ -24,6 +24,7 @@ Epic 実証（Epic Issue 本文の実証Case状態情報で共有評価ブラン
 - 現在 Wave の全子Issue マージ、クローズ完了（E4-1 最終 gate 違反子Issue は `blocked` としてマージ対象外、Epic status table へ反映）
 - Epic status table 更新完了（単一書き手 case-close のみ）
 - Epic Issue 完了条件チェックボックス最終評価・更新（QG-4 観点8、中間 Wave vs 最終 Wave 評価スコープ切替）
+- 当該 Wave スコープの一時成果物残留確認結果（残留時は当該 Wave を完了扱いにしない）
 - 最終 Wave 判定結果（Epic クローズ または 残 Wave 通知）
 - Epic 実証の最終 Wave 判定時: 最終評価結果の導出と Epic Issue 最終コメント正規記録、正式化経路案内（中間Waveでは案内しない）
 
@@ -80,18 +81,28 @@ gate 違反子Issue は本シーケンスの対象外とする。
 - Capture 回収（PR 本文の `## Findings / Capture候補` から intake/learning 分離）
 - コンフリクト解消（Level 1 rebase パス、Level 2/3 は case-auto エスカレーション）
 
-### E5: Epic status table 更新（単一書き手 case-close のみ）
+### E5: Epic Issue 本文更新（Epic status table 更新、完了条件チェックボックス評価、単一書き手 case-close のみ）
 
 Epic Issue 本文のステータス追跡テーブルを更新。
 **単一書き手制約**: case-close のみが実施（case-run は読み取りのみ、case-auto は Wave 反復制御のみで直接書き込まない、last-write-wins 競合防止）。
 
-### E5b: Epic Issue 完了条件チェックボックス最終評価・更新
+#### E5-1: Epic Issue 完了条件チェックボックス最終評価・更新
 
 QG-4 観点8 に基づく評価スコープ切替（中間 Wave vs 最終 Wave）を実施し、Epic Issue の完了条件チェックボックスを最終評価・更新する。
 
+完了条件チェックボックスの項目が字母後綴（a/b）形式の副項目列挙（「(a) …」「(b) …」等）を含む場合は、チェックボックス単位ではなく副項目単位で評価スコープを決定する（観点8 判定マトリクスを各副項目に適用）。
+中間 Wave では当該 Wave の PR 対象範囲に含まれる副項目のみ達成を評価し、範囲外の副項目は後続 Wave での評価対象として保留する（未達とは判定しない）。
+チェックボックスは全副項目の達成が確認できるまで更新しない。
+
 ### E6: 最終 Wave 判定
 
-- **全子Issue completed** → Epic Issue クローズ
+#### E6-1: 当該 Wave スコープの一時成果物残留確認
+
+最終 Wave 判定の前に、当該 Wave スコープの一時成果物（draft、RU、検出事項等のドメイン状態）の残留を確認する。
+あわせて当該実行で `.agentdev/tmp/` に作成した一時ファイルの残存を確認する（single-Issue ルートの STEP-6-6 と同一趣旨）。
+残留を検出した場合は当該 Wave を完了扱いにせず、残留内容と対応方針を構造化エラーで報告して停止する（自動削除しない）。
+
+- **全子Issue completed かつ一時成果物残留なし** → Epic Issue クローズ
 - **以外** → 残 Wave 通知（次 Wave の case-run 実行をユーザーに促す）
 
 **Epic 実証の最終 case-close（全子Issue completed で Epic クローズする場合のみ）**:
@@ -113,11 +124,12 @@ QG-4 観点8 に基づく評価スコープ切替（中間 Wave vs 最終 Wave�
 
 ## Evidence
 
-- Epic Issue 本文読取結果、Epic 実証判定根拠（実証Case状態情報と共有評価ブランチ）、E4-1 最終 gate の JSON 結果（子Issue 別）、マージ・クローズ結果、Epic status table 更新の VERIFY 結果、最終 Wave 判定根拠、Epic 実証最終クローズ時は最終評価結果の導出根拠と Epic Issue 最終コメントの VERIFY 結果
+- Epic Issue 本文読取結果、Epic 実証判定根拠（実証Case状態情報と共有評価ブランチ）、E4-1 最終 gate の JSON 結果（子Issue 別）、マージ・クローズ結果、Epic status table 更新の VERIFY 結果、一時成果物残留確認結果、最終 Wave 判定根拠、Epic 実証最終クローズ時は最終評価結果の導出根拠と Epic Issue 最終コメントの VERIFY 結果
 
 ## Completion Verification
 
 - E4-2 対象が E4-1 合格子Issue のみであること。`blocked`/`failed` を `completed` に上書きしていないこと。Epic status table 更新後の再読込 VERIFY が合格であること。Epic 実証の最終 Wave では新しい評価を開始せず最終評価結果が Epic Issue 最終コメントへ正規記録済みであり、正式化経路案内を含むこと（中間Waveでは案内していないこと）
+- 当該 Wave スコープの一時成果物（draft、RU、検出事項等）の残留と当該実行で `.agentdev/tmp/` に作成した一時ファイルの残存を E6-1 で確認済みであり、残留時は当該 Wave を完了扱いしていないこと
 
 ## Resume-Idempotency
 
@@ -130,6 +142,7 @@ QG-4 観点8 に基づく評価スコープ切替（中間 Wave vs 最終 Wave�
 - PR 作成済み子Issue 一覧、各子Issue の E4-1 最終 gate 結果（合格 / 違反 / スキップ）
 - 各子Issue のマージ・クローズ・評価状態（E4-2 対象は E4-1 合格子Issue のみ）
 - Epic status table 更新状態、Epic Issue 完了条件チェックボックス評価状態
+- 当該 Wave スコープの一時成果物残留確認状態（E6-1）
 - Epic 実証の最終評価結果導出・Epic Issue 最終コメント正規記録状態、正式化案内実施状態
 - 最終 Wave 判定結果
 
@@ -155,3 +168,4 @@ QG-4 観点8 に基づく評価スコープ切替（中間 Wave vs 最終 Wave�
 - G24・不変条件（Epic Issue 本文ステータス追跡テーブルの更新は case-close 単一書き手、case-run は読み取りのみ、case-auto は直接書き込まない、Epic Wave クローズは現在 Wave の `running` 子Issue のみ対象、`blocked`/ `failed` を `completed` に上書きしない、べき等性）
 - E4-1 gate 違反子Issue は `blocked` へ遷移し E4-2 マージ並列シーケンスの対象外、`completed` へ上書きしない（べき等性、case-close G24 準拠）
 - 不変条件（Epic 実証の最終 Wave は新しい評価を始めず最終評価結果を Epic Issue 最終コメントへ正規記録し正式化経路 req-define <実証Issue> を案内する、Epic 中間Waveでは正式化案内を出さない、後続 req-define を自動実行しない）
+- 不変条件（E6-1 は当該 Wave スコープの一時成果物（draft、RU、検出事項等）残留と当該実行で `.agentdev/tmp/` に作成した一時ファイルの残存を確認し、残留時は当該 Wave を完了扱いにしない）

--- a/src/opencode/skills/agentdev-workflow-design-save/SKILL.md
+++ b/src/opencode/skills/agentdev-workflow-design-save/SKILL.md
@@ -57,7 +57,7 @@ design-save workflow は次の11 STEP で構成する。
 | STEP-4 | Design 分離基準の最終確認 | 配置先解決済み | 適合判定（安定契約例外は除外し follow-up 明示） | [references/placement-and-save.md](references/placement-and-save.md) |
 | STEP-5 | Design ファイル操作 | 適合判定済み | Design create / update 実行（並列化、宣言付与） | [references/placement-and-save.md](references/placement-and-save.md) |
 | STEP-6 | インデックス整合 | ファイル操作完了 | 新規 Design の README 一覧登録（check-entry-existence 検証） | [references/verification-and-persistence.md](references/verification-and-persistence.md) |
-| STEP-7 | Design 一覧整合確認 | インデックス整合完了 | targeted docs guard、extension 更新要否確認 | [references/verification-and-persistence.md](references/verification-and-persistence.md) |
+| STEP-7 | Design 一覧整合確認 | インデックス整合完了 | targeted docs guard、extension 更新要否確認、Design バッチ更新時の参照先用語実在確認 | [references/verification-and-persistence.md](references/verification-and-persistence.md) |
 | STEP-8 | ドラフト status 更新 | 一覧整合確認完了 | Design 消費済みフラグ（commit 対象に含む） | [references/verification-and-persistence.md](references/verification-and-persistence.md) |
 | STEP-9 | 変更範囲検証 | status 更新済み | check-change-impact 検証 | [references/verification-and-persistence.md](references/verification-and-persistence.md) |
 | STEP-10 | コミット・プッシュ | 変更範囲検証合格 | 明示パス commit、push | [references/verification-and-persistence.md](references/verification-and-persistence.md) |

--- a/src/opencode/skills/agentdev-workflow-design-save/references/verification-and-persistence.md
+++ b/src/opencode/skills/agentdev-workflow-design-save/references/verification-and-persistence.md
@@ -74,6 +74,7 @@ Design 一覧表の整合を確認し、targeted docs guard と extension 更新
 Design 新規作成時は `docs/designs/README.md` の Design 一覧表に追加済みであることを確認する（STEP-6 で実施済みの場合は重複確認）。
 Design 一覧表の整合は Design 探索導線の維持に必要な更新のみを対象とし、要件、判断、仕様の更新は含まない。
 
+- **Design バッチ更新時の参照先用語横断確認**: 同一実行で複数の Design へ一括反映（バッチ更新）する場合、各 Design 本文が他の成果物（Design、command、skill 等）を整合先として引用する箇所について、引用した用語が参照先成果物に実在するかを横断確認する。参照先成果物に存在しない用語（未定義用語）を発見した場合は、実在する表現へ修正するか当該引用を除去してから保存を確定する。確認結果は STEP-11 の完了報告に含める。単一 Design のみを更新する場合は本確認を省略できる
 - **extension 更新要否の確認**: Design の追加、移動、分割が `.agentdev/extensions/**` に影響するか確認する。移動または分割により extension 参照先 Design パスが変わる場合、当該 extension の context paths を更新する。extension 参照先 Design を移動した場合はエラーとし、design-save 自身は移動を完了させずユーザー判断を仰ぐ（check #5 strict 違反を防止）。Design 新規作成で既存 command/skill の実行時参照が増える場合、対応 extension の `context` への追加をユーザーに提案する（直接編集しない）
 - **targeted docs guard**: 変更 Design ファイルと連動ファイル（`docs/designs/README.md`）に対し `bun run .opencode/skills/<integrity-detector-skill>/scripts/check_changed_docs.ts --workflow design-save --files <changed Design files> --json` を実行する（bun run 起動。モード使い分けの標準は コミット前の worktree 上での検証 = `--base-ref`、コミット後・PR 作成後の main 環境 = `--files` であり、保存直後ファイルの直接指定には `--files` を使用する。PowerShell で複数パスを渡す場合は配列変数経由（`$files = @('a.md','b.md')` を `--files $files` で渡す）または個別渡しとし、引用符まとめ渡し（`--files "a.md b.md"`）は使用しない）。`failures` に strict severity を含む場合は保存工程を継続せず修正して再実行する。`spec_readme_update_required` が true の場合は STEP-6 の更新要否判定に反映する。`full_docs_check_recommended` が true の場合は全体監査（self-hosting リポジトリ限定の自己監査コマンド）の実行をユーザーに提案する
 
@@ -88,6 +89,7 @@ Design 一覧表の整合は Design 探索導線の維持に必要な更新の�
 ### Completion Verification
 
 - targeted docs guard の failures に strict severity を含まないこと
+- Design バッチ更新（同一実行で複数 Design への一括反映）時は参照先用語の実在確認が完了していること
 
 ### Resume-Idempotency
 


### PR DESCRIPTION
Refs: #2384

## 概要

OU-006（RU-0006、AG-007、Epic #2378 Wave 2）。command 定義・template・skill ガイダンスの仕様修正5件。

## 変更内容

### (a) intake-promote 完了報告 template へ欠落 field 追加

- 対象: `src/opencode/commands/agentdev/templates/intake-promote/standard.md`
- `結果` ブロックへ「分類結果: 採用 {N}件/ 保留 {N}件/ 却下 {N}件」と「自律確定: {N}件（主要根拠とHITL不要理由: {grounds_list}）」を追加した
- workflow skill STEP-6 reference が要求する「採用、保留、却下の件数」「自律確定 item は主要根拠とHITL不要理由を含む」へ template を整合させた

### (b) agentdev-command-authoring の delegated_check 記述サンプルを現行手続きへ更新

- 対象: `src/opencode/skills/agentdev-command-authoring/references/command-authoring-standards.md`
- 旧 `### Step N: {検査名}（delegated_check）` 見出し形式のサンプルを、公開 command 手順セクションの正規形である工程表（前出出力検証表）の行形式へ更新した
- 委譲先の記述を skill 名と責務名までに限定した（内部 reference path の直接指定禁止は同ファイル「他 Skill 参照境界」と整合）

### (c) Design バッチ更新時の参照先用語横断確認手続きの追加

- 対象: `src/opencode/skills/agentdev-workflow-design-save/SKILL.md`（STEP-7 行）、`src/opencode/skills/agentdev-workflow-design-save/references/verification-and-persistence.md`（STEP-7 Procedure、Completion Verification）
- 同一実行で複数の Design へ一括反映（バッチ更新）する場合、各 Design 本文が整合先として引用する参照先成果物（Design、command、skill 等）の用語実在性を横断確認し、未定義用語を発見した場合は修正または引用除去してから保存を確定する手順を追加した

**AG-003（OU-005、#2383）との連動判断: docs-check 検査候補化は非採用（design-save の保存時手続きとして追加）**

判断理由:

- AG-003 の docs-check 検査強化（REQ-010-069/070）が機械検査クラス化する対象は「引用 REQ 識別子の実在性」など識別子空間が閉じた検出である。参照先用語の実在性確認は、Design 本文のどの箇所が参照先成果物の用語を引用しているかの特定に意味判断を要し、docs-check の機械検出と意味診断の分離境界（REQ-010-003）における意味診断側に属する
- したがって本件は SPEC（Design セクション）更新イベントに紐づく確認であるため、design-save STEP-7 の保存時手続きとして実装し、docs-check 検査クラスには追加しない
- 残存 dangling 参照先用語の恒常検出が必要になった場合は inspect 系（意味診断）側の候補として扱う
- docs-check 検査クラスの追加自体は OU-005（#2383）の対象範囲であり、本 Issue では実施しない

### (d) case-close workflow の E5b 判定への字母後綴（a/b）形式の考慮追加

- 対象: `src/opencode/skills/agentdev-workflow-case-close/references/epic-wave-close.md`
- 字母後綴（a/b）形式の識別子残存（旧 `E5a`/`E5b` ペアの残存）を解消し、サブステップ階層形式（`E5-1`、副番号 1 起点）へ振り直した。E5 見出しを「Epic Issue 本文更新（Epic status table 更新、完了条件チェックボックス評価、単一書き手 case-close のみ）」へ整理した
- E5-1 判定本文へ字母後綴（a/b）形式の副項目列挙（「(a) …」「(b) …」等）を含む完了条件チェックボックスの評価単位考慮を追加した: 副項目単位で評価スコープを決定し（観点8 判定マトリクスを各副項目に適用）、中間 Wave では当該 Wave の PR 対象範囲の副項目のみ評価し範囲外は後続 Wave の評価対象として保留し、全副項目の達成確認までチェックボックスを更新しない
- `E5b` の外部参照は epic-wave-close.md 内のみであることを grep で確認した（他ファイルに参照なし）

### (e) Epic Wave クローズ時の一時成果物残留チェックの追加（REQ-032-022）

- 対象: `src/opencode/skills/agentdev-workflow-case-close/references/epic-wave-close.md`（E6-1 新設、Result、Evidence、Completion Verification、resume point、関連ガードレール）、`src/opencode/skills/agentdev-workflow-case-close/SKILL.md`（STEP-E1〜E6 行、termination）
- E6 最終 Wave 判定の前に E6-1 で当該 Wave スコープの一時成果物（draft、RU、検出事項等のドメイン状態）残留と当該実行で `.agentdev/tmp/` に作成した一時ファイルの残存を確認し、残留時は当該 Wave を完了扱いにせず構造化エラーで停止する手順を追加した
- Epic クローズ条件を「全子Issue completed かつ一時成果物残留なし」へ反映した

## 実装メモ

- 変更ファイルは6件（template 1件、skill 5ファイル）。すべて配布成果物（`src/opencode/` 配下）であり、REQ/Design ファイルは未変更
- エンコーディングは UTF-8（BOM なし）、既存の改行形式を維持した

## 検証結果

### TS-007（完了条件 (a)〜(e)、REQ-032 と docs-check REQ 系検査の整合）

| 項目 | 検証内容 | 結果 |
|---|---|---|
| (a) | template に分類結果（採用/保留/却下件数）・自律確定（主要根拠とHITL不要理由）field が存在すること | ✅ 合格 |
| (b) | delegated_check サンプルが工程表形式・委譲先は skill 名と責務名まで（現行手続きと一致） | ✅ 合格 |
| (c) | Design バッチ更新時の参照先用語横断確認手続きの存在と AG-003 連動判断の記録（本 PR「変更内容 (c)」） | ✅ 合格 |
| (d) | E5b 字母後綴の解消（E5-1 へ振り直し）と E5-1 判定への字母後綴（a/b）形式考慮の反映 | ✅ 合格 |
| (e) | Epic Wave クローズ時残留チェック手順（E6-1）の workflow skill 内存在 | ✅ 合格 |
| REQ-032 整合 | check_integrity.ts（--profile source）で REQ ファイル系検査（frontmatter id↔filename、README 索引突合等）の NG 0件、REQ-032 は現行インデックスに登録済み | ✅ 合格 |

### TS-QC-OU006（品質査読）

Command 品質査読観点（完了報告必須 field 6種の維持、既存 template 様式との整合）、Skill 品質査読観点（サブステップ階層形式・副番号 1 起点、見出しレベル統一、control plane と reference の整合、段階的開示の維持）、文書品質査読観点（一文一行、用語の正規名称、見出しの 中黒回避）で変更差分を確認し、未解決違反なし。

### 機械検査（実行 cwd: worktree root `.worktrees/2384-fix`）

| 検査 | 結果 |
|---|---|
| `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_templates.ts` | worktree 環境（junction 未伝播）により REQ-018 の warning skip で正常終了 |
| `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_integrity.ts --profile source` | exit 1。未管理 NG 9件はすべて本変更外ファイル（`docs/guides/consumer-project-setup.md` の旧 specs/ パス参照 5件、`docs/designs/` 3ファイルの workflow-status-prohibition 4件。いずれも OU-007 #2385 の対象領域）。本 diff を stash した同一状態で同じ 9件・exit 1 を再現し、本変更起因の NG が 0件であることを確認済み |
| `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_command_format.ts --root .` | OK（exit 0） |
| `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_distribution_boundary.ts --profile source` | failures 0（exit 0）。変更差分に具体 ID・docs パスの混入なし |
| `bun run .opencode/skills/repo-agentdev-integrity/scripts/lint_skills.ts` | exit 1。NG 1件は agentdev-traceability の description 600 字超過（631字）で本変更外ファイルの既存指摘（OU-004 #2382 対象） |
| `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_autogen_freshness.ts` | 鮮度違反 0件（exit 0） |
| `bun run .opencode/skills/repo-agentdev-integrity/scripts/check_extensions.ts` | failures 0（exit 0） |
| `bun src/opencode/skills/agentdev-traceability/scripts/src/check.ts --root . --req REQ-032-022` | missing-implementation / missing-verification の2不合格（Findings 参照。対応宣言は Design ファイル編集を要し本 Issue 対象範囲外） |

### bun test フル suite（正規形 3 cwd 分割実行）

環境ラベル: worktree、junction 未伝播、依存パッケージは `bun install --cwd src/opencode/skills/agentdev-project-extensions/scripts` 前置（zod 解消）済み。各実行の cwd は worktree root、`./` prefix 付きで対象ディレクトリを明示指定。

| 分割 | 起動コマンド | 結果 |
|---|---|---|
| ① integrity suite | `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/` | 2252 pass / 0 fail（94 files） |
| ② src 側 skill script テスト | `bun test ./src/opencode/skills/` | 97 pass / 0 fail（9 files） |
| ③ repo ルート系 guard テスト | `bun test ./.opencode/plugins/ ./scripts/` | 116 pass / 0 fail（2 files） |

fail 全件の由来分類: bun install 前置前に依存解決失敗による 4 fail（zod 未解決、環境依存）を確認し、前置後に 0 fail。既知欠陥 0件、当該変更起因 0件。

## Findings / Capture候補

### intake

1. **REQ-032-022 の対応宣言（ADF-COVERS）が Design 側に未反映**

   - 観測: `agentdev-traceability` check（`--req REQ-032-022`）で missing-implementation / missing-verification の2不合格。REQ-032-022 を実装する case-close command Design（`docs/designs/commands/case-close.md`）の ADF-COVERS(implementation) 行は REQ-032-001〜021 のみで REQ-032-022 が未登録。検証対応は `docs/designs/foundations/references/verification-scope-catalog.md` の任意行エントリにも未登録（未登録のため検証対応必須行として計上される）
   - 対象範囲外の理由: 両ファイルとも Design ファイルであり、本 Issue（OU-006）の承認済み変更対象（template・skill・ガイダンス）から除外されるため本 PR では未対応
   - 影響: case-close QG-4 のトレーサビリティ独立再検査が対応欠落を検出した場合にマージ停止する可能性がある。REQ-010-069/070（OU-005 #2383）も同様の状況になると予測される
   - 修正候補: 上記 Design の ADF-COVERS(implementation) 行へ REQ-032-022 を追加し、検証対応は verification-scope-catalog.md の任意行エントリ（品質ゲート・レビュー検証行）への登録または恒常的検証手段の新設で対応する

### learning

なし

## Design確定候補

なし
