### PR TITLE
feat(agentdev): Custom Tool・Plugin/Hook 配布種別の実装と配布境界の確立（OU-003、Refs: #2430）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 !.opencode/commands/repo/
 .opencode/skills/*
 !.opencode/skills/repo-*/
+.opencode/tools/agentdev-*/
+.opencode/plugins/agentdev-*/
 .sisyphus/
 .worktrees/
 .omo/

--- a/.opencode/skills/repo-agentdev-integrity/scripts/lib/distribution-boundary-fs.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/lib/distribution-boundary-fs.ts
@@ -31,6 +31,10 @@ import type { BoundaryFailure } from "./distribution-boundary-types.ts";
 
 export const PUBLIC_COMMAND_DIR = "src/opencode/commands/agentdev";
 export const PUBLIC_SKILLS_PARENT = "src/opencode/skills";
+export const PUBLIC_TOOLS_PARENT = "src/opencode/tools";
+export const PUBLIC_PLUGINS_PARENT = "src/opencode/plugins";
+
+// ADF-COVERS(implementation): REQ-052-006, REQ-052-007
 
 export type FailureCategory = BoundaryFailure["category"];
 
@@ -131,23 +135,32 @@ export function collectTargets(repoRoot: string, projection: Projection): Artifa
 
   let merged: ArtifactListing = listArtifactsRec(path.join(repoRoot, commandRel));
 
-  const skillsParent = path.join(repoRoot, skillsRel);
-  if (dirExists(skillsParent)) {
+  // agentdev-* and japanese-tech-writing both ship in archive; others ignored.
+  const shippableSkills = (name: string): boolean =>
+    name.startsWith("agentdev-") || name === "japanese-tech-writing";
+  // Custom Tools and Plugins/Hooks ship under agentdev-* distribution names
+  // (REQ-052); other entries under these parents are repo-local and ignored.
+  const shippableDistribution = (name: string): boolean => name.startsWith("agentdev-");
+
+  for (const [rel, accept] of [
+    [skillsRel, shippableSkills],
+    [isInstalledProjection ? path.join(".opencode", "tools") : PUBLIC_TOOLS_PARENT, shippableDistribution],
+    [isInstalledProjection ? path.join(".opencode", "plugins") : PUBLIC_PLUGINS_PARENT, shippableDistribution],
+  ] as const) {
+    const parent = path.join(repoRoot, rel);
+    if (!dirExists(parent)) continue;
     let entries: Array<fs.Dirent>;
     try {
-      entries = fs.readdirSync(skillsParent, { withFileTypes: true }) as Array<fs.Dirent>;
+      entries = fs.readdirSync(parent, { withFileTypes: true }) as Array<fs.Dirent>;
     } catch {
-      return merged;
+      continue;
     }
     for (const ent of entries) {
       if (!ent.isDirectory()) continue;
-      // agentdev-* and japanese-tech-writing both ship in archive; others ignored.
-      if (!ent.name.startsWith("agentdev-") && ent.name !== "japanese-tech-writing") {
-        continue;
-      }
+      if (!accept(ent.name)) continue;
       merged = appendListing(
         merged,
-        listArtifactsRec(path.join(skillsParent, ent.name)),
+        listArtifactsRec(path.join(parent, ent.name)),
       );
     }
   }

--- a/.opencode/skills/repo-agentdev-integrity/scripts/package-release-archive.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/package-release-archive.test.ts
@@ -1,6 +1,7 @@
 // ADF-COVERS(verification): REQ-009-009, REQ-009-045
 // ADF-COVERS(verification): REQ-010-060
 // ADF-COVERS(verification): REQ-050-010, REQ-050-011
+// ADF-COVERS(verification): REQ-052-007
 // Regression harness for scripts/self/release/package-release-archive.ps1.
 //
 // Proves the hardening contract (Issue #2092 / DEC-014 decision 7):
@@ -234,6 +235,45 @@ describe("package-release-archive.ps1 / happy path", () => {
       rmrf(repo.root);
     }
   }, 120000);
+});
+
+describe("package-release-archive.ps1 / tools and plugins staging (REQ-052-007)", () => {
+  test("archives src/opencode/{tools,plugins}/agentdev-*/** without node_modules and without repo-local entries", () => {
+    const repo = makeFakeRepo();
+    try {
+      const toolDir = path.join(repo.root, "src", "opencode", "tools", "agentdev-probe");
+      const pluginDir = path.join(repo.root, "src", "opencode", "plugins", "agentdev-probe-guard");
+      fs.mkdirSync(toolDir, { recursive: true });
+      fs.writeFileSync(path.join(toolDir, "index.ts"), "// probe tool\n");
+      fs.mkdirSync(path.join(toolDir, "node_modules", "dep"), { recursive: true });
+      fs.writeFileSync(path.join(toolDir, "node_modules", "dep", "dep.js"), "// dependency\n");
+      fs.mkdirSync(pluginDir, { recursive: true });
+      fs.writeFileSync(path.join(pluginDir, "plugin.ts"), "// probe plugin\n");
+      fs.mkdirSync(path.join(repo.root, "src", "opencode", "tools", "local-only"), { recursive: true });
+      fs.writeFileSync(path.join(repo.root, "src", "opencode", "tools", "local-only", "x.ts"), "// repo-local\n");
+
+      const res = runScript(repo);
+      expect(res.exitCode).toBe(0);
+
+      const extracted = path.join(repo.root, "dist", "check-extract");
+      fs.mkdirSync(extracted, { recursive: true });
+      const expand = spawnSync(
+        "pwsh",
+        ["-NoProfile", "-NonInteractive", "-Command",
+          `Expand-Archive -LiteralPath "${repo.finalZipPath}" -DestinationPath "${extracted}" -Force`],
+        { encoding: "utf-8" },
+      );
+      expect(expand.status).toBe(0);
+      const rel = (p: string): string =>
+        path.join(extracted, `agentdev-release-${repo.commitShort}`, p);
+      expect(fs.existsSync(rel(path.join("src", "opencode", "tools", "agentdev-probe", "index.ts")))).toBe(true);
+      expect(fs.existsSync(rel(path.join("src", "opencode", "plugins", "agentdev-probe-guard", "plugin.ts")))).toBe(true);
+      expect(fs.existsSync(rel(path.join("src", "opencode", "tools", "agentdev-probe", "node_modules")))).toBe(false);
+      expect(fs.existsSync(rel(path.join("src", "opencode", "tools", "local-only")))).toBe(false);
+    } finally {
+      rmrf(repo.root);
+    }
+  }, 180000);
 });
 
 describe("package-release-archive.ps1 / archive boundary violation", () => {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/manifest.test.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/manifest.test.ts
@@ -10,6 +10,7 @@
 // public projection labels.
 
 // ADF-COVERS(verification): REQ-050-011
+// ADF-COVERS(verification): REQ-052-006, REQ-052-007
 
 import { describe, expect, test } from "bun:test";
 import {
@@ -40,12 +41,22 @@ describe("manifest / isRequiredRuntimePath", () => {
   test("accepts skills/japanese-tech-writing/**", () => {
     expect(isRequiredRuntimePath("src/opencode/skills/japanese-tech-writing/SKILL.md")).toBe(true);
   });
+  test("accepts tools/agentdev-*/** and plugins/agentdev-*/** (REQ-052 distribution kinds)", () => {
+    expect(isRequiredRuntimePath("src/opencode/tools/agentdev-gh/index.ts")).toBe(true);
+    expect(isRequiredRuntimePath("src/opencode/tools/agentdev-gh/tests/engine-fail-closed.test.ts")).toBe(true);
+    expect(isRequiredRuntimePath("src/opencode/plugins/agentdev-gh-write-guard/plugin.ts")).toBe(true);
+    expect(isRequiredRuntimePath("src/opencode/plugins/agentdev-gh-write-guard/lib/guard-config.ts")).toBe(true);
+  });
   test("rejects unrelated commands", () => {
     expect(isRequiredRuntimePath("src/opencode/commands/repo/x.md")).toBe(false);
     expect(isRequiredRuntimePath("src/opencode/commands/agentdev-other/x.md")).toBe(false);
   });
   test("rejects unrelated skills", () => {
     expect(isRequiredRuntimePath("src/opencode/skills/repo-integrity/SKILL.md")).toBe(false);
+  });
+  test("rejects non-agentdev tools/plugins entries (repo-local, REQ-052-006)", () => {
+    expect(isRequiredRuntimePath("src/opencode/tools/local-tool/index.ts")).toBe(false);
+    expect(isRequiredRuntimePath("src/opencode/plugins/local-guard/plugin.ts")).toBe(false);
   });
   test("includes tests, fixtures, README, package.json, tsconfig, lockfiles, and metadata", () => {
     expect(isRequiredRuntimePath("src/opencode/skills/agentdev-foo/scripts/x.test.ts")).toBe(true);
@@ -121,12 +132,16 @@ describe("manifest / buildLinkManifest", () => {
       entry("src/opencode/commands/agentdev/case-run.md", "a".repeat(64), 10),
       entry("src/opencode/skills/agentdev-foo/SKILL.md", "b".repeat(64), 20),
       entry("src/opencode/skills/japanese-tech-writing/SKILL.md", "c".repeat(64), 30),
+      entry("src/opencode/tools/agentdev-gh/index.ts", "0".repeat(64), 15),
+      entry("src/opencode/plugins/agentdev-gh-write-guard/plugin.ts", "1".repeat(64), 25),
     ];
     const m = buildLinkManifest(runtime);
     expect(m.entries.map((e) => e.path).sort()).toEqual([
       ".opencode/commands/agentdev/case-run.md",
+      ".opencode/plugins/agentdev-gh-write-guard/plugin.ts",
       ".opencode/skills/agentdev-foo/SKILL.md",
       ".opencode/skills/japanese-tech-writing/SKILL.md",
+      ".opencode/tools/agentdev-gh/index.ts",
     ]);
     // Identical digests required.
     for (const e of m.entries) {

--- a/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/manifest.ts
+++ b/.opencode/skills/repo-agentdev-integrity/scripts/trusted-distribution-gate/manifest.ts
@@ -6,7 +6,9 @@
 //   source           — every tracked regular file under
 //                      src/opencode/commands/agentdev/**,
 //                      src/opencode/skills/agentdev-*/**,
-//                      src/opencode/skills/japanese-tech-writing/**
+//                      src/opencode/skills/japanese-tech-writing/**,
+//                      src/opencode/tools/agentdev-*/**,
+//                      src/opencode/plugins/agentdev-/**
 //                      (including tests, fixtures, README, package.json,
 //                      tsconfig, lockfiles, and metadata — none excluded)
 //                      PLUS the trusted consumer bootstrap entry
@@ -42,6 +44,7 @@
 
 // ADF-COVERS(implementation): REQ-050-011
 // ADF-COVERS(verification): REQ-050-011
+// ADF-COVERS(implementation): REQ-052-006, REQ-052-007
 
 import type { ManifestEntry, ManifestSet, Projection, SourceSubset } from "./types.ts";
 
@@ -59,6 +62,8 @@ const RUNTIME_PREFIXES: readonly string[] = [
   "src/opencode/commands/agentdev/",
   "src/opencode/skills/agentdev-",
   "src/opencode/skills/japanese-tech-writing/",
+  "src/opencode/tools/agentdev-",
+  "src/opencode/plugins/agentdev-",
 ];
 
 const BOOTSTRAP_PATHS: readonly string[] = [

--- a/README.md
+++ b/README.md
@@ -139,13 +139,15 @@ cd .agentdev-plugin && git pull && cd ..
 
 ### 推奨 .gitignore 設定
 
-通常版・ローカル版ともに同一。`agentdev-gh-cli` はリンク先が異なるだけなので `.opencode/skills/agentdev-*/` パターンで網羅される。`japanese-tech-writing` は配布物依存スキル（`agentdev-doc-writing` が参照、REQ-002）のため別途 gitignore に含める。runtime workspace ディレクトリの管理は harness 側の責務であり（charter 原則、DEC-001）、本 gitignore 推奨には含めない。
+通常版・ローカル版ともに同一。`agentdev-gh-cli` はリンク先が異なるだけなので `.opencode/skills/agentdev-*/` パターンで網羅される。`japanese-tech-writing` は配布物依存スキル（`agentdev-doc-writing` が参照、REQ-002）のため別途 gitignore に含める。Custom Tool（`.opencode/tools/agentdev-*/`）と Plugin / Hook（`.opencode/plugins/agentdev-*/`）も配布種別として同様に gitignore に含める（REQ-052）。runtime workspace ディレクトリの管理は harness 側の責務であり（charter 原則、DEC-001）、本 gitignore 推奨には含めない。
 
 ```gitignore
 .agentdev-plugin/
 .opencode/commands/agentdev/
 .opencode/skills/agentdev-*/
 .opencode/skills/japanese-tech-writing/
+.opencode/tools/agentdev-*/
+.opencode/plugins/agentdev-*/
 ```
 
 > `.agentdev/` は gitignore に**含めない**こと（ドメイン状態として git 管理対象）。

--- a/scripts/consumer/archive/install.ps1
+++ b/scripts/consumer/archive/install.ps1
@@ -11,6 +11,8 @@ param(
 # tree into the projection directory (.opencode/) as real files.
 # Junctions are NOT created; release archives must be junction-free.
 #
+# ADF-COVERS(implementation): REQ-052-007
+#
 # Exit codes:
 #   0  success (every file placed, content matches)
 #   4  destination already has a file with different content (do not overwrite)
@@ -97,5 +99,24 @@ foreach ($skillDir in $skillDirs) {
     }
 }
 
-Write-Host "install-from-archive: placed commands and skills into $Target"
+# Custom Tools / Plugins (agentdev-* distribution types, REQ-052). Optional
+# kinds: archives without a kind directory simply skip it.
+foreach ($kind in @("tools", "plugins")) {
+    $kindSrc = Join-Path $Source $kind
+    if (-not (Test-Path -LiteralPath $kindSrc)) { continue }
+    $kindDst = Join-Path $Target $kind
+    $kindDirs = Get-ChildItem -LiteralPath $kindSrc -Directory | Where-Object {
+        $_.Name -like "agentdev-*"
+    }
+    foreach ($kindDir in $kindDirs) {
+        $kindFiles = Get-ChildItem -LiteralPath $kindDir.FullName -Recurse -File
+        foreach ($f in $kindFiles) {
+            $rel = $f.FullName.Substring($kindSrc.Length).TrimStart('\', '/')
+            $dst = Join-Path $kindDst $rel
+            Place-File -SrcFile $f.FullName -DstFile $dst
+        }
+    }
+}
+
+Write-Host "install-from-archive: placed commands, skills, tools, and plugins into $Target"
 exit 0

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -20,6 +20,10 @@
     - .opencode/skills/agentdev-*/  = individual junctions -> .agentdev-plugin/src/opencode/skills/agentdev-*/
     - .opencode/skills/japanese-tech-writing/ = junction -> .agentdev-plugin/src/opencode/skills/japanese-tech-writing/
       (distribution-dependent skill referenced by agentdev-doc-writing)
+    - .opencode/tools/agentdev-*/   = individual junctions -> .agentdev-plugin/src/opencode/tools/agentdev-*/
+      (Custom Tool distribution type)
+    - .opencode/plugins/agentdev-*/ = individual junctions -> .agentdev-plugin/src/opencode/plugins/agentdev-*/
+      (Plugin / Hook distribution type)
 
     Does NOT touch repo-local commands/skills:
     - .opencode/commands/repo/      = real directory (repo-local only)
@@ -61,6 +65,7 @@
 #>
 
 # ADF-COVERS(implementation): REQ-050-001, REQ-050-002, REQ-050-004, REQ-050-005, REQ-050-006, REQ-050-007, REQ-050-008, REQ-050-013
+# ADF-COVERS(implementation): REQ-052-007, REQ-052-008
 
 #Requires -Version 7.0
 
@@ -86,6 +91,12 @@ $LocalSourceDir = Join-Path $PluginPath 'src\opencode-local'
 $ProjectionDir = Join-Path $RepoRoot '.opencode'
 $CommandsDir = Join-Path $ProjectionDir 'commands'
 $SkillsDir = Join-Path $ProjectionDir 'skills'
+$ToolsDir = Join-Path $ProjectionDir 'tools'
+$PluginsDir = Join-Path $ProjectionDir 'plugins'
+
+# Parent directories that must exist as real directories (junction parents).
+$ProjectionParentDirs = @($CommandsDir, $SkillsDir, $ToolsDir, $PluginsDir)
+$ProjectionParentRels = @('commands', 'skills', 'tools', 'plugins')
 
 # Repo-local patterns excluded from junction management
 $RepoLocalCommandNames = @('repo')
@@ -175,6 +186,20 @@ function Get-ConsumerJunctionTargets {
         if (Test-Path -LiteralPath (Join-Path $skillsSource 'japanese-tech-writing')) {
             $targets.Add('skills\japanese-tech-writing')
         }
+    }
+
+    # tools\agentdev-* (Custom Tool 配布種別、動的列挙)
+    $toolsSource = Join-Path $SourceDir 'tools'
+    if (Test-Path -LiteralPath $toolsSource) {
+        Get-ChildItem -LiteralPath $toolsSource -Directory -Filter 'agentdev-*' |
+            ForEach-Object { $targets.Add("tools\$($_.Name)") }
+    }
+
+    # plugins\agentdev-* (Plugin / Hook 配布種別、動的列挙)
+    $pluginsSource = Join-Path $SourceDir 'plugins'
+    if (Test-Path -LiteralPath $pluginsSource) {
+        Get-ChildItem -LiteralPath $pluginsSource -Directory -Filter 'agentdev-*' |
+            ForEach-Object { $targets.Add("plugins\$($_.Name)") }
     }
 
     return ($targets | Sort-Object)
@@ -334,7 +359,7 @@ if ($Mode -eq 'check') {
     }
 
     # 5. Parent directories
-    foreach ($parentDir in @($CommandsDir, $SkillsDir)) {
+    foreach ($parentDir in $ProjectionParentDirs) {
         $parentRel = $parentDir.Substring($ProjectionDir.Length).TrimStart('\', '/')
         if (Test-Junction -Path $parentDir) {
             Write-Host "[DIVERGENCE] .opencode/$parentRel is a junction (must be real directory)"
@@ -376,7 +401,7 @@ if ($Mode -eq 'check') {
     Write-Host ''
     Write-Host '--- Orphan junctions ---'
     $orphansFound = $false
-    foreach ($parentRel in @('commands', 'skills')) {
+    foreach ($parentRel in $ProjectionParentRels) {
         $parentPath = Join-Path $ProjectionDir $parentRel
         if (-not (Test-Path -LiteralPath $parentPath)) { continue }
         Get-ChildItem -LiteralPath $parentPath -Directory -Force |
@@ -438,7 +463,7 @@ if ($Mode -eq 'dry-run') {
     }
 
     # Parent directory status
-    foreach ($parentRel in @('commands', 'skills')) {
+    foreach ($parentRel in $ProjectionParentRels) {
         $parentPath = Join-Path $ProjectionDir $parentRel
         if (-not (Test-Path -LiteralPath $parentPath)) {
             Write-Host "[WOULD ADD] .opencode/$parentRel/ (real directory)"

--- a/scripts/self-sync.ps1
+++ b/scripts/self-sync.ps1
@@ -21,6 +21,10 @@
     - .opencode/             = real directory (not a junction)
     - .opencode/commands/agentdev/  = junction -> src/opencode/commands/agentdev/
     - .opencode/skills/agentdev-*/  = individual junctions -> src/opencode/skills/agentdev-*/
+    - .opencode/tools/agentdev-*/   = individual junctions -> src/opencode/tools/agentdev-*/
+      (Custom Tool distribution type)
+    - .opencode/plugins/agentdev-*/ = individual junctions -> src/opencode/plugins/agentdev-*/
+      (Plugin / Hook distribution type)
 
     Repo-local artifacts are excluded from junction management:
     - .opencode/commands/repo/      = real directory (not a junction, repo-local only)
@@ -40,6 +44,7 @@
 #>
 
 # ADF-COVERS(implementation): REQ-050-001, REQ-050-003, REQ-050-005, REQ-050-006, REQ-050-007
+# ADF-COVERS(implementation): REQ-052-007, REQ-052-008
 
 #Requires -Version 7.0
 
@@ -55,6 +60,12 @@ $SourceDir = Join-Path $RepoRoot 'src\opencode'
 $ProjectionDir = Join-Path $RepoRoot '.opencode'
 $CommandsDir = Join-Path $ProjectionDir 'commands'
 $SkillsDir = Join-Path $ProjectionDir 'skills'
+$ToolsDir = Join-Path $ProjectionDir 'tools'
+$PluginsDir = Join-Path $ProjectionDir 'plugins'
+
+# Parent directories that must exist as real directories (junction parents).
+$ProjectionParentDirs = @($CommandsDir, $SkillsDir, $ToolsDir, $PluginsDir)
+$ProjectionParentRels = @('commands', 'skills', 'tools', 'plugins')
 
 # Repo-local patterns excluded from junction management (ADR-0020)
 $RepoLocalCommandNames = @('repo')
@@ -140,6 +151,20 @@ function Get-SelectiveJunctionTargets {
         }
     }
 
+    # tools\agentdev-* (Custom Tool 配布種別、動的列挙)
+    $toolsSource = Join-Path $SourceDir 'tools'
+    if (Test-Path -LiteralPath $toolsSource) {
+        Get-ChildItem -LiteralPath $toolsSource -Directory -Filter 'agentdev-*' |
+            ForEach-Object { $targets.Add("tools\$($_.Name)") }
+    }
+
+    # plugins\agentdev-* (Plugin / Hook 配布種別、動的列挙)
+    $pluginsSource = Join-Path $SourceDir 'plugins'
+    if (Test-Path -LiteralPath $pluginsSource) {
+        Get-ChildItem -LiteralPath $pluginsSource -Directory -Filter 'agentdev-*' |
+            ForEach-Object { $targets.Add("plugins\$($_.Name)") }
+    }
+
     return ($targets | Sort-Object)
 }
 
@@ -211,7 +236,7 @@ if ($Mode -eq 'check') {
     }
 
     # 4. Orphan detection in commands/ and skills/ (skip repo-local artifacts)
-    foreach ($parentRel in @('commands', 'skills')) {
+    foreach ($parentRel in $ProjectionParentRels) {
         $parentPath = Join-Path $ProjectionDir $parentRel
         if (-not (Test-Path -LiteralPath $parentPath)) { continue }
         Get-ChildItem -LiteralPath $parentPath -Directory -Force |
@@ -267,7 +292,7 @@ if ($Mode -eq 'dry-run') {
     }
 
     # Parent directory status
-    foreach ($parentRel in @('commands', 'skills')) {
+    foreach ($parentRel in $ProjectionParentRels) {
         $parentPath = Join-Path $ProjectionDir $parentRel
         if (-not (Test-Path -LiteralPath $parentPath)) {
             Write-Host "[WOULD ADD] .opencode/$parentRel/ (real directory)"
@@ -303,7 +328,7 @@ if ($Mode -eq 'dry-run') {
     Write-Host ''
     Write-Host '--- Orphan junctions ---'
     $orphansFound = $false
-    foreach ($parentRel in @('commands', 'skills')) {
+    foreach ($parentRel in $ProjectionParentRels) {
         $parentPath = Join-Path $ProjectionDir $parentRel
         if (-not (Test-Path -LiteralPath $parentPath)) { continue }
         Get-ChildItem -LiteralPath $parentPath -Directory -Force |
@@ -379,7 +404,7 @@ if ($Mode -eq 'apply') {
         exit 1
     }
 
-    foreach ($parentRel in @('commands', 'skills')) {
+    foreach ($parentRel in $ProjectionParentRels) {
         $parentPath = Join-Path $ProjectionDir $parentRel
         if (Test-Junction -Path $parentPath) {
             Write-Error "[ERROR] .opencode/$parentRel is a junction (must be real directory)"
@@ -434,7 +459,7 @@ if ($Mode -eq 'apply') {
     # Step 4: Orphan Junction Cleanup (skip repo-local artifacts)
     Write-Host ''
     Write-Host '--- Orphan cleanup ---'
-    foreach ($parentRel in @('commands', 'skills')) {
+    foreach ($parentRel in $ProjectionParentRels) {
         $parentPath = Join-Path $ProjectionDir $parentRel
         if (-not (Test-Path -LiteralPath $parentPath)) { continue }
         Get-ChildItem -LiteralPath $parentPath -Directory -Force |

--- a/scripts/self/release/package-release-archive.ps1
+++ b/scripts/self/release/package-release-archive.ps1
@@ -3,12 +3,15 @@ param()
 
 # ADF-COVERS(implementation): REQ-050-009, REQ-050-010
 # ADF-COVERS(verification): REQ-050-010, REQ-050-011
+# ADF-COVERS(implementation): REQ-052-007
 #
 # WP-3 (Issue #1928) §7.5.1: build a junction-free release archive from the
 # repo's src/opencode/ source tree. The archive contains:
 #   agentdev-release-<sha>/
 #     src/opencode/commands/agentdev/**.md
 #     src/opencode/skills/agentdev-*/**, japanese-tech-writing/**
+#     src/opencode/tools/agentdev-*/**        (Custom Tool distribution type)
+#     src/opencode/plugins/agentdev-*/**      (Plugin / Hook distribution type)
 #     scripts/install.ps1            (projected from scripts/consumer/archive/install.ps1)
 #     README-INSTALL.md
 # Junctions are resolved to real file content so the archive is self-contained.
@@ -171,8 +174,26 @@ try {
         Copy-Item -Path (Join-Path $d.FullName "*") -Destination $stageSkillDir -Recurse -Force
     }
 
+    # Custom Tools / Plugins (agentdev-* distribution types, REQ-052):
+    # staged under src/opencode/{tools,plugins}/ like skills. Optional at
+    # this stage — repos without these kinds simply skip them.
+    foreach ($kind in @("tools", "plugins")) {
+        $kindSource = Join-Path $repoRoot "src\opencode\$kind"
+        if (-not (Test-Path -LiteralPath $kindSource)) { continue }
+        $stageKindDir = Join-Path $stageSrcOpencode $kind
+        New-Item -ItemType Directory -Path $stageKindDir -Force | Out-Null
+        $kindDirs = Get-ChildItem -LiteralPath $kindSource -Directory | Where-Object {
+            $_.Name -like "agentdev-*"
+        }
+        foreach ($d in $kindDirs) {
+            $stageEntryDir = Join-Path $stageKindDir $d.Name
+            New-Item -ItemType Directory -Path $stageEntryDir -Force | Out-Null
+            Copy-Item -Path (Join-Path $d.FullName "*") -Destination $stageEntryDir -Recurse -Force
+        }
+    }
+
     # node_modules は配布アーカイブに含めない (サイズ増大・consumer側のnpm installで解決)
-    Get-ChildItem -LiteralPath $stageSkills -Recurse -Directory -Filter "node_modules" -ErrorAction SilentlyContinue |
+    Get-ChildItem -LiteralPath $stageSrcOpencode -Recurse -Directory -Filter "node_modules" -ErrorAction SilentlyContinue |
         Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 
     # The archive-dedicated installer travels inside the archive under the

--- a/scripts/self/release/scripts-behavior.test.ts
+++ b/scripts/self/release/scripts-behavior.test.ts
@@ -8,12 +8,15 @@
 //     untouched on a real consumer layout (REQ-050-005)
 //   - orphan detection: check reports an agentdev junction that is not in
 //     the current source enumeration (REQ-050-004)
+//   - tools/plugins projection: apply junctions the Custom Tool and
+//     Plugin / Hook distribution kinds into .opencode/ (REQ-052-007)
 //
 // The consumer layout is exercised in both checkout forms accepted by
 // REQ-050 / REQ-009: git clone style (.git present) and source ZIP style
 // (.git absent).
 
 // ADF-COVERS(verification): REQ-050-004, REQ-050-005, REQ-050-006
+// ADF-COVERS(verification): REQ-052-007
 
 import { describe, expect, test } from "bun:test";
 import * as crypto from "crypto";
@@ -83,9 +86,13 @@ function makeConsumerRepo(zipCheckout: boolean, localSource = false): string {
   fs.mkdirSync(path.join(root, ".agentdev-plugin", "src", "opencode", "commands", "agentdev"), { recursive: true });
   fs.mkdirSync(path.join(root, ".agentdev-plugin", "src", "opencode", "skills", "agentdev-gh-cli"), { recursive: true });
   fs.mkdirSync(path.join(root, ".agentdev-plugin", "src", "opencode", "skills", "japanese-tech-writing"), { recursive: true });
+  fs.mkdirSync(path.join(root, ".agentdev-plugin", "src", "opencode", "tools", "agentdev-gh"), { recursive: true });
+  fs.mkdirSync(path.join(root, ".agentdev-plugin", "src", "opencode", "plugins", "agentdev-gh-write-guard"), { recursive: true });
   fs.writeFileSync(path.join(root, ".agentdev-plugin", "src", "opencode", "commands", "agentdev", "case-run.md"), "# case-run\n");
   fs.writeFileSync(path.join(root, ".agentdev-plugin", "src", "opencode", "skills", "agentdev-gh-cli", "SKILL.md"), "# gh-cli\n");
   fs.writeFileSync(path.join(root, ".agentdev-plugin", "src", "opencode", "skills", "japanese-tech-writing", "SKILL.md"), "# jtw\n");
+  fs.writeFileSync(path.join(root, ".agentdev-plugin", "src", "opencode", "tools", "agentdev-gh", "index.ts"), "// agentdev-gh tool\n");
+  fs.writeFileSync(path.join(root, ".agentdev-plugin", "src", "opencode", "plugins", "agentdev-gh-write-guard", "plugin.ts"), "// agentdev-gh-write-guard plugin\n");
   if (localSource) {
     fs.mkdirSync(path.join(root, ".agentdev-plugin", "src", "opencode-local", "agentdev-gh-cli"), { recursive: true });
     fs.writeFileSync(path.join(root, ".agentdev-plugin", "src", "opencode-local", "agentdev-gh-cli", "SKILL.md"), "# gh-cli local\n");
@@ -183,6 +190,30 @@ describe("scripts behavior / non-destructive check and dry-run (REQ-050-005)", (
   nonDestructiveScenario("git clone checkout, normal mode", false);
   nonDestructiveScenario("git clone checkout, -LocalMode", false, true, ["-LocalMode"]);
   nonDestructiveScenario("source ZIP checkout (.git absent), normal mode", true);
+});
+
+describe("scripts behavior / tools and plugins projection (REQ-052-007)", () => {
+  test("apply junctions src/opencode/{tools,plugins}/agentdev-* into .opencode/ and check stays clean", () => {
+    const root = makeConsumerRepo(false);
+    try {
+      const apply = runInstall(root, "apply");
+      expect(apply.exitCode).toBe(0);
+
+      const toolLink = path.join(root, ".opencode", "tools", "agentdev-gh");
+      const pluginLink = path.join(root, ".opencode", "plugins", "agentdev-gh-write-guard");
+      expect(fs.existsSync(toolLink)).toBe(true);
+      expect(fs.existsSync(path.join(toolLink, "index.ts"))).toBe(true);
+      expect(fs.existsSync(pluginLink)).toBe(true);
+      expect(fs.existsSync(path.join(pluginLink, "plugin.ts"))).toBe(true);
+
+      const check = runInstall(root, "check");
+      expect(check.exitCode).toBe(0);
+      expect(check.stdout).toMatch(/tools\\agentdev-gh/);
+      expect(check.stdout).toMatch(/plugins\\agentdev-gh-write-guard/);
+    } finally {
+      rmrf(root);
+    }
+  }, 120000);
 });
 
 describe("scripts behavior / check capabilities (REQ-050-004)", () => {

--- a/scripts/self/release/scripts-layout.test.ts
+++ b/scripts/self/release/scripts-layout.test.ts
@@ -16,6 +16,7 @@
 //     entries as the current procedure (REQ-050-014)
 
 // ADF-COVERS(verification): REQ-050-001, REQ-050-002, REQ-050-003, REQ-050-004, REQ-050-007, REQ-050-008, REQ-050-009, REQ-050-013, REQ-050-014
+// ADF-COVERS(verification): REQ-052-008
 
 import { describe, expect, test } from "bun:test";
 import * as fs from "fs";

--- a/src/opencode/plugins/agentdev-gh-write-guard/.gitignore
+++ b/src/opencode/plugins/agentdev-gh-write-guard/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/opencode/plugins/agentdev-gh-write-guard/README.md
+++ b/src/opencode/plugins/agentdev-gh-write-guard/README.md
@@ -1,0 +1,47 @@
+# agentdev-gh-write-guard（Plugin / Hook）
+
+Custom Tool 等の正規経路の迂回（生 gh WRITE 等の直接実行）を検出・拒否する ADF 汎用 Plugin（決定5、多層 enforcement の適用対象拡張）。
+
+## 仕組み
+
+OpenCode の `tool.execute.before` フックでコマンド実行系ツール（既定: `bash`）の引数を検査し、`agentdev-gh` Custom Tool を迂回する生 gh WRITE コマンドを機械的に拒否する。モデルの遵守判断に委ねない。
+
+拒否時はフックが `GuardBlockError` を throw し、対象ツール呼び出しを block する。
+
+## fail-closed（決定6）
+
+| 状態 | 挙動 |
+|---|---|
+| 設定を解釈できない | 既定検査対象（`bash`）を安全性確認不能として block |
+| 強制処理自体が異常終了した | 検出器の例外を block へ変換 |
+| 必須検証が完了できない | 検査対象ツールでコマンド引数が検証不能なら block |
+
+パス解決不能系は本 Plugin の検査対象外（コマンド文字列検査はパス解決に依存しない）。Tool 側（`src/opencode/tools/agentdev-gh/`）の fail-closed テストが担保する。
+
+## 検出範囲
+
+拒否: `gh issue create/edit/close/...`、`gh pr create/merge/review/...`、`gh api` の書き込みメソッド（POST/PATCH/PUT/DELETE）、`gh label/release/repo/workflow/gist/milestone/project` の WRITE 系。
+
+許容: `gh issue view/list/status`、`gh pr view/list/diff/checks/status`、`gh api`（GET）、その他 gh 読み取り系。
+
+禁止範囲（読み取り系の許容等を含む）の詳細は Design `docs/designs/responsibilities/custom-tool-contracts.md`「迂回防止」が所有する。検出は over-block を許容し under-block を許さない（迂回防止優先）。
+
+## 設定
+
+環境変数 `AGENTDEV_GH_WRITE_GUARD_CONFIG` に JSON を指定できる（省略時は既定設定）。
+
+```json
+{ "enforcedTools": ["bash"] }
+```
+
+設定の解釈に失敗した場合は fail-closed として既定検査対象を block する。
+
+## 実行権限の所有者
+
+本 Plugin は実行前の拒否・強制の実行機構であり、副作用の実行権限の所有者を変更しない。
+
+## テスト実行
+
+```bash
+bun test        # cwd: src/opencode/plugins/agentdev-gh-write-guard
+```

--- a/src/opencode/plugins/agentdev-gh-write-guard/bun.lock
+++ b/src/opencode/plugins/agentdev-gh-write-guard/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "agentdev-gh-write-guard",
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
+        "typescript": "^5.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/src/opencode/plugins/agentdev-gh-write-guard/lib/gh-command-detector.ts
+++ b/src/opencode/plugins/agentdev-gh-write-guard/lib/gh-command-detector.ts
@@ -1,0 +1,86 @@
+// gh WRITE 迂回検出器（正規経路迂回防止、決定5）。
+//
+// Custom Tool（agentdev-gh 等）の正規経路を迂回する生 gh WRITE コマンドを
+// コマンド文字列から検出する純関数群。Plugin / Hook（tool.execute.before）が
+// 実行前に拒否するために使用する。
+//
+// 禁止範囲の詳細（読み取り系の許容等を含む）は Design
+// `docs/designs/responsibilities/custom-tool-contracts.md`「迂回防止」が所有する。
+// 本検出器は over-block を許容し under-block を許さない（迂回防止優先）。
+
+
+/** 検出結果。block は拒否すべき gh WRITE、allow は検出なし。 */
+export type GhWriteVerdict =
+  | { readonly kind: "block"; readonly command: string; readonly rule: string }
+  | { readonly kind: "allow" };
+
+interface WritePattern {
+  readonly re: RegExp;
+  readonly rule: string;
+}
+
+// gh の WRITE 系サブコマンド。読み取り系（view、list、status、diff、checks 等）
+// は Design の許容範囲であり、ここに列挙しない。
+const GH_WRITE_PATTERNS: readonly WritePattern[] = [
+  {
+    re: /\bgh\s+issue\s+(create|edit|close|reopen|comment|delete|pin|unpin|transfer|lock|unlock)\b/,
+    rule: "gh issue WRITE",
+  },
+  {
+    re: /\bgh\s+pr\s+(create|edit|merge|close|reopen|ready|review|comment|delete-branch)\b/,
+    rule: "gh pr WRITE",
+  },
+  {
+    re: /\bgh\s+api\b[^\n]*?(?:-X|--method)(?:=|\s+)\s*(?:POST|PATCH|PUT|DELETE)\b/i,
+    rule: "gh api WRITE method",
+  },
+  {
+    re: /\bgh\s+label\s+(create|edit|delete)\b/,
+    rule: "gh label WRITE",
+  },
+  {
+    re: /\bgh\s+release\s+(create|upload|delete|edit)\b/,
+    rule: "gh release WRITE",
+  },
+  {
+    re: /\bgh\s+repo\s+(create|edit|delete|archive|unarchive|rename)\b/,
+    rule: "gh repo WRITE",
+  },
+  {
+    re: /\bgh\s+workflow\s+run\b/,
+    rule: "gh workflow trigger",
+  },
+  {
+    re: /\bgh\s+gist\s+(create|edit|delete)\b/,
+    rule: "gh gist WRITE",
+  },
+  {
+    re: /\bgh\s+milestone\s+(create|edit|delete)\b/,
+    rule: "gh milestone WRITE",
+  },
+  {
+    re: /\bgh\s+project\s+(create|edit|delete|link|unlink)\b/,
+    rule: "gh project WRITE",
+  },
+];
+
+/** コマンド文字列から生 gh WRITE を検出する。行単位で判定する。 */
+export function detectGhWriteCommand(command: string): GhWriteVerdict {
+  for (const line of command.split(/\r?\n/)) {
+    for (const pattern of GH_WRITE_PATTERNS) {
+      if (pattern.re.test(line)) {
+        return { kind: "block", command: line.trim(), rule: pattern.rule };
+      }
+    }
+  }
+  return { kind: "allow" };
+}
+
+/** ブロック時のメッセージ。throw 内容として利用する。 */
+export function formatBlockReason(verdict: GhWriteVerdict & { kind: "block" }): string {
+  return (
+    "agentdev-gh-write-guard: blocked a raw gh WRITE command. " +
+    "GitHub side-effect operations must go through the agentdev-gh Custom Tool. " +
+    `rule=${verdict.rule} command=${verdict.command}`
+  );
+}

--- a/src/opencode/plugins/agentdev-gh-write-guard/lib/guard-config.ts
+++ b/src/opencode/plugins/agentdev-gh-write-guard/lib/guard-config.ts
@@ -1,0 +1,64 @@
+// ガード設定の解釈（fail-closed）。
+//
+// 設定を解釈できない場合、検査対象ツールの安全性を確認できないため
+// 対象副作用（コマンド実行）を block する。設定が存在しない場合は
+// 既定設定（bash のみ検査）を採用し、失敗扱いとしない。
+
+
+export interface GuardConfig {
+  /** 検査対象のコマンド実行系ツール名。既定は bash のみ。 */
+  readonly enforcedTools: readonly string[];
+}
+
+export type GuardConfigResult =
+  | { readonly ok: true; readonly config: GuardConfig }
+  | { readonly ok: false; readonly detail: string };
+
+const DEFAULT_ENFORCED_TOOLS: readonly string[] = ["bash"];
+
+/** 設定環境変数名（存在しない場合は既定設定）。 */
+export const GUARD_CONFIG_ENV = "AGENTDEV_GH_WRITE_GUARD_CONFIG";
+
+function isValidToolName(v: unknown): v is string {
+  return typeof v === "string" && /^[a-z][a-z0-9_-]*$/.test(v);
+}
+
+/** 生設定値の解釈。スキーマ違反は失敗（fail-closed）。 */
+export function interpretGuardConfig(raw: unknown): GuardConfigResult {
+  if (raw === undefined || raw === null) {
+    return { ok: true, config: { enforcedTools: DEFAULT_ENFORCED_TOOLS } };
+  }
+  let decoded: unknown = raw;
+  if (typeof decoded === "string") {
+    try {
+      decoded = JSON.parse(decoded);
+    } catch (e) {
+      return { ok: false, detail: `config is not valid JSON: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  }
+  if (typeof decoded !== "object" || decoded === null || Array.isArray(decoded)) {
+    return { ok: false, detail: "config must be an object when present" };
+  }
+  const obj = decoded as Record<string, unknown>;
+  if (obj.enforcedTools === undefined) {
+    return { ok: true, config: { enforcedTools: DEFAULT_ENFORCED_TOOLS } };
+  }
+  if (!Array.isArray(obj.enforcedTools) || obj.enforcedTools.length === 0) {
+    return { ok: false, detail: "config.enforcedTools must be a non-empty array when present" };
+  }
+  if (!obj.enforcedTools.every(isValidToolName)) {
+    return { ok: false, detail: "config.enforcedTools entries must be tool names" };
+  }
+  return { ok: true, config: { enforcedTools: obj.enforcedTools } };
+}
+
+/** 環境変数から設定を読み込む。変数がなければ既定設定。 */
+export function interpretGuardConfigFromEnv(
+  env: Record<string, string | undefined>,
+): GuardConfigResult {
+  const raw = env[GUARD_CONFIG_ENV];
+  if (raw === undefined) {
+    return { ok: true, config: { enforcedTools: DEFAULT_ENFORCED_TOOLS } };
+  }
+  return interpretGuardConfig(raw);
+}

--- a/src/opencode/plugins/agentdev-gh-write-guard/package.json
+++ b/src/opencode/plugins/agentdev-gh-write-guard/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "agentdev-gh-write-guard",
+  "version": "0.1.0",
+  "private": true,
+  "description": "agentdev-gh-write-guard Plugin. Detects and rejects raw gh WRITE commands that bypass the agentdev-gh Custom Tool's canonical path via OpenCode's tool.execute.before hook. Fail-closed: uninterpretable config, crashed detection, or unverifiable command input block the tool call.",
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/src/opencode/plugins/agentdev-gh-write-guard/plugin.ts
+++ b/src/opencode/plugins/agentdev-gh-write-guard/plugin.ts
@@ -1,0 +1,127 @@
+// agentdev-gh-write-guard Plugin（決定5、多層 enforcement の適用対象拡張）。
+//
+// OpenCode の tool.execute.before フックでコマンド実行系ツール（既定: bash）の
+// コマンド文字列を検査し、Custom Tool（agentdev-gh 等）の正規経路を迂回する
+// 生 gh WRITE を実行前に拒否する。モデルの遵守判断に委ねない機械的な拒否である。
+//
+// fail-closed:
+//   - 設定を解釈できない: 検査対象ツールは安全性を確認できないため block
+//   - 強制処理自体が異常終了した: 検出器の例外は throw に変換し block
+//   - 必須検証が完了できない: 検査対象ツールでコマンド引数が検証不能なら block
+//
+// 検出ルール（読み取り系の許容等を含む禁止範囲）は Design
+// custom-tool-contracts.md「迂回防止」が所有する。
+
+
+import {
+  detectGhWriteCommand,
+  formatBlockReason,
+  type GhWriteVerdict,
+} from "./lib/gh-command-detector.ts";
+import {
+  interpretGuardConfigFromEnv,
+  type GuardConfig,
+  type GuardConfigResult,
+} from "./lib/guard-config.ts";
+
+// OpenCode plugin plumbing types（@opencode-ai/plugin 1.3.x と同じ形状。
+// 本 plugin が消費するフィールドのみ宣言する）。
+
+export type ToolExecuteBeforeInput = {
+  readonly tool: string;
+  readonly sessionID: string;
+  readonly callID: string;
+};
+
+export type ToolExecuteBeforeOutput = {
+  readonly args: Record<string, unknown>;
+};
+
+export type PluginHooks = {
+  "tool.execute.before"?(
+    input: ToolExecuteBeforeInput,
+    output: ToolExecuteBeforeOutput,
+  ): Promise<void>;
+};
+
+export type PluginInput = {
+  readonly worktree: string;
+  readonly directory: string;
+  readonly project: { readonly worktree: string };
+  readonly [key: string]: unknown;
+};
+
+export type PluginServer = (input: PluginInput) => Promise<PluginHooks>;
+
+export type DetectFn = (command: string) => GhWriteVerdict;
+
+export class GuardBlockError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GuardBlockError";
+  }
+}
+
+function extractCommand(tool: string, args: Record<string, unknown>): string {
+  const command = args.command;
+  if (typeof command !== "string" || command.length === 0) {
+    throw new GuardBlockError(
+      `agentdev-gh-write-guard: cannot verify ${tool} invocation (command argument is missing or not a string); blocked per fail-closed`,
+    );
+  }
+  return command;
+}
+
+/**
+ * フック実装（テスト可能な分離点）。detect と configResult を注入できる。
+ * 設定解釈に失敗している場合、検査対象と判定できる既定ツール（bash）を
+ * 安全性確認不能として block する。
+ */
+export function makeGuardHooks(
+  detect: DetectFn,
+  configResult: GuardConfigResult,
+): PluginHooks {
+  const enforcedTools: readonly string[] = configResult.ok
+    ? configResult.config.enforcedTools
+    : ["bash"];
+  return {
+    "tool.execute.before": async (hookInput, hookOutput) => {
+      const isEnforced =
+        enforcedTools.includes(hookInput.tool) ||
+        (!configResult.ok && hookInput.tool === "bash");
+      if (!isEnforced) return;
+      if (!configResult.ok) {
+        throw new GuardBlockError(
+          `agentdev-gh-write-guard: guard config is uninterpretable (${configResult.detail}); blocked ${hookInput.tool} per fail-closed`,
+        );
+      }
+      const command = extractCommand(hookInput.tool, hookOutput.args);
+      let verdict: GhWriteVerdict;
+      try {
+        verdict = detect(command);
+      } catch (e) {
+        throw new GuardBlockError(
+          `agentdev-gh-write-guard: detection crashed (${e instanceof Error ? e.message : String(e)}); blocked ${hookInput.tool} per fail-closed`,
+        );
+      }
+      if (verdict.kind === "block") {
+        throw new GuardBlockError(formatBlockReason(verdict));
+      }
+    },
+  };
+}
+
+/** 既定の検出関数。 */
+export const defaultDetect: DetectFn = detectGhWriteCommand;
+
+const server: PluginServer = async (_input) => {
+  const configResult = interpretGuardConfigFromEnv(process.env);
+  return makeGuardHooks(defaultDetect, configResult);
+};
+
+export default {
+  id: "agentdev-gh-write-guard",
+  server,
+} as const;
+
+export type { GuardConfig };

--- a/src/opencode/plugins/agentdev-gh-write-guard/tests/gh-command-detector.test.ts
+++ b/src/opencode/plugins/agentdev-gh-write-guard/tests/gh-command-detector.test.ts
@@ -1,0 +1,101 @@
+// gh WRITE 迂回検出器の契約テスト。
+//
+// 正規経路迂回（生 gh WRITE）の検出・拒否と読み取り系の許容を固定する。
+// 禁止範囲の詳細は Design custom-tool-contracts.md「迂回防止」が所有する。
+
+
+import { describe, expect, test } from "bun:test";
+import {
+  detectGhWriteCommand,
+  formatBlockReason,
+} from "../lib/gh-command-detector.ts";
+
+describe("生 gh WRITE の検出（拒否）", () => {
+  test.each([
+    ["gh issue create --title x --body y", "gh issue WRITE"],
+    ["gh issue edit 5 --body y", "gh issue WRITE"],
+    ["gh issue close 5", "gh issue WRITE"],
+    ["gh issue comment 5 --body y", "gh issue WRITE"],
+    ["gh issue reopen 5", "gh issue WRITE"],
+    ["gh issue delete 5", "gh issue WRITE"],
+    ["gh pr create --fill", "gh pr WRITE"],
+    ["gh pr merge 7 --squash", "gh pr WRITE"],
+    ["gh pr close 7", "gh pr WRITE"],
+    ["gh pr ready 7", "gh pr WRITE"],
+    ["gh pr review 7 --approve", "gh pr WRITE"],
+    ["gh pr edit 7 --title x", "gh pr WRITE"],
+    ["gh api repos/o/r/issues -X POST -f title=x", "gh api WRITE method"],
+    ["gh api repos/o/r/issues/5 --method PATCH -f body=y", "gh api WRITE method"],
+    ["gh api repos/o/r/issues/5 --method=DELETE", "gh api WRITE method"],
+    ["gh label create foo", "gh label WRITE"],
+    ["gh release create v1", "gh release WRITE"],
+    ["gh repo edit --description x", "gh repo WRITE"],
+    ["gh workflow run ci.yml", "gh workflow trigger"],
+    ["gh gist create f.txt", "gh gist WRITE"],
+    ["gh milestone create m", "gh milestone WRITE"],
+    ["gh project create x", "gh project WRITE"],
+  ])("%s を block する", (command, rule) => {
+    const verdict = detectGhWriteCommand(command);
+    expect(verdict.kind).toBe("block");
+    if (verdict.kind === "block") expect(verdict.rule).toBe(rule);
+  });
+
+  test.each([
+    "echo 'gh issue create --title x' | gh issue view 5",
+    "cd /d && gh pr merge 7 --squash",
+  ])("複合コマンド中の gh WRITE も block する（%s）", (command) => {
+    expect(detectGhWriteCommand(command).kind).toBe("block");
+  });
+
+  test("複数行コマンドの2行目の gh WRITE を block する", () => {
+    const command = "echo hello\ngit status\ngh issue comment 5 --body y";
+    expect(detectGhWriteCommand(command).kind).toBe("block");
+  });
+
+  test("セミコロン区切りの後続 gh WRITE を block する", () => {
+    const command = "git add .; gh pr merge 7";
+    expect(detectGhWriteCommand(command).kind).toBe("block");
+  });
+
+  test("ブロック理由に rule と該当行を含む", () => {
+    const verdict = detectGhWriteCommand("gh issue close 5");
+    expect(verdict.kind).toBe("block");
+    if (verdict.kind === "block") {
+      const reason = formatBlockReason(verdict);
+      expect(reason).toContain("gh issue WRITE");
+      expect(reason).toContain("gh issue close 5");
+    }
+  });
+});
+
+describe("読み取り系の許容（Design 所有の禁止範囲）", () => {
+  test.each([
+    "gh issue view 5",
+    "gh issue list --state open",
+    "gh issue status",
+    "gh pr view 7 --json title",
+    "gh pr list",
+    "gh pr diff 7",
+    "gh pr checks 7",
+    "gh pr status",
+    "gh api repos/o/r/issues/5",
+    "gh api repos/o/r/issues/5 --method GET",
+    "gh api repos/o/r/issues/5 -X GET",
+    "gh label list",
+    "gh release view v1",
+    "gh release list",
+    "gh repo view",
+    "gh auth status",
+    "gh run list",
+    "gh run view 123",
+    "gh workflow view ci.yml",
+    "gh search issues 'text'",
+    "git status",
+    "git log --oneline -5",
+    "echo hello",
+    "bun test src/",
+    "powershell -Command Get-Location",
+  ])("%s は許容する", (command) => {
+    expect(detectGhWriteCommand(command).kind).toBe("allow");
+  });
+});

--- a/src/opencode/plugins/agentdev-gh-write-guard/tests/guard-fail-closed.test.ts
+++ b/src/opencode/plugins/agentdev-gh-write-guard/tests/guard-fail-closed.test.ts
@@ -1,0 +1,131 @@
+// Plugin フックの fail-closed 異常系テスト（TS 相当: 強制機能の fail-closed）。
+//
+// 設定解釈不能・強制処理異常終了・必須検証未了の各異常系を意図的に発生させ、
+// 対象副作用（コマンド実行）が成功扱いにならない（フックが throw して block する）
+// ことを検証する。パス解決不能系は Tool（agentdev-gh engine）側のテストが担保する。
+
+
+import { describe, expect, test } from "bun:test";
+import { detectGhWriteCommand } from "../lib/gh-command-detector.ts";
+import {
+  GUARD_CONFIG_ENV,
+  interpretGuardConfig,
+  interpretGuardConfigFromEnv,
+} from "../lib/guard-config.ts";
+import {
+  GuardBlockError,
+  makeGuardHooks,
+  type DetectFn,
+} from "../plugin.ts";
+
+function hookInput(tool: string) {
+  return { tool, sessionID: "s", callID: "c" };
+}
+
+function hookOutput(command: unknown) {
+  return { args: { command } };
+}
+
+async function expectBlock(hooks: ReturnType<typeof makeGuardHooks>, tool: string, command: unknown): Promise<string> {
+  const promise = hooks["tool.execute.before"]?.(hookInput(tool), hookOutput(command));
+  await expect(promise).rejects.toThrow(GuardBlockError);
+  try {
+    await promise;
+    throw new Error("unreachable");
+  } catch (e) {
+    return e instanceof GuardBlockError ? e.message : "";
+  }
+}
+
+async function expectPass(hooks: ReturnType<typeof makeGuardHooks>, tool: string, command: unknown): Promise<void> {
+  await hooks["tool.execute.before"]?.(hookInput(tool), hookOutput(command));
+}
+
+const okConfig = interpretGuardConfig(undefined);
+if (!okConfig.ok) throw new Error("default config must be valid");
+
+describe("正常系: 検出と迂回防止", () => {
+  test("生 gh WRITE を block する", async () => {
+    const hooks = makeGuardHooks(detectGhWriteCommand, okConfig);
+    const message = await expectBlock(hooks, "bash", "gh issue close 5");
+    expect(message).toContain("agentdev-gh");
+  });
+
+  test("読み取り系 gh コマンドは素通りする", async () => {
+    const hooks = makeGuardHooks(detectGhWriteCommand, okConfig);
+    await expectPass(hooks, "bash", "gh issue view 5");
+  });
+
+  test("検査対象外ツール（write 等）は素通りする", async () => {
+    const hooks = makeGuardHooks(detectGhWriteCommand, okConfig);
+    await expectPass(hooks, "write", { filePath: "a", content: "gh issue close 5" });
+    await expectPass(hooks, "edit", { command: "gh pr merge 7" });
+  });
+});
+
+describe("異常系1: 設定を解釈できない（config-uninterpretable）", () => {
+  test.each([
+    ["不正 JSON", "not json {", "not valid JSON"],
+    ["非オブジェクト", '"string-config"', "must be an object"],
+    ["enforcedTools 型違反", JSON.stringify({ enforcedTools: "bash" }), "non-empty array"],
+    ["enforcedTools 空", JSON.stringify({ enforcedTools: [] }), "non-empty array"],
+    ["ツール名形式違反", JSON.stringify({ enforcedTools: ["Bad Name"] }), "tool names"],
+  ])("%s は解釈失敗になる", (_label, raw, expectedDetailPart) => {
+    const result = interpretGuardConfig(raw);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.detail).toContain(expectedDetailPart);
+  });
+
+  test("設定解釈不能時は bash（既定検査対象）を block し、検査対象外は素通りする", async () => {
+    const broken = interpretGuardConfig("not json {");
+    expect(broken.ok).toBe(false);
+    const hooks = makeGuardHooks(detectGhWriteCommand, broken);
+    const message = await expectBlock(hooks, "bash", "echo hello");
+    expect(message).toContain("uninterpretable");
+    await expectPass(hooks, "write", { filePath: "a", content: "x" });
+  });
+
+  test("環境変数経由の設定解釈も失敗を伝える", () => {
+    const result = interpretGuardConfigFromEnv({
+      [GUARD_CONFIG_ENV]: "{invalid",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("環境変数がなければ既定設定（bash のみ）", () => {
+    const result = interpretGuardConfigFromEnv({});
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.config.enforcedTools).toEqual(["bash"]);
+  });
+});
+
+describe("異常系2: 強制処理自体が異常終了した（enforcement-crashed）", () => {
+  test("検出器が例外を投げた場合、block する", async () => {
+    const crashingDetect: DetectFn = () => {
+      throw new Error("detector bug");
+    };
+    const hooks = makeGuardHooks(crashingDetect, okConfig);
+    const message = await expectBlock(hooks, "bash", "gh issue view 5");
+    expect(message).toContain("detection crashed");
+    expect(message).toContain("detector bug");
+  });
+});
+
+describe("異常系3: 必須検証が完了できない（verification-incomplete）", () => {
+  test("command 引数が文字列でない場合、block する", async () => {
+    const hooks = makeGuardHooks(detectGhWriteCommand, okConfig);
+    const message = await expectBlock(hooks, "bash", 12345);
+    expect(message).toContain("cannot verify");
+  });
+
+  test("command 引数が欠落した場合、block する", async () => {
+    const hooks = makeGuardHooks(detectGhWriteCommand, okConfig);
+    const message = await expectBlock(hooks, "bash", undefined);
+    expect(message).toContain("cannot verify");
+  });
+
+  test("command 引数が空文字列の場合、block する", async () => {
+    const hooks = makeGuardHooks(detectGhWriteCommand, okConfig);
+    await expectBlock(hooks, "bash", "");
+  });
+});

--- a/src/opencode/plugins/agentdev-gh-write-guard/tsconfig.json
+++ b/src/opencode/plugins/agentdev-gh-write-guard/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["bun"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts", "./lib/*.ts", "./tests/*.ts"]
+}

--- a/src/opencode/tools/agentdev-gh/.gitignore
+++ b/src/opencode/tools/agentdev-gh/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/opencode/tools/agentdev-gh/README.md
+++ b/src/opencode/tools/agentdev-gh/README.md
@@ -1,0 +1,48 @@
+# agentdev-gh（Custom Tool）
+
+Git / GitHub 等への構造化された副作用操作を担う ADF 汎用 Custom Tool（種別契約 REQ、決定4）。
+
+## 操作契約
+
+各操作は次の外部契約のみを公開する（Design `docs/designs/responsibilities/custom-tool-contracts.md`）。
+
+| 要素 | 内容 | 実装 |
+|---|---|---|
+| 入力 | 操作名、構造化引数（title、body、labels 等） | `contracts.ts`（GhToolRequest） |
+| 出力 | 構造化結果（issue 番号、URL 等） | `contracts.ts`（GhToolSuccess） |
+| 保証 | 操作の結果を検証（読み戻し）してから成功を返す | `engine.ts`（VERIFY） |
+| 失敗 | 保存または検証に失敗した場合に成功扱いとしない。エラー種別と再試行可否を返す | `contracts.ts`（GhToolFailure） |
+
+実装詳細（gh オプション、`--body-file`、UTF-8 BOM なし、chcp 初期化、REST API PATCH、一時ファイル運用、シェル呼出）は `runner.ts` の実行境界の内側に隠蔽する。
+
+## 対象操作（初期セット）
+
+`issue_create`、`issue_read`、`issue_update`、`issue_comment`、`issue_close`、`pr_create`、`pr_read`、`pr_merge`、`pr_changed_files`、`pr_mergeable`。
+
+## fail-closed（決定6）
+
+設定を解釈できない（`config-uninterpretable`）、対象パス等を安全に解決できない（`path-unresolvable`）、強制処理自体が異常終了した（`enforcement-crashed`）、必須検証が完了できない（`verification-incomplete`）のいずれかの場合、対象副作用を実行せず成功扱いとしない。
+
+副作用操作（side-effect）は読み戻し照合（VERIFY）を通過した場合のみ成功を返す。読み取り操作（read-only）は応答の自己整合を確認する。
+
+## 補助能力の継続契約
+
+読み取り操作は代替手段（gh CLI 手動実行、GitHub Web UI）と継続可否（`canContinue: true`）を契約として公開する（`AGENTDEV_GH_PUBLIC_CONTRACTS`）。副作用操作は代替なし・継続不可（fail-closed）。
+
+## 実行権限の所有者
+
+本 Tool は実行機構であり、副作用の実行権限の所有者を変更しない。判断・承認は Workflow / 利用者側に残る。
+
+## 登録構造と後続実装
+
+- `index.ts` が Tool 名・公開契約・操作スペックを単一の登録単位へ接続する
+- gh CLI への具体的な写像（`GhRunner` 実装）と harness への tool 登録配線は GitHub I/O 移管の後続 Issue が本構造を再利用して実装する
+- ローカル版（consumer-generated）は同一操作契約で Case ファイル読み書きへ読み替えた `GhRunner` 実装を差し替える
+
+ツール名、ファイル構成、公開単位の詳細は Design `custom-tool-contracts.md` が所有する。
+
+## テスト実行
+
+```bash
+bun test        # cwd: src/opencode/tools/agentdev-gh
+```

--- a/src/opencode/tools/agentdev-gh/bun.lock
+++ b/src/opencode/tools/agentdev-gh/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "agentdev-gh-tool",
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
+        "typescript": "^5.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/src/opencode/tools/agentdev-gh/contracts.ts
+++ b/src/opencode/tools/agentdev-gh/contracts.ts
@@ -1,0 +1,229 @@
+// agentdev-gh Custom Tool の操作契約（種別契約 REQ、決定4・6）。
+//
+// 本ファイルは Design `docs/designs/responsibilities/custom-tool-contracts.md`
+// が所有する操作契約の構成要素（入力、出力、保証、失敗時の意味）を型と
+// 操作カタログとして公開する。ツール名・公開単位・ファイル構成の詳細は
+// 同 Design の所有事項である。
+//
+// 保証: 副作用操作は操作の結果を検証（読み戻し）してから成功を返す。
+// 検証は engine.ts が所有し、各操作の読み戻し照合は specs が定義する。
+//
+// 失敗: 設定解釈不能、パス解決不能、強制処理異常終了、必須検証未了の
+// いずれかの場合、対象副作用を実行せず成功扱いとしない（fail-closed）。
+
+
+/** Issue 番号（GitHub Issue の識別数値）。PrNumber と型上の混入を防ぐ。 */
+export type IssueNumber = number & { readonly __brand: "IssueNumber" };
+
+/** PR 番号（GitHub Pull Request の識別数値）。IssueNumber と型上の混入を防ぐ。 */
+export type PrNumber = number & { readonly __brand: "PrNumber" };
+
+/** Issue 番号の構築（境界でのみ使用）。 */
+export function issueNumber(n: number): IssueNumber {
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new RangeError(`invalid issue number: ${n}`);
+  }
+  return n as IssueNumber;
+}
+
+/** PR 番号の構築（境界でのみ使用）。 */
+export function prNumber(n: number): PrNumber {
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new RangeError(`invalid pr number: ${n}`);
+  }
+  return n as PrNumber;
+}
+
+/** 操作名（初期セット。Design「対象操作の境界（初期セット）」が所有）。 */
+export const GH_TOOL_OPERATIONS = [
+  "issue_create",
+  "issue_read",
+  "issue_update",
+  "issue_comment",
+  "issue_close",
+  "pr_create",
+  "pr_read",
+  "pr_merge",
+  "pr_changed_files",
+  "pr_mergeable",
+] as const;
+
+export type GhToolOperation = (typeof GH_TOOL_OPERATIONS)[number];
+
+/** 操作の副作用分類。side-effect 操作は VERIFY（読み戻し）を必須とする。 */
+export type OperationKind = "side-effect" | "read-only";
+
+/**
+ * 補助能力の継続契約。
+ *
+ * 能力が失敗したとき、利用者が代替手段へ継続できるかをこの契約が定義する。
+ * 副作用操作は fail-closed（canContinue: false）、読み取り操作は代替手段を
+ * 案内して継続できる（canContinue: true）。
+ */
+export interface CapabilityContingency {
+  /** 代替手段の説明。存在しない場合は空配列。 */
+  readonly fallbacks: readonly string[];
+  /** 当該能力の喪失時に処理を継続できるか。 */
+  readonly canContinue: boolean;
+}
+
+/** 操作カタログのエントリ。契約メタデータのみを保持する。 */
+export interface OperationCatalogEntry {
+  readonly operation: GhToolOperation;
+  readonly kind: OperationKind;
+  readonly contingency: CapabilityContingency;
+}
+
+const SIDE_EFFECT_CONTINGENCY: CapabilityContingency = {
+  fallbacks: [],
+  canContinue: false,
+};
+
+const READ_CONTINGENCY: CapabilityContingency = {
+  fallbacks: ["gh CLI（読み取り系）の手動実行", "GitHub Web UI での確認"],
+  canContinue: true,
+};
+
+function sideEffect(operation: GhToolOperation): OperationCatalogEntry {
+  return { operation, kind: "side-effect", contingency: SIDE_EFFECT_CONTINGENCY };
+}
+
+function readOnly(operation: GhToolOperation): OperationCatalogEntry {
+  return { operation, kind: "read-only", contingency: READ_CONTINGENCY };
+}
+
+/** 操作カタログ（Design の初期セットに対応）。 */
+export const GH_TOOL_OPERATION_CATALOG: readonly OperationCatalogEntry[] = [
+  sideEffect("issue_create"),
+  readOnly("issue_read"),
+  sideEffect("issue_update"),
+  sideEffect("issue_comment"),
+  sideEffect("issue_close"),
+  sideEffect("pr_create"),
+  readOnly("pr_read"),
+  sideEffect("pr_merge"),
+  readOnly("pr_changed_files"),
+  readOnly("pr_mergeable"),
+];
+
+/** fail-closed 4異常系と運用上の失敗種別。 */
+export type GhToolFailureKind =
+  | "config-uninterpretable"
+  | "path-unresolvable"
+  | "enforcement-crashed"
+  | "verification-incomplete"
+  | "operation-failed"
+  | "invalid-input";
+
+/** 失敗の意味。エラー種別と再試行可否を返す（Design「失敗」要素）。 */
+export interface GhToolFailure {
+  readonly kind: GhToolFailureKind;
+  readonly retryable: boolean;
+  readonly detail: string;
+  /** 当該操作の継続契約。 */
+  readonly contingency: CapabilityContingency;
+}
+
+/** 操作要求（入力）。構造化引数のみで、環境依存の引数運用規則を含まない。 */
+export type GhToolRequest =
+  | {
+      readonly operation: "issue_create";
+      readonly title: string;
+      readonly body: string;
+      readonly labels: readonly string[];
+    }
+  | { readonly operation: "issue_read"; readonly number: IssueNumber }
+  | {
+      readonly operation: "issue_update";
+      readonly number: IssueNumber;
+      readonly title?: string;
+      readonly body?: string;
+    }
+  | {
+      readonly operation: "issue_comment";
+      readonly number: IssueNumber;
+      readonly body: string;
+    }
+  | {
+      readonly operation: "issue_close";
+      readonly number: IssueNumber;
+      readonly reason?: "completed" | "not_planned";
+    }
+  | {
+      readonly operation: "pr_create";
+      readonly title: string;
+      readonly body: string;
+      readonly base: string;
+      readonly head: string;
+      readonly draft?: boolean;
+    }
+  | { readonly operation: "pr_read"; readonly number: PrNumber }
+  | {
+      readonly operation: "pr_merge";
+      readonly number: PrNumber;
+      readonly method: "merge" | "squash" | "rebase";
+    }
+  | { readonly operation: "pr_changed_files"; readonly number: PrNumber }
+  | { readonly operation: "pr_mergeable"; readonly number: PrNumber };
+
+/** 操作成功（出力）。構造化結果（番号、URL 等）のみを公開する。 */
+export type GhToolSuccess =
+  | {
+      readonly operation: "issue_create";
+      readonly number: IssueNumber;
+      readonly url: string;
+    }
+  | {
+      readonly operation: "issue_read";
+      readonly number: IssueNumber;
+      readonly title: string;
+      readonly body: string;
+      readonly state: "open" | "closed";
+    }
+  | {
+      readonly operation: "issue_update";
+      readonly number: IssueNumber;
+      readonly url: string;
+    }
+  | {
+      readonly operation: "issue_comment";
+      readonly number: IssueNumber;
+      readonly url: string;
+    }
+  | {
+      readonly operation: "issue_close";
+      readonly number: IssueNumber;
+      readonly state: "closed";
+    }
+  | {
+      readonly operation: "pr_create";
+      readonly number: PrNumber;
+      readonly url: string;
+    }
+  | {
+      readonly operation: "pr_read";
+      readonly number: PrNumber;
+      readonly title: string;
+      readonly state: "open" | "closed" | "merged";
+      readonly mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+    }
+  | {
+      readonly operation: "pr_merge";
+      readonly number: PrNumber;
+      readonly merged: true;
+    }
+  | {
+      readonly operation: "pr_changed_files";
+      readonly number: PrNumber;
+      readonly files: readonly string[];
+    }
+  | {
+      readonly operation: "pr_mergeable";
+      readonly number: PrNumber;
+      readonly mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+    };
+
+/** 操作結果（保証と失敗を型で強制する）。 */
+export type GhToolResult =
+  | { readonly ok: true; readonly success: GhToolSuccess }
+  | { readonly ok: false; readonly failure: GhToolFailure };

--- a/src/opencode/tools/agentdev-gh/engine.ts
+++ b/src/opencode/tools/agentdev-gh/engine.ts
@@ -1,0 +1,240 @@
+// agentdev-gh Custom Tool の fail-closed 実行ゲート（決定6）。
+//
+// 全操作に共通する実行制御を所有する:
+//   1. preflight  : 設定解釈（config-uninterpretable）とパス解決（path-unresolvable）。
+//                   いずれか失敗すれば対象副作用を実行しない。
+//   2. 実行       : 操作スペックの execute を呼ぶ。例外・異常終了は enforcement-crashed。
+//   3. VERIFY     : 読み戻し照合。失敗・未了は verification-incomplete とし成功扱いとしない。
+//
+// Tool は実行機構であり、副作用の実行権限の所有者を変更しない。
+// 権限の判断・承認は Workflow / 利用者側に留まり、本 Tool は操作の実行と検証のみを担う。
+
+
+import {
+  GH_TOOL_OPERATION_CATALOG,
+  type CapabilityContingency,
+  type GhToolFailure,
+  type GhToolOperation,
+  type GhToolRequest,
+  type GhToolResult,
+  type GhToolSuccess,
+  type OperationCatalogEntry,
+} from "./contracts.ts";
+import type { GhRunner, GhRunnerRequest } from "./runner.ts";
+
+// ---------------------------------------------------------------------------
+// 設定解釈（fail-closed 1: 設定を解釈できない場合は実行しない）
+// ---------------------------------------------------------------------------
+
+/** 正規化済み Tool 設定。 */
+export interface GhToolConfig {
+  /** 対象リポジトリ（owner/name 形式）。 */
+  readonly repo: string;
+  /** API base URL。省略時は GitHub 公開 API。 */
+  readonly apiBaseUrl: string | null;
+}
+
+export type ConfigResult =
+  | { readonly ok: true; readonly config: GhToolConfig }
+  | { readonly ok: false; readonly detail: string };
+
+const REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+/** 設定の解釈。不正な設定は失敗し、操作を実行しない。 */
+export function interpretGhToolConfig(raw: unknown): ConfigResult {
+  if (typeof raw !== "object" || raw === null) {
+    return { ok: false, detail: "config must be an object" };
+  }
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.repo !== "string" || !REPO_PATTERN.test(obj.repo)) {
+    return { ok: false, detail: `config.repo must be owner/name, got: ${String(obj.repo)}` };
+  }
+  let apiBaseUrl: string | null = null;
+  if (obj.apiBaseUrl !== undefined) {
+    if (typeof obj.apiBaseUrl !== "string" || !/^https:\/\//.test(obj.apiBaseUrl)) {
+      return { ok: false, detail: "config.apiBaseUrl must be an https:// URL when present" };
+    }
+    apiBaseUrl = obj.apiBaseUrl;
+  }
+  return { ok: true, config: { repo: obj.repo, apiBaseUrl } };
+}
+
+// ---------------------------------------------------------------------------
+// パス解決（fail-closed 2: 対象パスを安全に解決できない場合は実行しない）
+// ---------------------------------------------------------------------------
+
+/** Tool が使用する一時領域等の解決済みパス。 */
+export interface GhToolPaths {
+  /** 実装詳細（一時ファイル等）が使用する一時ディレクトリ。 */
+  readonly tempDir: string;
+}
+
+export type PathsResult =
+  | { readonly ok: true; readonly paths: GhToolPaths }
+  | { readonly ok: false; readonly detail: string };
+
+/** パス探査境界（OS の一時ディレクトリ解説等の注入点。テストは失敗を注入できる）。 */
+export interface PathProber {
+  tempDir(): string | null;
+}
+
+/** パス解決。解決不能は失敗し、操作を実行しない。 */
+export function resolveToolPaths(prober: PathProber): PathsResult {
+  const tempDir = prober.tempDir();
+  if (tempDir === null || tempDir.length === 0) {
+    return { ok: false, detail: "temp dir cannot be resolved safely" };
+  }
+  return { ok: true, paths: { tempDir } };
+}
+
+// ---------------------------------------------------------------------------
+// 実行環境
+// ---------------------------------------------------------------------------
+
+/** fail-closed 前提が成立した実行環境。 */
+export interface GhToolEnv {
+  readonly runner: GhRunner;
+  readonly config: GhToolConfig;
+  readonly paths: GhToolPaths;
+}
+
+export type EnvResult =
+  | { readonly ok: true; readonly env: GhToolEnv }
+  | { readonly ok: false; readonly failure: GhToolFailure };
+
+const CATALOG_BY_OPERATION: ReadonlyMap<GhToolOperation, OperationCatalogEntry> = new Map(
+  GH_TOOL_OPERATION_CATALOG.map((e) => [e.operation, e]),
+);
+
+function contingencyOf(operation: GhToolOperation): CapabilityContingency {
+  return CATALOG_BY_OPERATION.get(operation)?.contingency ?? {
+    fallbacks: [],
+    canContinue: false,
+  };
+}
+
+function fail(
+  operation: GhToolOperation,
+  kind: GhToolFailure["kind"],
+  retryable: boolean,
+  detail: string,
+): GhToolResult {
+  return {
+    ok: false,
+    failure: { kind, retryable, detail, contingency: contingencyOf(operation) },
+  };
+}
+
+/** 環境構築（preflight）。設定・パスのいずれかが解釈不能なら runner は一切呼ばれない。 */
+export function buildGhToolEnv(
+  rawConfig: unknown,
+  prober: PathProber,
+  runner: GhRunner,
+): EnvResult {
+  const config = interpretGhToolConfig(rawConfig);
+  if (!config.ok) {
+    return {
+      ok: false,
+      failure: {
+        kind: "config-uninterpretable",
+        retryable: false,
+        detail: config.detail,
+        contingency: { fallbacks: [], canContinue: false },
+      },
+    };
+  }
+  const paths = resolveToolPaths(prober);
+  if (!paths.ok) {
+    return {
+      ok: false,
+      failure: {
+        kind: "path-unresolvable",
+        retryable: false,
+        detail: paths.detail,
+        contingency: { fallbacks: [], canContinue: false },
+      },
+    };
+  }
+  return { ok: true, env: { runner, config: config.config, paths: paths.paths } };
+}
+
+// ---------------------------------------------------------------------------
+// 操作スペック（各操作の入力検証・実行・応答解釈・読み戻し照合）
+// ---------------------------------------------------------------------------
+
+/** 操作ごとの差分実装。specs-issue.ts / specs-pr.ts が10操作分を定義する。 */
+export interface OperationSpec {
+  readonly operation: GhToolOperation;
+  /** 未検証の要求（unknown）を構造化入力へ解釈する。失敗は invalid-input。 */
+  readonly validate: (raw: unknown) => GhToolRequest | null;
+  /** runner への構造化要求の組立て。 */
+  readonly buildRequest: (request: GhToolRequest) => GhRunnerRequest;
+  /** 実行応答の解釈。失敗は operation-failed。 */
+  readonly parseSuccess: (payload: unknown) => GhToolSuccess | null;
+  /**
+   * 読み戻し照合（VERIFY）。true のみ成功扱い。例外は engine が
+   * verification-incomplete へ分類する。要求（request）は照合値の参照用。
+   */
+  readonly verify: (
+    runner: GhRunner,
+    request: GhToolRequest,
+    success: GhToolSuccess,
+  ) => Promise<boolean>;
+}
+
+async function callRunner(
+  runner: GhRunner,
+  request: GhRunnerRequest,
+): Promise<{ readonly ok: true; readonly payload: unknown } | { readonly ok: false; readonly error: string }> {
+  try {
+    const reply = await runner.run(request);
+    if (reply.ok) return { ok: true, payload: reply.payload };
+    return { ok: false, error: reply.error };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/**
+ * fail-closed 実行ゲート。全操作がこの順序を通る:
+ * preflight（環境構築時）→ 入力解釈 → 実行 → 読み戻し照合 → 成功。
+ * いずれかの段階が失敗すれば成功を返さない。
+ */
+export async function executeOperation(
+  env: GhToolEnv,
+  spec: OperationSpec,
+  rawRequest: unknown,
+): Promise<GhToolResult> {
+  const request = spec.validate(rawRequest);
+  if (request === null) {
+    return fail(spec.operation, "invalid-input", true, "request does not match the operation contract");
+  }
+  const run = await callRunner(env.runner, spec.buildRequest(request));
+  if (!run.ok) {
+    return fail(spec.operation, "enforcement-crashed", true, `operation execution failed: ${run.error}`);
+  }
+  const success = spec.parseSuccess(run.payload);
+  if (success === null) {
+    return fail(spec.operation, "operation-failed", true, "operation reply does not match the success contract");
+  }
+  let verified: boolean;
+  try {
+    verified = await spec.verify(env.runner, request, success);
+  } catch (e) {
+    return fail(
+      spec.operation,
+      "verification-incomplete",
+      false,
+      `verification threw: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+  if (!verified) {
+    return fail(
+      spec.operation,
+      "verification-incomplete",
+      false,
+      "verification read-back did not confirm the operation result",
+    );
+  }
+  return { ok: true, success };
+}

--- a/src/opencode/tools/agentdev-gh/index.ts
+++ b/src/opencode/tools/agentdev-gh/index.ts
@@ -1,0 +1,107 @@
+// agentdev-gh Custom Tool の公開入口・登録構造（決定4）。
+//
+// 登録構造は操作カタログ（contracts.ts）、fail-closed 実行ゲート（engine.ts）、
+// 操作スペック（specs-issue.ts / specs-pr.ts）を単一の Tool 定義へ接続する。
+// ツール名・公開単位の詳細は Design `custom-tool-contracts.md` の所有事項である。
+//
+// gh CLI への具体的な実装（GhRunner 実装、harness への tool 登録配線）は
+// GitHub I/O 移管の後続 Issue が本構造を再利用して接続する。
+
+
+import {
+  GH_TOOL_OPERATION_CATALOG,
+  GH_TOOL_OPERATIONS,
+  type GhToolResult,
+} from "./contracts.ts";
+import type { GhToolEnv, OperationSpec } from "./engine.ts";
+import { executeOperation } from "./engine.ts";
+import { ISSUE_OPERATION_SPECS } from "./specs-issue.ts";
+import { PR_OPERATION_SPECS } from "./specs-pr.ts";
+
+/** Tool の公開名。命名は Design の所有事項（仮確定、Design確定候補参照）。 */
+export const AGENTDEV_GH_TOOL_NAME = "agentdev_gh";
+
+/** Tool の説明（利用者への公開契約の要約）。 */
+export const AGENTDEV_GH_TOOL_DESCRIPTION =
+  "Structured GitHub issue/PR operations with a verified operation contract. " +
+  "Each side-effect operation is read back and verified before success is returned.";
+
+/** 操作ごとの入力説明（JSON Schema の description 相当の公開メタデータ）。 */
+export interface OperationPublicContract {
+  readonly operation: string;
+  readonly sideEffect: boolean;
+  readonly fallbacks: readonly string[];
+  readonly canContinue: boolean;
+}
+
+/** 公開操作契約の一覧（モデル・利用者向けの契約公開。継続契約を含む）。 */
+export const AGENTDEV_GH_PUBLIC_CONTRACTS: readonly OperationPublicContract[] =
+  GH_TOOL_OPERATION_CATALOG.map((entry) => ({
+    operation: entry.operation,
+    sideEffect: entry.kind === "side-effect",
+    fallbacks: entry.contingency.fallbacks,
+    canContinue: entry.contingency.canContinue,
+  }));
+
+/** 全操作スペック（登録順はカタログ順に従う）。 */
+export const AGENTDEV_GH_OPERATION_SPECS: readonly OperationSpec[] = [
+  ...ISSUE_OPERATION_SPECS,
+  ...PR_OPERATION_SPECS,
+];
+
+const SPECS_BY_OPERATION: ReadonlyMap<string, OperationSpec> = new Map(
+  AGENTDEV_GH_OPERATION_SPECS.map((s) => [s.operation, s]),
+);
+
+/** 操作を1件実行する。戻り値の型が成功/失敗を強制する（GhToolResult）。 */
+export async function runAgentdevGhOperation(
+  env: GhToolEnv,
+  rawRequest: unknown,
+): Promise<GhToolResult> {
+  if (typeof rawRequest !== "object" || rawRequest === null) {
+    return {
+      ok: false,
+      failure: {
+        kind: "invalid-input",
+        retryable: true,
+        detail: "request must be an object with an operation field",
+        contingency: { fallbacks: [], canContinue: false },
+      },
+    };
+  }
+  const operation = (rawRequest as Record<string, unknown>).operation;
+  if (typeof operation !== "string") {
+    return {
+      ok: false,
+      failure: {
+        kind: "invalid-input",
+        retryable: true,
+        detail: `operation must be one of: ${GH_TOOL_OPERATIONS.join(", ")}`,
+        contingency: { fallbacks: [], canContinue: false },
+      },
+    };
+  }
+  const spec = SPECS_BY_OPERATION.get(operation);
+  if (spec === undefined) {
+    return {
+      ok: false,
+      failure: {
+        kind: "invalid-input",
+        retryable: true,
+        detail: `unknown operation: ${operation} (supported: ${GH_TOOL_OPERATIONS.join(", ")})`,
+        contingency: { fallbacks: [], canContinue: false },
+      },
+    };
+  }
+  return executeOperation(env, spec, rawRequest);
+}
+
+export { buildGhToolEnv, executeOperation } from "./engine.ts";
+export type {
+  GhToolConfig,
+  GhToolEnv,
+  GhToolPaths,
+  OperationSpec,
+  PathProber,
+} from "./engine.ts";
+export type { GhRunner, GhRunnerReply, GhRunnerRequest } from "./runner.ts";

--- a/src/opencode/tools/agentdev-gh/package.json
+++ b/src/opencode/tools/agentdev-gh/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "agentdev-gh-tool",
+  "version": "0.1.0",
+  "private": true,
+  "description": "agentdev-gh Custom Tool. Structured GitHub issue/PR operations with an operation contract (input, output, guarantee, failure) and a fail-closed execution gate.",
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/src/opencode/tools/agentdev-gh/runner.ts
+++ b/src/opencode/tools/agentdev-gh/runner.ts
@@ -1,0 +1,33 @@
+// agentdev-gh Custom Tool の実行境界。
+//
+// GhRunner は gh CLI（GitHub I/O）への構造化された実行境界である。文字コード制御、
+// シェル呼出、一時ファイル操作、CLI オプション運用等の実装詳細はこの境界の内側に
+// 隠蔽され、契約（contracts.ts）を利用する呼び出し側には現れない。
+// gh CLI への具体的な写像（--body-file、UTF-8 BOM なし、chcp 初期化等）は
+// 本境界の実装として GitHub I/O 移管の後続 Issue が接続する。
+//
+// ローカル版（consumer-generated）は同一の操作契約で Case ファイル
+// 読み書きへ読み替えた Local 実装をこの境界へ差し替える。Workflow は差を認識しない。
+
+
+import type { GhToolOperation } from "./contracts.ts";
+
+/** 実行要求。操作名と構造化引数のみ（コマンド文字列の組み立ては内側）。 */
+export interface GhRunnerRequest {
+  readonly operation: GhToolOperation;
+  readonly args: Readonly<Record<string, unknown>>;
+}
+
+/** 実行応答。ok=false は操作の実行失敗（exitCode は CLI 互換の終了コード）。 */
+export type GhRunnerReply =
+  | { readonly ok: true; readonly payload: unknown }
+  | { readonly ok: false; readonly error: string; readonly exitCode: number | null };
+
+/**
+ * gh CLI 実行境界。実装は構造化要求を実際の gh 呼び出しへ写像する。
+ * 呼び出しは副作用を持ち得る（side-effect 操作）。engine はこの境界の
+ * 応答を読み戻し検証（VERIFY）してから成功を返す。
+ */
+export interface GhRunner {
+  run(request: GhRunnerRequest): Promise<GhRunnerReply>;
+}

--- a/src/opencode/tools/agentdev-gh/specs-issue.ts
+++ b/src/opencode/tools/agentdev-gh/specs-issue.ts
@@ -1,0 +1,250 @@
+// Issue 系操作（5 操作）のスペック実装。
+//
+// 各スペックは操作ごとの差分（入力検証、runner 要求の組立て、応答解釈、
+// 読み戻し照合）のみを所有する。fail-closed の制御順序は engine.ts が所有する。
+// runner への要求・応答の接合形状（payload フィールド）は本ファイルと
+// runner 実装（GitHub I/O 移管の後続 Issue）間の契約である。
+
+
+import {
+  issueNumber,
+  type GhToolRequest,
+  type GhToolSuccess,
+} from "./contracts.ts";
+import type { GhRunner, GhRunnerRequest } from "./runner.ts";
+import type { OperationSpec } from "./engine.ts";
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function str(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+
+function positiveInt(v: unknown): number | null {
+  return typeof v === "number" && Number.isInteger(v) && v > 0 ? v : null;
+}
+
+function issueReadRequest(number: number): GhRunnerRequest {
+  return { operation: "issue_read", args: { number } };
+}
+
+async function readIssue(
+  runner: GhRunner,
+  number: number,
+): Promise<Record<string, unknown> | null> {
+  const reply = await runner.run(issueReadRequest(number));
+  if (!reply.ok || !isRecord(reply.payload)) return null;
+  if (positiveInt(reply.payload.number) !== number) return null;
+  return reply.payload;
+}
+
+function validateIssueBase(
+  raw: unknown,
+  requiredKeys: readonly string[],
+): Record<string, unknown> | null {
+  if (!isRecord(raw) || raw.operation === undefined) return null;
+  for (const key of requiredKeys) {
+    const value = raw[key];
+    if (typeof value !== "string" || value.length === 0) return null;
+  }
+  return raw;
+}
+
+// ---------------------------------------------------------------------------
+// issue_create
+// ---------------------------------------------------------------------------
+
+const issueCreateSpec: OperationSpec = {
+  operation: "issue_create",
+  validate(raw): GhToolRequest | null {
+    const rec = validateIssueBase(raw, ["title", "body"]);
+    if (rec === null) return null;
+    const title = str(rec.title);
+    const body = str(rec.body);
+    if (title === null || body === null) return null;
+    if (!Array.isArray(rec.labels)) return null;
+    if (!rec.labels.every((l) => typeof l === "string")) return null;
+    return {
+      operation: "issue_create",
+      title,
+      body,
+      labels: rec.labels,
+    };
+  },
+  buildRequest(request): GhRunnerRequest {
+    const r = request as Extract<GhToolRequest, { operation: "issue_create" }>;
+    return { operation: "issue_create", args: { title: r.title, body: r.body, labels: r.labels } };
+  },
+  parseSuccess(payload): GhToolSuccess | null {
+    if (!isRecord(payload)) return null;
+    const number = positiveInt(payload.number);
+    const url = str(payload.url);
+    if (number === null || url === null || !/^https:\/\//.test(url)) return null;
+    return { operation: "issue_create", number: issueNumber(number), url };
+  },
+  async verify(runner, request, success) {
+    const req = request as Extract<GhToolRequest, { operation: "issue_create" }>;
+    const created = success as Extract<GhToolSuccess, { operation: "issue_create" }>;
+    const issue = await readIssue(runner, created.number);
+    if (issue === null) return false;
+    return str(issue.state) === "open" && str(issue.title) === req.title;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// issue_read
+// ---------------------------------------------------------------------------
+
+function parseIssueRead(payload: unknown, number: number): GhToolSuccess | null {
+  if (!isRecord(payload)) return null;
+  const title = str(payload.title);
+  const body = str(payload.body);
+  const state = str(payload.state);
+  if (title === null || body === null) return null;
+  if (state !== "open" && state !== "closed") return null;
+  if (positiveInt(payload.number) !== number) return null;
+  return { operation: "issue_read", number: issueNumber(number), title, body, state };
+}
+
+const issueReadSpec: OperationSpec = {
+  operation: "issue_read",
+  validate(raw): GhToolRequest | null {
+    if (!isRecord(raw)) return null;
+    const number = positiveInt(raw.number);
+    if (number === null) return null;
+    return { operation: "issue_read", number: issueNumber(number) };
+  },
+  buildRequest(request): GhRunnerRequest {
+    const r = request as Extract<GhToolRequest, { operation: "issue_read" }>;
+    return issueReadRequest(r.number);
+  },
+  parseSuccess(payload): GhToolSuccess | null {
+    if (!isRecord(payload)) return null;
+    const number = positiveInt(payload.number);
+    if (number === null) return null;
+    return parseIssueRead(payload, number);
+  },
+  async verify(runner, _request, success) {
+    const read = success as Extract<GhToolSuccess, { operation: "issue_read" }>;
+    const issue = await readIssue(runner, read.number);
+    return issue !== null && str(issue.title) === read.title && str(issue.state) === read.state;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// issue_update
+// ---------------------------------------------------------------------------
+
+const issueUpdateSpec: OperationSpec = {
+  operation: "issue_update",
+  validate(raw): GhToolRequest | null {
+    if (!isRecord(raw)) return null;
+    const number = positiveInt(raw.number);
+    if (number === null) return null;
+    const title = str(raw.title);
+    const body = str(raw.body);
+    if (title === "" || body === "") return null;
+    const request: GhToolRequest = { operation: "issue_update", number: issueNumber(number) };
+    if (title === null) {
+      if (body === null) return null;
+      return { ...request, body };
+    }
+    if (body === null) return { ...request, title };
+    return { ...request, title, body };
+  },
+  buildRequest(request): GhRunnerRequest {
+    const r = request as Extract<GhToolRequest, { operation: "issue_update" }>;
+    return { operation: "issue_update", args: { number: r.number, title: r.title, body: r.body } };
+  },
+  parseSuccess(payload): GhToolSuccess | null {
+    if (!isRecord(payload)) return null;
+    const number = positiveInt(payload.number);
+    const url = str(payload.url);
+    if (number === null || url === null || !/^https:\/\//.test(url)) return null;
+    return { operation: "issue_update", number: issueNumber(number), url };
+  },
+  async verify(runner, request, _success) {
+    const req = request as Extract<GhToolRequest, { operation: "issue_update" }>;
+    const issue = await readIssue(runner, req.number);
+    if (issue === null) return false;
+    if (req.title !== undefined && str(issue.title) !== req.title) return false;
+    if (req.body !== undefined && str(issue.body) !== req.body) return false;
+    return true;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// issue_comment
+// ---------------------------------------------------------------------------
+
+const issueCommentSpec: OperationSpec = {
+  operation: "issue_comment",
+  validate(raw): GhToolRequest | null {
+    const rec = validateIssueBase(raw, ["body"]);
+    if (rec === null) return null;
+    const body = str(rec.body);
+    const number = positiveInt(rec.number);
+    if (body === null || number === null) return null;
+    return { operation: "issue_comment", number: issueNumber(number), body };
+  },
+  buildRequest(request): GhRunnerRequest {
+    const r = request as Extract<GhToolRequest, { operation: "issue_comment" }>;
+    return { operation: "issue_comment", args: { number: r.number, body: r.body } };
+  },
+  parseSuccess(payload): GhToolSuccess | null {
+    if (!isRecord(payload)) return null;
+    const number = positiveInt(payload.number);
+    const url = str(payload.url);
+    if (number === null || url === null || !/^https:\/\//.test(url)) return null;
+    return { operation: "issue_comment", number: issueNumber(number), url };
+  },
+  async verify(runner, _request, success) {
+    const commented = success as Extract<GhToolSuccess, { operation: "issue_comment" }>;
+    const issue = await readIssue(runner, commented.number);
+    return issue !== null && str(issue.state) === "open";
+  },
+};
+
+// ---------------------------------------------------------------------------
+// issue_close
+// ---------------------------------------------------------------------------
+
+const issueCloseSpec: OperationSpec = {
+  operation: "issue_close",
+  validate(raw): GhToolRequest | null {
+    if (!isRecord(raw)) return null;
+    const number = positiveInt(raw.number);
+    if (number === null) return null;
+    const reason = str(raw.reason);
+    if (reason === null) return { operation: "issue_close", number: issueNumber(number) };
+    if (reason !== "completed" && reason !== "not_planned") return null;
+    return { operation: "issue_close", number: issueNumber(number), reason };
+  },
+  buildRequest(request): GhRunnerRequest {
+    const r = request as Extract<GhToolRequest, { operation: "issue_close" }>;
+    return { operation: "issue_close", args: { number: r.number, reason: r.reason } };
+  },
+  parseSuccess(payload): GhToolSuccess | null {
+    if (!isRecord(payload)) return null;
+    const number = positiveInt(payload.number);
+    if (number === null) return null;
+    if (str(payload.state) !== "closed") return null;
+    return { operation: "issue_close", number: issueNumber(number), state: "closed" };
+  },
+  async verify(runner, success) {
+    const closed = success as Extract<GhToolSuccess, { operation: "issue_close" }>;
+    const issue = await readIssue(runner, closed.number);
+    return issue !== null && str(issue.state) === "closed";
+  },
+};
+
+/** Issue 系操作のスペック一覧。 */
+export const ISSUE_OPERATION_SPECS: readonly OperationSpec[] = [
+  issueCreateSpec,
+  issueReadSpec,
+  issueUpdateSpec,
+  issueCommentSpec,
+  issueCloseSpec,
+];

--- a/src/opencode/tools/agentdev-gh/specs-pr.ts
+++ b/src/opencode/tools/agentdev-gh/specs-pr.ts
@@ -1,0 +1,225 @@
+// PR 系操作（5 操作）のスペック実装。
+//
+// 各スペックは操作ごとの差分（入力検証、runner 要求の組立て、応答解釈、
+// 読み戻し照合）のみを所有する。fail-closed の制御順序は engine.ts が所有する。
+
+
+import {
+  prNumber,
+  type GhToolRequest,
+  type GhToolSuccess,
+} from "./contracts.ts";
+import type { GhRunner, GhRunnerRequest } from "./runner.ts";
+import type { OperationSpec } from "./engine.ts";
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function str(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+
+function positiveInt(v: unknown): number | null {
+  return typeof v === "number" && Number.isInteger(v) && v > 0 ? v : null;
+}
+
+function parseMergeable(v: unknown): "MERGEABLE" | "CONFLICTING" | "UNKNOWN" | null {
+  if (v === "MERGEABLE" || v === "CONFLICTING" || v === "UNKNOWN") return v;
+  return null;
+}
+
+function prReadRequest(number: number): GhRunnerRequest {
+  return { operation: "pr_read", args: { number } };
+}
+
+async function readPr(
+  runner: GhRunner,
+  number: number,
+): Promise<Record<string, unknown> | null> {
+  const reply = await runner.run(prReadRequest(number));
+  if (!reply.ok || !isRecord(reply.payload)) return null;
+  if (positiveInt(reply.payload.number) !== number) return null;
+  return reply.payload;
+}
+
+function parsePrState(v: unknown): "open" | "closed" | "merged" | null {
+  if (v === "open" || v === "closed" || v === "merged") return v;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// pr_create
+// ---------------------------------------------------------------------------
+
+const prCreateSpec: OperationSpec = {
+  operation: "pr_create",
+  validate(raw): GhToolRequest | null {
+    if (!isRecord(raw)) return null;
+    const title = str(raw.title);
+    const body = str(raw.body);
+    const base = str(raw.base);
+    const head = str(raw.head);
+    if (title === null || body === null || base === null || head === null) return null;
+    if (title.length === 0 || base.length === 0 || head.length === 0) return null;
+    const request: GhToolRequest = { operation: "pr_create", title, body, base, head };
+    if (raw.draft !== undefined && typeof raw.draft !== "boolean") return null;
+    if (raw.draft === true) return { ...request, draft: true };
+    return request;
+  },
+  buildRequest(request): GhRunnerRequest {
+    const r = request as Extract<GhToolRequest, { operation: "pr_create" }>;
+    return {
+      operation: "pr_create",
+      args: { title: r.title, body: r.body, base: r.base, head: r.head, draft: r.draft },
+    };
+  },
+  parseSuccess(payload): GhToolSuccess | null {
+    if (!isRecord(payload)) return null;
+    const number = positiveInt(payload.number);
+    const url = str(payload.url);
+    if (number === null || url === null || !/^https:\/\//.test(url)) return null;
+    return { operation: "pr_create", number: prNumber(number), url };
+  },
+  async verify(runner, request, success) {
+    const req = request as Extract<GhToolRequest, { operation: "pr_create" }>;
+    const created = success as Extract<GhToolSuccess, { operation: "pr_create" }>;
+    const pr = await readPr(runner, created.number);
+    if (pr === null) return false;
+    return str(pr.title) === req.title && str(pr.state) === "open";
+  },
+};
+
+// ---------------------------------------------------------------------------
+// pr_read
+// ---------------------------------------------------------------------------
+
+const prReadSpec: OperationSpec = {
+  operation: "pr_read",
+  validate(raw): GhToolRequest | null {
+    if (!isRecord(raw)) return null;
+    const number = positiveInt(raw.number);
+    if (number === null) return null;
+    return { operation: "pr_read", number: prNumber(number) };
+  },
+  buildRequest(request): GhRunnerRequest {
+    const r = request as Extract<GhToolRequest, { operation: "pr_read" }>;
+    return prReadRequest(r.number);
+  },
+  parseSuccess(payload): GhToolSuccess | null {
+    if (!isRecord(payload)) return null;
+    const number = positiveInt(payload.number);
+    const title = str(payload.title);
+    const state = parsePrState(payload.state);
+    const mergeable = parseMergeable(payload.mergeable);
+    if (number === null || title === null || state === null || mergeable === null) return null;
+    return { operation: "pr_read", number: prNumber(number), title, state, mergeable };
+  },
+  async verify(runner, _request, success) {
+    const read = success as Extract<GhToolSuccess, { operation: "pr_read" }>;
+    const pr = await readPr(runner, read.number);
+    return pr !== null && str(pr.title) === read.title && parsePrState(pr.state) === read.state;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// pr_merge
+// ---------------------------------------------------------------------------
+
+const prMergeSpec: OperationSpec = {
+  operation: "pr_merge",
+  validate(raw): GhToolRequest | null {
+    if (!isRecord(raw)) return null;
+    const number = positiveInt(raw.number);
+    if (number === null) return null;
+    const method = str(raw.method);
+    if (method !== "merge" && method !== "squash" && method !== "rebase") return null;
+    return { operation: "pr_merge", number: prNumber(number), method };
+  },
+  buildRequest(request): GhRunnerRequest {
+    const r = request as Extract<GhToolRequest, { operation: "pr_merge" }>;
+    return { operation: "pr_merge", args: { number: r.number, method: r.method } };
+  },
+  parseSuccess(payload): GhToolSuccess | null {
+    if (!isRecord(payload)) return null;
+    const number = positiveInt(payload.number);
+    if (number === null) return null;
+    if (payload.merged !== true) return null;
+    return { operation: "pr_merge", number: prNumber(number), merged: true };
+  },
+  async verify(runner, _request, success) {
+    const merged = success as Extract<GhToolSuccess, { operation: "pr_merge" }>;
+    const pr = await readPr(runner, merged.number);
+    return pr !== null && parsePrState(pr.state) === "merged";
+  },
+};
+
+// ---------------------------------------------------------------------------
+// pr_changed_files
+// ---------------------------------------------------------------------------
+
+const prChangedFilesSpec: OperationSpec = {
+  operation: "pr_changed_files",
+  validate(raw): GhToolRequest | null {
+    if (!isRecord(raw)) return null;
+    const number = positiveInt(raw.number);
+    if (number === null) return null;
+    return { operation: "pr_changed_files", number: prNumber(number) };
+  },
+  buildRequest(request): GhRunnerRequest {
+    const r = request as Extract<GhToolRequest, { operation: "pr_changed_files" }>;
+    return { operation: "pr_changed_files", args: { number: r.number } };
+  },
+  parseSuccess(payload): GhToolSuccess | null {
+    if (!isRecord(payload)) return null;
+    const number = positiveInt(payload.number);
+    if (number === null) return null;
+    if (!Array.isArray(payload.files)) return null;
+    if (!payload.files.every((f) => typeof f === "string" && f.length > 0)) return null;
+    return { operation: "pr_changed_files", number: prNumber(number), files: payload.files };
+  },
+  async verify(runner, success) {
+    const changed = success as Extract<GhToolSuccess, { operation: "pr_changed_files" }>;
+    const pr = await readPr(runner, changed.number);
+    return pr !== null;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// pr_mergeable
+// ---------------------------------------------------------------------------
+
+const prMergeableSpec: OperationSpec = {
+  operation: "pr_mergeable",
+  validate(raw): GhToolRequest | null {
+    if (!isRecord(raw)) return null;
+    const number = positiveInt(raw.number);
+    if (number === null) return null;
+    return { operation: "pr_mergeable", number: prNumber(number) };
+  },
+  buildRequest(request): GhRunnerRequest {
+    const r = request as Extract<GhToolRequest, { operation: "pr_mergeable" }>;
+    return { operation: "pr_mergeable", args: { number: r.number } };
+  },
+  parseSuccess(payload): GhToolSuccess | null {
+    if (!isRecord(payload)) return null;
+    const number = positiveInt(payload.number);
+    const mergeable = parseMergeable(payload.mergeable);
+    if (number === null || mergeable === null) return null;
+    return { operation: "pr_mergeable", number: prNumber(number), mergeable };
+  },
+  async verify(runner, success) {
+    const result = success as Extract<GhToolSuccess, { operation: "pr_mergeable" }>;
+    const pr = await readPr(runner, result.number);
+    return pr !== null && parseMergeable(pr.mergeable) === result.mergeable;
+  },
+};
+
+/** PR 系操作のスペック一覧。 */
+export const PR_OPERATION_SPECS: readonly OperationSpec[] = [
+  prCreateSpec,
+  prReadSpec,
+  prMergeSpec,
+  prChangedFilesSpec,
+  prMergeableSpec,
+];

--- a/src/opencode/tools/agentdev-gh/tests/contracts.test.ts
+++ b/src/opencode/tools/agentdev-gh/tests/contracts.test.ts
@@ -1,0 +1,104 @@
+// 操作契約の契約テスト。
+//
+// Design custom-tool-contracts.md が所有する対象操作の初期セットと、
+// 操作カタログの契約整合（副作用分類、継続契約）を固定する。
+
+
+import { describe, expect, test } from "bun:test";
+import {
+  GH_TOOL_OPERATIONS,
+  GH_TOOL_OPERATION_CATALOG,
+  issueNumber,
+  prNumber,
+} from "../contracts.ts";
+import {
+  AGENTDEV_GH_OPERATION_SPECS,
+  AGENTDEV_GH_PUBLIC_CONTRACTS,
+  AGENTDEV_GH_TOOL_DESCRIPTION,
+  AGENTDEV_GH_TOOL_NAME,
+} from "../index.ts";
+
+describe("操作カタログ（Design 初期セットとの一致）", () => {
+  test("初期セットの10操作を公開する", () => {
+    expect([...GH_TOOL_OPERATIONS]).toEqual([
+      "issue_create",
+      "issue_read",
+      "issue_update",
+      "issue_comment",
+      "issue_close",
+      "pr_create",
+      "pr_read",
+      "pr_merge",
+      "pr_changed_files",
+      "pr_mergeable",
+    ]);
+  });
+
+  test("カタログは全操作を重複なく網羅する", () => {
+    const catalogOps = GH_TOOL_OPERATION_CATALOG.map((e) => e.operation);
+    expect(new Set(catalogOps).size).toBe(GH_TOOL_OPERATIONS.length);
+    expect(catalogOps.sort()).toEqual([...GH_TOOL_OPERATIONS].sort());
+  });
+});
+
+describe("補助能力の継続契約", () => {
+  test("副作用操作は代替なし・継続不可（fail-closed）", () => {
+    for (const entry of GH_TOOL_OPERATION_CATALOG) {
+      if (entry.kind !== "side-effect") continue;
+      expect(entry.contingency.canContinue).toBe(false);
+      expect(entry.contingency.fallbacks).toEqual([]);
+    }
+  });
+
+  test("読み取り操作は代替手段を持ち継続可能", () => {
+    const readOnly = GH_TOOL_OPERATION_CATALOG.filter((e) => e.kind === "read-only");
+    expect(readOnly.length).toBeGreaterThan(0);
+    for (const entry of readOnly) {
+      expect(entry.contingency.canContinue).toBe(true);
+      expect(entry.contingency.fallbacks.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("公開契約（AGENTDEV_GH_PUBLIC_CONTRACTS）はカタログと一致する", () => {
+    expect(AGENTDEV_GH_PUBLIC_CONTRACTS.length).toBe(GH_TOOL_OPERATION_CATALOG.length);
+    for (const pub of AGENTDEV_GH_PUBLIC_CONTRACTS) {
+      const entry = GH_TOOL_OPERATION_CATALOG.find((e) => e.operation === pub.operation);
+      if (entry === undefined) {
+        throw new Error(`catalog entry missing for operation: ${pub.operation}`);
+      }
+      expect(pub.sideEffect).toBe(entry.kind === "side-effect");
+      expect(pub.canContinue).toBe(entry.contingency.canContinue);
+      expect(pub.fallbacks).toEqual(entry.contingency.fallbacks);
+    }
+  });
+});
+
+describe("登録構造", () => {
+  test("全操作にスペックが定義されている", () => {
+    expect(AGENTDEV_GH_OPERATION_SPECS.length).toBe(GH_TOOL_OPERATIONS.length);
+    const specOps = AGENTDEV_GH_OPERATION_SPECS.map((s) => s.operation);
+    expect(new Set(specOps).size).toBe(GH_TOOL_OPERATIONS.length);
+  });
+
+  test("Tool 名と説明が非空で公開されている", () => {
+    expect(AGENTDEV_GH_TOOL_NAME).toBe("agentdev_gh");
+    expect(AGENTDEV_GH_TOOL_DESCRIPTION.length).toBeGreaterThan(0);
+  });
+});
+
+describe("識別番号のブランド型", () => {
+  test("issueNumber は正整数のみ受け付ける", () => {
+    const one: number = issueNumber(1);
+    expect(one).toBe(1);
+    expect(() => issueNumber(0)).toThrow();
+    expect(() => issueNumber(-3)).toThrow();
+    expect(() => issueNumber(1.5)).toThrow();
+  });
+
+  test("prNumber は正整数のみ受け付ける", () => {
+    const seven: number = prNumber(7);
+    expect(seven).toBe(7);
+    expect(() => prNumber(0)).toThrow();
+    expect(() => prNumber(-1)).toThrow();
+  });
+});

--- a/src/opencode/tools/agentdev-gh/tests/engine-fail-closed.test.ts
+++ b/src/opencode/tools/agentdev-gh/tests/engine-fail-closed.test.ts
@@ -1,0 +1,284 @@
+// fail-closed 実行ゲートの異常系テスト（TS 相当: 強制機能の fail-closed）。
+//
+// 設定解釈不能・パス解決不能・強制処理異常終了・必須検証未了の4異常系を
+// 意図的に発生させ、対象副作用が実行されず（または完了せず）、成功扱いに
+// ならないことを検証する。FakeRunner は応答を返した時点を副作用の完了と
+// みなす（throw は副作用完了なし）。
+
+
+import { describe, expect, test } from "bun:test";
+import type { GhToolFailure, GhToolRequest } from "../contracts.ts";
+import {
+  buildGhToolEnv,
+  type PathProber,
+} from "../engine.ts";
+import { runAgentdevGhOperation } from "../index.ts";
+import type { GhRunner, GhRunnerReply, GhRunnerRequest } from "../runner.ts";
+
+const VALID_CONFIG = { repo: "owner/repo" };
+
+const okProber: PathProber = { tempDir: () => "/tmp" };
+const brokenProber: PathProber = { tempDir: () => null };
+
+class FakeRunner implements GhRunner {
+  readonly requests: GhRunnerRequest[] = [];
+  readonly completed: GhRunnerRequest[] = [];
+  private readonly handler: (request: GhRunnerRequest) => Promise<GhRunnerReply>;
+
+  constructor(handler: (request: GhRunnerRequest) => Promise<GhRunnerReply>) {
+    this.handler = handler;
+  }
+
+  async run(request: GhRunnerRequest): Promise<GhRunnerReply> {
+    this.requests.push(request);
+    const reply = await this.handler(request);
+    if (reply.ok) this.completed.push(request);
+    return reply;
+  }
+}
+
+function assertFailureKind(
+  failure: GhToolFailure | undefined,
+  kind: GhToolFailure["kind"],
+): void {
+  expect(failure).toBeDefined();
+  expect(failure?.kind).toBe(kind);
+}
+
+describe("異常系1: 設定を解釈できない（config-uninterpretable）", () => {
+  test.each([
+    ["非オブジェクト", "not-an-object"],
+    ["repo 形式不正", { repo: "invalid" }],
+    ["repo 欠落", {}],
+    ["apiBaseUrl 形式不正", { repo: "owner/repo", apiBaseUrl: "http://insecure" }],
+  ])("環境構築に失敗し、runner は一度も呼ばれない（%s）", async (_label, rawConfig) => {
+    const runner = new FakeRunner(async () => ({ ok: true, payload: {} }));
+    const env = buildGhToolEnv(rawConfig, okProber, runner);
+    expect(env.ok).toBe(false);
+    if (!env.ok) assertFailureKind(env.failure, "config-uninterpretable");
+    expect(runner.requests).toEqual([]);
+  });
+
+  test("副作用操作を実行しても成功扱いにならない（実行前に失敗）", async () => {
+    const runner = new FakeRunner(async () => ({ ok: true, payload: {} }));
+    const env = buildGhToolEnv({ repo: 123 }, okProber, runner);
+    expect(env.ok).toBe(false);
+    expect(runner.requests.length).toBe(0);
+  });
+});
+
+describe("異常系2: 対象パスを安全に解決できない（path-unresolvable）", () => {
+  test("環境構築に失敗し、runner は一度も呼ばれない", () => {
+    const runner = new FakeRunner(async () => ({ ok: true, payload: {} }));
+    const env = buildGhToolEnv(VALID_CONFIG, brokenProber, runner);
+    expect(env.ok).toBe(false);
+    if (!env.ok) assertFailureKind(env.failure, "path-unresolvable");
+    expect(runner.requests).toEqual([]);
+  });
+
+  test("空文字列の一時ディレクトリも解決不能扱い", () => {
+    const runner = new FakeRunner(async () => ({ ok: true, payload: {} }));
+    const env = buildGhToolEnv(VALID_CONFIG, { tempDir: () => "" }, runner);
+    expect(env.ok).toBe(false);
+    expect(runner.requests).toEqual([]);
+  });
+});
+
+describe("異常系3: 強制処理自体が異常終了した（enforcement-crashed）", () => {
+  test("runner が例外を投げた場合、成功を返さない", async () => {
+    const runner = new FakeRunner(async () => {
+      throw new Error("gh crashed");
+    });
+    const env = buildGhToolEnv(VALID_CONFIG, okProber, runner);
+    expect(env.ok).toBe(true);
+    if (!env.ok) return;
+    const result = await runAgentdevGhOperation(env.env, {
+      operation: "issue_comment",
+      number: 5,
+      body: "text",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) assertFailureKind(result.failure, "enforcement-crashed");
+    expect(runner.completed.length).toBe(0);
+  });
+
+  test("runner が実行失敗応答を返した場合、成功を返さない", async () => {
+    const runner = new FakeRunner(async () => ({
+      ok: false,
+      error: "gh: command failed",
+      exitCode: 1,
+    }));
+    const env = buildGhToolEnv(VALID_CONFIG, okProber, runner);
+    expect(env.ok).toBe(true);
+    if (!env.ok) return;
+    const result = await runAgentdevGhOperation(env.env, {
+      operation: "issue_close",
+      number: 5,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) assertFailureKind(result.failure, "enforcement-crashed");
+    expect(runner.completed.length).toBe(0);
+  });
+});
+
+describe("異常系4: 必須検証が完了できない（verification-incomplete）", () => {
+  function createRequest(): GhToolRequest {
+    return { operation: "issue_create", title: "T", body: "B", labels: [] };
+  }
+
+  test("読み戻し（VERIFY）が不一致の場合、成功を返さない", async () => {
+    const runner = new FakeRunner(async (request) => {
+      if (request.operation === "issue_create") {
+        return { ok: true, payload: { number: 42, url: "https://example/i/42" } };
+      }
+      // 読み戻し: title 不一致
+      return {
+        ok: true,
+        payload: { number: 42, title: "different", body: "B", state: "open" },
+      };
+    });
+    const env = buildGhToolEnv(VALID_CONFIG, okProber, runner);
+    expect(env.ok).toBe(true);
+    if (!env.ok) return;
+    const result = await runAgentdevGhOperation(env.env, createRequest());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      assertFailureKind(result.failure, "verification-incomplete");
+      expect(result.failure.retryable).toBe(false);
+    }
+  });
+
+  test("読み戻しが見つからない場合、成功を返さない", async () => {
+    const runner = new FakeRunner(async (request) => {
+      if (request.operation === "issue_create") {
+        return { ok: true, payload: { number: 42, url: "https://example/i/42" } };
+      }
+      return { ok: false, error: "not found", exitCode: 1 };
+    });
+    const env = buildGhToolEnv(VALID_CONFIG, okProber, runner);
+    expect(env.ok).toBe(true);
+    if (!env.ok) return;
+    const result = await runAgentdevGhOperation(env.env, createRequest());
+    expect(result.ok).toBe(false);
+    if (!result.ok) assertFailureKind(result.failure, "verification-incomplete");
+  });
+
+  test("読み戻し中に runner が例外を投げた場合も verification-incomplete", async () => {
+    const runner = new FakeRunner(async (request) => {
+      if (request.operation === "issue_create") {
+        return { ok: true, payload: { number: 42, url: "https://example/i/42" } };
+      }
+      throw new Error("read-back crashed");
+    });
+    const env = buildGhToolEnv(VALID_CONFIG, okProber, runner);
+    expect(env.ok).toBe(true);
+    if (!env.ok) return;
+    const result = await runAgentdevGhOperation(env.env, createRequest());
+    expect(result.ok).toBe(false);
+    if (!result.ok) assertFailureKind(result.failure, "verification-incomplete");
+  });
+});
+
+describe("入力解釈と実行の正常系", () => {
+  test("入力が操作契約に合致しない場合は invalid-input", async () => {
+    const runner = new FakeRunner(async () => ({ ok: true, payload: {} }));
+    const env = buildGhToolEnv(VALID_CONFIG, okProber, runner);
+    expect(env.ok).toBe(true);
+    if (!env.ok) return;
+    const result = await runAgentdevGhOperation(env.env, {
+      operation: "issue_create",
+      title: "",
+      body: "B",
+      labels: [],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) assertFailureKind(result.failure, "invalid-input");
+    expect(runner.requests.length).toBe(0);
+  });
+
+  test("未知の操作名は invalid-input", async () => {
+    const runner = new FakeRunner(async () => ({ ok: true, payload: {} }));
+    const env = buildGhToolEnv(VALID_CONFIG, okProber, runner);
+    expect(env.ok).toBe(true);
+    if (!env.ok) return;
+    const result = await runAgentdevGhOperation(env.env, { operation: "repo_delete" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) assertFailureKind(result.failure, "invalid-input");
+  });
+
+  test("VERIFY 通過時のみ成功を返す（issue_create）", async () => {
+    const runner = new FakeRunner(async (request) => {
+      if (request.operation === "issue_create") {
+        return { ok: true, payload: { number: 42, url: "https://example/i/42" } };
+      }
+      return {
+        ok: true,
+        payload: { number: 42, title: "T", body: "B", state: "open" },
+      };
+    });
+    const env = buildGhToolEnv(VALID_CONFIG, okProber, runner);
+    expect(env.ok).toBe(true);
+    if (!env.ok) return;
+    const result = await runAgentdevGhOperation(env.env, {
+      operation: "issue_create",
+      title: "T",
+      body: "B",
+      labels: [],
+    });
+    expect(result.ok).toBe(true);
+    expect(runner.requests.length).toBe(2);
+    expect(runner.requests[0]?.operation).toBe("issue_create");
+    expect(runner.requests[1]?.operation).toBe("issue_read");
+  });
+
+  test("title と body の両方を指定した issue_update は両方を検証に使う", async () => {
+    const runner = new FakeRunner(async (request) => {
+      if (request.operation === "issue_update") {
+        return { ok: true, payload: { number: 7, url: "https://example/i/7" } };
+      }
+      // 読み戻し: title のみ反映済み、body は旧のまま（body が検証対象なら失敗する）
+      return {
+        ok: true,
+        payload: { number: 7, title: "new-title", body: "old-body", state: "open" },
+      };
+    });
+    const env = buildGhToolEnv(VALID_CONFIG, okProber, runner);
+    expect(env.ok).toBe(true);
+    if (!env.ok) return;
+    const result = await runAgentdevGhOperation(env.env, {
+      operation: "issue_update",
+      number: 7,
+      title: "new-title",
+      body: "new-body",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) assertFailureKind(result.failure, "verification-incomplete");
+    expect(runner.requests[0]?.args).toEqual({
+      number: 7,
+      title: "new-title",
+      body: "new-body",
+    });
+  });
+
+  test("title と body の両方を反映した issue_update は成功する", async () => {
+    const runner = new FakeRunner(async (request) => {
+      if (request.operation === "issue_update") {
+        return { ok: true, payload: { number: 7, url: "https://example/i/7" } };
+      }
+      return {
+        ok: true,
+        payload: { number: 7, title: "new-title", body: "new-body", state: "open" },
+      };
+    });
+    const env = buildGhToolEnv(VALID_CONFIG, okProber, runner);
+    expect(env.ok).toBe(true);
+    if (!env.ok) return;
+    const result = await runAgentdevGhOperation(env.env, {
+      operation: "issue_update",
+      number: 7,
+      title: "new-title",
+      body: "new-body",
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/opencode/tools/agentdev-gh/tsconfig.json
+++ b/src/opencode/tools/agentdev-gh/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["bun"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts", "./tests/*.ts"]
+}


### PR DESCRIPTION
# 概要

OU-003（Wave 2、depends_on: OU-001）。REQ-052-001〜010 の実装。Custom Tool（`src/opencode/tools/agentdev-gh/`）と Plugin / Hook（`src/opencode/plugins/agentdev-gh-write-guard/`）を配布種別として実装し、操作契約（入力・出力・保証・失敗時の意味）、副作用操作の VERIFY 読み戻し、強制機能の fail-closed（4異常系）、生 gh WRITE 迂回の検出・拒否、ADF 汎用と repo-local の配布境界、install・link・archive の実行時投影を確立した。

**前委譲中断の経緯**: 本 Issue の先行委譲（DEL-2430-1/2）はいずれも result を返さず中断した。本 PR は durable state（worktree の未コミット変更: `scripts/install.ps1` の変更と `src/opencode/tools/`・`src/opencode/plugins/` のスケルトン一式）を唯一の情報源として DEL-2430-3 により再開したものである。スケルトンを契約に照らして評価し、欠陥修正・境界適合化・不足投影の追加を行った後、全検証を実施した。既存変更は破棄せず、以下を修正した:

- `specs-issue.ts` issue_update で title と body を両方指定した場合に body が runner 要求と VERIFY の双方から落ちる欠陥（回帰テスト追加済み）
- 配布物に producer 内部 ID（REQ-052・OU-004 等）が残存し distribution boundary gate が不合格になる状態（token 全除去で gate 合格化。宣言は配布境界上 Design が所有、Design確定候補へ起票）
- self-sync.ps1（自己ホスト投影）・配布 manifest・archive packager・archive installer に tools/plugins 投影が未反映だった点

## 実行識別情報

- adf_case: #2427
- adf_pr: #2434
- adf_execution_unit: standard:#2430
- adf_delegation: DEL-2430-3（先行委譲中断後、durable state からの再開・完了）
- adf_result: completed-pr
- adf_harness_ref: N/A

## 実装内容

**Custom Tool `agentdev-gh`（REQ-052-001, 003, 005, 009）**

- `contracts.ts`: 操作契約の型（GhToolRequest / GhToolSuccess / GhToolResult、ブランド型 IssueNumber / PrNumber）、Design「対象操作の境界（初期セット）」の10操作カタログ、補助能力の継続契約（CapabilityContingency: 副作用は代替なし・継続不可、読み取りは代替手段と canContinue を公開）
- `engine.ts`: fail-closed 実行ゲート。preflight（設定解釈 `config-uninterpretable`・パス解決 `path-unresolvable` で副作用実行前に拒否）→ 実行（例外・失敗応答は `enforcement-crashed`）→ VERIFY 読み戻し照合（不一致・未了は `verification-incomplete` で成功扱いにしない）
- `specs-issue.ts` / `specs-pr.ts`: 10操作分の入力検証・runner 要求組立・応答解釈・読み戻し照合。実装詳細（gh オプション、--body-file、文字コード、一時ファイル、シェル呼出）は `runner.ts` の実行境界の内側に隠蔽
- `index.ts`: 登録構造（単一 Tool 定義へ接続）。gh CLI への具体写像と harness 登録配線は後続の GitHub I/O 移行 Issue（OU-004）が再利用する

**Plugin / Hook `agentdev-gh-write-guard`（REQ-052-002, 004, 009）**

- `tool.execute.before` フックでコマンド実行系ツール（既定: bash）のコマンド文字列を検査し、Custom Tool の正規経路を迂回する生 gh WRITE（issue create/edit/close、pr create/merge/review、gh api の POST/PATCH/PUT/DELETE、label/release/repo/workflow/gist/milestone/project 系 WRITE）を実行前に拒否。読み取り系（view/list/diff 等、gh api GET）は Design「迂回防止」の許容範囲どおり素通り
- fail-closed: 設定解釈不能（既定検査対象を安全性確認不能として block）、検出器異常終了（block へ変換）、コマンド引数検証不能（block）。パス解決系は Tool 側テストが担保（コマンド文字列検査はパス解決に依存しない）

**配布境界と投影（REQ-052-006, 007, 008）**

- 汎用配布種別: `src/opencode/tools/agentdev-*/`・`src/opencode/plugins/agentdev-*/`。repo-local 固有（自己開発固有の整合性検査・ADF 原本/投影構造依存の検査）は従来どおり `.opencode/skills/repo-agentdev-integrity/` 等に留まり、manifest 対象外
- `scripts/install.ps1`（先行委譲由来を保持）・`scripts/self-sync.ps1`: tools/plugins 配下 `agentdev-*` の動的列挙と個別 junction 投影を追加。scripts/ 直下の公開入口は従来どおり2本固定（REQ-050-001、REQ-050-009、REQ-052-008）
- 配布 manifest（`trusted-distribution-gate/manifest.ts` RUNTIME_PREFIXES）と distribution boundary 走査対象（`distribution-boundary-fs.ts` collectTargets）へ tools/plugins を追加。link・archive・archive-installed の各投影へ波及
- `package-release-archive.ps1`・`scripts/consumer/archive/install.ps1`: release archive への tools/plugins 同包（node_modules 除外、agentdev-* 以外は対象外）
- `.gitignore`（`.opencode/plugins/agentdev-*/` の junction リーク防止）と README 推奨 .gitignore（`.opencode/tools/agentdev-*/`・`.opencode/plugins/agentdev-*/`）へ配布種別を追加

**対象外（維持確認済み）**: OU-004（GitHub I/O を担う Tool の具体実装）は本 Issue 対象外どおり未実施（再利用可能な操作契約・登録構造のみ提供）。#2429（Gxx-to-POL 移行）系の変更は含まない。

## 完了条件

- [x] REQ-052-001: Custom Tool が操作契約（入力、出力、保証、失敗時の意味）の下で構造化された副作用操作を提供し、実装詳細を Tool 内部に隠蔽していること
- [x] REQ-052-002: Plugin / Hook が実行前の拒否・強制を担い、正規経路の迂回（生 gh WRITE 直接実行）の検出・拒否に使用できること
- [x] REQ-052-003: 副作用操作を担う Tool が操作の結果を検証してから成功を返し、保存または検証に失敗した場合に成功扱いとしないこと
- [x] REQ-052-004: 強制境界を担う Tool / Hook が4異常系のいずれかの場合に対象副作用を実行せず成功扱いとしないこと
- [x] REQ-052-005: 補助能力がその能力の契約で代替手段の存在と継続可否を定義できること
- [x] REQ-052-006: ADF 汎用の Tool / Plugin / Hook が配布対象であり、自己開発固有の検査・強制が repo-local であること
- [x] REQ-052-007: ADF の実行時配布モデルが必要な Tools / Plugins を正規配布物として扱えること
- [x] REQ-052-008: scripts/ 直下の公開入口を増やしていないこと（REQ-050-001、REQ-050-009 維持）
- [x] REQ-052-009: Tool / Hook が実行機構であり、副作用の実行権限の所有者を変更していないこと（REQ-003 と整合）
- [x] REQ-052-010: ツール名、ファイル構成、ディレクトリ構造、公開単位、生コマンド禁止範囲の詳細が Design の所有になっていること（実装は Design 所有事項を参照のみ。確定すべき残課題は Design確定候補へ）
- [x] 契約テスト期待値の更新と固定トークン確認: 実施済み（期待値更新対象: `manifest.test.ts`、`scripts-layout.test.ts`、`scripts-behavior.test.ts`、`package-release-archive.test.ts`。固定トークン確認: 配布種別ディレクトリ内の producer 内部 ID トークンを grep で 0 件確認、check_distribution_boundary source profile で機械検証 ok）

## テスト結果

- **実行 cwd**: `.worktrees/2430-feature`（worktree root）
- **起動コマンド形式**: 3 cwd 正規形（`./` prefix 付きディレクトリ指定）+ 新配布種別スイート
- 依存パッケージ事前導入: `bun install --cwd src/opencode/skills/agentdev-project-extensions/scripts`（正規形の前置）ほか、正規形対象の node_modules（repo-agentdev-integrity、.opencode/plugins、新種別2パッケージ）を worktree へ導入
- スイート A（integrity suite）: `bun test ./.opencode/skills/repo-agentdev-integrity/scripts/` → **2447 pass / 0 fail**（99 files、227s）
- スイート B（src 配下 skill script テスト）: `bun test ./src/opencode/skills/` → **97 pass / 0 fail**（9 files）
- スイート C（repo ルート系 guard テスト）: `bun test ./.opencode/plugins/ ./scripts/` → **140 pass / 0 fail**（4 files、21.7s。tools/plugins junction 投影の実 junction 検証を含む）
- 新配布種別: `bun test ./src/opencode/tools/ ./src/opencode/plugins/` → **93 pass / 0 fail**（4 files。agentdev-gh 26、agentdev-gh-write-guard 67）
- typecheck: 両パッケージ `tsc --noEmit` 合格（型抑制なし）

環境忠実度（3要素）:

- 実行環境: worktree root `.worktrees/2430-feature`
- junction 転送状態: worktree に `.opencode` junction 未設定（install/self-sync の実行は委任契約上禁止）。link projection は `scripts-behavior.test.ts` が生成する使い捨て consumer 環境での実 junction 作成・check により検証した。main root の `.opencode` 構成は読み取りのみ確認（main には src/opencode/tools|plugins が未マージのため当該 junction は未生成。マージ後の self-sync apply で動的列挙により生成される）
- 依存パッケージ状態: node_modules は gitignore 対象のため worktree へ bun install で導入（上記）

## 品質メトリクス

| メトリクス | 結果 | 基準 | 判定 |
|---|---|---|---|
| 配布境界 source gate（check_distribution_boundary --profile source） | ok: true、324 files、concrete-id 0 / path 0 / url 0 | 0 violations | ✅ |
| traceability check missing-implementation（REQ-052 行） | main baseline 10行 → 本 PR 8行（REQ-052-006/007 を新規宣言で解消） | 全行解消が理想状態 | ⚠️ 残り8行は宣言の正規配置先が docs/designs（本委任の書込禁止範囲）。main でも同状態、Epic 全体で45行の既存未解消（REQ-051 等、姉妹課題と同型）。Design確定候補に正規配置案を記録 |
| bun test 全スイート | 2777 pass / 0 fail（A+B+C+新種別） | 0 fail | ✅ |
| tsc --noEmit（新種別2パッケージ） | 合格 | 0 error | ✅ |

## 検証差分

| 実行工程 | 検証種別 | 検証結果 | 新規 | 修正済み | 既出 | 撤回 | 無効 |
|---|---|---|---|---|---|---|---|
| case-run | TS-005 配布境界（source profile） | ok: 324 files / 0 violations（tools/plugins を走査対象に追加した状態で実施） | 該当なし | durable state のスケルトンが配布物に producer 内部 ID（REQ-052・OU-004）を含めていた件を全除去し gate を合格化 | 該当なし | 該当なし | 該当なし |
| case-run | TS-005 link projection（実 junction 検証） | scripts-behavior.test.ts 新規シナリオ合格: 使い捨て consumer 環境で tools/plugins の junction 作成・check clean を実 junction で確認 | 該当なし | 該当なし | 該当なし | 該当なし | 該当なし |
| case-run | TS-005 配布 manifest・archive 投影 | manifest.test.ts・package-release-archive.test.ts 合格: tools/plugins を runtime 対象に追加、archive へ同包、node_modules 除外、非 agentdev エントリ（repo-local）は対象外 | 該当なし | 該当なし | 該当なし | 該当なし | 該当なし |
| case-run | TS-006 fail-closed（Tool agentdev-gh） | 4異常系（設定解釈不能・パス解決不能・強制処理異常終了・必須検証未了）全ケースで副作用が成功扱いにならないことを FakeRunner で検証 | 該当なし | 該当なし | 該当なし | 該当なし | 該当なし |
| case-run | TS-006 fail-closed（Plugin agentdev-gh-write-guard） | 設定解釈不能・検出器異常終了・コマンド引数検証不能で block、読み取り系 gh コマンドは素通り、検査対象外ツールは素通り | 該当なし | 該当なし | 該当なし | 該当なし | 該当なし |
| case-run | traceability check（REQ-052-001〜010） | malformed / unknown-refs / invalid-catalog-refs は pass。missing-implementation 8行（006/007 は本 PR の宣言で解消済み） | REQ-052-001〜005・008〜010 の実装対応宣言は配置先が docs/designs（本委任では編集不可）のため Design確定候補へ起票 | 該当なし | main baseline から継続の未解消45行（REQ-051 8行を含む姉妹 Wave と同型。Epic 全体の既存状態） | 該当なし | 該当なし |
| case-run | 仕様準拠レビュー（Issue 完了条件・Execution Contract） | 完了条件10行+契約テスト行すべて充足。OU-004 具体実装・#2429 系は対象外どおり未実施 | 該当なし | durable state の issue_update における body 欠落欠陥を修正（回帰テスト2件追加） | 該当なし | 該当なし | 該当なし |

## Findings/ Capture候補

### intake

- （候補）agentdev-traceability の corpus は `.ps1` を走査しないため、`scripts/*.ps1` に直接記述した ADF-COVERS 宣言は check に反映されない。実装行の宣言を Design 側へ置く運用（runtime-package-boundary.md の注記）は既存だが、新規配布種別・新規スクリプト追加時に見落としやすい。配布種別追加時の宣言配置チェックを inspect 系（inspect-docs / inspect-skills）の観点として検討する価値がある。
- （候補）既存 Stage B pre-write guard（`.opencode/plugins/distribution-boundary-guard`）は、契約上の対象が src/opencode 配下の分散テキスト成果物であるにもかかわらず、リポジトリ外パス（TEMP 直下の PR 本文ドラフト等）への producer 内部 ID を含む書き込みも block した（over-block）。ガードのパス分類を対象スコープへ狭める検討の価値がある。

### learning

- （候補）Windows PowerShell の `Set-Content` は既定で CRLF を書き出す。LF の既存 UTF-8 ファイルを `Get-Content` / `Set-Content` 経由で書き換えると行末が全面変化する（本 PR では node による LF 正規化で対処）。pwsh での一括置換は、BOM なし UTF-8 かつ LF 保持のため node の `readFileSync` / `writeFileSync` 併用が安全。

## Design確定候補

1. **種別契約の実装・検証宣言の正規配置（要 Design 更新）**: 配布物は producer 内部 ID を含めない配布境界（REQ-029、DEC-014）に従うため、tool/plugin 本体の ADF-COVERS 宣言は Design が所有する（既存パターン: runtime-package-boundary.md が install/self-sync の実装行を所有）。case-close の Design 確定で以下の配置を候補とする:
   - `custom-tool-contracts.md` へ `ADF-COVERS(implementation): REQ-052-001, REQ-052-002, REQ-052-003, REQ-052-004, REQ-052-005, REQ-052-009`（実装体: `src/opencode/tools/agentdev-gh/**`、`src/opencode/plugins/agentdev-gh-write-guard/**`）と `ADF-COVERS(verification): REQ-052-001, REQ-052-003, REQ-052-005, REQ-052-010, REQ-052-002, REQ-052-004`（検証体: 同 tests/）
   - `runtime-package-boundary.md` へ `ADF-COVERS(implementation): REQ-052-008`（scripts 公開入口2本維持の実装行。install.ps1 / self-sync.ps1）
   - REQ-052-006 / REQ-052-007 は本 PR で repo-local（走査対象外）の manifest.ts / distribution-boundary-fs.ts / 各テストへ宣言済みで check も解消済み
2. **ツール名の確定**: `agentdev_gh` は仮確定（index.ts・README に注記済み）。Design「対象操作の境界（初期セット）」の後続更新でツール名・公開単位を確定する。
3. **bun test フルスイート正規形の拡張**: QG-4 の 3 cwd 正規形は `src/opencode/tools/`・`src/opencode/plugins/` を対象に含まない（スイート B は src/opencode/skills/ のみ）。新配布種別を正規形へ加めるかは quality-gates Design（qg-4-final-acceptance）の更新事項。
4. **Plugin 設定契約の確定**: 環境変数名 `AGENTDEV_GH_WRITE_GUARD_CONFIG`、既定検査対象（bash のみ）、検出ルールの禁止範囲詳細（読み取り系許容の境界）は Design「迂回防止」節の所有事項として確定を要する。

## 決定事項

- 適用: DEC-022 決定4〜6・9（Custom Tool 移管・実行前強制の軸・fail-closed・配布種別追加）、DEC-014（多層 enforcement の適用対象拡張として Plugin / Hook を配置）、DEC-021（scripts 公開入口2本固定の維持）、DEC-004（ローカル版は同一操作契約での実装差し替え。GhRunner 境界として具現化）
- 新規の決定事項: なし

## 関連Issue

Refs #2430（完了条件チェックボックスの評価・クローズは case-close が実施）